### PR TITLE
Add small left turn and right turn icons. Work on #1198.

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/TurnPathHelper.java
+++ b/OsmAnd/src/net/osmand/plus/views/TurnPathHelper.java
@@ -17,7 +17,7 @@ import android.util.FloatMath;
 public class TurnPathHelper {
 
 	// 72x72
-	public static void calcTurnPath(Path pathForTurn, TurnType turnType, Matrix transform) {
+	public static void calcTurnPath(Path pathForTurn, TurnType turnType, Matrix transform, boolean smallIcon) {
 		if(turnType == null){
 			return;
 		}
@@ -43,13 +43,20 @@ public class TurnPathHelper {
 			pathForTurn.rLineTo(0, h);
 		} else if (TurnType.TR == turnType.getValue()|| TurnType.TL == turnType.getValue()) {
 			int b = TurnType.TR == turnType.getValue()? 1 : -1;
-			float quadShiftX = 18;
-			float quadShiftY = 18;
-			int wl = 10; // width
+			float quadShiftX = smallIcon ? 9 : 18;
+			float quadShiftY = smallIcon ? 9 : 18;
+			int wl = smallIcon ? 1 : 10; // width
 			int h = (int) (ha - quadShiftY - harrowL + hpartArrowL - 5);
+			if (smallIcon) {
+				h = 2 * h / 5;
+			}
 			int sl = wl + th / 2;
 			
-			pathForTurn.rMoveTo(-b * sl, 0);
+			if (!smallIcon) {
+				pathForTurn.rMoveTo(-b * sl, 0);
+			} else {
+				pathForTurn.rMoveTo(b * th, 0);
+			}
 			pathForTurn.rLineTo(0, -h);
 			pathForTurn.rQuadTo(0, -quadShiftY, b * quadShiftX, -quadShiftY);
 			pathForTurn.rLineTo(b * wl, 0);
@@ -260,7 +267,7 @@ public class TurnPathHelper {
 			paintRouteDirection.setStyle(Style.FILL_AND_STROKE);
 			paintRouteDirection.setColor(resources.getColor(R.color.nav_arrow_distant));
 			paintRouteDirection.setAntiAlias(true);
-			TurnPathHelper.calcTurnPath(dp, TurnType.straight(), null);
+			TurnPathHelper.calcTurnPath(dp, TurnType.straight(), null, false);
 		}
 
 		@Override
@@ -271,7 +278,7 @@ public class TurnPathHelper {
 		}
 		
 		public void setRouteType(TurnType t){
-			TurnPathHelper.calcTurnPath(p, t, null);
+			TurnPathHelper.calcTurnPath(p, t, null, false);
 			onBoundsChange(getBounds());
 		}
 

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/NextTurnInfoWidget.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/NextTurnInfoWidget.java
@@ -181,7 +181,7 @@ public class NextTurnInfoWidget extends TextInfoWidget {
 		public boolean setTurnType(TurnType turnType) {
 			if(turnType != this.turnType) {
 				this.turnType = turnType;
-				TurnPathHelper.calcTurnPath(pathForTurn, turnType, null);
+				TurnPathHelper.calcTurnPath(pathForTurn, turnType, null, false);
 				onBoundsChange(getBounds());
 				return true;
 			}

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/RouteInfoWidgetsFactory.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/RouteInfoWidgetsFactory.java
@@ -505,7 +505,7 @@ public class RouteInfoWidgetsFactory {
 		Matrix pathTransform = new Matrix();
 		pathTransform.postScale(coef, coef );
 		TurnType tp = TurnType.valueOf(laneType, false);
-		TurnPathHelper.calcTurnPath(p, tp, pathTransform);
+		TurnPathHelper.calcTurnPath(p, tp, pathTransform, false);
 		paths.set(laneType, p);
 		return p;
 	}


### PR DESCRIPTION
If `true` is passed in into the `smallIcon` parameter, and a left or right turn is to be drawn, then it will draw a smaller version of those icons. These icons _should_ be centered on the straight arrow (haven't verified this), so they can be overlaid directly on that arrow.

Currently, these icons aren't used yet, but are planned to be used in drawing the turn lanes.