### PR TITLE
Add beanshell use in SQLiteDB

### DIFF
--- a/OsmAnd-java/src/net/osmand/map/TileSourceManager.java
+++ b/OsmAnd-java/src/net/osmand/map/TileSourceManager.java
@@ -30,7 +30,7 @@ import bsh.Interpreter;
 
 public class TileSourceManager {
 	private static final Log log = PlatformUtil.getLog(TileSourceManager.class);
-	private static final String RULE_BEANSHELL = "beanshell";
+	public static final String RULE_BEANSHELL = "beanshell";
 	public static final String RULE_YANDEX_TRAFFIC = "yandex_traffic";
 	private static final String RULE_WMS = "wms_tile";
 


### PR DESCRIPTION
Add beanshell use. Use new optional field RULE in table INFO. Value "beanshell" makes to use interpreter for processing of a script which put into the field URL. If there is no field RULE or its value differs from "beanshell", content of the field URL used as before.