### PR TITLE
Fixed problem with https in tags.

### DIFF
--- a/OsmAnd-java/src/net/osmand/osm/edit/EntityParser.java
+++ b/OsmAnd-java/src/net/osmand/osm/edit/EntityParser.java
@@ -95,7 +95,7 @@ public class EntityParser {
 					siteUrl = entity.getTag(OSMTagKey.CONTACT_WEBSITE);
 				}
 			}
-			if (siteUrl != null && !siteUrl.startsWith("http://")) {
+			if (siteUrl != null && !siteUrl.startsWith("http://") && !siteUrl.startsWith("https://")) {
 				siteUrl = "http://" + siteUrl;
 			}
 		}


### PR DESCRIPTION
If for example the website tag starts with https:// then it appeared in
OsmAnd as http://https://

https is not that unusual:
http://taginfo.openstreetmap.org/keys/website#values
http://taginfo.openstreetmap.org/keys/contact:website#values
