### PR TITLE
Continue work on BeanShell in SQLiteDB

### DIFF
--- a/OsmAnd/src/net/osmand/plus/SQLiteTileSource.java
+++ b/OsmAnd/src/net/osmand/plus/SQLiteTileSource.java
@@ -183,6 +183,10 @@ public class SQLiteTileSource implements ITileSource {
 							urlTemplate = template;
 						}
 					}
+					int ruleId = list.indexOf("rule");
+					if(ruleId != -1) {
+						rule = cursor.getString(ruleId);
+					}
 					int tnumbering = list.indexOf("tilenumbering");
 					if(tnumbering != -1) {
 						inversiveZoom = "BigPlanet".equalsIgnoreCase(cursor.getString(tnumbering));


### PR DESCRIPTION
Add beanshell use. Use new optional field RULE in table INFO. Value "beanshell" makes to use interpreter for processing of a script which put into the field URL. If there is no field RULE or its value differs from "beanshell", content of the field URL used as before.
