### PR TITLE
Don't copy unused specialphrases

### DIFF
--- a/OsmAnd/build.gradle
+++ b/OsmAnd/build.gradle
@@ -189,12 +189,6 @@ task collectVoiceAssets(type: Sync) {
 	include "**/*.p"
 }
 
-task collectSpecialPhrasesAssets(type: Sync) {
-	from "../../resources/specialphrases"
-	into "assets/specialphrases"
-	include "*.txt"
-}
-
 task collectHelpContentsAssets(type: Sync) {
 	from "../../help"
 	into "assets/help"
@@ -242,7 +236,6 @@ task copyStyleIcons(type: Copy) {
 
 task collectExternalResources << {}
 collectExternalResources.dependsOn collectVoiceAssets,
-		collectSpecialPhrasesAssets,
 		collectHelpContentsAssets,
 		collectRoutingResources,
 		collectRenderingStylesResources,

--- a/OsmAnd/build.xml
+++ b/OsmAnd/build.xml
@@ -78,7 +78,6 @@
 	<target name="copy_resources">
 		<copy todir="assets">
 			<fileset dir="../../resources/">
-				<include name="specialphrases/**" />
 				<include name="voice/**/*.p" />
 			</fileset>
 		</copy>


### PR DESCRIPTION
It seems that specialphrases were migrated to phrases.xml.