### PR TITLE
fix route recalculation and screen update issue on MapActivity resume

### DIFF
--- a/OsmAnd/src/net/osmand/plus/TargetPointsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/TargetPointsHelper.java
@@ -124,7 +124,15 @@ public class TargetPointsHelper {
 		return intermediatePoints;
 	}
 	
-
+	public List<LatLon> getIntermediatePointsLatLon() {
+		List<LatLon> intermediatePointsLatLon = new ArrayList<LatLon>();
+		
+		for (TargetPoint t : intermediatePoints) {
+			intermediatePointsLatLon.add(t.point);
+		}
+		
+		return intermediatePointsLatLon;
+	}
 
 	public List<TargetPoint> getIntermediatePointsWithTarget() {
 		List<TargetPoint> res = new ArrayList<TargetPoint>();

--- a/OsmAnd/src/net/osmand/plus/activities/MapActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/MapActivity.java
@@ -312,9 +312,7 @@ public class MapActivity extends AccessibleActivity implements
 	@Override
 	protected void onResume() {
 		super.onResume();
-		if (wakeLock != null) {
-			return;
-		}
+
 		cancelNotification();
 		//fixing bug with action bar appearing on android 2.3.3
 		if (getSupportActionBar() != null){
@@ -356,8 +354,8 @@ public class MapActivity extends AccessibleActivity implements
 		TargetPointsHelper targets = app.getTargetPointsHelper();
 		RoutingHelper routingHelper = app.getRoutingHelper();
 		if (routingHelper.isFollowingMode() && (
-				!Algorithms.objectEquals(targets.getPointToNavigate(), routingHelper.getFinalLocation() )||
-				!Algorithms.objectEquals(targets.getIntermediatePoints(), routingHelper.getIntermediatePoints())
+				!Algorithms.objectEquals(targets.getPointToNavigate().point, routingHelper.getFinalLocation() )||
+				!Algorithms.objectEquals(targets.getIntermediatePointsLatLon(), routingHelper.getIntermediatePoints())
 				)) {
 			targets.updateRouteAndReferesh(true);
 		}


### PR DESCRIPTION
In this commit https://github.com/osmandapp/Osmand/commit/4e848859d7308d256483bfde98ced5d320ab7f7c, the return type of getIntermediatePoints() and getPointToNavigate() has been changed from LatLon to TargetPoint.
Thus the Algorithms.objectEquals() checks always return false, because the type is different now (LatLon vs. TargetPoint).

See also:
https://github.com/osmandapp/Osmand/pull/935
