### PR TITLE
Fixed bug when user changes routing parameter and racalculation of route doesn't occur.

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/controls/MapRoutePreferencesControl.java
+++ b/OsmAnd/src/net/osmand/plus/views/controls/MapRoutePreferencesControl.java
@@ -296,9 +296,9 @@ public class MapRoutePreferencesControl extends MapControls {
 						//if short way that it should set valut to fast mode opposite of current
 						if (rp.routingParameter != null && rp.routingParameter.getId().equals("short_way")){
 							settings.FAST_ROUTE_MODE.set(!isChecked);
-						} else {
-							rp.setSelected(settings, isChecked);
 						}
+						rp.setSelected(settings, isChecked);
+
 						if(rp instanceof OtherLocalRoutingParameter) {
 							updateGpxRoutingParameter((OtherLocalRoutingParameter) rp);
 						}


### PR DESCRIPTION
Another small bug is this, I am not quite sure how to 100% reproduce it:

Calculate a route , then (while still on the route planning screen) press the transport mode button and change a route parameter (like change the "avoid motorways" flag, or the "shortest way" flag). It appears that in some cases the route gets re-calculated instantaneously, but with latest build I find many occurrences where this route-recalculation is not automatically triggered, i.e. you have to manually stop routing (X-button) and then re-start it to see the new route for the new parameter. I think automatic route-recalculation after a parameter change used to work ok, and was broken in the last 2 weeks.

It takes several tries to reproduce, the bug does not always seem to occur (Maybe not for all parameters).

Best, Hardy
