### PR TITLE
Fix http://maps.google.com/?daddr= intent

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
@@ -204,7 +204,7 @@ public class GeoIntentActivity extends OsmandListActivity {
 			String parameter = data.getQueryParameter("q");
 			if (parameter == null) {
 				parameter = data.getQueryParameter("daddr");
-            }
+			}
 			if(parameter != null) {
 			    q = parameter.split(" ")[0];	
 			}


### PR DESCRIPTION
I came across an existing issue https://code.google.com/p/osmand/issues/detail?id=2165 (osmand triggers on gmaps navigation url intent but can't cope with it), and prepared a fix for it.
