### PR TITLE
Change diving into scuba_diving (or add at least scuba_diving)

### DIFF
--- a/DataExtractionOSM/src/net/osmand/osm/rendering_types.xml
+++ b/DataExtractionOSM/src/net/osmand/osm/rendering_types.xml
@@ -674,6 +674,7 @@
 		<type tag="sport" value="croquet" minzoom="15" />
 		<type tag="sport" value="cycling" minzoom="15" />
 		<type tag="sport" value="diving" minzoom="15" />
+		<type tag="sport" value="scuba_diving" minzoom="15" />
 		<type tag="sport" value="dog_racing" minzoom="15" />
 		<type tag="sport" value="equestrian" minzoom="15" />
 		<type tag="sport" value="football" minzoom="15" />


### PR DESCRIPTION
I added sport=scuba_diving because there are more points than in sport=diving.
See OSM wiki: http://wiki.openstreetmap.org/wiki/Tag:sport%3Dscuba_diving
