### PR TITLE
Fix duplicate favourites again (issue 2400)

### DIFF
--- a/OsmAnd/src/net/osmand/plus/FavouritesDbHelper.java
+++ b/OsmAnd/src/net/osmand/plus/FavouritesDbHelper.java
@@ -196,7 +196,6 @@ public class FavouritesDbHelper {
 			} else {
 				builder.setMessage(uiContext.getString(R.string.fav_point_dublicate_message, name));
 			}
-			builder.setPositiveButton(R.string.shared_string_ok, null);
 			p.setName(name);
 			return builder;
 		}
@@ -231,6 +230,7 @@ public class FavouritesDbHelper {
 			++index;
 		}
 
+		builder.trimToSize(); // remove trailing null characters
 		return builder.toString();
 	}
 

--- a/OsmAnd/src/net/osmand/plus/dialogs/FavoriteDialogs.java
+++ b/OsmAnd/src/net/osmand/plus/dialogs/FavoriteDialogs.java
@@ -221,6 +221,7 @@ public class FavoriteDialogs {
 							addFavorite(activity, point, helper);							
 						}
 					});
+					bld.show();
 				} else {
 					addFavorite(activity, point, helper);
 				}


### PR DESCRIPTION
StringBuilder adds trailing null characters so that duplicate favourite names are never detected, because fp.getName().equals(name) always returns false.
Dialog was never shown, so that addFavorite() was never called, in case of duplicate favourite name.
Also setPositiveButton() was called twice.
https://code.google.com/p/osmand/issues/detail?id=2400