### PR TITLE
Add "more" to "search villages/postcodes"

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -949,7 +949,7 @@
     <string name="monitoring_control_start">GPX</string>
     <string name="no_buildings_found">No buildings found.</string>
     <string name="incremental_search_city">Search city incrementally</string>
-    <string name="search_villages_and_postcodes">Search villages/postcode</string>
+    <string name="search_villages_and_postcodes">Search more villages/postcode</string>
 	<string name="rendering_attr_showRoadMaps_description">Select when to display roads-only maps:</string>
 	<string name="rendering_attr_showRoadMaps_name">Roads-only maps</string>
     <string name="safe_mode_description">Run the application in safe mode (using slower Android instead of native code).</string>


### PR DESCRIPTION
each month we have users who cannot find places in offline address search because they do not press the button "search villages/postcode" because instant search has no result for smaller places.

see https://groups.google.com/forum/#!topic/osmand/IDm-pPb4IpI again.

So users need to know that this button does a further deeper search.

Alternatively add a text like "Press above button when place name is not found instantly."