### PR TITLE
Tolerate missing jnigraphics lib on Lollipop

### DIFF
--- a/OsmAnd/src/net/osmand/plus/render/NativeOsmandLibrary.java
+++ b/OsmAnd/src/net/osmand/plus/render/NativeOsmandLibrary.java
@@ -52,10 +52,8 @@ public class NativeOsmandLibrary extends NativeLibrary {
 							try {
 								System.loadLibrary("jnigraphics");
 							} catch( UnsatisfiedLinkError e ) {
-								// tolerate missing jnigraphics on Lollipop
+								// handle "Shared library already opened" error
 								log.debug("Failed to load jnigraphics: " + e); //$NON-NLS-1$
-								if (android.os.Build.VERSION.SDK_INT <= 20)
-									throw e;
 							}
 						}
 						final String libCpuSuffix = cpuHasNeonSupport() ? "_neon" : "";


### PR DESCRIPTION
This change is necesssary to make the native renderer work on Nexus 4 with Android 5.0 Lollipop.

Otherwise, OsmAnd falls back to the Java renderer. The most visible difference (apart from slowdown) is that the Java renderer currently mixes up various map name languages, regardless of user preferences.
