### PR TITLE
Fix error caused by missing lane tags.

### DIFF
--- a/OsmAnd-java/src/net/osmand/router/RouteResultPreparation.java
+++ b/OsmAnd-java/src/net/osmand/router/RouteResultPreparation.java
@@ -518,7 +518,9 @@ public class RouteResultPreparation {
 						if(attached.getObject().getOneway() == 0) {
 							lns = countLanes(attached, lns);
 						}
-						if (lns > 0) {
+						if (lns <= 0) {
+							right += 1;
+						} else {
 							right += lns;
 						}
 						speak = speak || rsSpeakPriority <= speakPriority;
@@ -528,7 +530,9 @@ public class RouteResultPreparation {
 						if(attached.getObject().getOneway() == 0) {
 							lns = countLanes(attached, lns);
 						}
-						if (lns > 0) {
+						if (lns <= 0) {
+							left += 1;
+						} else {
 							left += lns;
 						}
 						speak = speak || rsSpeakPriority <= speakPriority;


### PR DESCRIPTION
When there is both a slight left turn and a slight right turn possible at a point, and neither of the outbound roads have a lanes tag, then an ArrayIndexOutOfBoundsException is thrown.

This fix sets a default of one lane for the outbound roads.
