### PR TITLE
Saving tiles into sqlitedb

### DIFF
--- a/OsmAnd-java/src/net/osmand/map/MapTileDownloader.java
+++ b/OsmAnd-java/src/net/osmand/map/MapTileDownloader.java
@@ -4,6 +4,8 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.UnknownHostException;
@@ -106,6 +108,19 @@ public class MapTileDownloader {
 		
 		public void setError(boolean error){
 			this.error = error;
+		}
+		
+		public void saveTile(InputStream inputStream) throws IOException {
+			fileToSave.getParentFile().mkdirs();
+			OutputStream stream = null;
+			try {
+				stream = new FileOutputStream(fileToSave);
+				Algorithms.streamCopy(inputStream, stream);
+				stream.flush();
+			} finally {
+				Algorithms.closeStream(inputStream);
+				Algorithms.closeStream(stream);
+			}
 		}
 	}
 	
@@ -218,23 +233,15 @@ public class MapTileDownloader {
 					log.debug("Start downloading tile : " + request.url); //$NON-NLS-1$
 				}
 				long time = System.currentTimeMillis();
+				request.setError(false);
 				try {
-					request.fileToSave.getParentFile().mkdirs();
 					URL url = new URL(request.url);
 					URLConnection connection = url.openConnection();
 					connection.setRequestProperty("User-Agent", USER_AGENT); //$NON-NLS-1$
 					connection.setConnectTimeout(CONNECTION_TIMEOUT);
 					connection.setReadTimeout(CONNECTION_TIMEOUT);
 					BufferedInputStream inputStream = new BufferedInputStream(connection.getInputStream(), 8 * 1024);
-					FileOutputStream stream = null;
-					try {
-						stream = new FileOutputStream(request.fileToSave);
-						Algorithms.streamCopy(inputStream, stream);
-						stream.flush();
-					} finally {
-						Algorithms.closeStream(inputStream);
-						Algorithms.closeStream(stream);
-					}
+					request.saveTile(inputStream);
 					if (log.isDebugEnabled()) {
 						log.debug("Downloading tile : " + request.url + " successfull " + (System.currentTimeMillis() - time) + " ms"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 					}

--- a/OsmAnd/src/net/osmand/plus/resources/ResourceManager.java
+++ b/OsmAnd/src/net/osmand/plus/resources/ResourceManager.java
@@ -210,7 +210,7 @@ public class ResourceManager {
 		if(request instanceof TileLoadDownloadRequest){
 			TileLoadDownloadRequest req = ((TileLoadDownloadRequest) request);
 			imagesOnFS.put(req.tileId, Boolean.TRUE);
-			if(req.fileToSave != null && req.tileSource instanceof SQLiteTileSource){
+/*			if(req.fileToSave != null && req.tileSource instanceof SQLiteTileSource){
 				try {
 					((SQLiteTileSource) req.tileSource).insertImage(req.xTile, req.yTile, req.zoom, req.fileToSave);
 				} catch (IOException e) {
@@ -225,7 +225,7 @@ public class ResourceManager {
 						req.fileToSave.getParentFile().getParentFile().delete();
 					}
 				}
-			}
+			}*/
 		}
 		
 	}
@@ -437,7 +437,7 @@ public class ResourceManager {
 					Algorithms.streamCopy(OsmandRegions.class.getResourceAsStream("regions.ocbf"),
 							new FileOutputStream(file));
 				}
-			} 
+			}
 			regions.prepareFile(file.getAbsolutePath());
 		} catch (IOException e) {
 			log.error(e.getMessage(), e);


### PR DESCRIPTION
In case of SQLiteTileSource using:
Changed loading tiles into sqlitedb when using "Download map" from context menu. Before now in such cases tiles were saved in files in TEMP folder
Changed saving tiles directly into sqlitedb when browsing new area. Before now in such cases 
intermediate temp files were used.