### PR TITLE
Use wrap_content in ScrollView

### DIFF
--- a/OsmAnd/res/layout/navigate_point.xml
+++ b/OsmAnd/res/layout/navigate_point.xml
@@ -4,7 +4,7 @@
     android:layout_width="fill_parent" android:layout_height="fill_parent" >
 <LinearLayout
   android:layout_width="fill_parent"
-  android:layout_height="fill_parent" android:orientation="vertical" android:gravity="center_horizontal">
+  android:layout_height="wrap_content" android:orientation="vertical" android:gravity="center_horizontal">
 <net.osmand.view.ExpandableLinearLayout custom:maxVisibleWidth="800dp" android:layout_width="wrap_content" android:layout_height="wrap_content" android:orientation="vertical" >
 <TextView android:id="@+id/TextView" android:textSize="16sp" android:layout_width="fill_parent" android:layout_height="wrap_content" android:gravity="center" android:layout_marginTop="4dp" android:layout_marginBottom="4dp" android:text="@string/navigate_point_top_text"></TextView>
 


### PR DESCRIPTION
ScrollView children must set their layout_width or layout_height
attributes to wrap_content rather than fill_parent or match_parent in
the scrolling dimension.

This LinearLayout should use android:layout_height="wrap_content"
