### PR TITLE
Latvian tts file bugfix

### DIFF
--- a/OsmAnd/assets/voice/lv-tts/ttsconfig.p
+++ b/OsmAnd/assets/voice/lv-tts/ttsconfig.p
@@ -1,4 +1,4 @@
-:- op('==', xfy, 500).
+ï»¿:- op('==', xfy, 500).
 version(101).
 language(lv).
 
@@ -14,61 +14,67 @@ turn('right', ['griezties pa labi ']).
 turn('right_sh', ['strauji pagriezties pa labi ']).
 turn('right_sl', ['pagriezties pa labi ']).
 
-prepare_turn(Turn, Dist) == ['Pçc ', D, ' pagriezties ', M] :- distance(Dist) == D, turn(Turn, M).
-turn(Turn, Dist) == ['Pçc ', D, M] :- distance(Dist) == D, turn(Turn, M).
+prepare_turn(Turn, Dist) == ['PÄ“c ', D, ' gatavoties pa', M] :- distance(Dist) == D, turn(Turn, M).
+turn(Turn, Dist) == ['PÄ“c ', D, M] :- distance(Dist) == D, turn(Turn, M).
 turn(Turn) == M :- turn(Turn, M).
 
-prepare_make_ut(Dist) == ['Gatavojaties apgriezties pçc ', D] :- distance(Dist) == D.
-make_ut(Dist) == ['Pçc ', D, ' apgrieşaties '] :- distance(Dist) == D.
-make_ut == ['Apgrieşaties '].
-make_ut_wp == ['Apgrieşaties pie pirmâs iespçjas '].
+prepare_make_ut(Dist) == ['Gatavojaties apgriezties pÄ“c ', D] :- distance(Dist) == D.
+make_ut(Dist) == ['PÄ“c ', D, ' apgrieÅ¾aties '] :- distance(Dist) == D.
+make_ut == ['ApgrieÅ¾aties '].
+make_ut_wp == ['ApgrieÅ¾aties pie pirmÄs iespÄ“jas '].
 
-prepare_roundabout(Dist) == ['Sagatvojaties lokveida kustîbai ', D] :- distance(Dist) == D.
-roundabout(Dist, _Angle, Exit) == ['Pçc ', D, ' iebrauciet lokveida krustojumâ, un tad brauciet ', E, 'pagriezienâ'] :- distance(Dist) == D, nth(Exit, E).
-roundabout(_Angle, Exit) == ['izbrauciet ', E, 'izbrauktuvç'] :- nth(Exit, E).
+prepare_roundabout(Dist) == ['Sagatvojaties lokveida kustÄ«bai pÄ“c ', D] :- distance(Dist) == D.
+roundabout(Dist, _Angle, Exit) == ['PÄ“c ', D, ' iebrauciet lokveida krustojumÄ, un tad brauciet ', E, 'pagriezienÄ'] :- distance(Dist) == D, nth(Exit, E).
+roundabout(_Angle, Exit) == ['izbrauciet ', E, 'izbrauktuvÄ“'] :- nth(Exit, E).
 
-go_ahead == ['Dodaties taisni uz priekğu '].
-go_ahead(Dist) == ['Brauciet pa ceïu ', D]:- distance(Dist) == D.
+go_ahead == ['Dodaties taisni uz priekÅ¡u '].
+go_ahead(Dist) == ['Brauciet pa ceÄ¼u ', D]:- distance2(Dist) == D.
 
-and_arrive_destination == ['un ierodaties galapunktâ '].
+and_arrive_destination == ['un ierodaties galapunktÄ '].
 
 then == ['tad '].
-reached_destination == ['jûs esiet nokïuvis galapunktâ '].
-bear_right == ['turieties pa labi '].
-bear_left == ['turieties pa kreisi '].
+reached_destination == ['jÅ«s esiet nokÄ¼uvis galapunktÄ '].
+bear_right == ['turÄ“ties pa labi '].
+bear_left == ['turÄ“ties pa kreisi '].
 
