### PR TITLE
Only turn off the screen if map is shown (wake on voice)

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/MapActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/MapActivity.java
@@ -839,7 +839,7 @@ public class MapActivity extends AccessibleActivity implements
 		
 		if (mDevicePolicyManager != null && mDeviceAdmin != null) {
 			final Integer screenPowerSave = settings.WAKE_ON_VOICE_INT.get();
-			if (screenPowerSave > 0) {
+			if (screenPowerSave > 0 && settings.MAP_ACTIVITY_ENABLED.get()) {
 				if (mDevicePolicyManager.isAdminActive(mDeviceAdmin)) {
 					try {
 						mDevicePolicyManager.lockNow();


### PR DESCRIPTION
Don't turn screen of (via "wake on voice"), if the map is not shown (for example OsmAnd is in background or user is in OsmAnd menu).
