### PR TITLE
Fix null pointer

### DIFF
--- a/OsmAnd/src/net/osmand/plus/routing/VoiceRouter.java
+++ b/OsmAnd/src/net/osmand/plus/routing/VoiceRouter.java
@@ -77,7 +77,7 @@ public class VoiceRouter {
     public interface VoiceMessageListener {
     	void onVoiceMessage();
     }
-    private ConcurrentHashMap<VoiceMessageListener, Void> voiceMessageListeners;
+    private ConcurrentHashMap<VoiceMessageListener, Integer> voiceMessageListeners;
     
 	public VoiceRouter(RoutingHelper router, final OsmandSettings settings, CommandPlayer player) {
 		this.router = router;
@@ -85,7 +85,7 @@ public class VoiceRouter {
         this.settings = settings;
 
 		empty = new Struct("");
-		voiceMessageListeners = new ConcurrentHashMap<VoiceRouter.VoiceMessageListener, Void>();
+		voiceMessageListeners = new ConcurrentHashMap<VoiceRouter.VoiceMessageListener, Integer>();
 	}
 	
 	public void setPlayer(CommandPlayer player) {
@@ -842,7 +842,7 @@ public class VoiceRouter {
 	}
 
 	public void addVoiceMessageListener(VoiceMessageListener voiceMessageListener) {
-		voiceMessageListeners.put(voiceMessageListener, null);
+		voiceMessageListeners.put(voiceMessageListener, 0);
 	}
 	
 	public void removeVoiceMessageListener(VoiceMessageListener voiceMessageListener) {


### PR DESCRIPTION
ConcurrentHashMap does not allow null to be used as a key or value.

> Exception occured in thread Thread[main,5,main] : 
> java.lang.RuntimeException: Unable to stop activity {net.osmand.plus/net.osmand.plus.activities.MapActivity}: java.lang.NullPointerException
>   at android.app.ActivityThread.handleSleeping(ActivityThread.java:3461)
>   at android.app.ActivityThread.access$2900(ActivityThread.java:163)
>   at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1445)
>   at android.os.Handler.dispatchMessage(Handler.java:102)
>   at android.os.Looper.loop(Looper.java:157)
>   at android.app.ActivityThread.main(ActivityThread.java:5335)
>   at java.lang.reflect.Method.invokeNative(Native Method)
>   at java.lang.reflect.Method.invoke(Method.java:515)
>   at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1265)
>   at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1081)
>   at dalvik.system.NativeStart.main(Native Method)
> Caused by: java.lang.NullPointerException
>   at java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:1017)
>   at net.osmand.plus.routing.VoiceRouter.addVoiceMessageListener(VoiceRouter.java:845)
>   at net.osmand.plus.helpers.WakeLockHelper.onStop(WakeLockHelper.java:79)
>   at net.osmand.plus.activities.MapActivity.onStop(MapActivity.java:592)
>   at android.app.Instrumentation.callActivityOnStop(Instrumentation.java:1230)
>   at android.app.Activity.performStop(Activity.java:5534)
>   at android.app.ActivityThread.handleSleeping(ActivityThread.java:3458)
>   ... 10 more
