### PR TITLE
Fix inefficient layout weight

### DIFF
--- a/OsmAnd/res/layout-land/menu.xml
+++ b/OsmAnd/res/layout-land/menu.xml
@@ -12,7 +12,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 				<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" android:id="@+id/AppName" 
 				android:layout_marginLeft="3dp" android:layout_marginTop="3dp" 
 				android:text="@string/app_name" android:textColor="#000000" android:typeface="serif" android:textSize="20sp"/>
-				<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" android:layout_weight="1"
+				<TextView android:layout_height="wrap_content" android:layout_width="0dp" android:layout_weight="1"
 				android:layout_marginLeft="12dp" android:layout_marginTop="3dp" android:layout_marginBottom="3dp" android:text="@string/app_version" android:gravity="right"
 				android:textColor="#000000" android:typeface="serif" android:id="@+id/TextVersion" android:textSize="13sp"/> 
 				<ImageView android:src="@drawable/help_icon" android:id="@+id/HelpButton" android:layout_marginTop="7dp"
@@ -29,7 +29,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 	 		<TableRow android:layout_height = "wrap_content" android:layout_marginTop = "10dp">
 	 			<LinearLayout android:id="@+id/MapButton" android:background="@drawable/bg_left" android:clickable="true"
 	 			android:layout_weight="1" android:layout_height="112dp" android:focusable="true">
-	 				<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" 
+	 				<TextView android:layout_height="wrap_content" android:layout_width="0dp"
 					android:layout_gravity="center_vertical|left" android:layout_marginLeft="15dp"
 					android:text="@string/map_Button" android:textColor="#000000" android:typeface="serif"
 					android:layout_weight="1"
@@ -48,7 +48,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 					android:layout_gravity="center|left"
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"/>
-					<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" 
+					<TextView android:layout_height="wrap_content" android:layout_width="0dp"
 					android:layout_gravity="center_vertical|right"
 					android:layout_weight="1"
 					android:layout_marginRight="15dp"
@@ -59,7 +59,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 			<TableRow android:layout_height = "wrap_content" android:layout_marginTop = "10dp">
 				<LinearLayout android:id="@+id/FavoritesButton" android:background="@drawable/bg_left" 
 				android:layout_weight="1" android:layout_height="112dp" android:focusable="true" android:clickable="true">
-					<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" 
+					<TextView android:layout_height="wrap_content" android:layout_width="0dp"
 					android:layout_marginLeft="15dp" android:layout_gravity="center_vertical|left"
 					android:text="@string/favorites_Button" android:textColor="#000000" android:typeface="serif"
 					android:layout_weight="1" android:textSize="16sp"/>
@@ -77,7 +77,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 					android:layout_gravity="center|left"
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"/>
-					<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" 
+					<TextView android:layout_height="wrap_content" android:layout_width="0dp"
 					android:layout_gravity="center_vertical|right"
 					android:layout_weight="1"
 					android:layout_marginRight="15dp"

--- a/OsmAnd/res/layout-large-land/menu.xml
+++ b/OsmAnd/res/layout-large-land/menu.xml
@@ -12,7 +12,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 				<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" android:id="@+id/AppName" 
 				android:layout_marginLeft="4dp" android:layout_marginTop="8dp" 
 				android:text="@string/app_name" android:textColor="#000000" android:typeface="serif" android:textSize="30sp"/>
-				<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" android:layout_weight="1"
+				<TextView android:layout_height="wrap_content" android:layout_width="0dp" android:layout_weight="1"
 				android:layout_marginLeft="24dp" android:layout_marginTop="8dp" android:layout_marginBottom="8dp" android:text="@string/app_version" android:gravity="right"
 				android:textColor="#000000" android:typeface="serif" android:id="@+id/TextVersion" android:textSize="18sp"/> 
 				<ImageView android:src="@drawable/help_icon" android:id="@+id/HelpButton" android:layout_marginTop="9dp"
