### PR TITLE
Orange color for POIs that are closed in 30 minutes from now

### DIFF
--- a/OsmAnd/res/values/colors.xml
+++ b/OsmAnd/res/values/colors.xml
@@ -109,6 +109,8 @@
 	<color name="color_unknown">#C8C8C8</color>
 	<!-- good state, localindex loaded, poi_open, osm_create, index_ok   -->
 	<color name="color_ok">#32CD32</color>
+	<!-- intermediate state - poi is going to be closed -->
+	<color name="color_intermediate">#FFDD00</color>
 	<!-- update good state, osm_modify, index_update -->
 	<color name="color_update">#0080FF</color>
 	

--- a/OsmAnd/src/net/osmand/plus/activities/search/SearchPOIActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/search/SearchPOIActivity.java
@@ -744,11 +744,15 @@ public class SearchPOIActivity extends OsmandListActivity implements OsmAndCompa
 				if (rs != null) {
 					Calendar inst = Calendar.getInstance();
 					inst.setTimeInMillis(System.currentTimeMillis());
-					boolean work = rs.isOpenedForTime(inst);
+					boolean worksNow = rs.isOpenedForTime(inst);
+					inst.setTimeInMillis(System.currentTimeMillis() + 30 * 60 * 1000); // 30 minutes later
+					boolean worksLater = rs.isOpenedForTime(inst);
+					int colorId = worksNow ? worksLater ? color.color_ok : color.color_intermediate : color.color_warning;
+
 					timeIcon.setVisibility(View.VISIBLE);
 					timeText.setVisibility(View.VISIBLE);
-					timeIcon.setImageDrawable(app.getIconsCache().getIcon(R.drawable.ic_small_time, work ? R.color.color_ok : R.color.color_warning));
-					timeText.setTextColor(app.getResources().getColor(work ? R.color.color_ok : R.color.color_warning));
+					timeIcon.setImageDrawable(app.getIconsCache().getIcon(R.drawable.ic_small_time, colorId));
+					timeText.setTextColor(app.getResources().getColor(colorId));
 					String rt = rs.getCurrentRuleTime(inst);
 					timeText.setText(rt == null ? "" : rt);
 				} else {


### PR DESCRIPTION
Currently only colors used in the POI dialog for opening hours: red and green. I introduced new orange color for POIs that are closing in 30 minutes or less - this way we can easily distinguish POIs that are still open when we travel to them. 

I am not practically sure about 30 minutes, but it should be ok for shops, pharmacies and other pois of such type. Not very useful for restaurants, as an example.