### PR TITLE
Replace StringBuffer.toString() in concatenation

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/LiveMonitoringHelper.java
+++ b/OsmAnd/src/net/osmand/plus/activities/LiveMonitoringHelper.java
@@ -166,7 +166,7 @@ public class LiveMonitoringHelper  {
 					is.close();
 				}
 				httpclient.getConnectionManager().shutdown();
-				log.info("Montior response : " + responseBody.toString());
+				log.info("Montior response : " + responseBody);
 			}
 
 			

--- a/OsmAnd/src/net/osmand/plus/activities/search/SearchAddressOnlineFragment.java
+++ b/OsmAnd/src/net/osmand/plus/activities/search/SearchAddressOnlineFragment.java
@@ -161,7 +161,7 @@ public class SearchAddressOnlineFragment extends SherlockFragment implements Sea
 					b.append("?format=xml&addressdetails=0&accept-language=").append(Locale.getDefault().getLanguage()); //$NON-NLS-1$
 					b.append("&q=").append(URLEncoder.encode(search, "UTF-8")); //$NON-NLS-1$
 					
-					log.info("Searching address at : " + b.toString()); //$NON-NLS-1$
+					log.info("Searching address at : " + b); //$NON-NLS-1$
 					URL url = new URL(b.toString());
 					URLConnection conn = url.openConnection();
 					conn.setDoInput(true);

--- a/OsmAnd/src/net/osmand/plus/activities/search/SearchPOIActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/search/SearchPOIActivity.java
@@ -811,8 +811,8 @@ public class SearchPOIActivity extends OsmandListActivity implements OsmAndCompa
 			StringBuilder value = new StringBuilder();
 			MapRenderingTypes.getDefault().getAmenityTagValue(amenity.getType(), amenity.getSubType(),
 					tag, value);
-			if(RenderingIcons.containsBigIcon(tag.toString() + "_" + value.toString())) {
-				icon.setImageResource(RenderingIcons.getBigIconResourceId(tag.toString() + "_" + value.toString()));
+			if(RenderingIcons.containsBigIcon(tag + "_" + value)) {
+				icon.setImageResource(RenderingIcons.getBigIconResourceId(tag + "_" + value));
 			} else if(RenderingIcons.containsBigIcon(value.toString())) {
 				icon.setImageResource(RenderingIcons.getBigIconResourceId(value.toString()));
 			} else {

--- a/OsmAnd/src/net/osmand/plus/activities/search/SearchTransportFragment.java
+++ b/OsmAnd/src/net/osmand/plus/activities/search/SearchTransportFragment.java
@@ -505,7 +505,7 @@ public class SearchTransportFragment extends SherlockFragment implements SearchA
 			
 			int dist = locationToStart == null ? 0 : (int) (MapUtils.getDistance(stop.getStart().getLocation(), locationToStart));
 			String distance =  OsmAndFormatter.getFormattedDistance(dist, (ClientContext) getApplication()) + " "; //$NON-NLS-1$
-			label.setText(distance + labelW.toString(), TextView.BufferType.SPANNABLE);
+			label.setText(distance + labelW, TextView.BufferType.SPANNABLE);
 			((Spannable) label.getText()).setSpan(new ForegroundColorSpan(getResources().getColor(R.color.color_distance)), 0, distance.length() - 1, 0);
 			return (row);
 		}

--- a/OsmAnd/src/net/osmand/plus/osmedit/OsmBugsLayer.java
+++ b/OsmAnd/src/net/osmand/plus/osmedit/OsmBugsLayer.java
@@ -289,7 +289,7 @@ public class OsmBugsLayer extends OsmandMapLayer implements IContextMenuProvider
 		b.append(",").append(rightLongitude); //$NON-NLS-1$
 		b.append(",").append(topLatitude); //$NON-NLS-1$
 		try {
-			log.info("Loading bugs " + b.toString()); //$NON-NLS-1$
+			log.info("Loading bugs " + b); //$NON-NLS-1$
 			URL url = new URL(b.toString());
 			URLConnection connection = url.openConnection();
 			BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));

--- a/OsmAnd/src/net/osmand/plus/osmedit/OsmBugsRemoteUtil.java
+++ b/OsmAnd/src/net/osmand/plus/osmedit/OsmBugsRemoteUtil.java
@@ -107,11 +107,11 @@ public class OsmBugsRemoteUtil implements OsmBugsUtil {
 						responseBody.append(s);
 					}
 				}
-				log.info("Response : " + responseBody.toString()); //$NON-NLS-1$
+				log.info("Response : " + responseBody); //$NON-NLS-1$
 			}
 			connection.disconnect();
 			if (!ok) {
-				return msg + "\n" + responseBody.toString();
+				return msg + "\n" + responseBody;
 			}
 		} catch (NullPointerException e) {
 			// that's tricky case why NPE is thrown to fix that problem httpClient could be used

--- a/OsmAnd/src/net/osmand/plus/routing/RouteProvider.java
+++ b/OsmAnd/src/net/osmand/plus/routing/RouteProvider.java
@@ -630,7 +630,7 @@ public class RouteProvider {
 		// TODO if we would get instructions from the service, we could use this language setting
 		// .append("&language=").append(Locale.getDefault().getLanguage());
 
-		log.info("URL route " + request.toString());
+		log.info("URL route " + request);
 		URI uri = URI.create(request.toString());
 		URL url = uri.toURL();
 		URLConnection connection = url.openConnection();


### PR DESCRIPTION
In addition to being confusing, this code performs String allocation and
copying, which is unnecessary as of JDK1.4