@@ -30,7 +30,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 	 			<LinearLayout android:id="@+id/MapButton" android:background="@drawable/bg_left" 
 	 			android:focusable="true" android:clickable="true"
 	 			android:layout_weight="1" android:layout_height="165dp">
-	 				<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" 
+	 				<TextView android:layout_height="wrap_content" android:layout_width="0dp"
 					android:layout_gravity="center_vertical|left" 
 					android:layout_marginLeft="15dp" android:text="@string/map_Button" android:textColor="#000000"
 					android:typeface="serif" android:layout_weight="1" android:textSize="24sp"/>
@@ -49,7 +49,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 					android:layout_gravity="center|left"
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"/>	
-					<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" 
+					<TextView android:layout_height="wrap_content" android:layout_width="0dp"
 					android:layout_gravity="center_vertical|right"
 					android:layout_weight="1"
 					android:layout_marginRight="15dp"
@@ -61,7 +61,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 				<LinearLayout android:id="@+id/FavoritesButton" android:background="@drawable/bg_left"
 				android:focusable="true" android:clickable="true" 
 				android:layout_weight="1" android:layout_height="165dp">
-					<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" 
+					<TextView android:layout_height="wrap_content" android:layout_width="0dp"
 					android:layout_marginLeft="15dp" android:layout_gravity="center_vertical|left"
 					android:text="@string/favorites_Button" android:textColor="#000000" android:typeface="serif"
 					android:layout_weight="1" android:textSize="24sp"/>
@@ -80,7 +80,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 					android:layout_gravity="center|left"
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"/>		
-					<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" 
+					<TextView android:layout_height="wrap_content" android:layout_width="0dp"
 					android:layout_gravity="center_vertical|right"
 					android:layout_weight="1"
 					android:layout_marginRight="15dp"

--- a/OsmAnd/res/layout-large/menu.xml
+++ b/OsmAnd/res/layout-large/menu.xml
@@ -12,7 +12,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 				<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" android:id="@+id/AppName" 
 				android:layout_marginLeft="3dp" android:layout_marginTop="8dp" 
 				android:text="@string/app_name" android:textColor="#000000" android:typeface="serif" android:textSize="22sp"/>
-				<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" android:layout_weight="1"
+				<TextView android:layout_height="wrap_content" android:layout_width="0dp" android:layout_weight="1"
 				android:layout_marginLeft="24dp" android:layout_marginTop="8dp" android:layout_marginBottom="8dp" android:text="@string/app_version" android:gravity="right"
 				android:textColor="#000000" android:typeface="serif" android:id="@+id/TextVersion" android:textSize="20sp"/>
 				<ImageView android:id="@+id/HelpButton" android:layout_marginRight="0dp" android:layout_marginTop="9dp"
@@ -31,7 +31,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 	 			android:focusable="true" android:clickable="true" android:layout_weight="3" android:layout_height="250dp">
 	 				<ImageView
 					android:src="@drawable/button_icon_map" android:scaleType="center" android:layout_gravity="center"
-					android:layout_weight="1" android:layout_width="wrap_content" android:layout_height="wrap_content"/>
+					android:layout_weight="1" android:layout_width="wrap_content" android:layout_height="0dp"/>
 					<LinearLayout android:layout_height="wrap_content" android:layout_width="fill_parent" android:gravity="center">
 						<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" 
 						android:layout_gravity="center_horizontal|top" android:textSize="27sp" 
@@ -43,7 +43,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 				android:focusable="true" android:clickable="true" android:layout_weight="3" android:layout_height="250dp">
 					<ImageView
 					android:src="@drawable/button_icon_search" android:scaleType="center" android:layout_gravity="center"
-					android:layout_weight="1" android:layout_width="wrap_content" android:layout_height="wrap_content"/>
+					android:layout_weight="1" android:layout_width="wrap_content" android:layout_height="0dp"/>
 					<LinearLayout android:layout_height="wrap_content" android:layout_width="fill_parent" android:gravity="center">	
 						<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" 
 						android:layout_gravity="center_horizontal|top" android:textSize="27sp"					
