### PR TITLE
Orthographe

### DIFF
--- a/OsmAnd/res/values-fr/phrases.xml
+++ b/OsmAnd/res/values-fr/phrases.xml
@@ -763,7 +763,7 @@
 	<string name="poi_lean_to">Appentis</string>
 	<string name="poi_hunting_lodge">Pavillon de chasse</string>
 
-	<string name="poi_picnic_table">Table de picnic</string>
+	<string name="poi_picnic_table">Table de pique-nique</string>
 	<string name="poi_wine_cellar">Cave à vin</string>
 	<string name="poi_winery">Établissement viticole</string>
 


### PR DESCRIPTION
picnic (en) = pique-nique (fr)