### PR TITLE
import favourites, clear intent after usage, import waypoints from route...

### DIFF
--- a/OsmAnd-java/src/net/osmand/data/FavouritePoint.java
+++ b/OsmAnd-java/src/net/osmand/data/FavouritePoint.java
@@ -5,14 +5,11 @@ import java.io.Serializable;
 public class FavouritePoint implements Serializable {
 	private static final long serialVersionUID = 729654300829771466L;
 	private String name;
-	private String category = "";
+	private String category;
 	private double latitude;
 	private double longitude;
 	private boolean stored = false;
 	
-
-	public FavouritePoint(){
-	}
 
 	public FavouritePoint(double latitude, double longitude, String name, String category) {
 		this.latitude = latitude;

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -1751,4 +1751,9 @@ Afghanistan, Albania, Algeria, Andorra, Angola, Anguilla, Antigua and Barbuda, A
 	<string name="av_photo_play_sound">Play sound on photo shot</string>
 	<string name="av_photo_play_sound_descr">Choose whether to play a sound when shooting photos</string>
     <string name="navigation_intent_invalid">Invalid format : %s</string>
+	<string name="import_file_waypoints_message">Import %1$d waypoints or show track from gpx file?</string>
+	<string name="import_file_waypoints_button">Import</string>
+	<string name="import_file_show_button">Show</string>
+	<string name="import_file_no_waypoints">Imported file contains no waypoints</string>
+	<string name="import_file_favourites">Import these favourites?</string>
 </resources>

--- a/OsmAnd/src/net/osmand/plus/GPXUtilities.java
+++ b/OsmAnd/src/net/osmand/plus/GPXUtilities.java
@@ -88,6 +88,11 @@ public class GPXUtilities {
 			this.hdop = hdop;
 		}
 
+		public final boolean isFavourite()
+		{
+			return category != null;
+		}
+
 	}
 
 	public static class TrkSegment extends GPXExtensions {

--- a/OsmAnd/src/net/osmand/plus/OsmandApplication.java
+++ b/OsmAnd/src/net/osmand/plus/OsmandApplication.java
@@ -76,6 +76,9 @@ import com.actionbarsherlock.app.SherlockListActivity;
 
 
 public class OsmandApplication extends Application {
+	// externalize ?
+	public static final String GPX_GROUP = "Gpx";
+
 	public static final String EXCEPTION_PATH = "exception.log"; //$NON-NLS-1$
 	private static final org.apache.commons.logging.Log LOG = PlatformUtil.getLog(OsmandApplication.class);
 
@@ -229,25 +232,32 @@ public class OsmandApplication extends Application {
 		return poiFilters;
 	}
 
+	public void clearGpxFileToDisplay() {
+		this.gpxFileToDisplay = null;
+		osmandSettings.SHOW_CURRENT_GPX_TRACK.set(false);
+	}
+
 	public void setGpxFileToDisplay(GPXFile gpxFileToDisplay, boolean showCurrentGpxFile) {
 		this.gpxFileToDisplay = gpxFileToDisplay;
 		osmandSettings.SHOW_CURRENT_GPX_TRACK.set(showCurrentGpxFile);
-		if (gpxFileToDisplay == null) {
-			getFavorites().setFavoritePointsFromGPXFile(null);
-		} else {
-			List<FavouritePoint> pts = new ArrayList<FavouritePoint>();
-			for (WptPt p : gpxFileToDisplay.points) {
-				FavouritePoint pt = new FavouritePoint();
-				pt.setLatitude(p.lat);
-				pt.setLongitude(p.lon);
-				if (p.name == null) {
-					p.name = "";
-				}
-				pt.setName(p.name);
-				pts.add(pt);
+		gpxFileToDisplay.proccessPoints();
+	}
+
+	public void clearGpxFavourites() {
+		getFavorites().removeGroup(GPX_GROUP);
+	}
+
+	public void setGpxFavourites(List<WptPt> wayPts) {
+		for (WptPt p : wayPts) {
+			final String name = p.name == null ? "" : p.name;
+			if (p.category == null)
+			{
+				getFavorites().addFavourite(new FavouritePoint(p.lat, p.lon, name, GPX_GROUP));
 			}
-			gpxFileToDisplay.proccessPoints();
-			getFavorites().setFavoritePointsFromGPXFile(pts);
+			else
+			{
+				getFavorites().saveFavourite(new FavouritePoint(p.lat, p.lon, name, p.category));
+			}
 		}
 	}
 

--- a/OsmAnd/src/net/osmand/plus/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/OsmandSettings.java
@@ -1341,6 +1341,18 @@ public class OsmandSettings {
 		}
 		return saveIntermediatePoints(ps,ds);
 	}
+
+	public boolean addIntermediatePoint(double latitude, double longitude, String historyDescription) {
+		List<LatLon> ps = getIntermediatePoints();
+		List<String> ds = getIntermediatePointDescriptions(ps.size());
+		ps.add( new LatLon(latitude, longitude));
+		ds.add( historyDescription);
+		if (historyDescription != null) {
+			SearchHistoryHelper.getInstance(ctx).addNewItemToHistory(latitude, longitude, historyDescription);
+		}
+		return saveIntermediatePoints(ps,ds);
+	}
+
 	public boolean deleteIntermediatePoint( int index) {
 		List<LatLon> ps = getIntermediatePoints();
 		List<String> ds = getIntermediatePointDescriptions(ps.size());

--- a/OsmAnd/src/net/osmand/plus/TargetPointsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/TargetPointsHelper.java
@@ -255,6 +255,20 @@ public class TargetPointsHelper {
 		updateRouteAndReferesh(updateRoute);
 	}
 	
+	public void navigateToPoints(List<LatLon> points){
+		removeAllWayPoints(false);
+		settings.clearPointToNavigate();
+		settings.clearIntermediatePoints();
+
+		for(int i=0;i<points.size()-1;i++) {
+			settings.addIntermediatePoint(points.get(i).getLatitude(), points.get(i).getLongitude(), null);
+		}
+		settings.setPointToNavigate(points.get(points.size()-1).getLatitude(), points.get(points.size()-1).getLongitude(), null);
+
+		readFromSettings(settings);
+		updateRouteAndReferesh(true);
+	}
+
 	public void setStartPoint(LatLon startPoint, boolean updateRoute, String name) {
 		if(startPoint != null) {
 			settings.setPointToStart(startPoint.getLatitude(), startPoint.getLongitude(), name);

--- a/OsmAnd/src/net/osmand/plus/activities/FavouritesActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/FavouritesActivity.java
@@ -241,7 +241,7 @@ public class FavouritesActivity extends OsmandExpandableListActivity {
 		builder.setPositiveButton(R.string.default_buttons_apply, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int which) {
-				boolean editied = helper.editFavouriteName(point, editText.getText().toString().trim(), cat.getText().toString());
+				boolean editied = helper.updateFavourite(point, editText.getText().toString().trim(), cat.getText().toString());
 				if (editied) {
 					favouritesAdapter.synchronizeGroups();
 					favouritesAdapter.sort(favoritesComparator);
@@ -409,7 +409,7 @@ public class FavouritesActivity extends OsmandExpandableListActivity {
 							name = p.name.substring(0, c);
 						}
 						FavouritePoint fp = new FavouritePoint(p.lat, p.lon, name, categoryName);
-						if (helper.addFavourite(fp)) {
+						if (helper.saveFavourite(fp)) {
 							publishProgress(fp);
 						}
 					}
@@ -454,7 +454,7 @@ public class FavouritesActivity extends OsmandExpandableListActivity {
 			final AsyncTask<Void, Void, String> exportTask = new AsyncTask<Void, Void, String>() {
 				@Override
 				protected String doInBackground(Void... params) {
-					return helper.exportFavorites();
+					return helper.exportFavourites();
 				}
 
 				@Override

--- a/OsmAnd/src/net/osmand/plus/activities/LocalIndexesActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/LocalIndexesActivity.java
@@ -15,6 +15,7 @@ import net.osmand.IndexConstants;
 import net.osmand.access.AccessibleToast;
 import net.osmand.plus.ContextMenuAdapter;
 import net.osmand.plus.ContextMenuAdapter.OnContextMenuClick;
+import net.osmand.plus.GPXUtilities;
 import net.osmand.plus.GPXUtilities.WptPt;
 import net.osmand.plus.OsmandPlugin;
 import net.osmand.plus.OsmandSettings;
@@ -159,14 +160,15 @@ public class LocalIndexesActivity extends OsmandExpandableListActivity {
 			@Override
 			public void onContextMenuClick(int itemId, int pos, boolean isChecked, DialogInterface dialog) {
 				if (info != null && info.getGpxFile() != null) {
-					WptPt loc = info.getGpxFile().findPointToShow();
+					final GPXUtilities.GPXFile gpxFile = info.getGpxFile();
+					WptPt loc = gpxFile.findPointToShow();
 					if (loc != null) {
 						settings.setMapLocationToShow(loc.lat, loc.lon, settings.getLastKnownMapZoom());
 					}
-					getMyApplication().setGpxFileToDisplay(info.getGpxFile(), false);
+					getMyApplication().setGpxFileToDisplay(gpxFile, false);
+					getMyApplication().setGpxFavourites(gpxFile.points);
 					MapActivity.launchMapActivityMoveToTop(LocalIndexesActivity.this);
 				}
-				
 			}
 		}).reg();
 	}

--- a/OsmAnd/src/net/osmand/plus/activities/MapActivityActions.java
+++ b/OsmAnd/src/net/osmand/plus/activities/MapActivityActions.java
@@ -162,7 +162,7 @@ public class MapActivityActions implements DialogProvider {
 				final FavouritesDbHelper helper = ((OsmandApplication) activity.getApplication()).getFavorites();
 				point.setName(editText.getText().toString().trim());
 				point.setCategory(cat.getText().toString().trim());
-				boolean added = helper.addFavourite(point);
+				boolean added = helper.saveFavourite(point);
 				if (added) {
 					AccessibleToast.makeText(activity, MessageFormat.format(
 							activity.getString(R.string.add_favorite_dialog_favourite_added_template), point.getName()), Toast.LENGTH_SHORT)
@@ -248,7 +248,7 @@ public class MapActivityActions implements DialogProvider {
 				SavingTrackHelper savingTrackHelper = mapActivity.getMyApplication().getSavingTrackHelper();
 				savingTrackHelper.insertPointData(latitude, longitude, System.currentTimeMillis(), name);
 				if(settings.SHOW_CURRENT_GPX_TRACK.get()) {
-					getMyApplication().getFavorites().addFavoritePointToGPXFile(new FavouritePoint(latitude, longitude, name, ""));
+					getMyApplication().getFavorites().addFavourite(new FavouritePoint(latitude, longitude, name, OsmandApplication.GPX_GROUP));
 				}
 				AccessibleToast.makeText(mapActivity, MessageFormat.format(getString(R.string.add_waypoint_dialog_added), name), Toast.LENGTH_SHORT)
 							.show();

--- a/OsmAnd/src/net/osmand/plus/activities/MapActivityLayers.java
+++ b/OsmAnd/src/net/osmand/plus/activities/MapActivityLayers.java
@@ -255,7 +255,8 @@ public class MapActivityLayers {
 				settings.SHOW_FAVORITES.set(isChecked);
 			} else if(itemId == R.string.layer_gpx_layer){
 				if(getApplication().getGpxFileToDisplay() != null){
-					getApplication().setGpxFileToDisplay(null, false);
+					getApplication().clearGpxFileToDisplay();
+					getApplication().clearGpxFavourites();
 				} else {
 					dialog.dismiss();
 					showGPXFileLayer(mapView);
@@ -392,6 +393,7 @@ public class MapActivityLayers {
 				
 				settings.SHOW_FAVORITES.set(true);
 				getApplication().setGpxFileToDisplay(toShow, toShow.showCurrentTrack);
+				getApplication().setGpxFavourites(toShow.points);
 				WptPt loc = toShow.findPointToShow();
 				if(loc != null){
 					mapView.getAnimatedDraggingThread().startMoving(loc.lat, loc.lon, 

--- a/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
@@ -62,6 +62,7 @@ public class GeoIntentActivity extends OsmandListActivity {
         final Intent intent = getIntent();
         if (intent != null)
         {
+			setIntent(null);
             final ProgressDialog progress = ProgressDialog.show(GeoIntentActivity.this, getString(R.string.searching), getString(R.string.searching_address));
             final GeoIntentTask task = new GeoIntentTask(progress, intent);
 

--- a/OsmAnd/src/net/osmand/plus/audionotes/AudioVideoNotesPlugin.java
+++ b/OsmAnd/src/net/osmand/plus/audionotes/AudioVideoNotesPlugin.java
@@ -967,7 +967,7 @@ public class AudioVideoNotesPlugin extends OsmandPlugin {
 
                     savingTrackHelper.insertPointData(rec.lat, rec.lon, System.currentTimeMillis(), name);
                     if (app.getSettings().SHOW_CURRENT_GPX_TRACK.get()) {
-                        app.getFavorites().addFavoritePointToGPXFile(new FavouritePoint(rec.lat, rec.lon, name, ""));
+                        app.getFavorites().addFavourite(new FavouritePoint(rec.lat, rec.lon, name, OsmandApplication.GPX_GROUP));
                     }
                 }
             }


### PR DESCRIPTION
- Allow to import favourites files via Intent
- When importing a gpx file, allow to import the file as waypoints (intermediates). Routes calculated by osmand can then be reused later on for routing.
- Fix for intent that got resent after 'back' or 'cancel'

Need to do some more tests, so not ready yet to merge. Let me know if you're ok with the idea/changes, and I'll carry out some 'real world' testing.

This allows e.g. to clean up tracks and make routes out of them. --> Import a track, show it, start navigation, export the navigation to file/mail and then import again with waypoints.
