### PR TITLE
prevent double-lookup of a propertyName from router

### DIFF
--- a/OsmAnd-java/src/net/osmand/router/RoutingConfiguration.java
+++ b/OsmAnd-java/src/net/osmand/router/RoutingConfiguration.java
@@ -91,8 +91,9 @@ public class RoutingConfiguration {
 		}
 		
 		private String getAttribute(VehicleRouter router, String propertyName) {
-			if (router.containsAttribute(propertyName)) {
-				return router.getAttribute(propertyName);
+		    String attr = router.getAttribute(propertyName);
+			if (attr != null) {
+				return attr;
 			}
 			return attributes.get(propertyName);
 		}


### PR DESCRIPTION
this reduces the number of lookups for attributes by 50%
