### PR TITLE
Add in urlTemplate support of variables {z}, {x} and {0} interpreted like {0}, {1} and {2}

### DIFF
--- a/OsmAnd-java/src/net/osmand/map/TileSourceManager.java
+++ b/OsmAnd-java/src/net/osmand/map/TileSourceManager.java
@@ -62,6 +62,14 @@ public class TileSourceManager {
 			this.bitDensity = bitDensity;
 		}
 		
+		public static String normalizeUrl(String url){
+			if(url != null){
+				url = url.replaceAll("\\{\\$z\\}", "{0}"); //$NON-NLS-1$ //$NON-NLS-2$
+				url = url.replaceAll("\\{\\$x\\}", "{1}"); //$NON-NLS-1$//$NON-NLS-2$
+				url = url.replaceAll("\\{\\$y\\}", "{2}"); //$NON-NLS-1$ //$NON-NLS-2$
+			}
+			return url;
+		}
 		public void setMinZoom(int minZoom) {
 			this.minZoom = minZoom;
 		}
@@ -343,9 +351,10 @@ public class TileSourceManager {
 							new FileInputStream(readUrl), "UTF-8")); //$NON-NLS-1$
 					url = reader.readLine();
 					// 
-					url = url.replaceAll("\\{\\$z\\}", "{0}"); //$NON-NLS-1$ //$NON-NLS-2$
-					url = url.replaceAll("\\{\\$x\\}", "{1}"); //$NON-NLS-1$//$NON-NLS-2$
-					url = url.replaceAll("\\{\\$y\\}", "{2}"); //$NON-NLS-1$ //$NON-NLS-2$
+					//url = url.replaceAll("\\{\\$z\\}", "{0}"); //$NON-NLS-1$ //$NON-NLS-2$
+					//url = url.replaceAll("\\{\\$x\\}", "{1}"); //$NON-NLS-1$//$NON-NLS-2$
+					//url = url.replaceAll("\\{\\$y\\}", "{2}"); //$NON-NLS-1$ //$NON-NLS-2$
+					url = TileSourceTemplate.normalizeUrl(url);
 					reader.close();
 				}
 			} catch (IOException e) {
@@ -478,9 +487,11 @@ public class TileSourceManager {
 		if (name == null || (urlTemplate == null && !ignoreTemplate)) {
 			return null;
 		}
-		if(urlTemplate != null){
-			urlTemplate.replace("${x}", "{1}").replace("${y}", "{2}").replace("${z}", "{0}");
-		}
+		//if(urlTemplate != null){
+			//urlTemplate.replace("${x}", "{1}").replace("${y}", "{2}").replace("${z}", "{0}");
+		//}
+		urlTemplate = TileSourceTemplate.normalizeUrl(urlTemplate);
+
 		int maxZoom = parseInt(attributes, "max_zoom", 18);
 		int minZoom = parseInt(attributes, "min_zoom", 5);
 		int tileSize = parseInt(attributes, "tile_size", 256);

--- a/OsmAnd-java/src/net/osmand/map/TileSourceManager.java
+++ b/OsmAnd-java/src/net/osmand/map/TileSourceManager.java
@@ -487,6 +487,7 @@ public class TileSourceManager {
 		if (name == null || (urlTemplate == null && !ignoreTemplate)) {
 			return null;
 		}
+		//As I see, here is no changes to urlTemplate  
 		//if(urlTemplate != null){
 			//urlTemplate.replace("${x}", "{1}").replace("${y}", "{2}").replace("${z}", "{0}");
 		//}

--- a/OsmAnd/src/net/osmand/plus/SQLiteTileSource.java
+++ b/OsmAnd/src/net/osmand/plus/SQLiteTileSource.java
@@ -180,7 +180,8 @@ public class SQLiteTileSource implements ITileSource {
 					if(url != -1) {
 						String template = cursor.getString(url);
 						if(!Algorithms.isEmpty(template)){
-							urlTemplate = template;
+							//urlTemplate = template;
+							urlTemplate = TileSourceTemplate.normalizeUrl(template);
 						}
 					}
 					int ruleId = list.indexOf("rule");


### PR DESCRIPTION
Add in urlTemplate support of variables {z}, {x} and {0} interpreted like {0}, {1} and {2}.

Before now these variables were supported in some cases. Now they are supported always in both .metainso and sqlitedb.
No support in beanshell!