### PR TITLE
download progress bar

### DIFF
--- a/OsmAnd/src/net/osmand/plus/ProgressDialogImplementation.java
+++ b/OsmAnd/src/net/osmand/plus/ProgressDialogImplementation.java
@@ -48,12 +48,34 @@ public class ProgressDialogImplementation implements IProgress {
 	public ProgressDialogImplementation(ProgressDialog dlg, boolean cancelable){
 		this(dlg.getContext(), dlg, cancelable);
 	}
-	
-	
+
 	public ProgressDialogImplementation(final ProgressDialog dlg){
 		this(dlg, false);
 	}
-	
+
+	public static ProgressDialogImplementation createProgressDialog(Context ctx, String title, String message, int style) {
+		ProgressDialog dlg = new ProgressDialog(ctx);
+		dlg.setTitle(title);
+		dlg.setMessage(message);
+		dlg.setIndeterminate(style == ProgressDialog.STYLE_HORIZONTAL); // re-set in mViewUpdateHandler.handleMessage above
+		dlg.setCancelable(true);
+		// we'd prefer a plain progress bar without numbers,
+		// but that is only available starting from API level 11
+		try {
+			ProgressDialog.class
+				.getMethod("setProgressNumberFormat", new Class[] { String.class })
+				.invoke(dlg, (String)null);
+		} catch (NoSuchMethodException nsme) {
+			// failure, must be older device
+		} catch (IllegalAccessException nsme) {
+			// failure, must be older device
+		} catch (java.lang.reflect.InvocationTargetException nsme) {
+			// failure, must be older device
+		}
+		dlg.setProgressStyle(style);
+		return new ProgressDialogImplementation(dlg, true);
+	}
+
 	public void setDialog(ProgressDialog dlg){
 		if(dlg != null){
 			if(cancelable){

--- a/OsmAnd/src/net/osmand/plus/activities/DownloadIndexActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/DownloadIndexActivity.java
@@ -479,27 +479,13 @@ private class DownloadIndexesAsyncTask extends  AsyncTask<String, Object, String
 		
 		@Override
 		protected void onPreExecute() {
-			progressFileDlg = new ProgressDialog(DownloadIndexActivity.this);
-			progressFileDlg.setTitle(getString(R.string.downloading));
-			progressFileDlg.setMessage(getString(R.string.downloading_file));
-			progressFileDlg.setIndeterminate(false);
-			progressFileDlg.setCancelable(true);
-			// we'd prefer a plain progress bar without numbers,
-			// but that is only available starting from API level 11
-			try {
-				ProgressDialog.class
-					.getMethod("setProgressNumberFormat", new Class[] { String.class })
-					.invoke(progressFileDlg, (String)null);
-			} catch (NoSuchMethodException nsme) {
-				// failure, must be older device
-			} catch (IllegalAccessException nsme) {
-				// failure, must be older device
-			} catch (java.lang.reflect.InvocationTargetException nsme) {
-				// failure, must be older device
-			}
 			downloadFileHelper.setInterruptDownloading(false);
-			progressFileDlg.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
-			progress = new ProgressDialogImplementation(progressFileDlg, true);
+			progress = ProgressDialogImplementation.createProgressDialog(
+				DownloadIndexActivity.this,
+				getString(R.string.downloading),
+				getString(R.string.downloading_file),
+				ProgressDialog.STYLE_HORIZONTAL);
+			progressFileDlg = ((ProgressDialogImplementation)progress).getDialog();
 			progressFileDlg.setOnCancelListener(new DialogInterface.OnCancelListener() {
 				@Override
 				public void onCancel(DialogInterface dialog) {


### PR DESCRIPTION
As requested, moved settings for download progress bar into ProgressDialogImplementation.java

Since these settings cannot be applied after show() has been invoked, created factory method. This also improves the general design by increasing the separation of concerns.

Further improvements to consider that would build upon this change:
- The factory method could be used in more places.
- Unzipping should send progress notifications.
- Indexing should send progress notifications.
