### PR TITLE
If adding a left/right turn to a lane, make sure that that lane is ma…

### DIFF
--- a/OsmAnd-java/src/net/osmand/router/RouteResultPreparation.java
+++ b/OsmAnd-java/src/net/osmand/router/RouteResultPreparation.java
@@ -638,12 +638,14 @@ public class RouteResultPreparation {
 					// This was just to make sure that there's no bad data.
 					TurnType.setPrimaryTurnAndReset(lanesArray, ind, TurnType.TL);
 					TurnType.setSecondaryTurn(lanesArray, ind, tt);
+					lanesArray[ind] |= 1;
 				}
 			} else {
 				if (!TurnType.isRightTurn(tt)) {
 					// This was just to make sure that there's no bad data.
 					TurnType.setPrimaryTurnAndReset(lanesArray, ind, TurnType.TR);
 					TurnType.setSecondaryTurn(lanesArray, ind, tt);
+					lanesArray[ind] |= 1;
 				}
 			}
 			setAllowedLanes(tt, lanesArray);


### PR DESCRIPTION
…rked as selected.

If a segment has something like `turn:lanes=left|through`, and a right turn is being made, then the left arrow followed by the right arrow appear (correctly), but both arrows are gray. This change makes sure that the right-most lane (or left-most lane, in the case of a left turn) is selected to be highlighted.