### PR TITLE
Allow for more memory on 4.x devices via largeHeap in manifest

### DIFF
--- a/OsmAnd/AndroidManifest.xml
+++ b/OsmAnd/AndroidManifest.xml
@@ -36,7 +36,7 @@
 	<application android:icon="@drawable/icon" android:label="@string/app_name" 
 		android:debuggable="true" android:name="net.osmand.plus.OsmandApplication"  android:configChanges="locale"
 		android:theme="@style/OsmandDarkTheme"
-		android:backupAgent="net.osmand.plus.OsmandBackupAgent" android:restoreAnyVersion="true">
+		android:backupAgent="net.osmand.plus.OsmandBackupAgent" android:restoreAnyVersion="true" android:largeHeap="true">
 		
 	    <meta-data android:name="com.sec.android.support.multiwindow" android:value="true"/>
 	    <meta-data android:name="com.sec.android.multiwindow.DEFAULT_SIZE_W" android:resource="@dimen/app_defaultsize_w" />


### PR DESCRIPTION
Hi,

as discussed in the forum this would allow for 4.x devices to use more memory in Java, allowing the precise java routing to work over larger distances then currently.
There is no impact on pre 4.x devices as these will ignore this setting and behave as previously
