### PR TITLE
Replace concat() call with +

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/SeekBarPreference.java
+++ b/OsmAnd/src/net/osmand/plus/views/SeekBarPreference.java
@@ -149,7 +149,7 @@ public class SeekBarPreference extends DialogPreference implements
 	public void onProgressChanged(final SeekBar seek, final int value,
 			final boolean fromTouch) {
 		final String t = String.valueOf(value);
-		valueTextView.setText(valueText == null ? t : t.concat(valueText));
+		valueTextView.setText(valueText == null ? t : t + valueText);
 		valueToSave = value;
 	}
 


### PR DESCRIPTION
Such calls can be replaced with the '+' operator for increased code
clarity and possible increased performance if the method was invoked on
a constant with a constant argument.
