### PR TITLE
use NetworkUtils.getHttpURLConnection for all URLConnections

### DIFF
--- a/OsmAnd-java/src/net/osmand/map/MapTileDownloader.java
+++ b/OsmAnd-java/src/net/osmand/map/MapTileDownloader.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import net.osmand.PlatformUtil;
+import net.osmand.osm.io.NetworkUtils;
 import net.osmand.util.Algorithms;
 
 import org.apache.commons.logging.Log;
@@ -235,8 +236,7 @@ public class MapTileDownloader {
 				long time = System.currentTimeMillis();
 				request.setError(false);
 				try {
-					URL url = new URL(request.url);
-					URLConnection connection = url.openConnection();
+					URLConnection connection = NetworkUtils.getHttpURLConnection(request.url);
 					connection.setRequestProperty("User-Agent", USER_AGENT); //$NON-NLS-1$
 					connection.setConnectTimeout(CONNECTION_TIMEOUT);
 					connection.setReadTimeout(CONNECTION_TIMEOUT);

--- a/OsmAnd-java/src/net/osmand/map/TileSourceManager.java
+++ b/OsmAnd-java/src/net/osmand/map/TileSourceManager.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import net.osmand.PlatformUtil;
+import net.osmand.osm.io.NetworkUtils;
 import net.osmand.util.Algorithms;
 
 import org.apache.commons.logging.Log;
@@ -401,7 +402,7 @@ public class TileSourceManager {
 	public static List<TileSourceTemplate> downloadTileSourceTemplates(String versionAsUrl) {
 		final List<TileSourceTemplate> templates = new ArrayList<TileSourceTemplate>();
 		try {
-			URLConnection connection = new URL("http://download.osmand.net//tile_sources.php?" + versionAsUrl).openConnection();
+			URLConnection connection = NetworkUtils.getHttpURLConnection("http://download.osmand.net//tile_sources.php?" + versionAsUrl);
 			XmlPullParser parser = PlatformUtil.newXMLPullParser();
 			parser.setInput(connection.getInputStream(), "UTF-8");
 			int tok;

--- a/OsmAnd/src/net/osmand/plus/activities/ContributionVersionActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/ContributionVersionActivity.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import net.osmand.AndroidUtils;
 import net.osmand.access.AccessibleToast;
+import net.osmand.osm.io.NetworkUtils;
 import net.osmand.plus.R;
 
 import org.xmlpull.v1.XmlPullParser;
@@ -138,7 +139,7 @@ public class ContributionVersionActivity extends OsmandListActivity {
 	
 	protected void executeThreadOperation(int operationId) throws Exception {
 		if(operationId == DOWNLOAD_BUILDS_LIST){
-			URLConnection connection = new URL(URL_TO_RETRIEVE_BUILDS).openConnection();
+			URLConnection connection = NetworkUtils.getHttpURLConnection(URL_TO_RETRIEVE_BUILDS);
 			XmlPullParser parser = XmlPullParserFactory.newInstance().newPullParser();
 			parser.setInput(connection.getInputStream(), "UTF-8");
 			int next;
@@ -164,7 +165,7 @@ public class ContributionVersionActivity extends OsmandListActivity {
 				}
 			}
 		} else if(operationId == INSTALL_BUILD){
-			URLConnection connection = new URL(URL_GET_BUILD + currentSelectedBuild.path).openConnection();
+			URLConnection connection = NetworkUtils.getHttpURLConnection(URL_GET_BUILD + currentSelectedBuild.path);
 			if(pathToDownload.exists()){
 				pathToDownload.delete();
 			}

--- a/OsmAnd/src/net/osmand/plus/activities/search/SearchAddressOnlineFragment.java
+++ b/OsmAnd/src/net/osmand/plus/activities/search/SearchAddressOnlineFragment.java
@@ -17,6 +17,7 @@ import android.view.MenuItem.OnMenuItemClickListener;
 import net.osmand.PlatformUtil;
 import net.osmand.access.AccessibleToast;
 import net.osmand.data.LatLon;
+import net.osmand.osm.io.NetworkUtils;
 import net.osmand.plus.ContextMenuAdapter;
 import net.osmand.plus.OsmAndFormatter;
 import net.osmand.plus.OsmandApplication;
@@ -174,8 +175,7 @@ public class SearchAddressOnlineFragment extends Fragment implements SearchActiv
 					b.append("&q=").append(URLEncoder.encode(search, "UTF-8")); //$NON-NLS-1$
 					
 					log.info("Searching address at : " + b); //$NON-NLS-1$
-					URL url = new URL(b.toString());
-					URLConnection conn = url.openConnection();
+					URLConnection conn = NetworkUtils.getHttpURLConnection(b.toString());
 					conn.setDoInput(true);
 					conn.setRequestProperty("User-Agent", Version.getFullVersion((OsmandApplication) getActivity().getApplication())); //$NON-NLS-1$
 					conn.connect();

--- a/OsmAnd/src/net/osmand/plus/osmedit/OsmBugsLayer.java
+++ b/OsmAnd/src/net/osmand/plus/osmedit/OsmBugsLayer.java
@@ -16,6 +16,7 @@ import net.osmand.access.AccessibleToast;
 import net.osmand.data.LatLon;
 import net.osmand.data.QuadRect;
 import net.osmand.data.RotatedTileBox;
+import net.osmand.osm.io.NetworkUtils;
 import net.osmand.plus.ContextMenuAdapter;
 import net.osmand.plus.ContextMenuAdapter.OnContextMenuClick;
 import net.osmand.plus.OsmandApplication;
@@ -256,8 +257,7 @@ public class OsmBugsLayer extends OsmandMapLayer implements IContextMenuProvider
 		b.append(",").append(topLatitude); //$NON-NLS-1$
 		try {
 			log.info("Loading bugs " + b); //$NON-NLS-1$
-			URL url = new URL(b.toString());
-			URLConnection connection = url.openConnection();
+			URLConnection connection = NetworkUtils.getHttpURLConnection(b.toString());
 			BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
 			XmlPullParser parser = Xml.newPullParser();
 			parser.setInput(reader);

--- a/OsmAnd/src/net/osmand/plus/routing/RouteProvider.java
+++ b/OsmAnd/src/net/osmand/plus/routing/RouteProvider.java
@@ -574,8 +574,7 @@ public class RouteProvider {
 		}
 		uri.append("&fast=").append(params.fast ? "1" : "0").append("&layer=mapnik"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		log.info("URL route " + uri);
-		URL url = new URL(uri.toString());
-		URLConnection connection = url.openConnection();
+		URLConnection connection = NetworkUtils.getHttpURLConnection(uri.toString());
 		connection.setRequestProperty("User-Agent", Version.getFullVersion(params.ctx));
 		DocumentBuilder dom = DocumentBuilderFactory.newInstance().newDocumentBuilder();
 		Document doc = dom.parse(new InputSource(new InputStreamReader(connection.getInputStream())));
@@ -949,9 +948,7 @@ public class RouteProvider {
 		// .append("&language=").append(Locale.getDefault().getLanguage());
 
 		log.info("URL route " + request);
-		URI uri = URI.create(request.toString());
-		URL url = uri.toURL();
-		URLConnection connection = url.openConnection();
+		URLConnection connection = NetworkUtils.getHttpURLConnection(request.toString());
 		connection.setRequestProperty("User-Agent", Version.getFullVersion(params.ctx));
 
 		DocumentBuilder dom = DocumentBuilderFactory.newInstance().newDocumentBuilder();


### PR DESCRIPTION
This keeps the code consistent, provides a single common method for setting
up URLConnections, and allows the proxy support to work on all network
connections.

NetworkUtils.getHttpURLConnection() provides a common method for creating
HttpUrlConnection instances from URLs.  That's where the proxy config
happens.  If you can think of a better way to add proxy support, I'm all
ears.  This is the best that we've found in our proxy work at Guardian
Project.

this is a follow up on https://github.com/osmandapp/osmand/pull/1043