### PR TITLE
Update phrases.xml

### DIFF
--- a/OsmAnd/res/values/phrases.xml
+++ b/OsmAnd/res/values/phrases.xml
@@ -52,7 +52,7 @@
 	<string name="poi_bed_shop">Bed room furnishings</string>
 	<string name="poi_boutique">Fashion boutique</string>
 	<string name="poi_carpet_shop">Carpet shop</string>
-	<string name="poi_chemist_shop">Drug store</string>
+	<string name="poi_chemist_shop">Chemist shop</string>
 	<string name="poi_clothes_shop">Apparel store</string>
 	<string name="poi_child_clothes_shop">Childrens apparel</string>
 	<string name="poi_shoes">Shoe store</string>
@@ -82,7 +82,7 @@
 	<string name="poi_interior_decoration_shop">Interior decoration store</string>
 	<string name="poi_jewelry_shop">Jewelry store</string>
 	<string name="poi_kiosk">Kiosk</string>
-	<string name="poi_kitchen_shop">Kitchenware</string>
+	<string name="poi_kitchen_shop">Kitchen furnishings</string>
 	<string name="poi_mobile_phone_shop">Cell phone store</string>
 	<string name="poi_motorcycle_shop">Motorcycle shop</string>
 	<string name="poi_musical_instrument_shop">Musical instruments</string>
@@ -316,7 +316,7 @@
 	<string name="poi_telecommunication_office">Telecommunication office</string>
 	<string name="poi_ngo">NGO</string>
 	<string name="poi_town_hall">Town hall</string>
-	<string name="poi_employment_agency">Employement office</string>
+	<string name="poi_employment_agency">Employment office</string>
 	<string name="poi_research_office">Research office</string>
 	<string name="poi_it_office">IT office</string>
 	<string name="poi_newspaper_office">Newspaper office</string>


### PR DESCRIPTION
Bugs:
shop=chemist is not "Drug store" (that would be a pharmacy).
shop=kitchen is for a "kitchen studio", i.e. furnishing,architecting. Kitchenware (cooking stuff, etc) is explicitly under shop=houseware.