### PR TITLE
Disambiguate "v1.9 routing" strings in strings.xml

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -18,8 +18,8 @@
 	<string name="show_railway_warnings">Show railway warnings</string>
 	<string name="show_pedestrian_warnings">Show pedestrian warnings</string>
     <string name="rendering_value_americanRoadAtlas_name">American Road Atlas</string>
-    <string name="routing_attr_no_new_routing_name">Do not use v1.9 routing</string>
-    <string name="routing_attr_no_new_routing_description">Do not use v1.9 routing</string>
+    <string name="routing_attr_no_new_routing_name">No v1.9 routing rules</string>
+    <string name="routing_attr_no_new_routing_description">Do not use new routing rules from v1.9</string>
     <string name="dash_download_msg_none">Do you want to download any offline map?</string>
     <string name="dash_download_msg">You have %1$s maps downloaded</string>
     <string name="dash_download_new_one">Download New Map</string>


### PR DESCRIPTION
There are some localizers wondering about these strings at
https://hosted.weblate.org/projects/osmand/main/sk/translate/?sid=94cc6768-8491-11e4-a0db-5254000d9bae&offset=1#comments
Would this wording be better?
