### PR TITLE
Fix .equals() calls to empty string

### DIFF
--- a/OsmAnd/src/net/osmand/plus/OsmandApplication.java
+++ b/OsmAnd/src/net/osmand/plus/OsmandApplication.java
@@ -280,7 +280,7 @@ public class OsmandApplication extends Application implements ClientContext {
 	public void checkPrefferedLocale() {
 		Configuration config = getBaseContext().getResources().getConfiguration();
 		String lang = osmandSettings.PREFERRED_LOCALE.get();
-		if (!"".equals(lang) && !config.locale.getLanguage().equals(lang)) {
+		if (lang != null && !lang.isEmpty() && !config.locale.getLanguage().equals(lang)) {
 			prefferedLocale = new Locale(lang);
 			Locale.setDefault(prefferedLocale);
 			config.locale = prefferedLocale;

--- a/OsmAnd/src/net/osmand/plus/activities/FavouritesActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/FavouritesActivity.java
@@ -404,7 +404,7 @@ public class FavouritesActivity extends OsmandExpandableListActivity {
 							name = "";
 						}
 						// old way to store the category, in name.
-						if ("".equals(categoryName.trim()) && (c = p.name.lastIndexOf('_')) != -1) {
+						if (categoryName.trim() != null && categoryName.trim().isEmpty() && (c = p.name.lastIndexOf('_')) != -1) {
 							categoryName = p.name.substring(c + 1);
 							name = p.name.substring(0, c);
 						}

--- a/OsmAnd/src/net/osmand/plus/resources/ResourceManager.java
+++ b/OsmAnd/src/net/osmand/plus/resources/ResourceManager.java
@@ -438,7 +438,7 @@ public class ResourceManager {
 				try {
 					progress.startTask(context.getString(R.string.installing_new_resources), -1); 
 					AssetManager assetManager = context.getAssets();
-					boolean isFirstInstall = context.getSettings().PREVIOUS_INSTALLED_VERSION.get().equals("");
+					boolean isFirstInstall = context.getSettings().PREVIOUS_INSTALLED_VERSION.get().isEmpty();
 					unpackBundledAssets(assetManager, applicationDataDir, progress, isFirstInstall);
 					context.getSettings().PREVIOUS_INSTALLED_VERSION.set(Version.getFullVersion(context));
 					

--- a/OsmAnd/src/net/osmand/plus/srtmplugin/SRTMPlugin.java
+++ b/OsmAnd/src/net/osmand/plus/srtmplugin/SRTMPlugin.java
@@ -30,9 +30,9 @@ public class SRTMPlugin extends OsmandPlugin {
 		this.paid = paid;
 		OsmandSettings settings = app.getSettings();
 		CommonPreference<String> pref = settings.getCustomRenderProperty("contourLines");
-		if(pref.get().equals("")) {
+		if(pref.get().isEmpty()) {
 			for(ApplicationMode m : ApplicationMode.values()) {
-				if(pref.getModeValue(m).equals("")) {
+				if(pref.getModeValue(m).isEmpty()) {
 					pref.setModeValue(m, "13");
 				}
 			}

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/MapInfoWidgetsFactory.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/MapInfoWidgetsFactory.java
@@ -334,7 +334,7 @@ public class MapInfoWidgetsFactory {
 			}
 			if (!text.equals(getText().toString())) {
 				TextPaint pp = new TextPaint(getPaint());
-				if (!text.equals("")) {
+				if (!text.isEmpty()) {
 					pp.setTextSize(20 * scaleCoefficient);
 					float ts = pp.measureText(text);
 					int wth = getWidth();

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/MapWidgetRegistry.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/MapWidgetRegistry.java
@@ -58,7 +58,7 @@ public class MapWidgetRegistry {
 		
 		for(ApplicationMode ms : ApplicationMode.values() ) {
 			String mpf = settings.MAP_INFO_CONTROLS.getModeValue(ms);
-			if(mpf.equals("")) {
+			if(mpf.isEmpty()) {
 				visibleElements.put(ms, null);
 			} else {
 				LinkedHashSet<String> set = new LinkedHashSet<String>();


### PR DESCRIPTION
It is normally more performant to test a String for emptiness by
comparing its .length() to zero instead.
