### PR TITLE
.osc extension for OsmChange file 

### DIFF
--- a/OsmAnd/src/net/osmand/plus/osmedit/LocalOpenstreetmapActivity.java
+++ b/OsmAnd/src/net/osmand/plus/osmedit/LocalOpenstreetmapActivity.java
@@ -198,7 +198,7 @@ public class LocalOpenstreetmapActivity extends OsmandListActivity {
 
 		public BackupOpenstreetmapPointAsyncTask() {
 			OsmandApplication app = LocalOpenstreetmapActivity.this.getMyApplication();
-			osmchange = app.getAppPath("osm.osmchange");
+			osmchange = app.getAppPath("poi_modification.osc");
 		}
 		
 


### PR DESCRIPTION
JOSM supports only .osc as OsmChange extension.
If you have other plans with the filename, or I editied wrong file, just drop my changes.
