### PR TITLE
download progress bar

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/DownloadIndexActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/DownloadIndexActivity.java
@@ -479,10 +479,26 @@ private class DownloadIndexesAsyncTask extends  AsyncTask<String, Object, String
 		
 		@Override
 		protected void onPreExecute() {
-			progressFileDlg = ProgressDialog.show(DownloadIndexActivity.this, getString(R.string.downloading),
-					getString(R.string.downloading_file), true, true);
+			progressFileDlg = new ProgressDialog(DownloadIndexActivity.this);
+			progressFileDlg.setTitle(getString(R.string.downloading));
+			progressFileDlg.setMessage(getString(R.string.downloading_file));
+			progressFileDlg.setIndeterminate(false);
+			progressFileDlg.setCancelable(true);
+			// we'd prefer a plain progress bar without numbers,
+			// but that is only available starting from API level 11
+			try {
+				ProgressDialog.class
+					.getMethod("setProgressNumberFormat", new Class[] { String.class })
+					.invoke(progressFileDlg, (String)null);
+			} catch (NoSuchMethodException nsme) {
+				// failure, must be older device
+			} catch (IllegalAccessException nsme) {
+				// failure, must be older device
+			} catch (java.lang.reflect.InvocationTargetException nsme) {
+				// failure, must be older device
+			}
 			downloadFileHelper.setInterruptDownloading(false);
-			progressFileDlg.show();
+			progressFileDlg.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
 			progress = new ProgressDialogImplementation(progressFileDlg, true);
 			progressFileDlg.setOnCancelListener(new DialogInterface.OnCancelListener() {
 				@Override


### PR DESCRIPTION
cf. http://code.google.com/p/osmand/issues/detail?id=619:

I am not happy with the (infrequently updated) textual percentage in the download progress viewer and would like to suggest a standard progress bar instead.

I have implemented this suggestion, using Android's standard ProgressDialog with a bar. On Android 2.x, it will show the number of bytes actually downloaded; for 3.0, the code as written switches these numbers off.

We could also make the unzipping step report its progress, obviously, but that has not been done yet. For unzipping, the style is changed to indeterminate. Switching to spinner mode seems not to be possible after show() and would require two dialogs and calling hide() on one and show() on the other.
