### PR TITLE
Avoiding OutOfMemoryError during route calculation

### DIFF
--- a/DataExtractionOSM/src/net/osmand/router/RoutingConfiguration.java
+++ b/DataExtractionOSM/src/net/osmand/router/RoutingConfiguration.java
@@ -16,6 +16,9 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
 public class RoutingConfiguration {
+	//minimum free heap to continue routing
+	public long MINIMUM_FREE_HEAP = Math.round(4.5 * 1024 * 1024);
+
 	// 1. parameters of routing and different tweaks
 	// Influence on A* : f(x) + heuristicCoefficient*g(X)
 	public double heuristicCoefficient = 1;

--- a/DataExtractionOSM/src/net/osmand/router/RoutingContext.java
+++ b/DataExtractionOSM/src/net/osmand/router/RoutingContext.java
@@ -86,6 +86,12 @@ public class RoutingContext {
 		return false;
 	}
 	
+	public boolean dangerForOutOfMemory(){
+		long usedMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+		long freeMemory = Runtime.getRuntime().maxMemory() - usedMemory;
+		return (freeMemory < config.MINIMUM_FREE_HEAP);
+	}
+	
 	public boolean runRelaxingStrategy(){
 		if(!isUseRelaxingStrategy()){
 			return false;


### PR DESCRIPTION
Check for free heap when loading tile data. Throw an RuntimeException when were low on heap.

On my device less than 4.5 mb turned out to be not enough as someone
(image processing?) is allocating memory in chunks of more than 2mb.
