### PR TITLE
Cyclemaps cz

### DIFF
--- a/config/site/tile_sources.xml
+++ b/config/site/tile_sources.xml
@@ -28,6 +28,7 @@
    <tile_source name="Cykloatlas CZ" url_template="http://services.tmapserver.cz/tiles/gm/shc/{0}/{1}/{2}.png" ext=".png" min_zoom="7" max_zoom="16" tile_size="256" img_density="16" avg_img_size="26000"/>
    <tile_source name="Cykloatlas CZ HillShade" url_template="http://services.tmapserver.cz/tiles/gm/sum/{0}/{1}/{2}.png" ext=".png" min_zoom="7" max_zoom="15" tile_size="256" img_density="16" avg_img_size="26000"/>
 -->
+   <tile_source name="Prague cycle map" url_template="http://tiles.prahounakole.cz/media/tiles_OPNKM/{0}/{1}/{2}.png" ext=".png" min_zoom="11" max_zoom="18" tile_size="256" img_density="16" avg_img_size="26000"/>
 
    <tile_source name="MTB Map CZ" url_template="http://tchor.fi.muni.cz:8080/mtbmap_tiles/{0}/{1}/{2}.png" ext=".png" min_zoom="7" max_zoom="16" tile_size="256" img_density="32" avg_img_size="18000"/>
 


### PR DESCRIPTION
Hi,

this branch

1)  comments out Cykloatlas-CZ, because they recently added a time based token authorization, so it doesn't work in OsmAnd anymore.

2) adds a free bike map of Prague, based on OpenStreetMap data (http://mapa.prahounakole.cz/)
