### PR TITLE
Fix last Junit test + Bodensee issue

### DIFF
--- a/DataExtractionOSM/src-tests/net/osmand/data/MultipolygonTest.java
+++ b/DataExtractionOSM/src-tests/net/osmand/data/MultipolygonTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 public class MultipolygonTest {
 
 	private Multipolygon testee;
+	private Ring testRing;
 	private Way poly1_1_of_2;
 	private Way poly1_2_of_2;
 	private int wayid;
@@ -23,6 +24,7 @@ public class MultipolygonTest {
 	public void setUp() 
 	{
 		testee = new Multipolygon();
+		testRing = new Ring();
 		poly1_1_of_2 = polygon(n(0,0),n(1,0),n(1,1),n(1,2));
 		poly1_2_of_2 = polygon(n(1,2),n(0,2),n(-1,2),n(0,0));
 		poly2 = polygon(n(4,4), n(4,5), n(3,5), n(4,4));
@@ -167,6 +169,14 @@ public class MultipolygonTest {
 		assertEquals(2, testee.countOuterPolygons());
 		assertFalse(testee.hasOpenedPolygons());
 	}
+	
+	@Test
+	public void testRing_firstEmptyWayThanOpenedWay()
+	{
+		testRing.addWay(new Way(111));
+		testRing.addWay(poly1_1_of_2);
+		assertFalse(testRing.isClosed());
+	}
 
 	@Test
 	public void test_firstEmptyWayThanOpenedWay()
@@ -174,7 +184,7 @@ public class MultipolygonTest {
 		testee.addOuterWay(new Way(111));
 		testee.addOuterWay(poly1_1_of_2);
 		assertEquals(1, testee.countOuterPolygons());
-		// FIXME assertTrue(testee.hasOpenedPolygons());
+		assertTrue(testee.hasOpenedPolygons());
 	}
 
 	@Test

--- a/DataExtractionOSM/src/net/osmand/data/Multipolygon.java
+++ b/DataExtractionOSM/src/net/osmand/data/Multipolygon.java
@@ -23,7 +23,7 @@ import org.apache.commons.logging.Log;
  * 
  * @author Pavol Zibrita
  */
-public class Multipolygon {
+public class Multipolygon implements Comparable<Multipolygon> {
 	
 	/**
 	 * cache with the ways grouped per Ring
@@ -357,6 +357,43 @@ public class Multipolygon {
 	 */
 	public List<Node> getOuterNodes() {
 		return getOuterRings().get(0).getBorder().getNodes();
+	}
+	
+	@Override
+	/**
+	 * @return -1 if this Multipolygon is inside m <br />
+	 * 1 if m is inside this Multipolygon <br />
+	 * 0 otherwise (Multipolygon are next to each other, Multipolygon 
+	 * 				intersect or Multipolygon are malformed)
+	 */
+	public int compareTo(Multipolygon m) {
+		if (this.isIn(m)) return -1;
+		if (m.isIn(this)) return 1;
+		return 0;
+	}
+
+	/**
+	 * returns true if all outer rings of this multipolygon 
+	 * are inside an outer ring of the other multipolygon
+	 * @param m the other multipolygon
+	 * @return true if all outer rings of this multipolygon 
+	 * are inside an outer ring of the other multipolygon <br />
+	 * false otherwise
+	 */
+	private boolean isIn(Multipolygon m) {
+		List<Ring> thisOuters = getOuterRings();
+		List<Ring> otherOuters = m.getOuterRings();
+		for(Ring outer : thisOuters) {
+			boolean isincluded = false;
+			for(Ring otherOuter : otherOuters) {
+				if (outer.isIn(otherOuter)){
+					isincluded = true;
+					continue;
+				}
+			}
+			if (isincluded == false) return false;
+		}
+		return true;
 	}
 
 

--- a/DataExtractionOSM/src/net/osmand/osm/MapUtils.java
+++ b/DataExtractionOSM/src/net/osmand/osm/MapUtils.java
@@ -468,7 +468,96 @@ public class MapUtils {
 		}
 		return diff;
 		
-	}	
+	}
+	
+	/**
+	 * return true if the line segment [a,b] intersects [c,d]
+	 * @param a point 1
+	 * @param b point 2
+	 * @param c point 3
+	 * @param d point 4
+	 * @return true if the line segment [a,b] intersects [c,d]
+	 */
+	public static boolean linesIntersect(LatLon a, LatLon b, LatLon c, LatLon d){
+		return linesIntersect(
+				a.getLatitude(), a.getLongitude(),
+				b.getLatitude(), b.getLongitude(),
+				c.getLatitude(), c.getLongitude(),
+				d.getLatitude(), d.getLongitude());
+	}
+	
+	/**
+	 * Return true if two line segments intersect inside the segment
+	 * 
+	 * source: http://www.java-gaming.org/index.php?topic=22590.0
+	 * @param x1 line 1 point 1 latitude
+	 * @param y1 line 1 point 1 longitude
+	 * @param x2 line 1 point 2 latitude
+	 * @param y2 line 1 point 2 longitude
+	 * @param x3 line 2 point 1 latitude
+	 * @param y3 line 2 point 1 longitude
+	 * @param x4 line 2 point 2 latitude
+	 * @param y4 line 2 point 2 longitude
+	 * @return
+	 */
+	public static boolean linesIntersect(double x1, double y1, double x2, double y2, double x3, double y3, double x4, double y4){
+	      // Return false if either of the lines have zero length
+	      if (x1 == x2 && y1 == y2 ||
+	            x3 == x4 && y3 == y4){
+	         return false;
+	      }
+	      // Fastest method, based on Franklin Antonio's "Faster Line Segment Intersection" topic "in Graphics Gems III" book (http://www.graphicsgems.org/)
+	      double ax = x2-x1;
+	      double ay = y2-y1;
+	      double bx = x3-x4;
+	      double by = y3-y4;
+	      double cx = x1-x3;
+	      double cy = y1-y3;
+
+	      double alphaNumerator = by*cx - bx*cy;
+	      double commonDenominator = ay*bx - ax*by;
+	      if (commonDenominator > 0){
+	         if (alphaNumerator < 0 || alphaNumerator > commonDenominator){
+	            return false;
+	         }
+	      }else if (commonDenominator < 0){
+	         if (alphaNumerator > 0 || alphaNumerator < commonDenominator){
+	            return false;
+	         }
+	      }
+	      double betaNumerator = ax*cy - ay*cx;
+	      if (commonDenominator > 0){
+	         if (betaNumerator < 0 || betaNumerator > commonDenominator){
+	            return false;
+	         }
+	      }else if (commonDenominator < 0){
+	         if (betaNumerator > 0 || betaNumerator < commonDenominator){
+	            return false;
+	         }
+	      }
+	      if (commonDenominator == 0){
+	         // This code wasn't in Franklin Antonio's method. It was added by Keith Woodward.
+	         // The lines are parallel.
+	         // Check if they're collinear.
+	         double y3LessY1 = y3-y1;
+	         double collinearityTestForP3 = x1*(y2-y3) + x2*(y3LessY1) + x3*(y1-y2);   // see http://mathworld.wolfram.com/Collinear.html
+	         // If p3 is collinear with p1 and p2 then p4 will also be collinear, since p1-p2 is parallel with p3-p4
+	         if (collinearityTestForP3 == 0){
+	            // The lines are collinear. Now check if they overlap.
+	            if (x1 >= x3 && x1 <= x4 || x1 <= x3 && x1 >= x4 ||
+	                  x2 >= x3 && x2 <= x4 || x2 <= x3 && x2 >= x4 ||
+	                  x3 >= x1 && x3 <= x2 || x3 <= x1 && x3 >= x2){
+	               if (y1 >= y3 && y1 <= y4 || y1 <= y3 && y1 >= y4 ||
+	                     y2 >= y3 && y2 <= y4 || y2 <= y3 && y2 >= y4 ||
+	                     y3 >= y1 && y3 <= y2 || y3 <= y1 && y3 >= y2){
+	                  return true;
+	               }
+	            }
+	         }
+	         return false;
+	      }
+	      return true;
+	   }
 
 }
 


### PR DESCRIPTION
The last Junit test is trivally fixed.

For the bodensee issue, I created a method that should calculate the intersection of two Rings. So if you do

bodenseeMP.closeWithOtherRing(boundaryOfSwitserlandRing), it should return a complete Ring with the part of the Bodensee in Switserland.

Because this has to happen during indexing, and I don't think I can create extra nodes, there is a small overshoot. The lake will go one node over the boundary, to return and follow it. When installing the maps of the other side of the boundary, those overshoots should be invisible because of overlap.

Note, only the calculation method has been made, nothing has changed in the indexing method. It's still a matter of finding the right boundary to intersect with there.

It's also untested (this would be my next job), so it certainly can contain off-by-one errors, or other things.
