### PR TITLE
Translation of sustenance, now: Gastronomie

### DIFF
--- a/OsmAnd/res/values-de/strings.xml
+++ b/OsmAnd/res/values-de/strings.xml
@@ -297,7 +297,7 @@
 	<string name="amenity_type_other">Anderes</string>
 	<string name="amenity_type_shop">Geschäft</string>
 	<string name="amenity_type_sport">Sport</string>
-	<string name="amenity_type_sustenance">Lebensunterhalt</string>
+	<string name="amenity_type_sustenance">Gastronomie</string>
 	<string name="amenity_type_tourism">Touristik</string>
 	<string name="amenity_type_transportation">ÖPNV</string>
 	<string name="indexing_address">Indiziere Adressen...</string>


### PR DESCRIPTION
I have corrected a translation mistake: "Lebensunterhalt" is the money you earn from a job. Correct category for restaurants, bars etc is  "Gastronomie". Please pull
