### PR TITLE
added BRouter service interface

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/SettingsNavigationActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/SettingsNavigationActivity.java
@@ -80,18 +80,15 @@ public class SettingsNavigationActivity extends SettingsBaseActivity {
 		}
 		registerListPreference(settings.AUTO_FOLLOW_ROUTE, screen, entries, intValues);
 
-		// hide the brouter-service if not installed
+		// hide non-selectable routing-services
 		RoutingHelper routingHelper = getMyApplication().getRoutingHelper();
-		boolean hasBRouter = routingHelper != null && routingHelper.hasBRouter();
 		int nrouteservices = RouteService.values().length;
 		List<RouteService> routeServices = new ArrayList<RouteService>();
 		for( RouteService routeSrvc : RouteService.values() ) {
-			if ( RouteService.BROUTER == routeSrvc && !hasBRouter ) {
-				continue;
+			if ( routingHelper == null || routingHelper.isRoutingServiceSelectable( routeSrvc ) ) {
+				routeServices.add( routeSrvc );
 			}
-			routeServices.add( routeSrvc );
         }
-
 		entries = new String[routeServices.size()];
         RouteService[] rsValues = new RouteService[routeServices.size()];
 		for(int i=0; i<routeServices.size(); i++) {

--- a/OsmAnd/src/net/osmand/plus/routing/RouteCalculationParams.java
+++ b/OsmAnd/src/net/osmand/plus/routing/RouteCalculationParams.java
@@ -1,7 +1,5 @@
 package net.osmand.plus.routing;
 
-import btools.routingapp.IBRouterService;
-
 import java.util.List;
 
 import net.osmand.Location;
@@ -28,6 +26,4 @@ public class RouteCalculationParams {
 	public boolean leftSide;
 	public RouteCalculationProgress calculationProgress;
 	public boolean preciseRouting;
-
-	public IBRouterService brouterService;
 }


### PR DESCRIPTION
This is a patch to include offline routing via the aidl-interface of BRouter ( http://brensche.de/brouter ) to the list of routing services in OsmAnd.

The way I did it, the new entry "BRouter (offline)" always appears in the selection list if you choose a navigation service. If chosen, but BRouter is not installed on the device, you get the corresonding error message at the time of route calculation.

Maybe it's possible to only offer the service in the selection list if BRouter is installed (that is, if Osmand cound bind to it's service), but I didn't succeed, the "RouteService" enum seemed to static for me to do that?

Thanks for taking the patch to the main branch 
