### PR TITLE
Fix for bug that throws array out of bounds error when editing the waypo...

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/IntermediatePointsDialog.java
+++ b/OsmAnd/src/net/osmand/plus/activities/IntermediatePointsDialog.java
@@ -156,15 +156,22 @@ public class IntermediatePointsDialog {
 			}
 		}
 		if (cnt > 0) {
-			for (int i = checkedIntermediates.length - 1; i >= 0; i--) {
-				if (!checkedIntermediates[i]) {
-					cnt--;
-					app.getTargetPointsHelper().removeWayPoint((MapActivity) (mapActivity instanceof MapActivity?mapActivity : null), cnt == 0, 
-							i == checkedIntermediates.length - 1? -1 :  i);
+			boolean changeDestinationFlag =!checkedIntermediates [checkedIntermediates.length - 1];
+			if(cnt == checkedIntermediates.length){	//there is no alternative destination if all points are to be removed?
+				app.getTargetPointsHelper().removeAllWayPoints((MapActivity) (mapActivity instanceof MapActivity?mapActivity : null), true);	
+			}else{					
+				for (int i = checkedIntermediates.length - 2; i >= 0; i--) {	//skip the destination until a retained waypoint is found
+					if (checkedIntermediates[i] && changeDestinationFlag) {	//Find a valid replacement for the destination
+						app.getTargetPointsHelper().makeWayPointDestination((MapActivity) (mapActivity instanceof MapActivity?mapActivity : null), cnt == 0, i);				
+						changeDestinationFlag = false;
+					}else if(!checkedIntermediates[i]){
+						cnt--;
+						app.getTargetPointsHelper().removeWayPoint((MapActivity) (mapActivity instanceof MapActivity?mapActivity : null), cnt == 0, i);
+					}
 				}
-			}
-			if(mapActivity instanceof MapActivity) {
-				((MapActivity) mapActivity).getMapLayers().getContextMenuLayer().setLocation(null, "");
+				if(mapActivity instanceof MapActivity) {
+					((MapActivity) mapActivity).getMapLayers().getContextMenuLayer().setLocation(null, "");
+				}
 			}
 		}
 	}


### PR DESCRIPTION
...ints list

The IntermediatePointsDialog class throws an exception when the
waypoints list is edited (particularly if all points including the
Destination are selected for removal). The fix requires additional
methods in the TargetPointsHelper class in the OsmAnd-Jni project and a
fix and pull request have been provided to both projects