@@ -56,7 +56,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 	 			android:focusable="true" android:clickable="true" android:layout_weight="3" android:layout_height="250dp">
 	 				<ImageView
 					android:src="@drawable/button_icon_favorites" android:scaleType="center" android:layout_gravity="center"
-					android:layout_weight="1" android:layout_width="wrap_content" android:layout_height="wrap_content"/>
+					android:layout_weight="1" android:layout_width="wrap_content" android:layout_height="0dp"/>
 					<LinearLayout android:layout_height="wrap_content" android:layout_width="fill_parent" android:gravity="center">
 						<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" 
 						android:layout_gravity="center_horizontal|top" android:textSize="27sp" 
@@ -68,7 +68,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 				android:focusable="true" android:clickable="true" android:layout_weight="3" android:layout_height="250dp">
 					<ImageView
 					android:src="@drawable/button_icon_settings" android:scaleType="center" android:layout_gravity="center"
-					android:layout_weight="1" android:layout_width="wrap_content" android:layout_height="wrap_content"/>
+					android:layout_weight="1" android:layout_width="wrap_content" android:layout_height="0dp"/>
 					<LinearLayout android:layout_height="wrap_content" android:layout_width="fill_parent" android:gravity="center">
 						<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" 
 						android:layout_gravity="center_horizontal|top" android:textSize="27sp"					

--- a/OsmAnd/res/layout-large/route_info_list_item.xml
+++ b/OsmAnd/res/layout-large/route_info_list_item.xml
@@ -6,7 +6,7 @@
 	<TextView android:text="" android:id="@+id/distance" android:layout_marginLeft ="5dp" android:textSize="23sp" 
 		android:layout_width="70dp" android:layout_height="wrap_content"></TextView>
 	<TextView android:text="" android:id="@+id/description" android:layout_weight="1" android:textSize="23sp"
-		android:layout_width="wrap_content" android:layout_height="wrap_content"></TextView>
+		android:layout_width="0dp" android:layout_height="wrap_content"></TextView>
 	<TextView android:text="" android:id="@+id/time" android:layout_marginLeft ="5dp" 
 		android:layout_width="65dp" android:layout_height="wrap_content" android:textSize="23sp"></TextView>
 

--- a/OsmAnd/res/layout/change_order_item.xml
+++ b/OsmAnd/res/layout/change_order_item.xml
@@ -8,11 +8,12 @@
     android:layout_marginLeft="5dip"
     android:layout_marginRight="5dip"
     android:weightSum="1" android:background="@color/color_white">
-	<ImageButton android:src="@drawable/av_download" android:id="@+id/down" android:layout_width="wrap_content"
+
+	<ImageButton android:src="@drawable/av_download" android:id="@+id/down" android:layout_width="wrap_content"
 	    android:layout_height="wrap_content"/>
     <TextView
         android:id="@+id/title"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
         android:text="@string/layer_poi"

--- a/OsmAnd/res/layout/download_build_list_item.xml
+++ b/OsmAnd/res/layout/download_build_list_item.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="fill_parent"
 	android:layout_height="wrap_content">
 
-	<TextView android:id="@+id/download_tag" android:gravity="center_vertical" android:layout_width="wrap_content" android:layout_height="wrap_content"
+	<TextView android:id="@+id/download_tag" android:gravity="center_vertical" android:layout_width="0dp" android:layout_height="wrap_content"
 		 android:layout_weight="1" android:textSize="19sp"></TextView>
 
 	<TextView android:id="@+id/download_descr" android:layout_marginLeft="3dp" android:gravity="center_vertical" android:layout_width="105dp"

--- a/OsmAnd/res/layout/download_index.xml
+++ b/OsmAnd/res/layout/download_index.xml
@@ -65,7 +65,7 @@
             <ProgressBar
                 android:id="@+id/DeterminateProgressBar"
                 style="?android:attr/progressBarStyleHorizontal"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1" />
 

