### PR TITLE
Disambiguate "v1.9 routing" strings in strings.xml

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -18,8 +18,8 @@
 	<string name="show_railway_warnings">Show railroad crossings</string>
 	<string name="show_pedestrian_warnings">Show pedestrian crosswalks</string>
     <string name="rendering_value_americanRoadAtlas_name">American road atlas</string>
-    <string name="routing_attr_no_new_routing_name">Do not use v1.9 routing</string>
-    <string name="routing_attr_no_new_routing_description">Do not use v1.9 routing</string>
+    <string name="routing_attr_no_new_routing_name">No v1.9 routing rules</string>
+    <string name="routing_attr_no_new_routing_description">Do not use routing rules introduced in v1.9</string>
     <string name="dash_download_msg_none">Do you want to download offline maps?</string>
     <string name="dash_download_msg">You have downloaded %1$s maps</string>
     <string name="dash_download_new_one">Download new map</string>


### PR DESCRIPTION
There are some localizers wondering about these strings at
https://hosted.weblate.org/projects/osmand/main/sk/translate/?type=comments
Would this wording be better?
