### PR TITLE
GeoParsedPoint.toString() output a geo: URI string

### DIFF
--- a/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
+++ b/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
@@ -846,7 +846,7 @@ public class GeoPointParserUtil {
 
 		private String formatDouble(double d) {
 			if(d == (long) d)
-				return String.format("%d", (long)d);
+				return String.format(Locale.ENGLISH, "%d", (long)d);
 			else
 				return String.format("%s", d);
 		}

--- a/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
+++ b/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
@@ -398,7 +398,6 @@ public class GeoPointParserUtil {
 	private static boolean areCloseEnough(double a, double b, long howClose) {
 		long aRounded = (long) Math.round(a * Math.pow(10, howClose));
 		long bRounded = (long) Math.round(b * Math.pow(10, howClose));
-		System.out.println("areCloseEnough: " + aRounded + ", " + bRounded);
 		return aRounded == bRounded;
 	}
 

--- a/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
+++ b/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
@@ -1,8 +1,10 @@
+
 package net.osmand.util;
 
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -21,12 +23,14 @@ public class GeoPointParserUtil {
 		url = "geo:" + ilat + "," + ilon;
 		System.out.println("url: " + url);
 		GeoParsedPoint actual = GeoPointParserUtil.parse(url);
+		assertUrlEquals(url, actual.toString());
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon));
 
 		// geo:34.99393,-106.61568
 		url = "geo:" + dlat + "," + dlon;
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
+		assertUrlEquals(url, actual.toString());
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon));
 
 		// geo:34.99393,-106.61568?z=11
@@ -34,6 +38,7 @@ public class GeoPointParserUtil {
 		url = "geo:" + dlat + "," + dlon + "?z=" + z;
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
+		assertUrlEquals(url, actual.toString());
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// geo:34.99393,-106.61568 (Treasure Island)
@@ -56,16 +61,23 @@ public class GeoPointParserUtil {
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z, name));
 
+		// geo:34.99393,-106.61568?q=34.99393,-106.61568(Treasure+Island)
+		z = GeoParsedPoint.NO_ZOOM;
+		url = "geo:" + dlat + "," + dlon + "?q=" + dlat + "," + dlon + "(" + URLEncoder.encode(name) + ")";
+		System.out.println("url: " + url);
+		actual = GeoPointParserUtil.parse(url);
+		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z, name));
+		assertUrlEquals(url, actual.toString());
+
 		// 0,0?q=34,-106(Treasure Island)
 		z = GeoParsedPoint.NO_ZOOM;
-		url = "geo:0,0?q=" + ilat + "," + ilon + " (" + name + ")";
-		System.out.println("url: " + url);
+		url = "geo:0,0?q=" + ilat + "," + ilon + "(" + name + ")";
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z, name));
 
 		// 0,0?q=34.99393,-106.61568(Treasure Island)
 		z = GeoParsedPoint.NO_ZOOM;
-		url = "geo:0,0?q=" + dlat + "," + dlon + " (" + name + ")";
+		url = "geo:0,0?q=" + dlat + "," + dlon + "(" + name + ")";
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z, name));
@@ -87,10 +99,26 @@ public class GeoPointParserUtil {
 		// google calendar
 		// geo:0,0?q=760 West Genesee Street Syracuse NY 13204
 		String qstr = "760 West Genesee Street Syracuse NY 13204";
+		url = "geo:0,0?q=" + URLEncoder.encode(qstr);
+		System.out.println("url: " + url);
+		actual = GeoPointParserUtil.parse(url);
+		assertGeoPoint(actual, new GeoParsedPoint(qstr));
+		assertUrlEquals(url, actual.toString());
+
+		// geo:0,0?q=760 West Genesee Street Syracuse NY 13204
+		qstr = "760 West Genesee Street Syracuse NY 13204";
 		url = "geo:0,0?q=" + qstr;
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(qstr));
+
+		// geo:0,0?z=11&q=1600+Amphitheatre+Parkway,+CA
+		qstr = "1600 Amphitheatre Parkway, CA";
+		url = "geo:0,0?q=" + URLEncoder.encode(qstr);
+		System.out.println("url: " + url);
+		actual = GeoPointParserUtil.parse(url);
+		assertGeoPoint(actual, new GeoParsedPoint(qstr));
+		assertUrlEquals(url, actual.toString());
 
 		// geo:0,0?z=11&q=1600+Amphitheatre+Parkway,+CA
 		qstr = "1600 Amphitheatre Parkway, CA";