--- a/OsmAnd/res/layout/download_index_list_item.xml
+++ b/OsmAnd/res/layout/download_index_list_item.xml
@@ -6,7 +6,7 @@
 		<CheckBox android:id="@+id/check_download_item" android:layout_width="wrap_content" android:layout_height="wrap_content"
 			android:gravity="center_vertical" android:focusable="false" />
 	</LinearLayout>
-	<TextView android:id="@+id/download_item" android:gravity="center_vertical" android:layout_width="wrap_content" android:layout_height="wrap_content"
+	<TextView android:id="@+id/download_item" android:gravity="center_vertical" android:layout_width="0dp" android:layout_height="wrap_content"
 		android:maxLines="7" android:layout_weight="1" style="@style/ListText.Small"></TextView>
 
 	<TextView android:id="@+id/download_descr" android:layout_marginLeft="3dp" android:gravity="right" android:layout_width="wrap_content"

--- a/OsmAnd/res/layout/favourites_list.xml
+++ b/OsmAnd/res/layout/favourites_list.xml
@@ -10,7 +10,7 @@
     <ExpandableListView
         android:id="@android:id/list"
         android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         android:layout_marginLeft="0dp"
         android:layout_marginRight="0dp"
         android:layout_marginTop="0dp"

--- a/OsmAnd/res/layout/layers_list_activity_item.xml
+++ b/OsmAnd/res/layout/layers_list_activity_item.xml
@@ -6,10 +6,11 @@
     android:orientation="horizontal"
     android:layout_marginLeft="5dip"
     android:layout_marginRight="5dip"
-    android:background="@color/color_white">
+    android:background="@color/color_white">
+
     <TextView
         android:id="@+id/title"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="4dip"
     	android:layout_marginBottom="4dip"
@@ -19,7 +20,8 @@
         android:textColor="@color/color_black" android:layout_weight="1"/>
 
     <LinearLayout android:layout_width="wrap_content"
-        android:layout_height="fill_parent">
+        android:layout_height="fill_parent">
+
 
     <CheckBox
         android:id="@+id/check_item"

--- a/OsmAnd/res/layout/list_menu_item.xml
+++ b/OsmAnd/res/layout/list_menu_item.xml
@@ -6,10 +6,11 @@
     android:orientation="horizontal"
     android:layout_marginLeft="5dip"
     android:layout_marginRight="5dip"
-    android:background="@color/color_white">
+    android:background="@color/color_white">
+
     <TextView
         android:id="@+id/title"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginLeft="12dip"
         android:layout_marginTop="12dip"
@@ -20,7 +21,8 @@
         android:textColor="@color/color_black" android:layout_weight="1"/>
 
     <LinearLayout android:layout_width="wrap_content"
-        android:layout_height="fill_parent">
+        android:layout_height="fill_parent">
+
 
     <CheckBox
         android:id="@+id/check_item"

--- a/OsmAnd/res/layout/list_menu_item_native.xml
+++ b/OsmAnd/res/layout/list_menu_item_native.xml
@@ -6,10 +6,11 @@
     android:orientation="horizontal"
     android:layout_marginLeft="5dip"
     android:layout_marginRight="5dip">
-
+
+
     <TextView
         android:id="@+id/title"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginLeft="12dip"
         android:layout_marginTop="12dip"
@@ -20,7 +21,8 @@
         android:layout_weight="1"/>
 
     <LinearLayout android:layout_width="wrap_content"
-        android:layout_height="fill_parent">
+        android:layout_height="fill_parent">
+
 <!-- android:button="@drawable/ic_btn_wocheckbox" -->
     <CheckBox
         android:id="@+id/check_item"

--- a/OsmAnd/res/layout/local_index.xml
+++ b/OsmAnd/res/layout/local_index.xml
@@ -11,7 +11,7 @@
 <ExpandableListView
     android:id="@android:id/list"
     android:layout_width="fill_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="0dp"
     android:layout_marginLeft="0dp"
     android:layout_marginRight="0dp"
     android:layout_marginTop="0dp"

