### PR TITLE
More url parsing updates

### DIFF
--- a/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
+++ b/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
@@ -642,14 +642,16 @@ public class GeoPointParserUtil {
             String path = uri.getPath();
 			if (path == null) {
 				path = "";
-			} else if (path.startsWith("/")) {
-				path = path.substring(1);
 			}
             String fragment = uri.getFragment();
             String query = uri.getQuery();
             if(query == null) {
             	// DOUBLE check this may be wrong test of openstreetmap.de (looks very weird url and server doesn't respond)
-            	query = path;
+				if (path.startsWith("/")) {
+					query = path.substring(1);
+				} else {
+					query = path;
+				}
             }
             
             Map<String, String> params = new HashMap<String, String>();
@@ -672,9 +674,9 @@ public class GeoPointParserUtil {
                 if (host.equals("osm.org") || host.endsWith("openstreetmap.org")) {
                     Pattern p;
                     Matcher matcher;
-                    if (path.startsWith("go/")) { // short URL form
+                    if (path.startsWith("/go/")) { // short URL form
                         p = Pattern.compile("^/go/([A-Za-z0-9_@~]+-*)(?:.*)");
-                        matcher = p.matcher(uri.getPath());
+                        matcher = p.matcher(path);
                         if (matcher.matches()) {
                             return MapUtils.decodeShortLinkString(matcher.group(1));
                         }

--- a/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
+++ b/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
@@ -326,6 +326,18 @@ public class GeoPointParserUtil {
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
+		// http://www.google.com/maps/?q=loc:34,-106&z=11
+		url = "http://www.google.com/maps/?q=loc:" + ilat + "," + ilon + "&z=" + z;
+		System.out.println("url: " + url);
+		actual = GeoPointParserUtil.parse(url);
+		assertGeoPoint(actual, new GeoParsedPoint(ilat, ilon, z));
+
+		// http://www.google.com/maps/?q=loc:34.99393,-106.61568&z=11
+		url = "http://www.google.com/maps/?q=loc:" + dlat + "," + dlon + "&z=" + z;
+		System.out.println("url: " + url);
+		actual = GeoPointParserUtil.parse(url);
+		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
+
 		// whatsapp
 		// http://maps.google.com/maps/q=loc:34,-106 (You)
 		z = GeoParsedPoint.NO_ZOOM;
@@ -538,6 +550,9 @@ public class GeoPointParserUtil {
             "http://maps.apple.com/?daddr=Bargou,+Tunisien",
             "http://maps.apple.com/?lsp=7618&q=40.738065,-73.988898&sll=40.738065,-73.988898",
             "http://maps.apple.com/?lsp=9902&auid=13787349062281695774&sll=40.694576,-73.982992&q=Garden%20Nail%20%26%20Spa&hnear=325%20Gold%20St%2C%20Brooklyn%2C%20NY%20%2011201-3054%2C%20United%20States",
+            "https://www.google.com/maps/place/Wild+Herb+Market/@33.32787,-105.66291,14z/data=!4m5!1m2!2m1!1sfood!3m1!1s0x86e1ce2079e1f94b:0x1d7460465dcaf3ed",
+            "http://www.google.com/maps/search/food/@34,-106,14z",
+            "http://www.google.com/maps/search/food/@34.99393,-106.61568,14z",
         };
 
 		for (String u : urls) {

--- a/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
+++ b/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
@@ -770,15 +770,14 @@ public class GeoPointParserUtil {
 						|| host.equals("yandex.ru")
 						|| host.equals("www.yandex.ru")) {
 					Map<String, String> params = getQueryParameters(uri);
-					String zm = params.get("z");
-                    String[] vls = silentSplit(params.get("ll"),",");
-                    if ( vls != null && vls.length >= 2) {
-                        double lat = parseSilentDouble(vls[0]);
-                        double lon = parseSilentDouble(vls[1]) ;
-                        int zoom = parseZoom(zm);
-                        return new GeoParsedPoint(lat, lon, zoom);
-                    } 
-					
+					String ll = params.get("ll");
+					if (ll != null) {
+						Matcher matcher = commaSeparatedPairPattern.matcher(ll);
+						if (matcher.matches()) {
+							String z = String.valueOf(parseZoom(params.get("z")));
+							return new GeoParsedPoint(matcher.group(1), matcher.group(2), z);
+						}
+					}
 				} else if (host.equals("maps.google.com")
 						|| host.equals("google.com")
 						|| host.equals("www.google.com")) {

--- a/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
+++ b/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
@@ -511,6 +511,7 @@ public class GeoPointParserUtil {
             "https://www.openstreetmap.org/#map=0/180.0/180.0",
             "https://www.openstreetmap.org/#map=6/33.907/34.662",
             "https://www.openstreetmap.org/?mlat=49.56275939941406&mlon=17.291107177734375#map=8/49.563/17.291",
+            "https://www.google.at/maps/place/Bargou,+Tunesien/@36.0922506,9.5676327,15z/data=!3m1!4b1!4m2!3m1!1s0x12fc5d0b4dc5e66f:0xbd3618c6193d14cd",
             "http://www.amap.com/#!poi!!q=38.174596,114.995033,%E6%B2%B3%E5%8C%97%E7%9C%81%E7%9F%B3%E5%AE%B6%E5%BA%84%E5%B8%82%E6%97%A0%E6%9E%81%E5%8E%BF",
             "http://wb.amap.com/?p=B013706PJN,38.179456,114.98577,%E6%96%B0%E4%B8%9C%E6%96%B9%E5%A4%A7%E9%85%92%E5%BA%97(%E4%BF%9D%E9%99%A9%E8%8A%B1...,%E5%BB%BA%E8%AE%BE%E8%B7%AF67%E5%8F%B7",
             "http://www.amap.com/#!poi!!q=38.179456,114.98577|3|B013706PJN",
@@ -792,9 +793,7 @@ public class GeoPointParserUtil {
 							return new GeoParsedPoint(matcher.group(1), matcher.group(2), z, params.get("text"));
 						}
 					}
-				} else if (host.equals("maps.google.com")
-						|| host.equals("google.com")
-						|| host.equals("www.google.com")) {
+				} else if (host.matches("(?:www\\.)?(?:maps\\.)?google\\.[a-z]+")) {
 					Map<String, String> params = getQueryParameters(uri);
 					if(params.containsKey("daddr")){
 						return parseGoogleMapsPath(params.get("daddr"), params);

--- a/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
+++ b/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
@@ -550,6 +550,12 @@ public class GeoPointParserUtil {
 		String[] unparsableUrls = {
 			"http://maps.yandex.ru/-/CVCw6M9g",
 			"http://maps.yandex.com/-/CVCXEKYW",
+			"http://goo.gl/maps/Cji0V",
+			"http://amap.com/0F0i02",
+			"http://j.map.baidu.com/oXrVz",
+			"http://l.map.qq.com/9741483212?m",
+			"http://map.qq.com/?l=261496722",
+			"http://her.is/vLCEXE",
 		};
 
 		for (String u : unparsableUrls) {

--- a/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
+++ b/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
@@ -397,29 +397,29 @@ public class GeoPointParserUtil {
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// http://www.google.com/maps/place/760+West+Genesee+Street+Syracuse+NY+13204
-		qstr = "760+West+Genesee+Street+Syracuse+NY+13204";
-		url = "http://www.google.com/maps/place/" + qstr;
+		qstr = "760 West Genesee Street Syracuse NY 13204";
+		url = "http://www.google.com/maps/place/" + URLEncoder.encode(qstr);
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(qstr));
 
 		// http://maps.google.com/maps?q=760+West+Genesee+Street+Syracuse+NY+13204
-		qstr = "760+West+Genesee+Street+Syracuse+NY+13204";
-		url = "http://www.google.com/maps?q=" + qstr;
+		qstr = "760 West Genesee Street Syracuse NY 13204";
+		url = "http://www.google.com/maps?q=" + URLEncoder.encode(qstr);
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(qstr));
 
 		// http://maps.google.com/maps?daddr=760+West+Genesee+Street+Syracuse+NY+13204
-		qstr = "760+West+Genesee+Street+Syracuse+NY+13204";
-		url = "http://www.google.com/maps?daddr=" + qstr;
+		qstr = "760 West Genesee Street Syracuse NY 13204";
+		url = "http://www.google.com/maps?daddr=" + URLEncoder.encode(qstr);
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(qstr));
 
 		// http://www.google.com/maps/dir/Current+Location/760+West+Genesee+Street+Syracuse+NY+13204
-		qstr = "760+West+Genesee+Street+Syracuse+NY+13204";
-		url = "http://www.google.com/maps/dir/Current+Location/" + qstr;
+		qstr = "760 West Genesee Street Syracuse NY 13204";
+		url = "http://www.google.com/maps/dir/Current+Location/" + URLEncoder.encode(qstr);
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(qstr));
@@ -536,6 +536,8 @@ public class GeoPointParserUtil {
             "http://maps.yandex.com/?text=Australia%2C%20Victoria%2C%20Christmas%20Hills&sll=145.319026%2C-37.650344&ll=145.319026%2C-37.650344&spn=0.352249%2C0.151501&z=12&l=map",
             "http://maps.apple.com/?q=Bargou,+Tunisien",
             "http://maps.apple.com/?daddr=Bargou,+Tunisien",
+            "http://maps.apple.com/?lsp=7618&q=40.738065,-73.988898&sll=40.738065,-73.988898",
+            "http://maps.apple.com/?lsp=9902&auid=13787349062281695774&sll=40.694576,-73.982992&q=Garden%20Nail%20%26%20Spa&hnear=325%20Gold%20St%2C%20Brooklyn%2C%20NY%20%2011201-3054%2C%20United%20States",
         };
 
 		for (String u : urls) {
@@ -576,7 +578,8 @@ public class GeoPointParserUtil {
 	private static void assertGeoPoint(GeoParsedPoint actual, GeoParsedPoint expected) {
 		if (expected.getQuery() != null) {
 			if (!expected.getQuery().equals(actual.getQuery()))
-				throw new RuntimeException("Query param not equal");
+				throw new RuntimeException("Query param not equal:\n'" +
+                                           actual.getQuery() + "' != '" + expected.getQuery());
 		} else {
 			double aLat = actual.getLatitude(), eLat = expected.getLatitude(), aLon = actual.getLongitude(), eLon = expected.getLongitude();
 			int aZoom = actual.getZoom(), eZoom = expected.getZoom();
@@ -668,7 +671,7 @@ public class GeoPointParserUtil {
                 query = schemeSpecificPart.substring(pos + 1);
             }
         } else {
-            query = uri.getQuery();
+            query = uri.getRawQuery();
         }
         return getQueryParameters(query);
     }
@@ -682,7 +685,7 @@ public class GeoPointParserUtil {
                 if (keyValue.length == 1)
                     map.put(keyValue[0], "");
                 else if (keyValue.length > 1)
-                    map.put(keyValue[0], keyValue[1]);
+                    map.put(keyValue[0], URLDecoder.decode(keyValue[1]));
             }
 		}
 		return map;
@@ -1101,7 +1104,7 @@ public class GeoPointParserUtil {
 		    }
 		    return new GeoParsedPoint(lat, lon, zoom);
 		}
-		return new GeoParsedPoint(opath);
+		return new GeoParsedPoint(URLDecoder.decode(opath));
 	}
 
     private static String[] silentSplit(String vl, String split) {
@@ -1190,6 +1193,9 @@ public class GeoPointParserUtil {
 			this.zoom = NO_ZOOM;
 		}
 
+		/**
+		 * Accepts a plain {@code String}, not URL-encoded
+		 */
 		public GeoParsedPoint(String query) {
 			super();
 			this.query = query;

--- a/OsmAnd/AndroidManifest.xml
+++ b/OsmAnd/AndroidManifest.xml
@@ -198,6 +198,7 @@
 				<data android:host="share.here.com" />
 				<data android:host="map.wap.qq.com" />
 				<data android:host="map.qq.com" />
+				<data android:host="maps.apple.com" />
 				<action android:name="android.intent.action.VIEW" />
 				<category android:name="android.intent.category.DEFAULT" />
 				<category android:name="android.intent.category.BROWSABLE" />

--- a/OsmAnd/AndroidManifest.xml
+++ b/OsmAnd/AndroidManifest.xml
@@ -193,6 +193,9 @@
 				<data android:host="map.baidu.com" />
 				<data android:host="wb.amap.com" />
 				<data android:host="www.amap.com" />
+				<data android:host="here.com" />
+				<data android:host="www.here.com" />
+				<data android:host="share.here.com" />
 				<action android:name="android.intent.action.VIEW" />
 				<category android:name="android.intent.category.DEFAULT" />
 				<category android:name="android.intent.category.BROWSABLE" />

--- a/OsmAnd/AndroidManifest.xml
+++ b/OsmAnd/AndroidManifest.xml
@@ -191,6 +191,8 @@
 				<data android:host="osm.org" />
 				<data android:host="map.baidu.cn" />
 				<data android:host="map.baidu.com" />
+				<data android:host="wb.amap.com" />
+				<data android:host="www.amap.com" />
 				<action android:name="android.intent.action.VIEW" />
 				<category android:name="android.intent.category.DEFAULT" />
 				<category android:name="android.intent.category.BROWSABLE" />

--- a/OsmAnd/AndroidManifest.xml
+++ b/OsmAnd/AndroidManifest.xml
@@ -196,6 +196,8 @@
 				<data android:host="here.com" />
 				<data android:host="www.here.com" />
 				<data android:host="share.here.com" />
+				<data android:host="map.wap.qq.com" />
+				<data android:host="map.qq.com" />
 				<action android:name="android.intent.action.VIEW" />
 				<category android:name="android.intent.category.DEFAULT" />
 				<category android:name="android.intent.category.BROWSABLE" />


### PR DESCRIPTION
This pull request adds support for parsing more URLs:
* http://amap.com
* https://www.here.com
* http://map.qq.com
* http://maps.apple.com
* https://maps.yandex.com
* all Google map domains (e.g. https://www.google.at/maps, google.ru, google.es, etc.)

It also adds more tests including adding unparsable URLs to make sure the parsing does the right thing.  The last commit includes some valid Google Maps links that cause problems with the new `parseGoogleMapsPath()` method.  I didn't have time to fix `parseGoogleMapsPath()` though, and I couldn't really make senses of it either, so I'm just documenting the issues with that commit.