### PR TITLE
Better Russian strings

### DIFF
--- a/OsmAnd/res/values-ru/strings.xml
+++ b/OsmAnd/res/values-ru/strings.xml
@@ -545,10 +545,10 @@
   <string name="unzipping_file">Файл распаковывается…</string>
   <string name="route_tr">Поверните направо и двигайтесь</string>
   <string name="route_tshr">Поверните резко направо и двигайтесь</string>
-  <string name="route_tslr">Поверните направо и двигайтесь</string>
+  <string name="route_tslr">Поверните слегка направо и двигайтесь</string>
   <string name="route_tl">Поверните налево и двигайтесь</string>
   <string name="route_tshl">Поверните резко налево и двигайтесь</string>
-  <string name="route_tsll">Поверните налево и двигайтесь</string>
+  <string name="route_tsll">Поверните слегка налево и двигайтесь</string>
   <string name="route_tu">Выполните разворот и двигайтесь</string>
   <string name="route_head">Двигайтесь</string>
   <string name="first_time_continue">Продолжить</string>


### PR DESCRIPTION
In fact, I'd like to suggest additionally change route_head string
from "Head" to "Go ahead", but I am in doubt. And how it would affect
other translations? Anyway, for Russian "Двигайтесь прямо" or
"Продолжайте движение" or something like that seems more appropriate
than simply "Двигайтесь" as well, IMHO.