-route_new_calc(Dist) == ['Brauciens ir ', D] :- distance(Dist) == D.
-route_recalc(Dist) == ['Marğruts ir pârçíinâts, attâlums ', D] :- distance(Dist) == D.
+route_new_calc(Dist) == ['Brauciens ir ', D] :- distance2(Dist) == D.
+route_recalc(Dist) == ['MarÅ¡ruts ir pÄrÄ“Ä·inÄts, attÄlums ir ', D] :- distance2(Dist) == D.
 
-location_lost == ['pazudis g p s signâls '].
+location_lost == ['pazudis g p s signÄls '].
 
 
 %% 
-nth(1, 'pirmais ').
-nth(2, 'otrais ').
-nth(3, 'treğais ').
-nth(4, 'ceturtais ').
-nth(5, 'piektais ').
-nth(6, 'sestais ').
-nth(7, 'septîtais ').
-nth(8, 'astotais ').
-nth(9, 'devîtais ').
-nth(10, 'desmit ').
-nth(11, 'vienpadsmitais ').
-nth(12, 'divpadsmitais ').
-nth(13, 'trîspadsmitais ').
-nth(14, 'èetrpadsmitais ').
-nth(15, 'piecpadsmitais ').
-nth(16, 'seğpadsmitais ').
-nth(17, 'septiòpadsmitais ').
+nth(1, 'pirmajÄ ').
+nth(2, 'otrajÄ ').
+nth(3, 'treÅ¡ajÄ ').
+nth(4, 'ceturtajÄ ').
+nth(5, 'piektajÄ ').
+nth(6, 'sestajÄ ').
+nth(7, 'septÄ«tajÄ ').
+nth(8, 'astotajÄ ').
+nth(9, 'devÄ«tajÄ ').
+nth(10, 'desmitajÄ ').
+nth(11, 'vienpadsmitajÄ ').
+nth(12, 'divpadsmitajÄ ').
+nth(13, 'trÄ«spadsmitajÄ ').
+nth(14, 'ÄetrpadsmitajÄ ').
+nth(15, 'piecpadsmitajÄ ').
+nth(16, 'seÅ¡padsmitajÄ ').
+nth(17, 'septiÅ†padsmitajÄ ').
 
 
-%%% distance measure
+%%% distance measure - PÄ“c xxx 
 distance(Dist) == [ X, ' meteriem'] :- Dist < 100, D is round(Dist/10)*10, num_atom(D, X).
 distance(Dist) == [ X, ' meteriem'] :- Dist < 1000, D is round(2*Dist/100)*50, num_atom(D, X).
-distance(Dist) == ['aptuveni 1 kilometers '] :- Dist < 1500.
-distance(Dist) == ['aptuveni ', X, ' kilometeri '] :- Dist < 10000, D is round(Dist/1000), num_atom(D, X).
-distance(Dist) == [ X, ' kilometri '] :- D is round(Dist/1000), num_atom(D, X).
+distance(Dist) == ['aptuveni viena kilometera '] :- Dist < 1500.
+distance(Dist) == ['aptuveni ', X, ' kilometeriem '] :- Dist < 10000, D is round(Dist/1000), num_atom(D, X).
+distance(Dist) == [ X, ' kilometriem '] :- D is round(Dist/1000), num_atom(D, X).
+%%% distance mesure - AttÄlums ir xxx ....metri...
+distance2(Dist) == [ X, ' meteri'] :- Dist < 100, D is round(Dist/10)*10, num_atom(D, X).
+distance2(Dist) == [ X, ' meteri'] :- Dist < 1000, D is round(2*Dist/100)*50, num_atom(D, X).
+distance2(Dist) == ['aptuveni 1 kilometrs '] :- Dist < 1500.
+distance2(Dist) == ['aptuveni ', X, ' kilometri '] :- Dist < 10000, D is round(Dist/1000), num_atom(D, X).
+distance2(Dist) == [ X, ' kilometri '] :- D is round(Dist/1000), num_atom(D, X).
 
 
 %% resolve command main method


### PR DESCRIPTION
- ttsconfig.p was not UTF-8 as it should be. So was problems with special characters
  Latvian has two ways here to say distance
  Small word replacements to correct ones like turn -> prepeare
