### PR TITLE
Patch for issue1384 "wrong left turn info"

### DIFF
--- a/OsmAnd-java/src/net/osmand/binary/BinaryMapRouteReaderAdapter.java
+++ b/OsmAnd-java/src/net/osmand/binary/BinaryMapRouteReaderAdapter.java
@@ -418,7 +418,7 @@ public class BinaryMapRouteReaderAdapter {
 		TIntArrayList pointsY = new TIntArrayList();
 		TIntArrayList types = new TIntArrayList();
 		List<TIntArrayList> globalpointTypes = new ArrayList<TIntArrayList>();
-		boolean dropped = false;
+		//boolean dropped = false;
 		while (true) {
 			int ts = codedIS.readTag();
 			int tags = WireFormat.getTagFieldNumber(ts);
@@ -437,7 +437,7 @@ public class BinaryMapRouteReaderAdapter {
 					}
 				}
 				
-				if (dropped) System.err.println("of way locally identified as " + o.id + " because has same coordinates than previous point."); //$NON-NLS-1$ //$NON-NLS-2$ 
+				//if (dropped) System.err.println("of way locally identified as " + o.id + " because has same coordinates than previous point."); //$NON-NLS-1$ //$NON-NLS-2$ 
 					
 				return o;
 
@@ -470,8 +470,8 @@ public class BinaryMapRouteReaderAdapter {
 					int deltaY = codedIS.readSInt32();
 					if (deltaX == 0 && deltaY == 0)
 					{
-						System.err.println("Dropping point " + pointsX.size()); //$NON-NLS-1$
-						dropped = true;
+						//System.err.println("Dropping point " + pointsX.size()); //$NON-NLS-1$
+						//dropped = true;
 						continue;
 					}
 					int x = deltaX + px;


### PR DESCRIPTION
Discard points with same coordinates.

Translating coordinates from OSM to OBF can colapse near points to same
coordinates. When that happens, new connections between ways appears
and zero length segments becomes a source of trouble for algoritms.

Explanation
Transformation from lattitude-longitude coordinates to tile coordinates has a precision loss.
Firstly it does Merkator projection and then adjusts origin and range from 0 to 2^31 (get31TileNumberX, get31TileNumberY on MapUtils.java). Then applies a 4 bits right shift with precision loss and finally writes, to obf, deltas from one point to next (writeRouteData on BinaryMapIndexWriter.java). This precision loss can transform 2 different OSM points with different coordinates to 2 different obf points with same coordinates.
On issue 1384 this occurs on points 3 and 4 of road with id 76419769. On OSM next segment was only connected to point 4 but now both 3 and 4 are connected to start of next segment. When routing algorithm selects the segment from 3 to 4, its bearing is 0 degrees because atan2(0,0)=0 (incorrectely, it must be undefined). Then addTurnInfo adds a left turn because bearing of surrounding segments is around 70.
Additionally when route connects to point 3 and skip point 4, segment from 3 to 4 is evaluated to know if keep right info must be added. Fortunatelly atan2 bug avoids unnecessary keep right turn info now.
