### PR TITLE
Fix work with SQLiteDB

### DIFF
--- a/OsmAnd-java/src/net/osmand/map/TileSourceManager.java
+++ b/OsmAnd-java/src/net/osmand/map/TileSourceManager.java
@@ -30,7 +30,7 @@ import bsh.Interpreter;
 
 public class TileSourceManager {
 	private static final Log log = PlatformUtil.getLog(TileSourceManager.class);
-	private static final String RULE_BEANSHELL = "beanshell";
+	public static final String RULE_BEANSHELL = "beanshell";
 	public static final String RULE_YANDEX_TRAFFIC = "yandex_traffic";
 	private static final String RULE_WMS = "wms_tile";
 
@@ -62,6 +62,14 @@ public class TileSourceManager {
 			this.bitDensity = bitDensity;
 		}
 		
+		public static String normalizeUrl(String url){
+			if(url != null){
+				url = url.replaceAll("\\{\\$z\\}", "{0}"); //$NON-NLS-1$ //$NON-NLS-2$
+				url = url.replaceAll("\\{\\$x\\}", "{1}"); //$NON-NLS-1$//$NON-NLS-2$
+				url = url.replaceAll("\\{\\$y\\}", "{2}"); //$NON-NLS-1$ //$NON-NLS-2$
+			}
+			return url;
+		}
 		public void setMinZoom(int minZoom) {
 			this.minZoom = minZoom;
 		}
@@ -343,9 +351,10 @@ public class TileSourceManager {
 							new FileInputStream(readUrl), "UTF-8")); //$NON-NLS-1$
 					url = reader.readLine();
 					// 
-					url = url.replaceAll("\\{\\$z\\}", "{0}"); //$NON-NLS-1$ //$NON-NLS-2$
-					url = url.replaceAll("\\{\\$x\\}", "{1}"); //$NON-NLS-1$//$NON-NLS-2$
-					url = url.replaceAll("\\{\\$y\\}", "{2}"); //$NON-NLS-1$ //$NON-NLS-2$
+					//url = url.replaceAll("\\{\\$z\\}", "{0}"); //$NON-NLS-1$ //$NON-NLS-2$
+					//url = url.replaceAll("\\{\\$x\\}", "{1}"); //$NON-NLS-1$//$NON-NLS-2$
+					//url = url.replaceAll("\\{\\$y\\}", "{2}"); //$NON-NLS-1$ //$NON-NLS-2$
+					url = TileSourceTemplate.normalizeUrl(url);
 					reader.close();
 				}
 			} catch (IOException e) {
@@ -478,9 +487,11 @@ public class TileSourceManager {
 		if (name == null || (urlTemplate == null && !ignoreTemplate)) {
 			return null;
 		}
-		if(urlTemplate != null){
-			urlTemplate.replace("${x}", "{1}").replace("${y}", "{2}").replace("${z}", "{0}");
-		}
+		//if(urlTemplate != null){
+			//urlTemplate.replace("${x}", "{1}").replace("${y}", "{2}").replace("${z}", "{0}");
+		//}
+		urlTemplate = TileSourceTemplate.normalizeUrl(urlTemplate);
+
 		int maxZoom = parseInt(attributes, "max_zoom", 18);
 		int minZoom = parseInt(attributes, "min_zoom", 5);
 		int tileSize = parseInt(attributes, "tile_size", 256);

--- a/OsmAnd/src/net/osmand/plus/resources/ResourceManager.java
+++ b/OsmAnd/src/net/osmand/plus/resources/ResourceManager.java
@@ -210,7 +210,7 @@ public class ResourceManager {
 		if(request instanceof TileLoadDownloadRequest){
 			TileLoadDownloadRequest req = ((TileLoadDownloadRequest) request);
 			imagesOnFS.put(req.tileId, Boolean.TRUE);
-			if(req.fileToSave != null && req.tileSource instanceof SQLiteTileSource){
+/*			if(req.fileToSave != null && req.tileSource instanceof SQLiteTileSource){
 				try {
 					((SQLiteTileSource) req.tileSource).insertImage(req.xTile, req.yTile, req.zoom, req.fileToSave);
 				} catch (IOException e) {
@@ -225,7 +225,7 @@ public class ResourceManager {
 						req.fileToSave.getParentFile().getParentFile().delete();
 					}
 				}
-			}
+			}*/
 		}
 		
 	}


### PR DESCRIPTION
1. Add ellipsoid projection (Yandex). Use new optional field ELLIPSOID in table INFO. 1 means ellipsoid. If there is no field ELLIPSOID or its value differs from 1, used default spheroid projection.
2. Add beanshell use. Use new optional field RULE in table INFO. Value "beanshell" makes to use interpreter for processing of a script which put into the field URL. If there is no field RULE or its value differs from "beanshell", content of the field URL used as before.
3. Enable load map to db in case of SQLiteDBSource. 
4. Saving imidiatelly to db (no temp file)  in case of SQLiteDBSource.
5. Fixed urlTemplate wildcards replacing for SQLiteDB field URL and metainfo field urlTemplate in case of not using beanshell. {$z}->{0}, {$x}->{1}, {$y}->{2}