### PR TITLE
bug 1128: Better support for new public transport specification

### DIFF
--- a/DataExtractionOSM/src/net/osmand/data/preparation/IndexCreator.java
+++ b/DataExtractionOSM/src/net/osmand/data/preparation/IndexCreator.java
@@ -536,6 +536,9 @@ public class IndexCreator {
 							if (indexRouting) {
 								indexRouteCreator.indexRelations(e, ctx);
 							}
+							if (indexTransport) {
+								indexTransportCreator.indexRelations(e, ctx);
+							}
 						}
 					});
 					if (indexAddress) {

--- a/DataExtractionOSM/src/net/osmand/osm/OSMSettings.java
+++ b/DataExtractionOSM/src/net/osmand/osm/OSMSettings.java
@@ -22,6 +22,7 @@ public class OSMSettings {
 		
 		// transport
 		ROUTE("route"), //$NON-NLS-1$
+		ROUTE_MASTER("route_master"), //$NON-NLS-1$
 		OPERATOR("operator"), //$NON-NLS-1$
 		REF("ref"), //$NON-NLS-1$
 		


### PR DESCRIPTION
New public transport specification has one relation for each direction and all directions are contained in route master relation. So some information could only be in route master (like ref, operator). Current code omit transport line if the route does not contain tag ref. I am attaching patch that use tag "ref" and tag "operator" from route master if route does not contain them.
