### PR TITLE
disable the native rendering option when it fails to load

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/OsmandApplication.java
+++ b/OsmAnd/src/net/osmand/plus/activities/OsmandApplication.java
@@ -334,6 +334,7 @@ public class OsmandApplication extends Application {
 				boolean initialized = NativeOsmandLibrary.getLibrary(storage) != null;
 				if (!initialized) {
 					LOG.info("Native library could not loaded!");
+					osmandSettings.NATIVE_RENDERING.set(false);
 				}
 			}
 			warnings = manager.reloadIndexes(startDialog);


### PR DESCRIPTION
With build w/o native library, it's now impossible to uncheck the native renderer option, because the checkbox is now disabled. This means if the option was set previously, OsmAnd always shows "Initializing native renderer" at startup, even is the native renderer is not there.

This patch sets the option to false when the native renderer fails to load.
