### PR TITLE
sni patch

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/LiveMonitoringHelper.java
+++ b/OsmAnd/src/net/osmand/plus/activities/LiveMonitoringHelper.java
@@ -24,6 +24,25 @@ import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 
+import org.apache.http.client.HttpClient;
+import org.apache.http.conn.scheme.Scheme;
+import org.apache.http.conn.scheme.SchemeRegistry;
+import org.apache.http.conn.ssl.SSLSocketFactory;
+import org.apache.http.impl.conn.SingleClientConnManager;
+import org.apache.http.conn.scheme.LayeredSocketFactory;
+import javax.net.ssl.HostnameVerifier;
+import org.apache.http.conn.ssl.StrictHostnameVerifier;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSession;
+import android.annotation.TargetApi;
+import android.net.SSLCertificateSocketFactory;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import java.io.IOException;
+import android.os.Build;
+
 import android.content.Context;
 import android.os.AsyncTask;
 
@@ -32,7 +51,7 @@ public class LiveMonitoringHelper  {
 	protected Context ctx;
 	private OsmandSettings settings;
 	private long lastTimeUpdated;
-	private final static Log log = PlatformUtil.getLog(LiveMonitoringHelper.class); 
+	/*private*/ final static Log log = PlatformUtil.getLog(LiveMonitoringHelper.class); 
 
 	public LiveMonitoringHelper(Context ctx){
 		this.ctx = ctx;
@@ -57,6 +76,80 @@ public class LiveMonitoringHelper  {
 			}
 		}
 		
+	}
+
+    /*private*/ static final String TAG = "davdroid.SNISocketFactory";
+
+    final static HostnameVerifier hostnameVerifier = new StrictHostnameVerifier();
+
+
+// http://blog.dev001.net/post/67082904181/android-using-sni-and-tlsv1-2-with-apache-httpclient
+	@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+	class TlsSniSocketFactory implements LayeredSocketFactory {
+	
+
+	    // Plain TCP/IP (layer below TLS)
+
+	    @Override
+	    public Socket connectSocket(Socket s, String host, int port, InetAddress localAddress, int localPort, HttpParams params) throws IOException {
+		    return null;
+	    }
+
+	    @Override
+	    public Socket createSocket() throws IOException {
+		    return null;
+	    }
+
+	    @Override
+	    public boolean isSecure(Socket s) throws IllegalArgumentException {
+		    if (s instanceof SSLSocket)
+		            return ((SSLSocket)s).isConnected();
+		    return false;
+	    }
+
+
+	    // TLS layer
+
+	    @Override
+	    public Socket createSocket(Socket plainSocket, String host, int port, boolean autoClose) throws IOException, UnknownHostException {
+		    if (autoClose) {
+		            // we don't need the plainSocket
+		            plainSocket.close();
+		    }
+
+		    // create and connect SSL socket, but don't do hostname/certificate verification yet
+		    SSLCertificateSocketFactory sslSocketFactory = (SSLCertificateSocketFactory) SSLCertificateSocketFactory.getDefault(0);
+		    SSLSocket ssl = (SSLSocket)sslSocketFactory.createSocket(InetAddress.getByName(host), port);
+
+		    // enable TLSv1.1/1.2 if available
+		    // (see https://github.com/rfc2822/davdroid/issues/229)
+		    ssl.setEnabledProtocols(ssl.getSupportedProtocols());
+
+		    // set up SNI before the handshake
+		    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+		            log.info(/*TAG, */"Setting SNI hostname");
+		            sslSocketFactory.setHostname(ssl, host);
+		    } else {
+		            log.debug(/*TAG, */"No documented SNI support on Android <4.2, trying with reflection");
+		            try {
+		                 java.lang.reflect.Method setHostnameMethod = ssl.getClass().getMethod("setHostname", String.class);
+		                 //setHostnameMethod.invoke(ssl, host.getHostName());
+				 setHostnameMethod.invoke(ssl, host);
+		            } catch (Exception e) {
+		                    log.warn(/*TAG, */"SNI not useable", e);
+		            }
+		    }
+
+		    // verify hostname and certificate
+		    SSLSession session = ssl.getSession();
+		    if (!hostnameVerifier.verify(host, session))
+		            throw new SSLPeerUnverifiedException("Cannot verify hostname: " + host);
+
+		    log.info(/*TAG, */"Established " + session.getProtocol() + " connection with " + session.getPeerHost() +
+		                    " using " + session.getCipherSuite());
+
+		    return ssl;
+	    }
 	}
 	
 	
@@ -134,10 +227,18 @@ public class LiveMonitoringHelper  {
 		}
 		String url = MessageFormat.format(st, prm.toArray());
 		try {
-
+			HttpClient httpclient = null;
 			HttpParams params = new BasicHttpParams();
 			HttpConnectionParams.setConnectionTimeout(params, 15000);
-			DefaultHttpClient httpclient = new DefaultHttpClient(params);
+			if (url.startsWith("https:")) {
+				SchemeRegistry schemeRegistry = new SchemeRegistry();
+//				schemeRegistry.register(new Scheme("https", SSLSocketFactory.getSocketFactory(), 443));
+				schemeRegistry.register(new Scheme("https", new TlsSniSocketFactory(), 443));
+				SingleClientConnManager mgr = new SingleClientConnManager(params, schemeRegistry);
+				httpclient = new DefaultHttpClient(mgr, params);
+			} else {
+				httpclient = new DefaultHttpClient(params);
+			}
 			HttpRequestBase method = new HttpGet(url);
 			log.info("Monitor " + url);
 			HttpResponse response = httpclient.execute(method);


### PR DESCRIPTION
In accordance with http://blog.dev001.net/post/67082904181/android-using-sni-and-tlsv1-2-with-apache-httpclient I created this (temporary: Android should implement this natively) little patch which allows to share live monitoring data with an SNI enabled server. The way this is implemented as is this should not connect to a regular ssl host.
