### PR TITLE
Routing for bicycles on one way roads

### DIFF
--- a/OsmAnd-java/src/net/osmand/router/routing.xml
+++ b/OsmAnd-java/src/net/osmand/router/routing.xml
@@ -368,9 +368,12 @@
 		</way>
 		
 		<way attribute="oneway">
-			<select value="-1" t="cycleway" v="opposite_lane"/>
-			<select value="-1" t="cycleway" v="opposite"/>
+			<select value="0" t="cycleway" v="opposite_lane"/>
+			<select value="0" t="cycleway" v="opposite_track"/>
+			<select value="0" t="cycleway" v="opposite_share_busway"/>
+			<select value="0" t="cycleway" v="opposite"/>
 			<select value="0" t="oneway:bicycle" v="no"/>
+			<select value="1" t="oneway:bicycle" v="yes"/>
 			<select value="-1" t="oneway" v="reverse"/>
 			<select value="1" t="oneway" v="1"/>
 			<select value="1" t="oneway" v="+1"/>


### PR DESCRIPTION
This change updates routing.xml to properly handle bicycle routing on one way roads.

With a tag cycleway=opposite_, bicycles can go both ways.
A tag oneway:bicycle=_ will take precedence over a tag oneway=*.
