### PR TITLE
set routing mode to current application mode

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/MapActivityActions.java
+++ b/OsmAnd/src/net/osmand/plus/activities/MapActivityActions.java
@@ -959,7 +959,7 @@ public class MapActivityActions implements DialogProvider {
 		}
 		routingHelper.clearCurrentRoute(null, new ArrayList<LatLon>());
 		routingHelper.setRoutePlanningMode(false);
-		//settings.APPLICATION_MODE.set(settings.DEFAULT_APPLICATION_MODE.get());
+		settings.APPLICATION_MODE.set(settings.DEFAULT_APPLICATION_MODE.get());
 		mapActivity.updateApplicationModeSettings();
 	}
 	


### PR DESCRIPTION
Fix a)
https://groups.google.com/forum/#!msg/osmand/CU4VQvU7J2U/t4JiFn4tTpEJ
AKA jira 100.

After destination is reached, default application mode applies, I didn't change this.

I'm not sure, if we want to set application mode to default application mode in stopNavigationWithoutConfirm(), so I commented it out:
//settings.APPLICATION_MODE.set(settings.DEFAULT_APPLICATION_MODE.get());
But I'm not sure about that.
