### PR TITLE
Another take on issue 293. After downloading offline vector data the user

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <resources>
-	<string name="voice_is_not_available_msg">Voice guidance is not available. Please go to settings, choose preferrable voice data or download it.</string>
+	<string name="map_download_success">Successful. Switch on Layers -> Map Source... -> Vector OSM maps to see the data.</string>	<string name="voice_is_not_available_msg">Voice guidance is not available. Please go to settings, choose preferrable voice data or download it.</string>
 	<string name="voice_is_not_available_title">Voice data is not specified</string>
 	<string name="trace_rendering_descr">Use this flag to check rendering performance</string>
     <string name="trace_rendering">Trace rendering</string>

--- a/OsmAnd/src/net/osmand/activities/DownloadIndexActivity.java
+++ b/OsmAnd/src/net/osmand/activities/DownloadIndexActivity.java
@@ -43,6 +43,7 @@ import java.util.zip.ZipInputStream;
 import net.osmand.DownloadOsmandIndexesHelper;
 import net.osmand.IProgress;
 import net.osmand.LogUtil;
+import net.osmand.OsmandSettings;
 import net.osmand.ProgressDialogImplementation;
 import net.osmand.R;
 import net.osmand.ResourceManager;
@@ -58,7 +59,9 @@ import android.app.AlertDialog;
 import android.app.ListActivity;
 import android.app.ProgressDialog;
 import android.app.AlertDialog.Builder;
+import android.content.Context;
 import android.content.DialogInterface;
+import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.os.Environment;
@@ -665,6 +668,14 @@ public class DownloadIndexActivity extends ListActivity {
 			}
 
 			ArrayList<String> warnings = new ArrayList<String>();
+			
+			if (toIndex.getName().endsWith(IndexConstants.BINARY_MAP_INDEX_EXT)) {
+				SharedPreferences prefs = getSharedPreferences(OsmandSettings.SHARED_PREFERENCES_NAME, Context.MODE_WORLD_READABLE);
+				if (!OsmandSettings.isUsingMapVectorData(prefs)) {
+					warnings.add(getString(R.string.map_download_success));
+				}
+			}
+			
 			ResourceManager manager = ((OsmandApplication) getApplication()).getResourceManager();
 			if(dateModified != null){
 				toIndex.setLastModified(dateModified);


### PR DESCRIPTION
Another take on issue 293. After downloading offline vector data the user is warned to switch map source to OSM Vector Data. (if it's not the active layer already)

I put the new item in strings.xml to the top and the new warning to (hopefully) more sensible place.
