### PR TITLE
Use building entrance as a building location (handy for routing)

### DIFF
--- a/OsmAnd-java/src/net/osmand/osm/edit/OSMSettings.java
+++ b/OsmAnd-java/src/net/osmand/osm/edit/OSMSettings.java
@@ -73,7 +73,8 @@ public class OSMSettings {
 		WIKIPEDIA("wikipedia"), //$NON-NLS-1$
 		
 		ADMIN_LEVEL("admin_level"), //$NON-NLS-1$
-		PUBLIC_TRANSPORT("public_transport") //$NON-NLS-1$
+		PUBLIC_TRANSPORT("public_transport"), //$NON-NLS-1$
+		ENTRANCE("entrance"), //$NON-NLS-1$
 		;
 		
 		private final String value;


### PR DESCRIPTION
In case when only one entrance is present it is nice to route user directly to that entrance. 

Logic: if only one main entrance is present - it's chosen. If only one entrance in a building - it's chosen. Otherwise, default behavior is using weighted center.