### PR TITLE
Fix buttons order

### DIFF
--- a/OsmAnd/res/layout/editing_poi.xml
+++ b/OsmAnd/res/layout/editing_poi.xml
@@ -206,8 +206,8 @@
 <TextView android:text="@string/poi_dialog_other_tags_message" android:id="@+id/TextView" android:layout_marginLeft="5dp" android:layout_width="fill_parent" android:layout_height="wrap_content"/>
 <LinearLayout android:id="@+id/LinearLayout" android:layout_width="fill_parent" android:layout_height="fill_parent" android:orientation="horizontal" 
 	android:gravity="bottom|center">
-    <Button android:layout_width="125dp" android:layout_height="wrap_content" android:text="@string/default_buttons_commit" android:id="@+id/Commit"></Button>
     <Button android:layout_width="125dp" android:layout_height="wrap_content" android:text="@string/default_buttons_cancel" android:id="@+id/Cancel"></Button>
+    <Button android:layout_width="125dp" android:layout_height="wrap_content" android:text="@string/default_buttons_commit" android:id="@+id/Commit"></Button>
 </LinearLayout>
 </LinearLayout>
 </ScrollView>

--- a/OsmAnd/res/layout/save_directions_dialog.xml
+++ b/OsmAnd/res/layout/save_directions_dialog.xml
@@ -10,7 +10,7 @@
 </LinearLayout>
 <LinearLayout android:layout_width="fill_parent" android:layout_height="fill_parent" android:orientation="horizontal" 
 	android:gravity="bottom|center" android:layout_marginTop="5dp">
-    <Button android:layout_width="125dp" android:layout_height="wrap_content" android:text="@string/default_buttons_save" android:id="@+id/Save"></Button>
     <Button android:layout_width="125dp" android:layout_height="wrap_content" android:text="@string/default_buttons_cancel" android:id="@+id/Cancel"></Button>
+    <Button android:layout_width="125dp" android:layout_height="wrap_content" android:text="@string/default_buttons_save" android:id="@+id/Save"></Button>
 </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
Layout uses the wrong button order for API >= 14:
Cancel button should be on the left (was "Save | Cancel", should be
"Cancel | Save")
