### PR TITLE
Make streets close to each other as one street.

### DIFF
--- a/DataExtractionOSM/OsmAndMapCreator.launch
+++ b/DataExtractionOSM/OsmAndMapCreator.launch
@@ -12,5 +12,5 @@
 </listAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="net.osmand.swing.OsmExtractionUI"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="DataExtractionOSM"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-XX:+UseParallelGC -Xmx640M -Xmn256M"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-XX:+UseParallelGC -Xmx1300M -Xmn256M"/>
 </launchConfiguration>


### PR DESCRIPTION
Issue 352 made a small problem, that long streets, streets that were made of more ways with same name could fall in different districts and so there was quite a mess than.
This patch tries to identify the streets with same name but different district that are close to each other by comparing the  distance between their nodes.
If a new street wants to be added, but it is close to the other one, that this street will be merged to it.
