### PR TITLE
Adjustments to English strings

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -75,7 +75,7 @@
     <string name="audionotes_plugin_name">Audio/video notes</string>
     <string name="index_srtm_parts">parts</string>
     <string name="index_srtm_ele">Contour lines</string>
-    <string name="srtm_plugin_description">This plugin facilitates downloading contour lines (Offline data Download -> Menu -> "Other maps") for use with offline maps.</string>
+    <string name="srtm_plugin_description">This plugin facilitates downloading contour lines (Data Management -> Menu -> "Other maps") for use with offline maps.</string>
     <string name="srtm_plugin_name">Contour lines plugin</string>
     <string name="download_select_map_types">Other maps</string>
     <string name="download_roads_only_item">Roads </string>
@@ -91,7 +91,7 @@
 	<string name="tip_altitude_offset">Altitude Display - Offset Correction</string>
 	<string name="tip_altitude_offset_t">\tMost GPS devices report altitude measurements in the ellipsoid-based WGS84 reference system, from which a conversion to locally used systems requires a position-dependent correction.
 		\n\tA better approximation to these local systems is the EGM96 reference. OsmAnd now also supports the automatic display of altitudes in the EGM96 system.
-		\n\tIn order to achieve this, simply download the file WW15MGH.DAC via Offline Data Manager (original is at http://earth-info.nga.mil/GandG/wgs84/gravitymod/egm96/binary/WW15MGH.DAC).
+		\n\tIn order to achieve this, simply download the file WW15MGH.DAC via Data Management (original is at http://earth-info.nga.mil/GandG/wgs84/gravitymod/egm96/binary/WW15MGH.DAC).
 	</string>
     <string name="map_widget_max_speed">Speed limit</string>
     <string name="monitoring_control_start">GPX</string>
@@ -230,7 +230,7 @@
 	</string>
 	<string name="tip_update_index">Update of Offline Data</string>
 	<string name="tip_update_index_t">\tHaving up-to-date map data is essential. OsmAnd provides a download manager which can check for available offline data updates.
-		\n\tTo check for updates go to \'Settings\' -> \'Offline data\' -> \'Download offline data\'. After region list is retrieved from the internet, you can select option \'Menu\' -> \'Filter downloaded\' to indicate updates only for data already on your device.
+		\n\tTo check for updates go to \'Settings\' -> \'Data Management\' -> \'Download offline data\'. After region list is retrieved from the internet, you can select option \'Menu\' -> \'Filter downloaded\' to indicate updates only for data already on your device.
 		\n\tThe availability of updates  is depicted by the following colors:
 		\n\t\'Green\' - indicates data files identical on device and server
 		\n\t\'Blue\' - indicates available updates on server
@@ -372,7 +372,7 @@
 	<string name="context_menu_item_directions">Directions to here</string>
 	<string name="modify_transparency">Modify transparency (0 - transparent, 255 - opaque)</string>
 	<string name="confirm_interrupt_download">Do you want to interrupt file downloading?</string>
-	<string name="first_time_msg">Thank you for using OsmAnd. For many features of this application you need some regional offline data which you can download via \'Settings\' ->  \'Offline data\'. Afterwards you will be able to view maps, locate addresses, look up POIs, and find public transportation.</string>    
+	<string name="first_time_msg">Thank you for using OsmAnd. For many features of this application you need some regional offline data which you can download via \'Settings\' ->  \'Data Management\'. Afterwards you will be able to view maps, locate addresses, look up POIs, and find public transportation.</string>    
 	<string name="basemap_was_selected_to_download">Basemap is required for proper application functioning and was selected to download.</string>
 	<string name="select_index_file_to_download">Nothing was found. If you can\'t find your region, you can make it yourself (see http://osmand.net).</string>
 	<string name="local_indexes_cat_tile">Online and tile maps</string>
@@ -415,7 +415,7 @@
 	<string name="debugging_and_development">OsmAnd development</string>
 	<string name="native_rendering">Native rendering</string>
 	<string name="test_voice_prompts">Test voice prompts</string>    
-	<string name="switch_to_raster_map_to_see">No offline vector map present for this location. You can download one in Settings (Offline data), or switch to online maps.</string>
+	<string name="switch_to_raster_map_to_see">No offline vector map present for this location. You can download one in Settings (Data Management), or switch to online maps.</string>
 	<string name="tip_recent_changes_0_7_2_t">Changes in 0.7.2 :
 		\n\t- Native rendering for all devices
 		\n\t- Offline POI editing
@@ -555,7 +555,7 @@
 	<string name="routing_settings">Navigation</string>
 	<string name="routing_settings_descr">Specify options for the navigation</string>
 	<string name="global_settings">Global Settings</string>
-	<string name="index_settings">Data management</string>
+	<string name="index_settings">Data Management</string>
 	<string name="general_settings">General</string>
 	<string name="general_settings_descr">Configure common settings for the application</string>
 	<string name="global_app_settings">Global app settings</string>
@@ -704,7 +704,7 @@
 	<string name="local_index_items_restored">%1$d of %2$d item(s) successfully activated.</string>
 	<string name="local_index_no_items_to_do">No items to %1$s</string>
 	<string name="local_index_action_do">You are about to %1$s %2$s item(s). Continue?</string>
-	<string name="local_index_descr_title">Data management</string>
+	<string name="local_index_descr_title">Data Management</string>
 	<string name="local_index_mi_restore">Activate</string>
 	<string name="local_index_mi_backup">Deactivate</string>
 	<string name="local_index_mi_delete">Delete</string>


### PR DESCRIPTION
I've made some adjustments to some strings.
a) simplified "Offline data (Download)" to just "Data management"
b) changed the description for it since this screen is not only for offline maps
c) simplified some option titles and descriptions
d) made some small corrections
