### PR TITLE
Don't match space, since it deletes properties

### DIFF
--- a/OsmAnd/build.xml
+++ b/OsmAnd/build.xml
@@ -78,7 +78,7 @@
 			<then>
 				<property name="package.name" value="net.osmand.sherpafy" />
 				<property name="app.name" value="Sherpafy" />
-				<replaceregexp file="AndroidManifest.xml" match='"@drawable/(.*)"' replace='"@drawable/icon_sherpafy"' byline="true" />
+				<replaceregexp file="AndroidManifest.xml" match='"@drawable/([^\s]*)"' replace='"@drawable/icon_sherpafy"' byline="true" />
 			</then>
 		</if>
 		<if>
@@ -88,7 +88,7 @@
   			<then>
   			    <property name="package.name" value="net.osmand" />
 				<property name="app.name" value="OsmAnd" />
-				<replaceregexp file="AndroidManifest.xml" match='"@drawable/(.*)"' replace='"@drawable/icon_free"' byline="true" />
+				<replaceregexp file="AndroidManifest.xml" match='"@drawable/([^\s]*)"' replace='"@drawable/icon_free"' byline="true" />
   		    </then>
   		</if>
 		<if>
@@ -98,7 +98,7 @@
   				<then>
   				    <property name="package.name" value="net.osmand.plus" />
 			    	<property name="app.name" value="OsmAnd+" />
-			    	<replaceregexp file="AndroidManifest.xml" match='"@drawable/(.*)"' replace='"@drawable/icon"' byline="true" />
+			    	<replaceregexp file="AndroidManifest.xml" match='"@drawable/([^\s]*)"' replace='"@drawable/icon"' byline="true" />
   			    </then>
   		</if>
 		<if>


### PR DESCRIPTION
It is dangerous to use `(.*)`, because it matches several properties within the same line.
For example
`"@drawable/(.*)"`
matches
`"@drawable/icon" android:label="@string/app_name"`
thus
`android:label="@string/app_name"`
will be removed, leading to this issue:
https://groups.google.com/forum/#!topic/osmand/g05wYLexF00
