### PR TITLE
Translation mistake fixed

### DIFF
--- a/OsmAnd/res/values-ru/phrases.xml
+++ b/OsmAnd/res/values-ru/phrases.xml
@@ -595,7 +595,7 @@
 
 	<string name="poi_military_airfield">Военный аэродром</string>
 	<string name="poi_military_bunker">Военный бункер</string>
-	<string name="poi_military_barracks">Бараки</string>
+	<string name="poi_military_barracks">Казармы</string>
 	<string name="poi_military_danger_area">Опасная зона</string>
 	<string name="poi_military_range">Военное стрельбище</string>
 	<string name="poi_military_naval_base">Военно-морская база</string>


### PR DESCRIPTION
Barracks does not mean _бараки_ [ba'raki], it means _казармы_ [ka'zarmɨ].
