### PR TITLE
Add support for reading in lanes that have multiple turns

### DIFF
--- a/OsmAnd-java/src/net/osmand/router/RouteResultPreparation.java
+++ b/OsmAnd-java/src/net/osmand/router/RouteResultPreparation.java
@@ -624,11 +624,56 @@ public class RouteResultPreparation {
 
 		if (t.getLanes().length != lanes) {
 			// The turn:lanes don't easily match up to the target road.
-			// TODO: Add support for lanes that can go in multiple directions
-			return;
+			List<Integer> sourceLanes = new ArrayList<Integer>();
+
+			int outgoingLanesIndex = 0;
+			int sourceLanesIndex = 0;
+
+			while (outgoingLanesIndex < t.getLanes().length && sourceLanesIndex < lanes) {
+				if (splitLaneOptions[sourceLanesIndex].contains(";")) {
+					// Two or more allowed turns for this lane
+					int options = countOccurrences(splitLaneOptions[sourceLanesIndex], ';');
+					if (options == 1) {
+						if (outgoingLanesIndex + 1 >= t.getLanes().length) {
+							// Likely an error in data
+							return;
+						}
+						int usability = t.getLanes()[outgoingLanesIndex] | t.getLanes()[outgoingLanesIndex + 1];
+						sourceLanes.add(usability);
+						outgoingLanesIndex += 2;
+						sourceLanesIndex++;
+					} else {
+						// Not supported
+						return;
+					}
+				} else {
+					// Only one allowed turn; behave normally
+					sourceLanes.add(t.getLanes()[outgoingLanesIndex]);
+					outgoingLanesIndex++;
+					sourceLanesIndex++;
+				}
+			}
+
+			int[] newLanes = new int[sourceLanes.size()];
+
+			for (int i = 0; i < sourceLanes.size(); i++) {
+				newLanes[i] = sourceLanes.get(i);
+			}
+
+			t.setLanes(newLanes);
 		}
 
 		assignTurns(splitLaneOptions, t);
+	}
+
+	private int countOccurrences(String haystack, char needle) {
+	    int count = 0;
+		for (int i = 0; i < haystack.length(); i++) {
+			if (haystack.charAt(i) == needle) {
+				count++;
+			}
+		}
+		return count;
 	}
 
 	private void assignTurns(String[] splitLaneOptions, TurnType t) {


### PR DESCRIPTION
At this point, there may be cases where all the displayed lanes are green. For example, if you're taking a left turn at a standard (90-degree) intersection, and there's a right-turn island, then for the segment leading up to the island, all displayed lanes will be green.

This will be fixed later when support is added for having 90-degree turns with `turn:lanes` info displayed and when the turn lane information is copied to nearby intersections before the main turning intersection.
