### PR TITLE
osmand specific intents

### DIFF
--- a/OsmAnd/AndroidManifest.xml
+++ b/OsmAnd/AndroidManifest.xml
@@ -85,6 +85,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:scheme="google.navigation"/>
+                <data android:scheme="osmand.navigation"/>
             </intent-filter>
 
             <receiver android:name="net.osmand.plus.audionotes.MediaRemoteControlReceiver">
@@ -130,6 +131,7 @@
         <activity android:name="net.osmand.plus.activities.search.GeoIntentActivity">
             <intent-filter>
                 <data android:scheme="geo" />
+                <data android:scheme="osmand.geo" />
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>

--- a/OsmAnd/src/net/osmand/plus/activities/MapActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/MapActivity.java
@@ -342,7 +342,7 @@ public class MapActivity extends AccessibleActivity  {
                     {
                         showImportedGpx(data.getPath());
                     }
-                    else if("google.navigation".equals(scheme))
+                    else if("google.navigation".equals(scheme) || "osmand.navigation".equals(scheme))
                     {
                         final String schemeSpecificPart = data.getSchemeSpecificPart();
 

--- a/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
@@ -276,7 +276,7 @@ public class GeoIntentActivity extends OsmandListActivity {
                 return null;
             }
         }
-        if ("geo".equals(scheme))
+        if ("geo".equals(scheme) || "osmand.geo".equals(scheme))
         {
             //geo:
             final String schemeSpecific = data.getSchemeSpecificPart();


### PR DESCRIPTION
Addition of 2 schemes for osmand specific intents
- osmand.navigation: same behaviour as google.navigation: e.g. osmand.navigation:q=51.00,3.00
- osmand.geo:  same behaviour as geo: e.g. osmand.geo:47.6,-122.3?z=11 or osmand.geo:0,0?q=34.99,-106.61(Treasure)
