### PR TITLE
MessageFormat did not work when sharing a position

### DIFF
--- a/OsmAnd/res/values-cs/strings.xml
+++ b/OsmAnd/res/values-cs/strings.xml
@@ -521,10 +521,10 @@
   <string name="mile_per_hour">mph</string>
   <string name="mile">mi</string>
   <string name="send_location_way_choose_title">Sdílet polohu pomocí</string>
-  <string name="send_location_sms_pattern">Jsem tady : {0}\n{1}</string>
+  <string name="send_location_sms_pattern">Jsem tady : %1$s\n%2$s</string>
   <string name="send_location_email_pattern">
-    Pro zobrazení polohy následujte link {0} v prohlížeči nebo android
-    intent link {1}
+    Pro zobrazení polohy následujte link %1$s v prohlížeči nebo android
+    intent link %2$s
   </string>
   <string name="send_location">Poslat polohu</string>
   <string name="context_menu_item_share_location">Sdílet polohu</string>

--- a/OsmAnd/res/values-de/strings.xml
+++ b/OsmAnd/res/values-de/strings.xml
@@ -224,8 +224,8 @@
 	<string name="mile_per_hour">mph</string>
 	<string name="mile">mi</string>
 	<string name="send_location_way_choose_title">Position mitteilen mittels</string>
-	<string name="send_location_sms_pattern">Ich bin hier: {0}, {1}</string>
-	<string name="send_location_email_pattern">Um die Position zu sehen, folge dem Web-Link {0} oder Android Intent Link {1}</string>
+	<string name="send_location_sms_pattern">Ich bin hier: %1$s, %2$s</string>
+	<string name="send_location_email_pattern">Um die Position zu sehen, folge dem Web-Link %1$s oder Android Intent Link %2$s</string>
 	<string name="send_location">Position senden</string>
 	<string name="context_menu_item_share_location">Position mitteilen</string>
 	<string name="add_waypoint_dialog_added">Wegpunkt \'\'{0}\'\' erfolgreich hinzugefügt</string>

--- a/OsmAnd/res/values-fr/strings.xml
+++ b/OsmAnd/res/values-fr/strings.xml
@@ -208,8 +208,8 @@
 <string name="mile_per_hour">mph</string>
 <string name="mile">mi</string>
 <string name="send_location_way_choose_title">Partager un lieu utilisant</string>
-<string name="send_location_sms_pattern">Je suis ici : {0}\n{1}</string>
-<string name="send_location_email_pattern">Pour voir ce lieu, suivre le lien web {0} ou android {1}</string>
+<string name="send_location_sms_pattern">Je suis ici : %1$s\n%2$s</string>
+<string name="send_location_email_pattern">Pour voir ce lieu, suivre le lien web %1$s ou android %2$s</string>
 <string name="send_location">Envoyer le lieu</string>
 <string name="context_menu_item_share_location">Partager lieu</string>
 <string name="add_waypoint_dialog_added">Etape \'\'{0}\'\' ajoutée avec succés</string>

--- a/OsmAnd/res/values-hu/strings.xml
+++ b/OsmAnd/res/values-hu/strings.xml
@@ -212,8 +212,8 @@ A cél megadása sokszor távolságmérésre használatos vagy az egyenes odanav
 <string name="mile_per_hour">mph</string>
 <string name="mile">mi</string>
 <string name="send_location_way_choose_title">Hely megosztásának módja</string>
-<string name="send_location_sms_pattern">Itt vagyok / I\'m here : {0}\n{1}</string>
-<string name="send_location_email_pattern">A hely megjelenítéséhez kattints a {0} linkre a webböngészőben vagy az Androidra szánt linkre {1}\n\nTo see location follow the web browser link {0} or android intent link {1}</string>
+<string name="send_location_sms_pattern">Itt vagyok / I\'m here : %1$s\n%2$s</string>
+<string name="send_location_email_pattern">A hely megjelenítéséhez kattints a %1$s linkre a webböngészőben vagy az Androidra szánt linkre %2$s\n\nTo see location follow the web browser link %1$s or android intent link %2$s</string>
 <string name="send_location">Hely pozíció elküldése</string>
 <string name="context_menu_item_share_location">Hely megosztása</string>
 <string name="add_waypoint_dialog_added">Sikeres útpont felvétel: \'\'{0}\'\'</string>

--- a/OsmAnd/res/values-it/strings.xml
+++ b/OsmAnd/res/values-it/strings.xml
@@ -223,8 +223,8 @@
 	<string name="mile_per_hour">mph</string>
 	<string name="mile">mi</string>
 	<string name="send_location_way_choose_title">Condividi la posizione</string>
-	<string name="send_location_sms_pattern">Sono quì: {0}\n{1}</string>
-	<string name="send_location_email_pattern">Per vedere la posizione segui il link web {0} o il link {1}</string>
+	<string name="send_location_sms_pattern">Sono quì: %1$s\n%2$s</string>
+	<string name="send_location_email_pattern">Per vedere la posizione segui il link web %1$s o il link %2$s</string>
 	<string name="send_location">Invia posizione</string>
 	<string name="context_menu_item_share_location">Condividi posizione</string>
 	<string name="add_waypoint_dialog_added">Waypoint \'\'{0}\'\' aggiunto</string>

