### PR TITLE
Improvements in strings

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -9,12 +9,12 @@
          1. All your modified/created strings are in the top of the file (to make easier find what\'s translated).
     PLEASE: Have a look at http://code.google.com/p/osmand/wiki/UIConsistency, it may really improve your and our work  :-)  Thx - Hardy
     -->
-    <string name="download_hillshade_item">Hillshade </string>
+    <string name="download_hillshade_item">Hillshade</string>
     <string name="download_hillshade_maps">Hillshade overlays</string>
     <string name="tip_recent_changes_1_1_2_t">Changes in 1.1.2:
 		\n\t* Audio/video plugin enhancement (photos with EXIF information)
 		\n\t* Usability fixed and restructured Contour lines plugin
-		\n\t* Hillshade packages for Contour lines plugin 
+		\n\t* Hillshade packages for Contour lines plugin
 		\n\t* Bug fixes (suboptimal routing)
     </string>
     <string name="dist_control_start">Start</string>
@@ -88,7 +88,7 @@
     <string name="srtm_plugin_description">This plugin facilitates downloading contour lines (Data Management -> Menu -> "Other maps") for use with offline maps.</string>
     <string name="srtm_plugin_name">Contour lines plugin</string>
     <string name="download_select_map_types">Other maps</string>
-    <string name="download_roads_only_item">Roads </string>
+    <string name="download_roads_only_item">Roads</string>
     <string name="download_srtm_maps">Contour lines</string>
     <string name="download_regular_maps">Regular maps</string>
     <string name="download_roads_only_maps">Roads-only maps</string>
@@ -179,7 +179,7 @@
 	<string name="show_warnings_descr">Configure traffic warnings (speed limits, forced stops, speed bumps), speed camera warnings, and lane information</string>
 	<string name="use_compass_navigation_descr">Use the compass when no heading is detected otherwise</string>
 	<string name="use_compass_navigation">Use compass</string>
-	<string name="avoid_motorway">Avoid motorways</string>
+	<string name="avoid_motorway">Motorways</string>
 	<string name="auto_zoom_map_descr">Auto zoom map according to your speed (while map is synchronized with current position)</string>
 	<string name="auto_zoom_map">Auto zoom map</string>
 	<string name="snap_to_road_descr">Snap position to roads during navigation</string>
@@ -259,9 +259,9 @@
 	<string name="position_on_map_descr">Choose location of position marker on the map</string>
 	<string name="position_on_map">Position marker</string>
 	<string name="layer_map_appearance">Configure screen&#8230;</string>
-	<string name="show_lanes">Show lanes</string>
-	<string name="avoid_unpaved">Avoid unpaved roads</string>
-	<string name="avoid_ferries">Avoid ferries</string>
+	<string name="show_lanes">Lanes</string>
+	<string name="avoid_unpaved">Unpaved roads</string>
+	<string name="avoid_ferries">Ferries</string>
 	<string name="avoid_in_routing_title">Avoid&#8230;</string>
 	<string name="avoid_in_routing_descr">Avoid toll roads, unpaved, ferries</string>
 	<string name="map_widget_fluorescent">Fluorescent routes</string>
@@ -300,9 +300,9 @@
 	<string name="bg_service_screen_unlock">Unlock screen</string>
 	<string name="bg_service_screen_lock_toast">The screen is locked</string>
 	<string name="bg_service_interval">Set wake-up interval:</string>
-	<string name="show_cameras">Show speed cameras</string>
-	<string name="show_speed_limits">Show traffic warnings</string>
-	<string name="avoid_toll_roads">Avoid toll roads</string>
+	<string name="show_cameras">Speed cameras</string>
+	<string name="show_speed_limits">Traffic warnings</string>
+	<string name="avoid_toll_roads">Toll roads</string>
 	<string name="continue_follow_previous_route_auto">Previous navigation was unfinished. Continue following it? (%1$s seconds)</string>
 	<string name="route_updated_loc_found">Route will be calculated once position is found</string>
 	<string name="osmand_parking_hours">Hours</string>


### PR DESCRIPTION
1. Removed some white space.
2. Removed redundant "avoid" and "show". There is no point in repeating the word since it's used in the menu item that you tap on in the first place.