--- a/OsmAnd/res/layout/local_index_list_item.xml
+++ b/OsmAnd/res/layout/local_index_list_item.xml
@@ -7,7 +7,7 @@
 			<CheckBox android:id="@+id/check_local_index" android:layout_width="wrap_content" android:layout_height="wrap_content"
 				android:gravity="center_vertical" android:focusable="false" />
 		</LinearLayout>
-		<TextView android:id="@+id/local_index_name" android:gravity="center_vertical" android:layout_width="wrap_content" android:layout_height="wrap_content"
+		<TextView android:id="@+id/local_index_name" android:gravity="center_vertical" android:layout_width="0dp" android:layout_height="wrap_content"
 			android:layout_weight="1" style="@style/ListText.Small"></TextView>
 		<TextView android:id="@+id/local_index_size" android:layout_marginLeft="3dp" android:gravity="right" android:layout_width="wrap_content"
 			android:layout_height="wrap_content" style="@style/ListText.Small"></TextView>

--- a/OsmAnd/res/layout/local_openstreetmap_list_item.xml
+++ b/OsmAnd/res/layout/local_openstreetmap_list_item.xml
@@ -2,6 +2,6 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"   android:layout_width="fill_parent"	android:layout_height="wrap_content" 
 android:orientation="vertical">
 
-	<TextView android:id="@+id/local_openstreetmap_name" android:gravity="center_vertical" android:layout_width="wrap_content" android:layout_height="wrap_content"
+	<TextView android:id="@+id/local_openstreetmap_name" android:gravity="center_vertical" android:layout_width="wrap_content" android:layout_height="0dp"
 		android:layout_weight="1" style="@style/ListText.Small" android:layout_marginLeft="8dp"></TextView>
 </LinearLayout>

--- a/OsmAnd/res/layout/menu.xml
+++ b/OsmAnd/res/layout/menu.xml
@@ -12,7 +12,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
   				<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" android:id="@+id/AppName"
   				android:layout_marginLeft="2dp" android:layout_marginTop="3dp" 
 				android:text="@string/app_name" android:textColor="#000000" android:typeface="serif" android:textSize="20sp"/>
-				<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" android:layout_weight="1"
+				<TextView android:layout_height="wrap_content" android:layout_width="0dp" android:layout_weight="1"
 				android:layout_marginLeft="12dp" android:layout_marginTop="3dp" android:layout_marginBottom="3dp" android:text="@string/app_version" android:gravity="right"
 				android:textColor="#000000" android:typeface="serif" android:id="@+id/TextVersion" android:textSize="13sp"/> 
 				<ImageView android:id="@+id/HelpButton" android:clickable="true" android:layout_marginTop="7dp" android:layout_marginLeft="4dp" 
@@ -31,7 +31,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 	 			android:layout_weight="3" android:layout_height="175dp" android:focusable="true">
 	 				<ImageView
 					android:src="@drawable/button_icon_map" android:scaleType="center" android:layout_gravity="center"
-					android:layout_weight="1" android:layout_width="wrap_content" android:layout_height="wrap_content"/>
+					android:layout_weight="1" android:layout_width="wrap_content" android:layout_height="0dp"/>
 					<LinearLayout  android:layout_height="wrap_content" android:layout_width="fill_parent" android:gravity="center">
 						<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" 
 						android:layout_gravity="center_horizontal|top" android:textSize="18sp" 
@@ -43,7 +43,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 				android:layout_weight="3" android:layout_height="175dp" android:focusable="true">
 					<ImageView
 					android:src="@drawable/button_icon_search" android:scaleType="center" android:layout_gravity="center"
-					android:layout_weight="1" android:layout_width="wrap_content" android:layout_height="wrap_content"/>
+					android:layout_weight="1" android:layout_width="wrap_content" android:layout_height="0dp"/>
 					<LinearLayout  android:layout_height="wrap_content" android:layout_width="fill_parent" android:gravity="center">
 						<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" 
 						android:layout_gravity="center_horizontal|top" android:textSize="18sp"		
