### PR TITLE
Use full 3 digit resolution in distance display - very useful for off-road navigation.

### DIFF
--- a/OsmAnd/src/net/osmand/OsmAndFormatter.java
+++ b/OsmAnd/src/net/osmand/OsmAndFormatter.java
@@ -63,9 +63,9 @@ public class OsmAndFormatter {
 
 		if (meters >= 100 * mainUnitInMeters) {
 			return (int) (meters / mainUnitInMeters) + " " + ctx.getString(mainUnitStr); //$NON-NLS-1$
-		} else if (meters > 1.5f * mainUnitInMeters) {
+		} else if (meters > 9.99f * mainUnitInMeters) {
 			return MessageFormat.format("{0,number,#.#} " + ctx.getString(mainUnitStr), ((float) meters) / mainUnitInMeters); //$NON-NLS-1$ 
-		} else if (meters > 0.9f * mainUnitInMeters) {
+		} else if (meters > 0.999f * mainUnitInMeters) {
 			return MessageFormat.format("{0,number,#.##} " + ctx.getString(mainUnitStr), ((float) meters) / mainUnitInMeters); //$NON-NLS-1$
 		} else {
 			if (mc == MetricsConstants.KILOMETERS_AND_METERS) {


### PR DESCRIPTION
The distance to point display currently use 100m resolution above 1.5km. For off-road and marine navigation it is important to have better resolution. This modification implements full 3 digit resolution, i.e. 10m resolution up to 10km. The space required for the display is the same as earlier.
