### PR TITLE
Remove useless LinearLayout views

### DIFF
--- a/OsmAnd/res/layout-land/menu.xml
+++ b/OsmAnd/res/layout-land/menu.xml
@@ -40,7 +40,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"/>
 	 			</LinearLayout>
-				<LinearLayout android:layout_weight="2" android:layout_height="fill_parent"/>
+				
 				<LinearLayout android:id="@+id/SearchButton" android:background="@drawable/bg_right" android:clickable="true"
 				android:layout_weight="1" android:layout_height="112dp" android:focusable="true">
 					<ImageView
@@ -69,7 +69,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"/>
 	 			</LinearLayout>
-				<LinearLayout android:layout_weight="2" android:layout_height="fill_parent"/>
+				
 				<LinearLayout android:id="@+id/SettingsButton" android:background="@drawable/bg_right" 
 				android:layout_weight="1" android:layout_height="112dp" android:focusable="true" android:clickable="true">
 					<ImageView

--- a/OsmAnd/res/layout-large-land/menu.xml
+++ b/OsmAnd/res/layout-large-land/menu.xml
@@ -40,7 +40,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"/>
 	 			</LinearLayout>
-				<LinearLayout android:layout_weight="2" android:layout_height="fill_parent"/>
+				
 				<LinearLayout android:id="@+id/SearchButton" android:background="@drawable/bg_right" 
 				android:focusable="true" android:clickable="true"
 				android:layout_weight="1" android:layout_height="165dp">
@@ -71,7 +71,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"/>
 	 			</LinearLayout>
-				<LinearLayout android:layout_weight="2" android:layout_height="fill_parent"/>
+				
 				<LinearLayout android:id="@+id/SettingsButton" android:background="@drawable/bg_right"
 				android:focusable="true" android:clickable="true" 
 				android:layout_weight="1" android:layout_height="165dp">

--- a/OsmAnd/res/layout-large/menu.xml
+++ b/OsmAnd/res/layout-large/menu.xml
@@ -38,7 +38,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 						android:text="@string/map_Button" android:typeface="serif" android:textColor="#000000"/>
 					</LinearLayout>	
 	 			</LinearLayout>
-				<LinearLayout android:layout_weight="2" android:layout_height="fill_parent"/>
+				
 				<LinearLayout android:id="@+id/SearchButton" android:background="@drawable/bg_rightr" android:orientation="vertical"
 				android:focusable="true" android:clickable="true" android:layout_weight="3" android:layout_height="250dp">
 					<ImageView
@@ -63,7 +63,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 				 		android:text="@string/favorites_Button" android:typeface="serif" android:textColor="#000000"/>
 					</LinearLayout>
 	 			</LinearLayout>
-				<LinearLayout android:layout_weight="2" android:layout_height="fill_parent"/>
+				
 				<LinearLayout android:id="@+id/SettingsButton" android:background="@drawable/bg_rightr" android:orientation="vertical" 
 				android:focusable="true" android:clickable="true" android:layout_weight="3" android:layout_height="250dp">
 					<ImageView

--- a/OsmAnd/res/layout/menu.xml
+++ b/OsmAnd/res/layout/menu.xml
@@ -38,7 +38,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 				    		android:text="@string/map_Button" android:typeface="serif" android:textColor="#000000"/>
 					</LinearLayout>	
 	 			</LinearLayout>
-				<LinearLayout android:layout_weight="2" android:layout_height="fill_parent"/>
+				
 				<LinearLayout android:id="@+id/SearchButton" android:background="@drawable/bg_rightr" android:orientation="vertical" android:clickable="true"
 				android:layout_weight="3" android:layout_height="175dp" android:focusable="true">
 					<ImageView
@@ -63,7 +63,7 @@ android:layout_width="fill_parent" android:layout_height="fill_parent" android:b
 						android:text="@string/favorites_Button" android:typeface="serif" android:textColor="#000000"/>
 					</LinearLayout>	
 	 			</LinearLayout>
-				<LinearLayout android:layout_weight="2" android:layout_height="fill_parent"/>
+				
 				<LinearLayout android:id="@+id/SettingsButton"  android:background="@drawable/bg_rightr" android:orientation="vertical" android:clickable="true"
 				android:layout_weight="3" android:layout_height="175dp" android:focusable="true">
 					<ImageView


### PR DESCRIPTION
A layout that has no children or no background can often be removed
(since it is invisible) for a flatter and more efficient layout
hierarchy.
