### PR TITLE
Do not put irrelvant tags (source, created_by, converted_by) in the data...

### DIFF
--- a/DataExtractionOSM/src/net/osmand/data/preparation/OsmDbCreator.java
+++ b/DataExtractionOSM/src/net/osmand/data/preparation/OsmDbCreator.java
@@ -30,7 +30,9 @@ public class OsmDbCreator implements IOsmStorageFilter {
 
 	public static final int BATCH_SIZE_OSM = 100000;
 
-
+	// do not store these tags in the database, just ignore them
+	final String[] tagsToIgnore= {"created_by","source","converted_by"};
+	
 	DBDialect dialect;
 	int currentCountNode = 0;
 	private PreparedStatement prepNode;
@@ -235,6 +237,7 @@ public class OsmDbCreator implements IOsmStorageFilter {
 						currentRelationsCount = 0;
 					}
 				}
+				e.removeTags(tagsToIgnore);
 				for (Entry<String, String> i : e.getTags().entrySet()) {
 					currentTagsCount++;
 					prepTags.setLong(1, e.getId());

--- a/DataExtractionOSM/src/net/osmand/osm/Entity.java
+++ b/DataExtractionOSM/src/net/osmand/osm/Entity.java
@@ -115,6 +115,14 @@ public abstract class Entity {
 		return tags.remove(key);
 	}
 	
+	public void removeTags(String[] keys){
+		if (tags != null){
+			for (String key : keys){
+				tags.remove(key);
+			}
+		}
+	}
+	
 	public String putTag(String key, String value){
 		if(tags == null){
 			tags = new LinkedHashMap<String, String>();


### PR DESCRIPTION
Please consider pulling this change. It removes tags that are irrelevant for the map creation (currently: "converted_by", "source" and "created_by") from the nodes.tmp database.

result of this change: smaller nodes.tmp.odb database (about 100 MB less for the austria.osm), faster processing (due to less disk I/O).

On my system (Athlon X2 with SATA disk), this patch saves some seconds on the first step of the processing; so the cost of the comparison of the strings with the tags is smaller than the time for writing to disk.
