### PR TITLE
Remove wrong substring

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
@@ -476,8 +476,7 @@ public class GeoIntentActivity extends OsmandListActivity {
 					.replaceAll(" ", ",");
 			System.out.println(query);
 			//String is split on each comma
-			String[] s = query.substring(query
-					.indexOf("q=") + 2).split(",");
+			String[] s = query.split(",");
 			
 			elements = new ArrayList<String>();
 			for (int i = 0;  i<s.length; i++) {


### PR DESCRIPTION
One char is lost, because "q=" is already removed by
`final String query = schemeSpecific.substring("0,0?q=".length());`
thus
`query.indexOf("q=")`
returns -1.
