### PR TITLE
Make some inner classes static

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
@@ -422,7 +422,7 @@ public class GeoIntentActivity extends OsmandListActivity {
 		});
 	}
 	
-	private class Empty implements MyService {
+	private static class Empty implements MyService {
 
 		@Override
 		public Collection<MapObject> execute() {
@@ -431,7 +431,7 @@ public class GeoIntentActivity extends OsmandListActivity {
 		
 	}
 	
-	private class GeoPointSearch implements MyService {
+	private static class GeoPointSearch implements MyService {
 		private MapObject point;
 		/**
 		 * geo:latitude,longitude geo:latitude,longitude?z=zoom

--- a/OsmAnd/src/net/osmand/plus/views/MapInfoLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/MapInfoLayer.java
@@ -745,7 +745,7 @@ public class MapInfoLayer extends OsmandMapLayer {
 		return progressBar;
 	}
 
-	private class ConfigLayout extends FrameLayout implements UpdateableWidget {
+	private static class ConfigLayout extends FrameLayout implements UpdateableWidget {
 		private ImageViewWidget config;
 
 		private ConfigLayout(Context c, ImageViewWidget config) {

--- a/OsmAnd/src/net/osmand/plus/voice/TTSCommandPlayerImpl.java
+++ b/OsmAnd/src/net/osmand/plus/voice/TTSCommandPlayerImpl.java
@@ -31,7 +31,7 @@ import android.speech.tts.TextToSpeech.OnUtteranceCompletedListener;
 
 public class TTSCommandPlayerImpl extends AbstractPrologCommandPlayer {
 	public final static String PEBBLE_ALERT = "PEBBLE_ALERT";
-	private final class IntentStarter implements
+	private static final class IntentStarter implements
 			DialogInterface.OnClickListener {
 		private final Context ctx;
 		private final String intentAction;


### PR DESCRIPTION
An inner class may be static if it doesn't reference its enclosing class
instance. A static inner class uses slightly less memory.
