### PR TITLE
rendering_types: Export smoothness key used on tracks

### DIFF
--- a/DataExtractionOSM/src/net/osmand/osm/rendering_types.xml
+++ b/DataExtractionOSM/src/net/osmand/osm/rendering_types.xml
@@ -93,6 +93,17 @@
 		<type tag="tracktype" value="grade5" minzoom="12" additional="true"/>
 	</category>
 
+	<category name="smoothness">
+		<type tag="smoothness" value="excelent" minzoom="12" additional="true"/>
+		<type tag="smoothness" value="good" minzoom="12" additional="true"/>
+		<type tag="smoothness" value="intermediate" minzoom="12" additional="true"/>
+		<type tag="smoothness" value="bad" minzoom="12" additional="true"/>
+		<type tag="smoothness" value="very_bad" minzoom="12" additional="true"/>
+		<type tag="smoothness" value="horrible" minzoom="12" additional="true"/>
+		<type tag="smoothness" value="very_horrible" minzoom="12" additional="true"/>
+		<type tag="smoothness" value="impassable" minzoom="12" additional="true"/>
+	</category>
+
 	<category name="sac_scale">
 		<type tag="sac_scale" value="hiking" minzoom="12" additional="true"/>
 		<type tag="sac_scale" value="mountain_hiking" minzoom="12" additional="true"/>


### PR DESCRIPTION
Include smoothness values in standard maps.
Useful to determine passability of tracks
Additional style will be posted later after testing and consulting
Example rendering:
http://psha.org.ru/tmp/osmand-smoothness.png
