### PR TITLE
remove references to non-existant drawable resources

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/search/SearchPoiFilterActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/search/SearchPoiFilterActivity.java
@@ -156,8 +156,6 @@ public class SearchPoiFilterActivity extends SherlockListFragment  implements Se
 			} else {
 				if(RenderingIcons.containsBigIcon(model.getSimplifiedId())) {
 					icon.setImageDrawable(RenderingIcons.getBigIcon(getActivity(), model.getSimplifiedId()));
-				} else {
-					icon.setImageResource(R.drawable.mx_user_defined);
 				}
 			}
 			ImageView editIcon = (ImageView) row.findViewById(R.id.folder_edit_icon);

--- a/OsmAnd/src/net/osmand/plus/helpers/WaypointHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/WaypointHelper.java
@@ -683,11 +683,7 @@ public class WaypointHelper {
 				return FavoriteImageDrawable.getOrCreate(uiCtx, point.getColor());
 			} else if(type == ALARMS) {
 				//assign alarm list icons manually for now
-				if(((AlarmInfo) point).getType().toString() == "SPEED_CAMERA") {
-					return uiCtx.getResources().getDrawable(R.drawable.mx_highway_speed_camera);
-				} else if(((AlarmInfo) point).getType().toString() == "BORDER_CONTROL") {
-					return uiCtx.getResources().getDrawable(R.drawable.mx_barrier_border_control);
-				} else	if(((AlarmInfo) point).getType().toString() == "RAILWAY") {
+				if(((AlarmInfo) point).getType().toString() == "RAILWAY") {
 					if(app.getSettings().DRIVING_REGION.get().americanSigns){
 						return uiCtx.getResources().getDrawable(R.drawable.list_warnings_railways_us);
 					} else {
@@ -699,8 +695,6 @@ public class WaypointHelper {
 					} else {
 						return uiCtx.getResources().getDrawable(R.drawable.list_warnings_traffic_calming);
 					}
-				} else if(((AlarmInfo) point).getType().toString() == "TOLL_BOOTH") {
-					return uiCtx.getResources().getDrawable(R.drawable.mx_barrier_toll_booth);
 				} else if(((AlarmInfo) point).getType().toString() == "STOP") {
 					return uiCtx.getResources().getDrawable(R.drawable.list_stop);
 				} else if(((AlarmInfo) point).getType().toString() == "PEDESTRIAN") {

--- a/OsmAnd/src/net/osmand/plus/views/RouteLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/RouteLayer.java
@@ -124,12 +124,6 @@ public class RouteLayer extends OsmandMapLayer {
 		path.reset();
 		if (helper.getFinalLocation() != null && helper.getRoute().isCalculated()) {
 			updatePaints(settings, tileBox);
-			if(coloredArrowUp == null) {
-				Bitmap originalArrowUp = BitmapFactory.decodeResource(view.getResources(), R.drawable.h_arrow, null);
-				coloredArrowUp = originalArrowUp;
-//				coloredArrowUp = Bitmap.createScaledBitmap(originalArrowUp, originalArrowUp.getWidth() * 3 / 4,	
-//						originalArrowUp.getHeight() * 3 / 4, true);
-			}
 			int w = tileBox.getPixWidth();
 			int h = tileBox.getPixHeight();
 			Location lastProjection = helper.getLastProjection();


### PR DESCRIPTION
This probably isn't the correct fix, but this is necessary to build straight from git.  Perhaps these drawable resources were not committed and pushed?  These references were mostly added in 4060c772f7ead6f7bf6a422668ab460a20b10263 by @sonora 

This just removes code that references drawable resources that do not exist
at all in this git repo.  Building OsmAnd with the current version of
Android Studio refused to run the app because of the errors related to
these missing resources.

```
:OsmAnd:compileFreeGoogleplayArmv5DebugJava
/media/share/code/osmandapp/Osmand/OsmAnd/src/net/osmand/plus/helpers/WaypointHelper.java:687: error: cannot find symbol
                    return uiCtx.getResources().getDrawable(R.drawable.mx_highway_speed_camera);
                                                                      ^
  symbol:   variable mx_highway_speed_camera
  location: class drawable
/media/share/code/osmandapp/Osmand/OsmAnd/src/net/osmand/plus/helpers/WaypointHelper.java:689: error: cannot find symbol
                    return uiCtx.getResources().getDrawable(R.drawable.mx_barrier_border_control);
                                                                      ^
  symbol:   variable mx_barrier_border_control
  location: class drawable
/media/share/code/osmandapp/Osmand/OsmAnd/src/net/osmand/plus/helpers/WaypointHelper.java:703: error: cannot find symbol
                    return uiCtx.getResources().getDrawable(R.drawable.mx_barrier_toll_booth);
                                                                      ^
  symbol:   variable mx_barrier_toll_booth
  location: class drawable
/media/share/code/osmandapp/Osmand/OsmAnd/src/net/osmand/plus/views/RouteLayer.java:128: error: cannot find symbol
                Bitmap originalArrowUp = BitmapFactory.decodeResource(view.getResources(), R.drawable.h_arrow, null);
                                                                                                     ^
  symbol:   variable h_arrow
  location: class drawable
/media/share/code/osmandapp/Osmand/OsmAnd/src/net/osmand/plus/activities/search/SearchPoiFilterActivity.java:160: error: cannot find symbol
                    icon.setImageResource(R.drawable.mx_user_defined);
                                                    ^
  symbol:   variable mx_user_defined
  location: class drawable
```
