### PR TITLE
Update URL parsing to include OSM shortlinks, Baidu, Apple, AutoNavi

### DIFF
--- a/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
+++ b/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
@@ -328,6 +328,19 @@ public class GeoPointParserUtil {
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
+        // http://www.amap.com/#!poi!!q=38.174596,114.995033|2|%E5%AE%BE%E9%A6%86&radius=1000
+		z = 13; // amap uses radius, so 1000m is roughly zoom level 13
+		url = "http://www.amap.com/#!poi!!q=" + dlat + "," + dlon + "|2|%E5%AE%BE%E9%A6%86&radius=1000";
+		System.out.println("\nurl: " + url);
+		actual = GeoPointParserUtil.parse(url);
+		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
+
+		z = GeoParsedPoint.NO_ZOOM;
+		url = "http://www.amap.com/?q=" + dlat + "," + dlon + ",%E4%B8%8A%E6%B5v%B7%E5%B8%82%E6%B5%A6%E4%B8%9C%E6%96%B0%E5%8C%BA%E4%BA%91%E5%8F%B0%E8%B7%AF8086";
+		System.out.println("\nurl: " + url);
+		actual = GeoPointParserUtil.parse(url);
+		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
+
         /* URLs straight from various services, instead of generated here */
         
         String urls[] = {
@@ -338,13 +351,18 @@ public class GeoPointParserUtil {
             "https://www.openstreetmap.org/#map=6/33.907/34.662",
             "https://www.openstreetmap.org/?mlat=49.56275939941406&mlon=17.291107177734375#map=8/49.563/17.291",
             "https://www.google.com/maps/place/Wild+Herb+Market/@33.32787,-105.66291,14z/data=!4m5!1m2!2m1!1sfood!3m1!1s0x86e1ce2079e1f94b:0x1d7460465dcaf3ed",
+            "http://www.amap.com/#!poi!!q=38.174596,114.995033,%E6%B2%B3%E5%8C%97%E7%9C%81%E7%9F%B3%E5%AE%B6%E5%BA%84%E5%B8%82%E6%97%A0%E6%9E%81%E5%8E%BF",
+            "http://wb.amap.com/?p=B013706PJN,38.179456,114.98577,%E6%96%B0%E4%B8%9C%E6%96%B9%E5%A4%A7%E9%85%92%E5%BA%97(%E4%BF%9D%E9%99%A9%E8%8A%B1...,%E5%BB%BA%E8%AE%BE%E8%B7%AF67%E5%8F%B7",
+            "http://www.amap.com/#!poi!!q=38.179456,114.98577|3|B013706PJN",
+            "http://www.amap.com/#!poi!!q=38.174596,114.995033|2|%E5%AE%BE%E9%A6%86&radius=1000",
+            "http://www.amap.com/?p=B013704EJT,38.17914,114.976337,%E6%97%A0%E6%9E%81%E5%8E%BF%E4%BA%BA%E6%B0%91%E6%94%BF%E5%BA%9C,%E5%BB%BA%E8%AE%BE%E4%B8%9C%E8%B7%AF12%E5%8F%B7",
         };
 
         for (String u : urls) {
             System.out.println("url: " + u);
             actual = GeoPointParserUtil.parse(u);
             assert(actual != null);
-            System.out.println("Passed!");
+            System.out.println("Properly parsed!");
         }
 	}
 
@@ -398,7 +416,16 @@ public class GeoPointParserUtil {
 	 * @return {@link GeoParsedPoint}
 	 */
 	public static GeoParsedPoint parse(final String uriString) {
-		final URI uri = URI.create(uriString.replaceAll("\\s+", "+").replaceAll("%20", "+").replaceAll("%2C", ","));
+        URI uri;
+        try {
+            // amap.com uses | in their URLs, which is an illegal character
+            uri = URI.create(uriString.replaceAll("\\s+", "+")
+                             .replaceAll("%20", "+")
+                             .replaceAll("%2C", ",")
+                             .replaceAll("\\|", ";"));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
 
         String scheme = uri.getScheme();
         if (scheme == null)
@@ -499,6 +526,32 @@ public class GeoPointParserUtil {
                     Matcher matcher = p.matcher(uri.getQuery());
                     if (matcher.matches()) {
                         return new GeoParsedPoint(matcher.group(1), matcher.group(2), matcher.group(3));
+                    }
+                } else if (host.endsWith(".amap.com")) {
+                    /* amap (mis)uses the Fragment, which is not included in the Scheme Specific Part,
+                     * so instead we make a custom "everything but the Authority subString */
+                    // +4 for the :// and the /
+                    final String subString = uri.toString().substring(scheme.length() + host.length() + 4);
+                    Pattern p;
+                    Matcher matcher;
+                    final String[] patterns = {
+                        /* though this looks like Query String, it is also used as part of the Fragment */
+                        ".*q=([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?).*&radius=(\\d+).*",
+                        ".*q=([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?).*",
+                        ".*p=(?:[A-Z0-9]+),([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?).*", };
+                    for (int i = 0; i < patterns.length; i++) {
+                        p = Pattern.compile(patterns[i]);
+                        matcher = p.matcher(subString);
+                        if (matcher.matches()) {
+                            if (matcher.groupCount() == 3) {
+                                // amap uses radius in meters, so do rough conversion into zoom level
+                                float radius = Float.valueOf(matcher.group(3));
+                                long zoom = Math.round(23. - Math.log(radius)/Math.log(2.0));
+                                return new GeoParsedPoint(matcher.group(1), matcher.group(2), String.valueOf(zoom));
+                            } else if (matcher.groupCount() == 2) {
+                                return new GeoParsedPoint(matcher.group(1), matcher.group(2));
+                            }
+                        }
                     }
                 } else if (host.endsWith("openstreetmap.de")) {
                     Pattern p = Pattern.compile("(?:.*)zoom=(\\d{1,2})&lat=([+-]?\\d+(?:\\.\\d+)?)&lon=([+-]?\\d+(?:\\.\\d+)?)(?:.*)");

--- a/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
+++ b/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
@@ -123,6 +123,7 @@ public class GeoPointParserUtil {
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// http://openstreetmap.org/#map=11/34/-106
+		z = 11;
 		url = "http://openstreetmap.org/#map=" + z + "/" + ilat + "/" + ilon;
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
@@ -146,14 +147,33 @@ public class GeoPointParserUtil {
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
-        // https://www.openstreetmap.org/?mlat=49.56275939941406&mlon=17.291107177734375#map=11/49.563/17.291
+		// https://www.openstreetmap.org/?mlat=34.993933029174805&mlon=-106.61568069458008#map=11/34.99393/-106.61568
 		url = "https://www.openstreetmap.org/?mlat=" + longLat + "&mlon=" + longLon
             + "#map=" + z + "/" + dlat + "/" + dlon;
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
-		assertGeoPoint(actual, new GeoParsedPoint(longLat, longLon, z));
+		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
+
+		// https://wiki.openstreetmap.org/wiki/Shortlink
+
+		// http://osm.org/go/TyFSutZ-?m=
+		// https://www.openstreetmap.org/?mlat=34.993933029174805&mlon=-106.61568069458008#map=15/34.99393/-106.61568
+		z = 15;
+		url = "http://osm.org/go/TyFYuF6P--?m=";
+		System.out.println("url: " + url);
+		actual = GeoPointParserUtil.parse(url);
+		assertApproximateGeoPoint(actual, new GeoParsedPoint(longLat, longLon, z));
+
+		// http://osm.org/go/TyFS--
+		// http://www.openstreetmap.org/#map=3/34.99/-106.70
+		z = 3;
+		url = "http://osm.org/go/TyFS--";
+		System.out.println("url: " + url);
+		actual = GeoPointParserUtil.parse(url);
+		assertApproximateGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// http://openstreetmap.de/zoom=11&lat=34&lon=-106
+		z = 11;
 		url = "http://openstreetmap.de/zoom=" + z + "&lat=" + ilat + "&lon=" + ilon;
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
@@ -344,6 +364,10 @@ public class GeoPointParserUtil {
         /* URLs straight from various services, instead of generated here */
         
         String urls[] = {
+			"https://openstreetmap.org/go/0LQ127-?m",
+			"http://osm.org/go/0LQ127-?m",
+			"http://osm.org/go/0EEQjE==",
+			"http://osm.org/go/0EEQjEEb",
             "https://www.openstreetmap.org/#map=0/0/0",
             "https://www.openstreetmap.org/#map=0/180/180",
             "https://www.openstreetmap.org/#map=0/-180/-180",
@@ -366,6 +390,17 @@ public class GeoPointParserUtil {
         }
 	}
 
+	private static boolean areCloseEnough(int a, int b) {
+		return a == b;
+	}
+
+	private static boolean areCloseEnough(double a, double b, long howClose) {
+		long aRounded = (long) Math.round(a * Math.pow(10, howClose));
+		long bRounded = (long) Math.round(b * Math.pow(10, howClose));
+		System.out.println("areCloseEnough: " + aRounded + ", " + bRounded);
+		return aRounded == bRounded;
+	}
+
 	private static void assertGeoPoint(GeoParsedPoint actual, GeoParsedPoint expected) {
 		if (expected.getQuery() != null) {
 			if (!expected.getQuery().equals(actual.getQuery()))
@@ -380,10 +415,37 @@ public class GeoPointParserUtil {
 							+ eName);
 				}
 			}
-			if (eLat != aLat) {
+			if (!areCloseEnough(eLat, aLat, 5)) {
 				throw new RuntimeException("Latitude is not equal; actual=" + aLat + ", expected=" + eLat);
 			}
-			if (eLon != aLon) {
+			if (!areCloseEnough(eLon, aLon, 5)) {
+				throw new RuntimeException("Longitude is not equal; actual=" + aLon + ", expected=" + eLon);
+			}
+			if (eZoom != aZoom) {
+				throw new RuntimeException("Zoom is not equal; actual=" + aZoom + ", expected=" + eZoom);
+			}
+		}
+		System.out.println("Passed!");
+	}
+
+	private static void assertApproximateGeoPoint(GeoParsedPoint actual, GeoParsedPoint expected) {
+		if (expected.getQuery() != null) {
+			if (!expected.getQuery().equals(actual.getQuery()))
+				throw new RuntimeException("Query param not equal");
+		} else {
+			double aLat = actual.getLatitude(), eLat = expected.getLatitude(), aLon = actual.getLongitude(), eLon = expected.getLongitude();
+			int aZoom = actual.getZoom(), eZoom = expected.getZoom();
+			String aName = actual.getName(), eName = expected.getName();
+			if (eName != null) {
+				if (!aName.equals(eName)) {
+					throw new RuntimeException("Point name\\capture is not equal; actual=" + aName + ", expected="
+							+ eName);
+				}
+			}
+			if (((int)eLat) != ((int)aLat)) {
+				throw new RuntimeException("Latitude is not equal; actual=" + aLat + ", expected=" + eLat);
+			}
+			if (((int)eLon) != ((int)aLon)) {
 				throw new RuntimeException("Longitude is not equal; actual=" + aLon + ", expected=" + eLon);
 			}
 			if (eZoom != aZoom) {
@@ -449,10 +511,12 @@ public class GeoPointParserUtil {
                     Pattern p;
                     Matcher matcher;
                     String path = uri.getPath();
-                    if ("go".equals(path)) { // short URL form
-                        // TODO decode OSM short URL and delete this:
-                        p = Pattern.compile("(?:.*)(?:map=)(\\d{1,2})/([+-]?\\d+(?:\\.\\d+)?)/([+-]?\\d+(?:\\.\\d+)?)(?:.*)");
-                        matcher = p.matcher(schemeSpecific);
+                    if (path != null && path.startsWith("/go/")) { // short URL form
+                        p = Pattern.compile("^/go/([A-Za-z0-9_@~]+-*)(?:.*)");
+                        matcher = p.matcher(uri.getPath());
+                        if (matcher.matches()) {
+                            return MapUtils.decodeShortLinkString(matcher.group(1));
+                        }
                     } else { // data in the query and/or feature strings
                         String lat = "0";
                         String lon = "0";
@@ -480,7 +544,6 @@ public class GeoPointParserUtil {
                         return new GeoParsedPoint(lat, lon, zoom);
                     }
                 } else if (host.matches("(maps|www)\\.?google.[a-z]+")) { // support www./maps. and .de/.com/.in/.eg/etc.
-                    System.out.println("google: " + schemeSpecific);
                     final String subString = schemeSpecific.substring(host.length() + 3); // +3 for the // and the /
                     Pattern p;
                     Matcher matcher;

--- a/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
+++ b/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
@@ -361,6 +361,15 @@ public class GeoPointParserUtil {
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
+		// https://developer.apple.com/library/ios/featuredarticles/iPhoneURLScheme_Reference/MapLinks/MapLinks.html
+
+		// http://maps.apple.com/?ll=
+		z = 11;
+		url = "http://maps.apple.com/?ll=" + dlat + "," + dlon + "&z=" + z;
+		System.out.println("\nurl: " + url);
+		actual = GeoPointParserUtil.parse(url);
+		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
+
         /* URLs straight from various services, instead of generated here */
         
         String urls[] = {
@@ -584,6 +593,25 @@ public class GeoPointParserUtil {
                         int zoom = parseZoom(matcher.group(1));
                         return new GeoParsedPoint(lat, lon, zoom);
                     }
+				} else if (host.equals("maps.apple.com")) {
+					Pattern p = Pattern.compile(".*ll=([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?)(?:.+z=(\\d{1,2}).*)");
+					Matcher matcher = p.matcher(uri.getQuery());
+					if (matcher.matches()) {
+						String lat = matcher.group(1);
+						String lon = matcher.group(2);
+						String zoom = String.valueOf(GeoParsedPoint.NO_ZOOM);
+						if (matcher.groupCount() == 3) {
+							zoom = matcher.group(3);
+						} else if (matcher.groupCount() == 2) {
+							// see if z= precedes ll=
+							p = Pattern.compile(".*z=(\\d{1,2}).*");
+							Matcher zoomMatcher = p.matcher(uri.getQuery());
+							if (zoomMatcher.matches()) {
+								zoom = zoomMatcher.group(1);
+							}
+						}
+						return new GeoParsedPoint(lat, lon, zoom);
+					}
                 } else if (host.startsWith("maps.yandex.")) {
                     Pattern p = Pattern.compile("(?:.*)ll=([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?)(?:.+)z=(\\d{1,2})(?:.*)");
                     Matcher matcher = p.matcher(uri.getQuery());

--- a/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
+++ b/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
@@ -371,7 +371,7 @@ public class GeoPointParserUtil {
 			if (!expected.getQuery().equals(actual.getQuery()))
 				throw new RuntimeException("Query param not equal");
 		} else {
-			double aLat = actual.getLat(), eLat = expected.getLat(), aLon = actual.getLon(), eLon = expected.getLon();
+			double aLat = actual.getLatitude(), eLat = expected.getLatitude(), aLon = actual.getLongitude(), eLon = expected.getLongitude();
 			int aZoom = actual.getZoom(), eZoom = expected.getZoom();
 			String aName = actual.getName(), eName = expected.getName();
 			if (eName != null) {
@@ -714,11 +714,11 @@ public class GeoPointParserUtil {
 			this.geoAddress = true;
 		}
 
-		public double getLat() {
+		public double getLatitude() {
 			return lat;
 		}
 
-		public double getLon() {
+		public double getLongitude() {
 			return lon;
 		}
 

--- a/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
+++ b/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
@@ -11,7 +11,7 @@ public class GeoPointParserUtil {
 
 	public static void main(String[] args) {
 		final int ilat = 34, ilon = -106;
-		final double dlat = 34.99, dlon = -106.61;
+		final double dlat = 34.99393, dlon = -106.61568;
 		final double longLat = 34.993933029174805, longLon = -106.615680694580078;
 		final String name = "Treasure Island";
 		int z = GeoParsedPoint.NO_ZOOM;
@@ -23,33 +23,33 @@ public class GeoPointParserUtil {
 		GeoParsedPoint actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon));
 
-		// geo:34.99,-106.61
+		// geo:34.99393,-106.61568
 		url = "geo:" + dlat + "," + dlon;
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon));
 
-		// geo:34.99,-106.61?z=11
+		// geo:34.99393,-106.61568?z=11
 		z = 11;
 		url = "geo:" + dlat + "," + dlon + "?z=" + z;
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
-		// geo:34.99,-106.61 (Treasure Island)
+		// geo:34.99393,-106.61568 (Treasure Island)
 		url = "geo:" + dlat + "," + dlon + " (" + name + ")";
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, name));
 
-		// geo:34.99,-106.61?z=11 (Treasure Island)
+		// geo:34.99393,-106.61568?z=11 (Treasure Island)
 		z = 11;
 		url = "geo:" + dlat + "," + dlon + "?z=" + z + " (" + name + ")";
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z, name));
 
-		// geo:34.99,-106.61?q=34.99%2C-106.61 (Treasure Island)
+		// geo:34.99393,-106.61568?q=34.99393%2C-106.61568 (Treasure Island)
 		z = GeoParsedPoint.NO_ZOOM;
 		url = "geo:" + dlat + "," + dlon + "?q=" + dlat + "%2C" + dlon + " (" + name + ")";
 		System.out.println("url: " + url);
@@ -63,21 +63,21 @@ public class GeoPointParserUtil {
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z, name));
 
-		// 0,0?q=34.99,-106.61(Treasure Island)
+		// 0,0?q=34.99393,-106.61568(Treasure Island)
 		z = GeoParsedPoint.NO_ZOOM;
 		url = "geo:0,0?q=" + dlat + "," + dlon + " (" + name + ")";
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z, name));
 
-		// geo:0,0?z=11&q=34.99,-106.61(Treasure Island)
+		// geo:0,0?z=11&q=34.99393,-106.61568(Treasure Island)
 		z = 11;
 		url = "geo:0,0?z=" + z + "&q=" + dlat + "," + dlon + " (" + name + ")";
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z, name));
 
-		// geo:0,0?z=11&q=34.99,-106.61
+		// geo:0,0?z=11&q=34.99393,-106.61568
 		z = 11;
 		url = "geo:0,0?z=" + z + "&q=" + dlat + "," + dlon;
 		System.out.println("url: " + url);
@@ -116,7 +116,7 @@ public class GeoPointParserUtil {
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
-		// http://download.osmand.net/go?lat=34.99&lon=-106.61&z=11
+		// http://download.osmand.net/go?lat=34.99393&lon=-106.61568&z=11
 		url = "http://download.osmand.net/go?lat=" + dlat + "&lon=" + dlon + "&z=" + z;
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
@@ -128,13 +128,13 @@ public class GeoPointParserUtil {
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
-		// http://openstreetmap.org/#map=11/34.99/-106.61
+		// http://openstreetmap.org/#map=11/34.99393/-106.61568
 		url = "http://openstreetmap.org/#map=" + z + "/" + dlat + "/" + dlon;
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
-		// http://openstreetmap.org/#11/34.99/-106.61
+		// http://openstreetmap.org/#11/34.99393/-106.61568
 		url = "http://openstreetmap.org/#" + z + "/" + dlat + "/" + dlon;
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
@@ -159,13 +159,13 @@ public class GeoPointParserUtil {
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
-		// http://openstreetmap.de/zoom=11&lat=34.99&lon=-106.61
+		// http://openstreetmap.de/zoom=11&lat=34.99393&lon=-106.61568
 		url = "http://openstreetmap.de/zoom=" + z + "&lat=" + dlat + "&lon=" + dlon;
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
-		// http://openstreetmap.de/lat=34.99&lon=-106.61&zoom=11
+		// http://openstreetmap.de/lat=34.99393&lon=-106.61568&zoom=11
 		url = "http://openstreetmap.de/lat=" + dlat + "&lon=" + dlon + "&zoom=" + z;
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
@@ -177,7 +177,7 @@ public class GeoPointParserUtil {
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
-		// http://maps.google.com/maps/@34.99,-106.61,11z
+		// http://maps.google.com/maps/@34.99393,-106.61568,11z
 		url = "http://maps.google.com/maps/@" + dlat + "," + dlon + "," + z + "z";
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
@@ -189,7 +189,7 @@ public class GeoPointParserUtil {
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
-		// http://maps.google.com/maps/ll=34.99,-106.61,z=11
+		// http://maps.google.com/maps/ll=34.99393,-106.61568,z=11
 		url = "http://maps.google.com/maps/ll=" + dlat + "," + dlon + ",z=" + z;
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
@@ -201,7 +201,7 @@ public class GeoPointParserUtil {
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
-		// http://maps.google.com/maps/q=loc:34.99,-106.61&z=11
+		// http://maps.google.com/maps/q=loc:34.99393,-106.61568&z=11
 		url = "http://maps.google.com/maps/q=loc:" + dlat + "," + dlon + "&z=" + z;
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
@@ -216,7 +216,7 @@ public class GeoPointParserUtil {
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
 		// whatsapp
-		// http://maps.google.com/maps/q=loc:34.99,-106.61 (You)
+		// http://maps.google.com/maps/q=loc:34.99393,-106.61568 (You)
 		z = GeoParsedPoint.NO_ZOOM;
 		url = "http://maps.google.com/maps/q=loc:" + dlat + "," + dlon + " (You)";
 		System.out.println("url: " + url);
@@ -229,7 +229,7 @@ public class GeoPointParserUtil {
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
-		// http://www.google.com/maps/search/food/34.99,-106.61,14z
+		// http://www.google.com/maps/search/food/34.99393,-106.61568,14z
 		url = "http://www.google.com/maps/search/food/" + dlat + "," + dlon + "," + z + "z";
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
@@ -242,7 +242,7 @@ public class GeoPointParserUtil {
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
-		// http://maps.google.com?saddr=Current+Location&daddr=34.99,-106.61
+		// http://maps.google.com?saddr=Current+Location&daddr=34.99393,-106.61568
 		z = GeoParsedPoint.NO_ZOOM;
 		url = "http://maps.google.com?saddr=Current+Location&daddr=" + dlat + "," + dlon;
 		System.out.println("url: " + url);
@@ -256,7 +256,7 @@ public class GeoPointParserUtil {
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
-		// http://www.google.com/maps/dir/Current+Location/34.99,-106.61
+		// http://www.google.com/maps/dir/Current+Location/34.99393,-106.61568
 		z = GeoParsedPoint.NO_ZOOM;
 		url = "http://www.google.com/maps/dir/Current+Location/" + dlat + "," + dlon;
 		System.out.println("url: " + url);
@@ -270,7 +270,7 @@ public class GeoPointParserUtil {
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
-		// http://maps.google.com/maps?q=34.99,-106.61
+		// http://maps.google.com/maps?q=34.99393,-106.61568
 		z = GeoParsedPoint.NO_ZOOM;
 		url = "http://maps.google.com/maps?q=" + dlat + "," + dlon;
 		System.out.println("url: " + url);
@@ -312,7 +312,7 @@ public class GeoPointParserUtil {
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
-		// http://maps.yandex.ru/?ll=34.99,-106.61&z=11
+		// http://maps.yandex.ru/?ll=34.99393,-106.61568&z=11
 		z = 11;
 		url = "http://maps.yandex.ru/?ll=" + dlat + "," + dlon + "&z=" + z;
 		System.out.println("url: " + url);

--- a/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
+++ b/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
@@ -195,42 +195,42 @@ public class GeoPointParserUtil {
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
-		// http://maps.google.com/maps/q=loc:34,-106&z=11
+		// http://maps.google.com/maps/?q=loc:34,-106&z=11
 		url = "http://maps.google.com/maps/q=loc:" + ilat + "," + ilon + "&z=" + z;
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
-		// http://maps.google.com/maps/q=loc:34.99393,-106.61568&z=11
-		url = "http://maps.google.com/maps/q=loc:" + dlat + "," + dlon + "&z=" + z;
+		// http://maps.google.com/maps/?q=loc:34.99393,-106.61568&z=11
+		url = "http://maps.google.com/maps/?q=loc:" + dlat + "," + dlon + "&z=" + z;
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// whatsapp
-		// http://maps.google.com/maps/q=loc:34,-106 (You)
+		// http://maps.google.com/maps/?q=loc:34,-106 (You)
 		z = GeoParsedPoint.NO_ZOOM;
-		url = "http://maps.google.com/maps/q=loc:" + ilat + "," + ilon + " (You)";
+		url = "http://maps.google.com/maps/?q=loc:" + ilat + "," + ilon + " (You)";
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
 		// whatsapp
-		// http://maps.google.com/maps/q=loc:34.99393,-106.61568 (You)
+		// http://maps.google.com/maps/?q=loc:34.99393,-106.61568 (You)
 		z = GeoParsedPoint.NO_ZOOM;
-		url = "http://maps.google.com/maps/q=loc:" + dlat + "," + dlon + " (You)";
+		url = "http://maps.google.com/maps/?q=loc:" + dlat + "," + dlon + " (You)";
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
-		// http://www.google.com/maps/search/food/34,-106,14z
-		url = "http://www.google.com/maps/search/food/" + ilat + "," + ilon + "," + z + "z";
+		// http://www.google.com/maps/search/food/@34,-106,14z
+		url = "http://www.google.com/maps/search/food/@" + ilat + "," + ilon + "," + z + "z";
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
-		// http://www.google.com/maps/search/food/34.99393,-106.61568,14z
-		url = "http://www.google.com/maps/search/food/" + dlat + "," + dlon + "," + z + "z";
+		// http://www.google.com/maps/search/food/@34.99393,-106.61568,14z
+		url = "http://www.google.com/maps/search/food/@" + dlat + "," + dlon + "," + z + "z";
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
@@ -337,6 +337,7 @@ public class GeoPointParserUtil {
             "https://www.openstreetmap.org/#map=0/180.0/180.0",
             "https://www.openstreetmap.org/#map=6/33.907/34.662",
             "https://www.openstreetmap.org/?mlat=49.56275939941406&mlon=17.291107177734375#map=8/49.563/17.291",
+            "https://www.google.com/maps/place/Wild+Herb+Market/@33.32787,-105.66291,14z/data=!4m5!1m2!2m1!1sfood!3m1!1s0x86e1ce2079e1f94b:0x1d7460465dcaf3ed",
         };
 
         for (String u : urls) {
@@ -416,38 +417,6 @@ public class GeoPointParserUtil {
 			if (schemeSpecific == null)
 				return null;
 
-			final String[] osmandNetSite = { "//download.osmand.net/go?" };
-
-			final String[] osmandNetPattern = { "lat=([+-]?\\d+(?:\\.\\d+)?)&lon=([+-]?\\d+(?:\\.\\d+)?)&?(z=\\d{1,2})" };
-
-			final String[] openstreetmapDeSite = { "//openstreetmap.de/", "//www.openstreetmap.de/" };
-
-			final String[] openstreetmapDePattern = {
-					"(?:.*)zoom=(\\d{1,2})&lat=([+-]?\\d+(?:\\.\\d+)?)&lon=([+-]?\\d+(?:\\.\\d+)?)(?:.*)",
-					"(?:.*)lat=([+-]?\\d+(?:\\.\\d+)?)&lon=([+-]?\\d+(?:\\.\\d+)?)&?(z(?:oom)?=\\d{1,2})(?:.*)" };
-
-			final String[] googleComSite = { "//www.google.com/maps/", "//maps.google.com/maps", "//maps.google.com" };
-
-			final String[] googleComPattern = {
-					"(?:.*)[@/]([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?),(\\d{1,2}z)(?:.*)",
-					"(?:.*)ll=([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?)(?:.+)(z=\\d{1,2})(?:.*)",
-					"(?:.*)q=([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?)(?:.*)&?(z=\\d{1,2})",
-					"(?:.*)(q=)([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?)(?:.*)",
-					"(?:.*)q=loc:([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?)&?(z=\\d{1,2})(?:.*)",
-					"(?:.*)(q=loc:)([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?)(?:.*)",
-					"(.*)daddr=([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?)(?:.*)",
-					"(.*)/([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?)(?:.*)" };
-
-			final String[] yandexRuSite = { "//maps.yandex.ru/" };
-
-			final String[] yandexRuPattern = { "(?:.*)ll=([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?)(?:.+)(z=\\d{1,2})(?:.*)" };
-
-			final String sites[][] = { osmandNetSite, openstreetmapDeSite,
-					googleComSite, yandexRuSite };
-
-			final String patterns[][] = { osmandNetPattern,
-					openstreetmapDePattern, googleComPattern, yandexRuPattern };
-
             try {
                 if (host.equals("osm.org") || host.endsWith("openstreetmap.org")) {
                     Pattern p;
@@ -483,6 +452,37 @@ public class GeoPointParserUtil {
                         }
                         return new GeoParsedPoint(lat, lon, zoom);
                     }
+                } else if (host.matches("(maps|www)\\.?google.[a-z]+")) { // support www./maps. and .de/.com/.in/.eg/etc.
+                    System.out.println("google: " + schemeSpecific);
+                    final String subString = schemeSpecific.substring(host.length() + 3); // +3 for the // and the /
+                    Pattern p;
+                    Matcher matcher;
+                    final String[] patterns = {
+                        "(?:.*)[@/]([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d{1,2})z(?:.*)",
+                        "(?:.*)ll=([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?)(?:.+)z=([+-]?\\d{1,2})(?:.*)",
+                        "(?:.*)q=([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?)(?:.*)&?z=([+-]?\\d{1,2})",
+                        "(?:.*)q=([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?)(?:.*)",
+                        "(?:.*)q=loc:([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?)&?z=([+-]?\\d{1,2})(?:.*)",
+                        // only includes lat/lon, not zoom
+                        "(?:.*)q=loc:([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?)(?:.*)",
+                        "(?:.*)daddr=([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?)(?:.*)",
+                        "(?:.*)/([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?)(?:.*)",
+                        // match as a single group
+                        "(?:.*)daddr=(.*)",
+                        ".*[/?&]?q=(.*)",
+                        "(?:.*)/(.*)", };
+                    for (int i = 0; i < patterns.length; i++) {
+                        p = Pattern.compile(patterns[i]);
+                        matcher = p.matcher(subString);
+                        if (matcher.matches()) {
+                            if (matcher.groupCount() == 3)
+                                return new GeoParsedPoint(matcher.group(1), matcher.group(2), matcher.group(3));
+                            else if (matcher.groupCount() == 2)
+                                return new GeoParsedPoint(matcher.group(1), matcher.group(2));
+                            else if (matcher.groupCount() == 1)
+                                return new GeoParsedPoint(matcher.group(1));
+                        }
+                    }
                 } else if (schemeSpecific.startsWith("//map.baidu.")) { // .com and .cn both work
                     /* Baidu Map uses a custom format for lat/lon., it is basically standard lat/lon
                      * multiplied by 100,000, then rounded to an integer */
@@ -494,80 +494,36 @@ public class GeoPointParserUtil {
                         int zoom = parseZoom(matcher.group(1));
                         return new GeoParsedPoint(lat, lon, zoom);
                     }
+                } else if (host.startsWith("maps.yandex.")) {
+                    Pattern p = Pattern.compile("(?:.*)ll=([+-]?\\d+(?:\\.\\d+)?),([+-]?\\d+(?:\\.\\d+)?)(?:.+)z=(\\d{1,2})(?:.*)");
+                    Matcher matcher = p.matcher(uri.getQuery());
+                    if (matcher.matches()) {
+                        return new GeoParsedPoint(matcher.group(1), matcher.group(2), matcher.group(3));
+                    }
+                } else if (host.endsWith("openstreetmap.de")) {
+                    Pattern p = Pattern.compile("(?:.*)zoom=(\\d{1,2})&lat=([+-]?\\d+(?:\\.\\d+)?)&lon=([+-]?\\d+(?:\\.\\d+)?)(?:.*)");
+                    Matcher matcher = p.matcher(schemeSpecific);
+                    if (matcher.matches()) {
+                        return new GeoParsedPoint(matcher.group(2), matcher.group(3), matcher.group(1));
+                    }
+                    // try the secondary pattern
+                    p = Pattern.compile("(?:.*)lat=([+-]?\\d+(?:\\.\\d+)?)&lon=([+-]?\\d+(?:\\.\\d+)?)&?z(?:oom)?=(\\d{1,2})(?:.*)");
+                    matcher = p.matcher(schemeSpecific);
+                    if (matcher.matches()) {
+                        return new GeoParsedPoint(matcher.group(1), matcher.group(2), matcher.group(3));
+                    }
+                } else if (host.equals("download.osmand.net")) {
+                    Pattern p = Pattern.compile("lat=([+-]?\\d+(?:\\.\\d+)?)&lon=([+-]?\\d+(?:\\.\\d+)?)&?z=(\\d{1,2})");
+                    Matcher matcher = p.matcher(uri.getQuery());
+                    if (matcher.matches()) {
+                        return new GeoParsedPoint(matcher.group(1), matcher.group(2), matcher.group(3));
+                    }
                 }
             } catch (IllegalStateException e) {
                 e.printStackTrace();
-                return null;
             } catch (NumberFormatException e) {
                 e.printStackTrace();
-                return null;
             }
-
-			// search by geo coordinates
-			for (int s = 0; s < sites.length; s++) {
-				for (int si = 0; si < sites[s].length; si++) {
-					if (schemeSpecific.startsWith(sites[s][si])) {
-						for (int p = 0; p < patterns[s].length; p++) {
-							String subString = schemeSpecific.substring(sites[s][si].length());
-
-							if (subString.equals("")) {
-								subString = uri.getFragment();
-							}
-
-							final Matcher matcher = Pattern.compile(patterns[s][p]).matcher(subString);
-
-							if (matcher.matches()) {
-								try {
-
-									final double lat;
-									final double lon;
-									int zoom;
-
-									// check sequence of values
-									if (matcher.group(3).contains("z=")) {
-										lat = Double.valueOf(matcher.group(1));
-										lon = Double.valueOf(matcher.group(2));
-										zoom = Integer.valueOf(matcher.group(3).substring("z=".length()));
-									} else if (matcher.group(3).contains("zoom=")) {
-										lat = Double.valueOf(matcher.group(1));
-										lon = Double.valueOf(matcher.group(2));
-										zoom = Integer.valueOf(matcher.group(3).substring("zoom=".length()));
-									} else if (matcher.group(3).contains("z")) {
-										lat = Double.valueOf(matcher.group(1));
-										lon = Double.valueOf(matcher.group(2));
-										zoom = Integer.valueOf(matcher.group(3).substring(0,
-												matcher.group(3).length() - 1));
-									} else {
-										lat = Double.valueOf(matcher.group(2));
-										lon = Double.valueOf(matcher.group(3));
-										try {
-											zoom = Integer.valueOf(matcher.group(1));
-										} catch (NumberFormatException e) {
-											zoom = GeoParsedPoint.NO_ZOOM;
-										}
-									}
-
-									return new GeoParsedPoint(lat, lon, zoom);
-								} catch (NumberFormatException e) {
-									return null;
-								}
-							}
-						}
-						break;
-					}
-				}
-			}
-			// search by address string
-			final String[] googleComAddressPattern = new String[] { "(?:.*)daddr=(.*)", "q=(.*)", "(?:.*)/(.*)" };
-			for (int s = 0; s < googleComSite.length; s++) {
-				for (int p = 0; p < googleComAddressPattern.length; p++) {
-					final String subString = schemeSpecific.substring(googleComSite[s].length());
-					final Matcher matcher = Pattern.compile(googleComAddressPattern[p]).matcher(subString);
-					if (matcher.matches()) {
-						return new GeoParsedPoint(matcher.group(1));
-					}
-				}
-			}
 			return null;
 		} else if ("geo".equals(scheme) || "osmand.geo".equals(scheme)) {
 			String schemeSpecific = uri.getSchemeSpecificPart();

--- a/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
+++ b/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
@@ -3,6 +3,7 @@ package net.osmand.util;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -18,68 +19,68 @@ public class GeoPointParserUtil {
 		// geo:34,-106
 		url = "geo:" + ilat + "," + ilon;
 		System.out.println("url: " + url);
-		GeoParsedPoint actual = GeoPointParserUtil.parse("geo", url);
+		GeoParsedPoint actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon));
 
 		// geo:34.99,-106.61
 		url = "geo:" + dlat + "," + dlon;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("geo", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon));
 
 		// geo:34.99,-106.61?z=11
 		z = 11;
 		url = "geo:" + dlat + "," + dlon + "?z=" + z;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("geo", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// geo:34.99,-106.61 (Treasure Island)
 		url = "geo:" + dlat + "," + dlon + " (" + name + ")";
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("geo", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, name));
 
 		// geo:34.99,-106.61?z=11 (Treasure Island)
 		z = 11;
 		url = "geo:" + dlat + "," + dlon + "?z=" + z + " (" + name + ")";
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("geo", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z, name));
 
 		// geo:34.99,-106.61?q=34.99%2C-106.61 (Treasure Island)
 		z = GeoParsedPoint.NO_ZOOM;
 		url = "geo:" + dlat + "," + dlon + "?q=" + dlat + "%2C" + dlon + " (" + name + ")";
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("geo", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z, name));
 
 		// 0,0?q=34,-106(Treasure Island)
 		z = GeoParsedPoint.NO_ZOOM;
 		url = "geo:0,0?q=" + ilat + "," + ilon + " (" + name + ")";
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("geo", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z, name));
 
 		// 0,0?q=34.99,-106.61(Treasure Island)
 		z = GeoParsedPoint.NO_ZOOM;
 		url = "geo:0,0?q=" + dlat + "," + dlon + " (" + name + ")";
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("geo", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z, name));
 
 		// geo:0,0?z=11&q=34.99,-106.61(Treasure Island)
 		z = 11;
 		url = "geo:0,0?z=" + z + "&q=" + dlat + "," + dlon + " (" + name + ")";
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("geo", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z, name));
 
 		// geo:0,0?z=11&q=34.99,-106.61
 		z = 11;
 		url = "geo:0,0?z=" + z + "&q=" + dlat + "," + dlon;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("geo", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// google calendar
@@ -87,14 +88,14 @@ public class GeoPointParserUtil {
 		String qstr = "760 West Genesee Street Syracuse NY 13204";
 		url = "geo:0,0?q=" + qstr;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("geo", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(qstr));
 
 		// geo:0,0?z=11&q=1600+Amphitheatre+Parkway,+CA
 		qstr = "1600 Amphitheatre Parkway, CA";
 		url = "geo:0,0?z=11&q=" + URLEncoder.encode(qstr);
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("geo", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(qstr));
 
 		// geo:50.451300,30.569900?z=15&q=50.451300,30.569900 (Kiev)
@@ -105,85 +106,85 @@ public class GeoPointParserUtil {
 
 		url = "geo:50.451300,30.569900?z=15&q=50.451300,30.569900 (Kiev)";
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("geo", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(qlat, qlon, z, qname));
 
 		// http://download.osmand.net/go?lat=34&lon=-106&z=11
 		url = "http://download.osmand.net/go?lat=" + ilat + "&lon=" + ilon + "&z=" + z;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
 		// http://download.osmand.net/go?lat=34.99&lon=-106.61&z=11
 		url = "http://download.osmand.net/go?lat=" + dlat + "&lon=" + dlon + "&z=" + z;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// http://openstreetmap.org/map=11/34/-106
 		url = "http://openstreetmap.org/map=" + z + "/" + ilat + "/" + ilon;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
 		// http://openstreetmap.org/map=11/34.99/-106.61
 		url = "http://openstreetmap.org/map=" + z + "/" + dlat + "/" + dlon;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// http://openstreetmap.de/zoom=11&lat=34&lon=-106
 		url = "http://openstreetmap.de/zoom=" + z + "&lat=" + ilat + "&lon=" + ilon;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
 		// http://openstreetmap.de/zoom=11&lat=34.99&lon=-106.61
 		url = "http://openstreetmap.de/zoom=" + z + "&lat=" + dlat + "&lon=" + dlon;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// http://openstreetmap.de/lat=34.99&lon=-106.61&zoom=11
 		url = "http://openstreetmap.de/lat=" + dlat + "&lon=" + dlon + "&zoom=" + z;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// http://maps.google.com/maps/@34,-106,11z
 		url = "http://maps.google.com/maps/@" + ilat + "," + ilon + "," + z + "z";
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
 		// http://maps.google.com/maps/@34.99,-106.61,11z
 		url = "http://maps.google.com/maps/@" + dlat + "," + dlon + "," + z + "z";
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// http://maps.google.com/maps/ll=34,-106,z=11
 		url = "http://maps.google.com/maps/ll=" + ilat + "," + ilon + ",z=" + z;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
 		// http://maps.google.com/maps/ll=34.99,-106.61,z=11
 		url = "http://maps.google.com/maps/ll=" + dlat + "," + dlon + ",z=" + z;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// http://maps.google.com/maps/q=loc:34,-106&z=11
 		url = "http://maps.google.com/maps/q=loc:" + ilat + "," + ilon + "&z=" + z;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
 		// http://maps.google.com/maps/q=loc:34.99,-106.61&z=11
 		url = "http://maps.google.com/maps/q=loc:" + dlat + "," + dlon + "&z=" + z;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// whatsapp
@@ -191,7 +192,7 @@ public class GeoPointParserUtil {
 		z = GeoParsedPoint.NO_ZOOM;
 		url = "http://maps.google.com/maps/q=loc:" + ilat + "," + ilon + " (You)";
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
 		// whatsapp
@@ -199,103 +200,103 @@ public class GeoPointParserUtil {
 		z = GeoParsedPoint.NO_ZOOM;
 		url = "http://maps.google.com/maps/q=loc:" + dlat + "," + dlon + " (You)";
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// http://www.google.com/maps/search/food/34,-106,14z
 		url = "http://www.google.com/maps/search/food/" + ilat + "," + ilon + "," + z + "z";
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
 		// http://www.google.com/maps/search/food/34.99,-106.61,14z
 		url = "http://www.google.com/maps/search/food/" + dlat + "," + dlon + "," + z + "z";
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// http://maps.google.com?saddr=Current+Location&daddr=34,-106
 		z = GeoParsedPoint.NO_ZOOM;
 		url = "http://maps.google.com?saddr=Current+Location&daddr=" + ilat + "," + ilon;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
 		// http://maps.google.com?saddr=Current+Location&daddr=34.99,-106.61
 		z = GeoParsedPoint.NO_ZOOM;
 		url = "http://maps.google.com?saddr=Current+Location&daddr=" + dlat + "," + dlon;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// http://www.google.com/maps/dir/Current+Location/34,-106
 		z = GeoParsedPoint.NO_ZOOM;
 		url = "http://www.google.com/maps/dir/Current+Location/" + ilat + "," + ilon;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
 		// http://www.google.com/maps/dir/Current+Location/34.99,-106.61
 		z = GeoParsedPoint.NO_ZOOM;
 		url = "http://www.google.com/maps/dir/Current+Location/" + dlat + "," + dlon;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// http://maps.google.com/maps?q=34,-106
 		z = GeoParsedPoint.NO_ZOOM;
 		url = "http://maps.google.com/maps?q=" + ilat + "," + ilon;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
 		// http://maps.google.com/maps?q=34.99,-106.61
 		z = GeoParsedPoint.NO_ZOOM;
 		url = "http://maps.google.com/maps?q=" + dlat + "," + dlon;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// http://www.google.com/maps/place/760+West+Genesee+Street+Syracuse+NY+13204
 		qstr = "760+West+Genesee+Street+Syracuse+NY+13204";
 		url = "http://www.google.com/maps/place/" + qstr;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(qstr));
 
 		// http://maps.google.com/maps?q=760+West+Genesee+Street+Syracuse+NY+13204
 		qstr = "760+West+Genesee+Street+Syracuse+NY+13204";
 		url = "http://www.google.com/maps?q=" + qstr;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(qstr));
 
 		// http://maps.google.com/maps?daddr=760+West+Genesee+Street+Syracuse+NY+13204
 		qstr = "760+West+Genesee+Street+Syracuse+NY+13204";
 		url = "http://www.google.com/maps?daddr=" + qstr;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(qstr));
 
 		// http://www.google.com/maps/dir/Current+Location/760+West+Genesee+Street+Syracuse+NY+13204
 		qstr = "760+West+Genesee+Street+Syracuse+NY+13204";
 		url = "http://www.google.com/maps/dir/Current+Location/" + qstr;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(qstr));
 
 		// http://maps.yandex.ru/?ll=34,-106&z=11
 		z = 11;
 		url = "http://maps.yandex.ru/?ll=" + ilat + "," + ilon + "&z=" + z;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
 
 		// http://maps.yandex.ru/?ll=34.99,-106.61&z=11
 		z = 11;
 		url = "http://maps.yandex.ru/?ll=" + dlat + "," + dlon + "&z=" + z;
 		System.out.println("url: " + url);
-		actual = GeoPointParserUtil.parse("http", url);
+		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 	}
 
@@ -326,8 +327,8 @@ public class GeoPointParserUtil {
 		System.out.println("Passed!");
 	}
 
-	private static String getQueryParameter(final String param, URI data) {
-		final String query = data.getQuery();
+	private static String getQueryParameter(final String param, URI uri) {
+		final String query = uri.getQuery();
 		String value = null;
 		if (query != null && query.contains(param)) {
 			String[] params = query.split("&");
@@ -344,17 +345,21 @@ public class GeoPointParserUtil {
 	/**
 	 * Parses geo and map intents:
 	 *
-	 * @param scheme
-	 *            The intent scheme
 	 * @param uri
 	 *            The URI object
 	 * @return {@link GeoParsedPoint}
 	 */
-	public static GeoParsedPoint parse(final String scheme, final String uri) {
-		final URI data = URI.create(uri.replaceAll("\\s+", "+").replaceAll("%20", "+").replaceAll("%2C", ","));
+	public static GeoParsedPoint parse(final String uriString) {
+		final URI uri = URI.create(uriString.replaceAll("\\s+", "+").replaceAll("%20", "+").replaceAll("%2C", ","));
+
+        String scheme = uri.getScheme();
+        if (scheme == null)
+            return null;
+        else
+            scheme = scheme.toLowerCase(Locale.US);
 		if ("http".equals(scheme) || "https".equals(scheme)) {
 
-			final String schemeSpecific = data.getSchemeSpecificPart();
+			final String schemeSpecific = uri.getSchemeSpecificPart();
 
 			if (schemeSpecific == null) {
 				return null;
@@ -403,7 +408,7 @@ public class GeoPointParserUtil {
 							String subString = schemeSpecific.substring(sites[s][si].length());
 
 							if (subString.equals("")) {
-								subString = data.getFragment();
+								subString = uri.getFragment();
 							}
 
 							final Matcher matcher = Pattern.compile(patterns[s][p]).matcher(subString);
@@ -463,7 +468,7 @@ public class GeoPointParserUtil {
 			return null;
 		}
 		if ("geo".equals(scheme) || "osmand.geo".equals(scheme)) {
-			String schemeSpecific = data.getSchemeSpecificPart();
+			String schemeSpecific = uri.getSchemeSpecificPart();
 			if (schemeSpecific == null) {
 				return null;
 			}

--- a/OsmAnd-java/src/net/osmand/util/MapUtils.java
+++ b/OsmAnd-java/src/net/osmand/util/MapUtils.java
@@ -277,6 +277,9 @@ public class MapUtils {
 		});
 	}
 	
+	public static String buildGeoUrl(double latitude, double longitude, int zoom) {
+        return "geo:" + ((float) latitude) + "," + ((float)longitude) + "?z=" + zoom;
+	}
 	
 	// Examples
 //	System.out.println(buildShortOsmUrl(51.51829d, 0.07347d, 16)); // http://osm.org/go/0EEQsyfu

--- a/OsmAnd-java/src/net/osmand/util/MapUtils.java
+++ b/OsmAnd-java/src/net/osmand/util/MapUtils.java
@@ -20,7 +20,9 @@ import net.osmand.data.QuadPoint;
  */
 public class MapUtils {
 	
-	private static final String BASE_SHORT_OSM_URL = "http://osm.org/go/";
+    // TODO change the hostname back to osm.org once HTTPS works for it
+    // https://github.com/openstreetmap/operations/issues/2
+    private static final String BASE_SHORT_OSM_URL = "https://openstreetmap.org/go/";
 	
 	/**
      * This array is a lookup table that translates 6-bit positive integer

--- a/OsmAnd-java/src/net/osmand/util/MapUtils.java
+++ b/OsmAnd-java/src/net/osmand/util/MapUtils.java
@@ -34,7 +34,7 @@ public class MapUtils {
         'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
         'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
         'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
-        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '_', '@'
+        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '_', '~'
     };
 
 	public static double getDistance(LatLon l, double latitude, double longitude){

--- a/OsmAnd/AndroidManifest.xml
+++ b/OsmAnd/AndroidManifest.xml
@@ -177,10 +177,18 @@
 				<category android:name="android.intent.category.BROWSABLE"/>
 			</intent-filter>
 			<intent-filter>
-				<data android:scheme="http" android:host="maps.google.com" />
-				<data android:scheme="https" android:host="maps.google.com" />
-				<data android:scheme="http" android:host="maps.yandex.ru" />
-				<data android:scheme="https" android:host="maps.yandex.ru" />
+				<data android:scheme="http" />
+				<data android:scheme="https" />
+				<data android:host="maps.google.com" />
+				<data android:host="maps.yandex.ru" />
+				<data android:host="maps.yandex.com" />
+				<data android:host="www.openstreetmap.org" />
+				<data android:host="openstreetmap.org" />
+				<data android:host="osm.org" />
+				<data android:host="map.baidu.cn" />
+				<data android:host="map.baidu.com" />
+				<data android:host="wb.amap.com" />
+				<data android:host="www.amap.com" />
 				<action android:name="android.intent.action.VIEW" />
 				<category android:name="android.intent.category.DEFAULT" />
 				<category android:name="android.intent.category.BROWSABLE" />
@@ -188,17 +196,6 @@
 			<intent-filter>
 				<data android:scheme="http" android:host="www.google.com" android:pathPrefix="/maps" />
 				<data android:scheme="https" android:host="www.google.com" android:pathPrefix="/maps" />
-				<action android:name="android.intent.action.VIEW" />
-				<category android:name="android.intent.category.DEFAULT" />
-				<category android:name="android.intent.category.BROWSABLE" />
-			</intent-filter>
-			<intent-filter>
-				<data android:scheme="http" android:host="www.openstreetmap.org" />
-				<data android:scheme="https" android:host="www.openstreetmap.org" />
-				<data android:scheme="http" android:host="openstreetmap.org" />
-				<data android:scheme="https" android:host="openstreetmap.org" />
-				<data android:scheme="http" android:host="osm.org" />
-				<data android:scheme="https" android:host="osm.org" />
 				<action android:name="android.intent.action.VIEW" />
 				<category android:name="android.intent.category.DEFAULT" />
 				<category android:name="android.intent.category.BROWSABLE" />

--- a/OsmAnd/AndroidManifest.xml
+++ b/OsmAnd/AndroidManifest.xml
@@ -195,6 +195,10 @@
 			<intent-filter>
 				<data android:scheme="http" android:host="www.openstreetmap.org" />
 				<data android:scheme="https" android:host="www.openstreetmap.org" />
+				<data android:scheme="http" android:host="openstreetmap.org" />
+				<data android:scheme="https" android:host="openstreetmap.org" />
+				<data android:scheme="http" android:host="osm.org" />
+				<data android:scheme="https" android:host="osm.org" />
 				<action android:name="android.intent.action.VIEW" />
 				<category android:name="android.intent.category.DEFAULT" />
 				<category android:name="android.intent.category.BROWSABLE" />

--- a/OsmAnd/AndroidManifest.xml
+++ b/OsmAnd/AndroidManifest.xml
@@ -189,6 +189,7 @@
 				<data android:host="map.baidu.com" />
 				<data android:host="wb.amap.com" />
 				<data android:host="www.amap.com" />
+				<data android:host="maps.apple.com" />
 				<action android:name="android.intent.action.VIEW" />
 				<category android:name="android.intent.category.DEFAULT" />
 				<category android:name="android.intent.category.BROWSABLE" />

--- a/OsmAnd/old-ndk-build.sh
+++ b/OsmAnd/old-ndk-build.sh
@@ -4,15 +4,23 @@ SCRIPT_LOC="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 NAME=$(basename $(dirname "${BASH_SOURCE[0]}") )
 
 
-if [ ! -d "$ANDROID_SDK" ]; then
-	echo "ANDROID_SDK is not set"
-	exit
+if [ -d "$ANDROID_HOME" ]; then
+    # for backwards compatbility
+    export ANDROID_SDK=$ANDROID_HOME
+else
+	echo "ANDROID_HOME is not set, trying ANDROID_SDK:"
+    if [ -d "$ANDROID_SDK" ]; then
+        export ANDROID_HOME=$ANDROID_SDK
+    else
+	    echo "ANDROID_SDK is also not set"
+	    exit
+    fi
 fi
 if [ ! -d "$ANDROID_NDK" ]; then
 	echo "ANDROID_NDK is not set"
 	exit
 fi
-export ANDROID_SDK_ROOT=$ANDROID_SDK
+export ANDROID_SDK_ROOT=$ANDROID_HOME
 export ANDROID_NDK_ROOT=$ANDROID_NDK
 export ANDROID_NDK_TOOLCHAIN_VERSION=4.7
 

--- a/OsmAnd/src/net/osmand/plus/activities/actions/ShareLocation.java
+++ b/OsmAnd/src/net/osmand/plus/activities/actions/ShareLocation.java
@@ -44,16 +44,16 @@ public class ShareLocation extends OsmAndAction {
 				final int zoom = args.getInt(MapActivityActions.KEY_ZOOM);
 				try {
 					final String shortOsmUrl = MapUtils.buildShortOsmUrl(latitude, longitude, zoom);
-					final String appLink = "http://download.osmand.net/go?lat=" + ((float) latitude) + "&lon=" + ((float) longitude) + "&z=" + zoom;
-					String sms = mapActivity.getString(R.string.send_location_sms_pattern, shortOsmUrl, appLink);
+					final String geoUrl = MapUtils.buildGeoUrl(latitude, longitude, zoom);
+					String sms = mapActivity.getString(R.string.send_location_sms_pattern, geoUrl, shortOsmUrl);
 					if (which == 0) {
-						sendEmail(shortOsmUrl, appLink);
+						sendEmail(shortOsmUrl, geoUrl);
 					} else if (which == 1) {
 						sendSms(sms);
 					} else if (which == 2) {
 						sendToClipboard(sms);
 					} else if (which == 3) {
-						sendGeoActivity(latitude, longitude, zoom);
+						sendGeoActivity(geoUrl);
 					} else if (which == 4) {
 						sendQRCode(latitude, longitude);
 					}
@@ -69,8 +69,8 @@ public class ShareLocation extends OsmAndAction {
 	
 
 
-	private void sendEmail(final String shortOsmUrl, final String appLink) {
-		String email = mapActivity.getString(R.string.send_location_email_pattern, shortOsmUrl, appLink);
+	private void sendEmail(final String shortOsmUrl, final String geoUrl) {
+		String email = mapActivity.getString(R.string.send_location_email_pattern, shortOsmUrl, geoUrl);
 		ShareDialog.sendEmail(mapActivity, email, getString(R.string.send_location));
 	}
 
@@ -83,10 +83,8 @@ public class ShareLocation extends OsmAndAction {
 		
 	}
 
-	private void sendGeoActivity(final double latitude, final double longitude, final int zoom) {
-		final String simpleGeo = "geo:"+((float) latitude)+","+((float)longitude) +"?z="+zoom;
-		Uri location = Uri.parse(simpleGeo);
-		Intent mapIntent = new Intent(Intent.ACTION_VIEW, location);
+	private void sendGeoActivity(final String geoUrl) {
+		Intent mapIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(geoUrl));
 		mapActivity.startActivity(mapIntent);
 	}
 

--- a/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
@@ -120,6 +120,7 @@ public class GeoIntentActivity extends OsmandListActivity {
 								.getItemId(0));
 					}
 				}
+				finish();
 			} else {
 				AccessibleToast.makeText(GeoIntentActivity.this,
 						getString(R.string.search_offline_geo_error, intent.getData()), Toast.LENGTH_LONG).show();

--- a/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
@@ -213,9 +213,9 @@ public class GeoIntentActivity extends OsmandListActivity {
 		GeoPointParserUtil.GeoParsedPoint p = GeoPointParserUtil.parse(uri.toString());
 		if (p.isGeoPoint()) {
 			if (p.getName() != null) {
-				return new GeoPointSearch(p.getLat(), p.getLon(), p.getName(), p.getZoom());
+				return new GeoPointSearch(p.getLatitude(), p.getLongitude(), p.getName(), p.getZoom());
 			}
-			return new GeoPointSearch(p.getLat(), p.getLon(), p.getZoom());
+			return new GeoPointSearch(p.getLatitude(), p.getLongitude(), p.getZoom());
 		} else {
 			return new GeoAddressSearch(p.getQuery());
 		}

--- a/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
@@ -95,7 +95,7 @@ public class GeoIntentActivity extends OsmandListActivity {
 				while (getMyApplication().isApplicationInitializing()) {
 					Thread.sleep(200);
 				}
-				return extract(intent.getScheme(), intent.getData()).execute();
+				return extract(intent.getData()).execute();
 			} catch (Exception e) {
 				return null;
 			}
@@ -205,14 +205,12 @@ public class GeoIntentActivity extends OsmandListActivity {
 	 * geo:0,0?q=34.99,-106.61(Treasure)<br/>
 	 * geo:0,0?q=1600+Amphitheatre+Parkway%2C+CA<br/>
 	 * 
-	 * @param scheme
-	 *            The intent scheme
 	 * @param data
 	 *            The intent uri
 	 * @return
 	 */
-	private MyService extract(final String scheme, final Uri data) {
-		GeoPointParserUtil.GeoParsedPoint p = GeoPointParserUtil.parse(scheme, data.toString());
+	private MyService extract(final Uri uri) {
+		GeoPointParserUtil.GeoParsedPoint p = GeoPointParserUtil.parse(uri.toString());
 		if (p.isGeoPoint()) {
 			if (p.getName() != null) {
 				return new GeoPointSearch(p.getLat(), p.getLon(), p.getName(), p.getZoom());

--- a/OsmAnd/src/net/osmand/plus/audionotes/AudioVideoNotesPlugin.java
+++ b/OsmAnd/src/net/osmand/plus/audionotes/AudioVideoNotesPlugin.java
@@ -22,7 +22,6 @@ import net.osmand.PlatformUtil;
 import net.osmand.access.AccessibleAlertBuilder;
 import net.osmand.access.AccessibleToast;
 import net.osmand.data.DataTileManager;
-import net.osmand.data.LatLon;
 import net.osmand.plus.ApplicationMode;
 import net.osmand.plus.ContextMenuAdapter;
 import net.osmand.plus.ContextMenuAdapter.OnContextMenuClick;
@@ -45,6 +44,7 @@ import net.osmand.plus.views.OsmandMapTileView;
 import net.osmand.plus.views.mapwidgets.StackWidgetView;
 import net.osmand.plus.views.mapwidgets.TextInfoWidget;
 import net.osmand.util.Algorithms;
+import net.osmand.util.GeoPointParserUtil.GeoParsedPoint;
 import net.osmand.util.MapUtils;
 
 import org.apache.commons.logging.Log;
@@ -553,7 +553,7 @@ public class AudioVideoNotesPlugin extends OsmandPlugin {
 	}
 
 	private File getBaseFileName(double lat, double lon, OsmandApplication app, String ext) {
-		String basename = MapUtils.createShortLocString(lat, lon, 15);
+		String basename = MapUtils.createShortLinkString(lat, lon, 15);
 		int k = 1;
 		File f = app.getAppPath(IndexConstants.AV_INDEX_DIR);
 		f.mkdirs();
@@ -932,9 +932,9 @@ public class AudioVideoNotesPlugin extends OsmandPlugin {
 			encodeName = encodeName.substring(0, i);
 		}
 		r.file = f;
-		LatLon l = MapUtils.decodeShortLocString(encodeName);
-		r.lat = l.getLatitude();
-		r.lon = l.getLongitude();
+		GeoParsedPoint geo = MapUtils.decodeShortLinkString(encodeName);
+		r.lat = geo.getLatitude();
+		r.lon = geo.getLongitude();
 		Float heading = app.getLocationProvider().getHeading();
 		Location loc = app.getLocationProvider().getLastKnownLocation();
 		if (lastTakingPhoto != null && lastTakingPhoto.getName().equals(f.getName()) && heading != null) {


### PR DESCRIPTION
This is a big update to the code that handles parsing incoming URLs for location information, and then displaying that location.  This reorganizes the code somewhat to make it easier to add more patterns and services. Then the new services are included, as well as support for decoding OpenStreetMap shortlinks.  There are also some bug fixes here and there, mostly related to bitrot.  Things like updated shortlink parsing (for example, OSM's format now uses `~` instead of `@`).

This includes a couple of commits that were originally included in #1033, but they were moved here since they are more relevant to this pull request.

This is probably of most interest to @alexey-pelykh, @Bars107, and @Zahnstocher since they have most recently worked on this code.