### PR TITLE
Update OsmAnd/AndroidManifest.xml

### DIFF
--- a/OsmAnd/AndroidManifest.xml
+++ b/OsmAnd/AndroidManifest.xml
@@ -7,7 +7,7 @@
 	<!--  comment change build properties for release & set targetSdkVersion="7", build and  reverse changes-->
 	<!--  <uses-sdk android:minSdkVersion="3"/> -->
 	<!--   uncomment it to allow different screen supports (large/small)-->
-	<uses-sdk android:minSdkVersion="4" android:targetSdkVersion="4"/>
+	<uses-sdk android:minSdkVersion="8" android:targetSdkVersion="8"/>
 	
 	<uses-feature android:name="android.hardware.camera" android:required="false" />
 	<uses-feature android:name="android.hardware.microphone" android:required="false"/>
@@ -35,7 +35,7 @@
 		<activity android:name="net.osmand.plus.activities.MapActivity" android:label="@string/app_name" android:screenOrientation="unspecified"
 			android:launchMode="singleTop">
 			<intent-filter>
-    			<data android:scheme="http" android:host="download.osmand.net" path="go"/>
+    			<data android:scheme="http" android:host="download.osmand.net" android:path="go"/>
     			<action android:name="android.intent.action.VIEW" />
     			<category android:name="android.intent.category.DEFAULT"/>
 				<category android:name="android.intent.category.BROWSABLE"/>


### PR DESCRIPTION
1) OsmAnd must use API level 8 (Android 2.2) as a minimum because of use of these calls: requestAudioFocus, abandonAudioFocus, BackupAgentHelper, ...

2) Fixed a typo