@@ -56,7 +56,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 	 			android:layout_weight="3" android:layout_height="175dp" android:focusable="true">
 	 				<ImageView
 					android:src="@drawable/button_icon_favorites" android:scaleType="center" android:layout_gravity="center"
-					android:layout_weight="1" android:layout_width="wrap_content" android:layout_height="wrap_content"/>
+					android:layout_weight="1" android:layout_width="wrap_content" android:layout_height="0dp"/>
 					<LinearLayout  android:layout_height="wrap_content" android:layout_width="fill_parent" android:gravity="center">
 						<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" 
 						android:layout_gravity="center_horizontal|top" android:textSize="18sp" 
@@ -68,7 +68,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 				android:layout_weight="3" android:layout_height="175dp" android:focusable="true">
 					<ImageView
 					android:src="@drawable/button_icon_settings" android:scaleType="center" android:layout_gravity="center"
-					android:layout_weight="1" android:layout_width="wrap_content" android:layout_height="wrap_content"/>
+					android:layout_weight="1" android:layout_width="wrap_content" android:layout_height="0dp"/>
 					<LinearLayout  android:layout_height="wrap_content" android:layout_width="fill_parent" android:gravity="center">
 						<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" 
 						android:layout_gravity="center_horizontal|top" android:textSize="18sp"

--- a/OsmAnd/res/layout/open_hours_list_item.xml
+++ b/OsmAnd/res/layout/open_hours_list_item.xml
@@ -3,7 +3,7 @@
 	android:layout_width="fill_parent" android:layout_height="wrap_content"
 	android:orientation="horizontal">
 
-	<TextView android:id="@+id/label" android:layout_weight="1" android:layout_width="wrap_content"
+	<TextView android:id="@+id/label" android:layout_weight="1" android:layout_width="0dp"
 		android:layout_height="wrap_content" android:textSize="20sp" />
 		
 	<ImageButton android:id="@+id/remove" android:layout_width="wrap_content" android:background="?attr/reset_image" 

--- a/OsmAnd/res/layout/plugins.xml
+++ b/OsmAnd/res/layout/plugins.xml
@@ -6,6 +6,6 @@
   
 <TextView android:id="@+id/Label" android:layout_width="fill_parent" android:layout_height="wrap_content" android:gravity="center" android:text="@string/select_plugin_to_activate"></TextView>
 
-<ListView android:id="@android:id/list" android:layout_width="fill_parent" android:layout_weight="1" android:layout_height="wrap_content" 
+<ListView android:id="@android:id/list" android:layout_width="fill_parent" android:layout_weight="1" android:layout_height="0dp"
 		android:layout_marginTop="10dp"></ListView>
 </LinearLayout>

--- a/OsmAnd/res/layout/route_info_list_item.xml
+++ b/OsmAnd/res/layout/route_info_list_item.xml
@@ -6,7 +6,7 @@
 	<TextView android:text="" android:id="@+id/distance" android:layout_marginLeft ="5dp" 
 		android:layout_width="50dp" android:layout_height="wrap_content"></TextView>
 	<TextView android:text="" android:id="@+id/description" android:layout_weight="1"
-		android:layout_width="wrap_content" android:layout_height="wrap_content"></TextView>
+		android:layout_width="0dp" android:layout_height="wrap_content"></TextView>
 	<TextView android:text="" android:id="@+id/time" android:layout_marginLeft ="5dp" 
 		android:layout_width="45dp" android:layout_height="wrap_content"></TextView>
 

--- a/OsmAnd/res/layout/search_address_offline.xml
+++ b/OsmAnd/res/layout/search_address_offline.xml
@@ -8,7 +8,7 @@
         android:id="@android:id/list"
         style="@style/OsmandListView"
         android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         android:layout_weight="1" >
     </ListView>
 

--- a/OsmAnd/res/layout/search_address_online.xml
+++ b/OsmAnd/res/layout/search_address_online.xml
@@ -20,7 +20,7 @@
 
         <EditText
             android:id="@+id/SearchText"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:hint="@string/hint_search_online"
