### PR TITLE
Add road style translations

### DIFF
--- a/OsmAnd/res/values-de/strings.xml
+++ b/OsmAnd/res/values-de/strings.xml
@@ -2017,9 +2017,11 @@ Afghanistan, Ägypten, Albanien, Algerien, Andorra, Angola, Anguilla, Antigua an
     <string name="dash_download_new_one">Neue Karte herunterladen</string>
     <string name="dash_download_manage">Karten verwalten</string>
     <string name="rendering_attr_roadStyle_name">Straßen-Darstellung</string>
+    <string name="rendering_value__name">Standard</string>
     <string name="rendering_value_default_name">Standard</string>
     <string name="rendering_value_orange_name">Orange</string>
     <string name="rendering_value_germanRoadAtlas_name">Deutscher Straßenatlas</string>
+    <string name="rendering_value_highContrastRoads_name">Kontrastreiche Straßen</string>
     <string name="traffic_warning_railways">Bahnübergang</string>
     <string name="traffic_warning_pedestrian">Fußgängerübergang</string>
     <string name="show_railway_warnings">Eisenbahnübergänge anzeigen</string>

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -214,9 +214,11 @@
 	<string name="avoid_roads_msg">You can trigger an alternative route by selecting roads to avoid</string>
 	<string name="speak_pedestrian">Announce pedestrian crosswalks</string>
     <string name="rendering_attr_roadStyle_name">Road style</string>
+    <string name="rendering_value__name">Default</string>
     <string name="rendering_value_default_name">Default</string>
     <string name="rendering_value_orange_name">Orange</string>
     <string name="rendering_value_germanRoadAtlas_name">German road atlas</string>
+    <string name="rendering_value_highContrastRoads_name">High contrast roads</string>
 	<string name="traffic_warning_railways">Railroad crossing</string>
 	<string name="traffic_warning_pedestrian">Pedestrian crosswalk</string>
 	<string name="show_railway_warnings">Show railroad crossings</string>


### PR DESCRIPTION
"default" value was replaced with empty value [1], thus I also added translation for empty value "rendering_value__name".

[1] https://github.com/osmandapp/OsmAnd-resources/commit/cfa2123c0e97f786d59958a4c56e1f89fb4d4b02
