### PR TITLE
Add support for determining the actual turn to be taken based on the lanes highlighted

### DIFF
--- a/OsmAnd-java/src/net/osmand/router/RouteResultPreparation.java
+++ b/OsmAnd-java/src/net/osmand/router/RouteResultPreparation.java
@@ -831,6 +831,15 @@ public class RouteResultPreparation {
 			derivedTurnType.setLanes(t.getLanes());
 			derivedTurnType.setSkipToSpeak(t.isSkipToSpeak());
 			t = derivedTurnType;
+
+			// Because only the primary turn is displayed, if the turn to be taken is currently set as the secondary turn, then that needs to be switched around.
+			for (int i = 0; i < t.getLanes().length; i++) {
+				if (TurnType.getSecondaryTurn(t.getLanes()[i]) == t.getValue()) {
+					int temp = TurnType.getSecondaryTurn(t.getLanes()[i]);
+					t.setSecondaryTurn(i, TurnType.getPrimaryTurn(t.getLanes()[i]));
+					t.setPrimaryTurn(i, temp);
+				}
+			}
 		}
 
 		return t;


### PR DESCRIPTION
This code looks at the lanes that are highlighted (and, to some extent, not highlighted), and derives the appropriate turn type based on the marking there. For example, if the current turn type is a slight-left turn (based on road angles), but `turn:lanes` says that the highlighted lane is for a left turn, then the turn type will be changed to a left turn.

This hasn't been tested yet, but, for the most part, it should work.
