### PR TITLE
Turn display fix

### DIFF
--- a/OsmAnd-java/src/net/osmand/router/TurnType.java
+++ b/OsmAnd-java/src/net/osmand/router/TurnType.java
@@ -162,12 +162,13 @@ public class TurnType {
 		this.lanes = lanes;
 	}
 	
-	// Note that there is no "weight" or ordering between the primary and secondary turns.
+	// Note that the primary turn will be the one displayed on the map.
 	public static void setPrimaryTurn(int[] lanes, int lane, int turnType) {
 		lanes[lane] |= (turnType << 1);
 	}
 	
 	public void setPrimaryTurn(int lane, int turnType) {
+		lanes[lane] &= ~(15 << 1);
 		lanes[lane] |= (turnType << 1);
 	}
 	
@@ -177,6 +178,7 @@ public class TurnType {
 	}
 
 	public static void setSecondaryTurn(int[] lanes, int lane, int turnType) {
+		lanes[lane] &= ~(15 << 5);
 		lanes[lane] |= (turnType << 5);
 	}
 	


### PR DESCRIPTION
When setting a new primary or secondary turn, clear the bits from the currently-set turn first.

This issue occurs when, for example, a lane can go both straight or slight-right, and the required turn is slight-right. This would then cause a sharp-right turn to be displayed. (because the bits are just OR'd together, so you would have `001 | 110 = 111`)

Also, update the comment on the weight between the primary and secondary turns.