--- a/OsmAnd/res/values-jp/strings.xml
+++ b/OsmAnd/res/values-jp/strings.xml
@@ -206,9 +206,9 @@ OSMコミュニティはこの問題をいち早く修正することができ�
      <string name="mile_per_hour">mph</string>
      <string name="mile">mi</string>
      <string name="send_location_way_choose_title">次の方法で位置をシェア</string>
-     <string name="send_location_sms_pattern">いまここ : {0}\n{1}</string>
+     <string name="send_location_sms_pattern">いまここ : %1$s\n%2$s</string>
      <string name="send_location_email_pattern">位置を見るには
-次のWebブラウザ用リンク {0}、もしくはandroidインテントリンク{1}を参照</string>
+次のWebブラウザ用リンク %1$s、もしくはandroidインテントリンク%2$sを参照</string>
      <string name="send_location">位置を送信</string>
      <string name="context_menu_item_share_location">位置をシェア</string>
      <string name="add_waypoint_dialog_added">ウェイポイント \'\'{0}\'\'

--- a/OsmAnd/res/values-ru/strings.xml
+++ b/OsmAnd/res/values-ru/strings.xml
@@ -176,8 +176,8 @@
 	<string name="mile_per_hour">мл/ч</string>
 	<string name="mile">мл</string>
 	<string name="send_location_way_choose_title">Поделиться используя</string>
-	<string name="send_location_sms_pattern">Tut : {0}\n{1}</string>
-	<string name="send_location_email_pattern">Чтобы увидить местоположение следуйте ссылке {0} или android ссылке {1}</string>
+	<string name="send_location_sms_pattern">Tut : %1$s\n%2$s</string>
+	<string name="send_location_email_pattern">Чтобы увидить местоположение следуйте ссылке %1$s или android ссылке %2$s</string>
 	<string name="send_location">Отправить местоположение</string>
 	<string name="context_menu_item_share_location">Поделиться местоположением</string>
 	<string name="add_waypoint_dialog_added">Точка \'\'{0}\'\' была успешно добавлена</string>

--- a/OsmAnd/res/values-sk/strings.xml
+++ b/OsmAnd/res/values-sk/strings.xml
@@ -199,8 +199,8 @@ Cieľový bod je hlavne používaný na meranie vzdialenosti a napredovanú navi
 	<string name="mile_per_hour">mph</string>
 	<string name="mile">mi</string>
 	<string name="send_location_way_choose_title">Zdieľať umiestnenie cez</string>
-	<string name="send_location_sms_pattern">Ja som tu: {0}, {1}</string>
-	<string name="send_location_email_pattern">Na zobrazenie umiestnenia nasledujte webovský odkaz {0} alebo odkaz androidovského obsahu {1}</string>
+	<string name="send_location_sms_pattern">Ja som tu: %1$s, %2$s</string>
+	<string name="send_location_email_pattern">Na zobrazenie umiestnenia nasledujte webovský odkaz %1$s alebo odkaz androidovského obsahu %2$s</string>
 	<string name="send_location">Poslať umiestnenie</string>
 	<string name="context_menu_item_share_location">Zdieľať umiestnenie</string>
 	<string name="add_waypoint_dialog_added">Waypoint \'\'{0}\'\' bol úspešne pridaný</string>

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -223,8 +223,8 @@
 	<string name="mile_per_hour">mph</string>
 	<string name="mile">mi</string>
 	<string name="send_location_way_choose_title">Share location using</string>
-	<string name="send_location_sms_pattern">I\'m here: {0}\n{1}</string>
-	<string name="send_location_email_pattern">To see location follow the web browser link {0} or android intent link {1}</string>
+	<string name="send_location_sms_pattern">I\'m here: %1$s\n%2$s</string>
+	<string name="send_location_email_pattern">To see location follow the web browser link %1$s or android intent link %2$s</string>
 	<string name="send_location">Send location</string>
 	<string name="context_menu_item_share_location">Share location</string>
 	<string name="add_waypoint_dialog_added">Waypoint \'\'{0}\'\' was successfully added</string>

--- a/OsmAnd/src/net/osmand/plus/activities/MapActivityActions.java
+++ b/OsmAnd/src/net/osmand/plus/activities/MapActivityActions.java
@@ -281,8 +281,8 @@ public class MapActivityActions {
 			
 			@Override
 			public void onClick(DialogInterface dialog, int which) {
-				String sms = MessageFormat.format(getString(R.string.send_location_sms_pattern), shortOsmUrl, appLink);
-				String email = MessageFormat.format(getString(R.string.send_location_email_pattern), shortOsmUrl, appLink );
+				String sms = mapActivity.getString(R.string.send_location_sms_pattern, shortOsmUrl, appLink);
+				String email = mapActivity.getString(R.string.send_location_email_pattern, shortOsmUrl, appLink);
 				if(which == 0){
 					Intent intent = new Intent(Intent.ACTION_SEND);
 					intent.setType("vnd.android.cursor.dir/email"); //$NON-NLS-1$


### PR DESCRIPTION
I noticed that sharing my position did not work properly. Instead of a
link to the position, there was a {0} and {1}. The MessageFormat did not
seem to work and because I couldn't get it working with MessageFormat, I
did it the way as the SaveDirectionsAsyncTask in MapActivityActions with
the getString(int, Object...) of mapActivity's parent.

As this change used a different format for replacements, I updated the
strings.xml too.