@@ -455,6 +483,11 @@ public class GeoPointParserUtil {
 		System.out.println("Passed!");
 	}
 
+    private static void assertUrlEquals(String actual, String expected) {
+        if (actual == null || !actual.equals(expected))
+            throw new RuntimeException("URLs not equal; actual=" + actual + ", expected=" + expected);
+    }
+
 	private static String getQueryParameter(final String param, URI uri) {
 		final String query = uri.getQuery();
 		String value = null;
@@ -473,8 +506,7 @@ public class GeoPointParserUtil {
 	/**
 	 * Parses geo and map intents:
 	 *
-	 * @param uri
-	 *            The URI object
+	 * @param uriString The URI as a String
 	 * @return {@link GeoParsedPoint}
 	 */
 	public static GeoParsedPoint parse(final String uriString) {
@@ -812,19 +844,57 @@ public class GeoPointParserUtil {
 			return geoPoint;
 		}
 
+		private String formatDouble(double d) {
+			if(d == (long) d)
+				return String.format("%d", (long)d);
+			else
+				return String.format("%s", d);
+		}
+
 		public boolean isGeoAddress() {
 			return geoAddress;
 		}
 
 		/**
-		 * Generates a URI string according to http://geouri.org and
+		 * Generates a URI string according to https://tools.ietf.org/html/rfc5870 and
 		 * https://developer.android.com/guide/components/intents-common.html#Maps
 		 */
 		@Override
 		public String toString() {
-			return isGeoPoint() ? "GeoParsedPoint [lat=" + lat + ", lon=" + lon + ", zoom=" + zoom + ", name=" + name
-					+ "]" : "GeoParsedPoint [query=" + query;
+			String uriString;
+			if (isGeoPoint()) {
+				String latlon = formatDouble(lat) + "," + formatDouble(lon);
+				uriString = "geo:" + latlon;
+				LinkedHashMap<String, String> map = new LinkedHashMap<String, String>();
+				if (zoom != NO_ZOOM)
+					map.put("z", String.valueOf(zoom));
+				if (query != null)
+					map.put("q", URLEncoder.encode(query));
+				if (label != null)
+					if (query == null)
+						map.put("q", latlon + "(" + URLEncoder.encode(label) + ")");
+				if (map.size() > 0)
+					uriString += "?";
+				int i = 0;
+				for (String key : map.keySet()) {
+					if (i > 0)
+						uriString += "&";
+					uriString += key + "=" + map.get(key);
+					i++;
+				}
+				return uriString;
+			}
+			if (isGeoAddress()) {
+				uriString = "geo:0,0";
+				if (query != null) {
+					uriString += "?";
+					if (zoom != NO_ZOOM)
+						uriString += "z=" + zoom + "&";
+					uriString += "q=" + URLEncoder.encode(query);
+				}
+				return uriString;
+			}
+			return null;
 		}
-
 	}
 }

--- a/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
+++ b/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
@@ -408,11 +408,11 @@ public class GeoPointParserUtil {
 		} else {
 			double aLat = actual.getLatitude(), eLat = expected.getLatitude(), aLon = actual.getLongitude(), eLon = expected.getLongitude();
 			int aZoom = actual.getZoom(), eZoom = expected.getZoom();
-			String aName = actual.getName(), eName = expected.getName();
-			if (eName != null) {
-				if (!aName.equals(eName)) {
-					throw new RuntimeException("Point name\\capture is not equal; actual=" + aName + ", expected="
-							+ eName);
+			String aLabel = actual.getLabel(), eLabel = expected.getLabel();
+			if (eLabel != null) {
+				if (!aLabel.equals(eLabel)) {
+					throw new RuntimeException("Point label is not equal; actual="
+							+ aLabel + ", expected=" + eLabel);
 				}
 			}
 			if (!areCloseEnough(eLat, aLat, 5)) {
@@ -435,11 +435,11 @@ public class GeoPointParserUtil {
 		} else {
 			double aLat = actual.getLatitude(), eLat = expected.getLatitude(), aLon = actual.getLongitude(), eLon = expected.getLongitude();
 			int aZoom = actual.getZoom(), eZoom = expected.getZoom();
-			String aName = actual.getName(), eName = expected.getName();
-			if (eName != null) {
-				if (!aName.equals(eName)) {
-					throw new RuntimeException("Point name\\capture is not equal; actual=" + aName + ", expected="
-							+ eName);
+			String aLabel = actual.getLabel(), eLabel = expected.getLabel();
+			if (eLabel != null) {
+				if (!aLabel.equals(eLabel)) {
+					throw new RuntimeException("Point label is not equal; actual="
+							+ aLabel + ", expected=" + eLabel);
 				}
 			}
 			if (((int)eLat) != ((int)aLat)) {
@@ -741,10 +741,10 @@ public class GeoPointParserUtil {
 	public static class GeoParsedPoint {
 		private static final int NO_ZOOM = -1;
 
-		private double lat;
-		private double lon;
+		private double lat = 0;
+		private double lon = 0;
 		private int zoom = NO_ZOOM;
-		private String name;
+		private String label;
 		private String query;
 		private boolean geoPoint;
 		private boolean geoAddress;
@@ -756,10 +756,10 @@ public class GeoPointParserUtil {
 			this.geoPoint = true;
 		}
 
-		public GeoParsedPoint(double lat, double lon, String name) {
+		public GeoParsedPoint(double lat, double lon, String label) {
 			this(lat, lon);
-			if (name != null)
-				this.name = name.replaceAll("\\+", " ");
+			if (label != null)
+				this.label = label.replaceAll("\\+", " ");
 		}
 
 		public GeoParsedPoint(double lat, double lon, int zoom) {
@@ -767,8 +767,8 @@ public class GeoPointParserUtil {
 			this.zoom = zoom;
 		}
 
-		public GeoParsedPoint(double lat, double lon, int zoom, String name) {
-			this(lat, lon, name);
+		public GeoParsedPoint(double lat, double lon, int zoom, String label) {
+			this(lat, lon, label);
 			this.zoom = zoom;
 		}
 
@@ -800,8 +800,8 @@ public class GeoPointParserUtil {
 			return zoom;
 		}
 
-		public String getName() {
-			return name;
+		public String getLabel() {
+			return label;
 		}
 
 		public String getQuery() {
@@ -816,6 +816,10 @@ public class GeoPointParserUtil {
 			return geoAddress;
 		}
 
+		/**
+		 * Generates a URI string according to http://geouri.org and
+		 * https://developer.android.com/guide/components/intents-common.html#Maps
+		 */
 		@Override
 		public String toString() {
 			return isGeoPoint() ? "GeoParsedPoint [lat=" + lat + ", lon=" + lon + ", zoom=" + zoom + ", name=" + name

--- a/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
@@ -210,8 +210,8 @@ public class GeoIntentActivity extends OsmandListActivity {
 	private MyService extract(final Uri uri) {
 		GeoPointParserUtil.GeoParsedPoint p = GeoPointParserUtil.parse(uri.toString());
 		if (p.isGeoPoint()) {
-			if (p.getName() != null) {
-				return new GeoPointSearch(p.getLatitude(), p.getLongitude(), p.getName(), p.getZoom());
+			if (p.getLabel() != null) {
+				return new GeoPointSearch(p.getLatitude(), p.getLongitude(), p.getLabel(), p.getZoom());
 			}
 			return new GeoPointSearch(p.getLatitude(), p.getLongitude(), p.getZoom());
 		} else {


### PR DESCRIPTION
This pull request makes `GeoParsedPoint.toString()` a valid `geo:` URI that represents the data in the `GeoParsedPoint`.  It also tries to include the "query" and "label" parts, i.e. `geo:0,0?q=query(label)` but that part could still be improved.  Previously, `GeoParsedPoint.toString()` returned some debug info that was not really used.

This follows the pattern established by:
* http://docs.oracle.com/javase/7/docs/api/java/net/URL.html#toString()
* https://developer.android.com/reference/android/net/Uri.html#toString()

I am using this a lot in work that will be in coming pull requests, including the "Share location" revamp.