### PR TITLE
bicycle routing: Don't prefer cycleways too much over tracks/path/footways

### DIFF
--- a/DataExtractionOSM/src/net/osmand/router/routing.xml
+++ b/DataExtractionOSM/src/net/osmand/router/routing.xml
@@ -145,21 +145,20 @@
 		<road tag="highway" value="trunk_link" speed="16" priority="0.7" dynamicPriority="0.7"/>
 		<road tag="highway" value="primary" speed="16" priority="0.8" dynamicPriority="0.9"/>
 		<road tag="highway" value="primary_link" speed="16" priority="0.8" dynamicPriority="0.9"/>
-		<road tag="highway" value="secondary" speed="16" priority="1" dynamicPriority="1"/>
-		<road tag="highway" value="secondary_link" speed="16" priority="1" dynamicPriority="1"/>
+		<road tag="highway" value="secondary" speed="16" priority="0.9" dynamicPriority="0.9"/>
+		<road tag="highway" value="secondary_link" speed="16" priority="0.9" dynamicPriority="0.9"/>
 		<road tag="highway" value="tertiary" speed="16" priority="1" dynamicPriority="1"/>
 		<road tag="highway" value="tertiary_link" speed="16" priority="1" dynamicPriority="1"/>
 		<road tag="highway" value="road" speed="16" priority="1" dynamicPriority="1"/>
 		<road tag="highway" value="residential" speed="16" priority="1.1" dynamicPriority="1.1"/>
-		<road tag="highway" value="cycleway" speed="16" priority="1.5" dynamicPriority="1"/>
-		
+		<road tag="highway" value="cycleway" speed="16" priority="1.3" dynamicPriority="1.3"/>
 		<road tag="highway" value="unclassified" speed="13" priority="1" dynamicPriority="1"/>
 		<road tag="highway" value="service" speed="13" priority="1" dynamicPriority="1"/>
-		<road tag="highway" value="track" speed="12" priority="1.5" dynamicPriority="1.5"/>
-		<road tag="highway" value="path" speed="12" priority="1.5" dynamicPriority="1.5"/>
+		<road tag="highway" value="track" speed="12" priority="1.3" dynamicPriority="1.3"/>
+		<road tag="highway" value="path" speed="12" priority="1.3" dynamicPriority="1.3"/>
 		<road tag="highway" value="living_street" speed="15" priority="1.1" dynamicPriority="1.1"/>
 		<road tag="highway" value="pedestrian" speed="10" priority="0.9" dynamicPriority="0.9"/>
-		<road tag="highway" value="footway" speed="8" priority="0.9" dynamicPriority="0.9"/>
+		<road tag="highway" value="footway" speed="12" priority="1" dynamicPriority="1"/>
 		<road tag="highway" value="byway" speed="8" priority="1" dynamicPriority="1"/>
 		<road tag="highway" value="services" speed="13" priority="1" dynamicPriority="1"/>
 		<road tag="highway" value="bridleway" speed="8" priority="0.8" dynamicPriority="0.8"/>


### PR DESCRIPTION
Previously we would make huge detours to prefer cycleways. E.g. versus a
footway with bicycle=yes we would take more than 3 time as long ways
(16/8)*(1.5/0.9) > 3 to use a cycleway. We would also take long detours
(more than twice as long ways) to prefer a track/path over a footway with
bicycle=yes. Often footway/bicycle=yes are synonyms for highway=path,
and the latter is not faster or better at all. This led to weird bicycle
routing where I was taking long detours to stay on a "path" rather than
a "footway".

Take up Victors suggestion of bumbing the speed of a footway
from 8 to 12, which is still realistic and tone down the priority of 1.5
for cycleways/track/path to 1.3 which was too high.
This is what this patch does. Now we have:

Highway=   Speed=   Priority=  Detours-vs-footway=
footway    12       1          --
track/path 12       1.3        30%
cycleway   16       1.3        73%

I believe this still prefers tracks/path and cycleway enough and the
weird routing went away. (the data has changed now or I would give
the example location. But I tested a few bike routes involving various
ways and the suggestions were sensible.

Signed-off-by: Sebastian Spaeth Sebastian@SSpaeth.de