@@ -39,7 +39,7 @@
     <ListView
         android:id="@android:id/list"
         android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         android:layout_weight="1"
         style="@style/OsmandListView">
     </ListView>

--- a/OsmAnd/res/layout/search_history_list_item.xml
+++ b/OsmAnd/res/layout/search_history_list_item.xml
@@ -7,7 +7,7 @@
     <TextView
         android:id="@+id/label"
         style="@style/ListText"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginLeft="3dp"
         android:layout_marginRight="3dp"

--- a/OsmAnd/res/layout/search_transport.xml
+++ b/OsmAnd/res/layout/search_transport.xml
@@ -19,7 +19,7 @@
 
         <Button
             android:id="@+id/SearchTransportLevelButton"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1" >
         </Button>

--- a/OsmAnd/res/layout/search_transport_route_item.xml
+++ b/OsmAnd/res/layout/search_transport_route_item.xml
@@ -6,7 +6,7 @@
 <!-- 	<TextView android:id="@+id/distance_label" android:layout_marginLeft="5dp"
 		android:layout_width="80dp" android:layout_height="fill_parent" android:gravity="left"
 		android:textSize="20sp"/>  -->
-	<TextView android:id="@+id/label" android:layout_weight="1" android:layout_width="wrap_content"
+	<TextView android:id="@+id/label" android:layout_weight="1" android:layout_width="0dp"
 		android:layout_height="wrap_content" style="@style/ListText" />
 		
 	<ImageButton android:id="@+id/remove" android:layout_width="wrap_content" android:background="?attr/reset_image" 

--- a/OsmAnd/res/layout/searchpoifolder_list.xml
+++ b/OsmAnd/res/layout/searchpoifolder_list.xml
@@ -8,7 +8,7 @@
 	<ImageView android:id="@+id/folder_icon" android:layout_width="37dip"
 		android:paddingLeft="8dp" android:paddingRight="8dp"
 		android:paddingTop="2dp" android:layout_height="fill_parent" />
-	<TextView android:id="@+id/folder_label" android:layout_width="wrap_content" android:layout_weight="1"
+	<TextView android:id="@+id/folder_label" android:layout_width="0dp" android:layout_weight="1"
 		android:layout_height="wrap_content" style="@style/ListText"/>
 	
 	<ImageView android:id="@+id/folder_edit_icon"

--- a/OsmAnd/res/layout/tips_and_tricks.xml
+++ b/OsmAnd/res/layout/tips_and_tricks.xml
@@ -3,7 +3,7 @@
 	android:layout_height="fill_parent" android:orientation="vertical" >
 
 	<net.osmand.access.ExplorableTextView android:text="" android:id="@+id/TipDescription" android:layout_marginLeft="4dp" android:scrollbars="vertical"
-		android:layout_width="fill_parent" android:layout_height="fill_parent" android:layout_marginRight="4dp" android:layout_weight="1"
+		android:layout_width="fill_parent" android:layout_height="0dp" android:layout_marginRight="4dp" android:layout_weight="1"
 		style="@style/ListText" android:gravity="fill_horizontal"
 		/>
 

--- a/SherlockBar/res/layout/abs__search_view.xml
+++ b/SherlockBar/res/layout/abs__search_view.xml
@@ -50,7 +50,7 @@
 
     <LinearLayout
             android:id="@+id/abs__search_edit_frame"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:layout_gravity="center_vertical"
@@ -74,7 +74,7 @@
         <!-- Inner layout contains the app icon, button(s) and EditText -->
         <LinearLayout
                 android:id="@+id/abs__search_plate"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:layout_gravity="center_vertical"


### PR DESCRIPTION
When only a single widget in a LinearLayout defines a weight, it is more
efficient to assign a width/height of 0dp to it since it will absorb all
the remaining space anyway. With a declared width/height of 0dp it does
not have to measure its own size first.
