### PR TITLE
Fixed a crash due to errors in format strings

### DIFF
--- a/OsmAnd/res/values-bg/strings.xml
+++ b/OsmAnd/res/values-bg/strings.xml
@@ -1845,7 +1845,7 @@ OsmAnd е с отворен код и активно да се развива. �
 	<string name="current_route">Текущ маршрут</string>
     <string name="mark_to_delete">Изберете за изтриване</string>
 	<string name="osmo_grop_name_length_alert">Името на групата трябва да бъде най-малко от 3 символа!</string>
-	<string name="local_osm_changes_upload_all_confirm">Ще да качите %1$ d промени към OSM. Сигурни ли сте?</string>
+	<string name="local_osm_changes_upload_all_confirm">Ще да качите %1$d промени към OSM. Сигурни ли сте?</string>
     <string name="confirmation_to_clear_history">Искате ли да изчистите хронологията?</string>
     <string name="delay_to_start_navigation">Стартиране на навигацията след…</string>
     <string name="shared_string_go">Старт</string>
@@ -1909,7 +1909,7 @@ OsmAnd е с отворен код и активно да се развива. �
 	<string name="online_map">Онлайн карта</string>
 	<string name="roads_only">Само пътища</string>
     <string name="rendering_attr_pisteRoutes_name">Ски писти</string>
-	<string name="free">"Свободни %1$ s "</string>
+	<string name="free">"Свободни %1$s "</string>
 	<string name="device_memory">Памет на устройството</string>
     <string name="parking_place">Паркинг място</string>
     <string name="remove_the_tag">ПРЕМАХНИ ЕТИКЕТА</string>
@@ -1964,7 +1964,7 @@ OsmAnd е с отворен код и активно да се развива. �
 	<string name="coordinates">Координати</string>
 	<string name="anonymous_user_hint">"Анонимен потребител не може  да:\n-създава групи;\n-синхронизира групи и устройства със сървъра;\n-управлява групи и устройства в частен режим."</string>
     <string name="anonymous_user">Анонимен потребител</string>
-    <string name="logged_as">Влезли сте като %1$ s</string>
+    <string name="logged_as">Влезли сте като %1$s</string>
 	<string name="print_route">Печат на маршрут</string>
     <string name="enable_proxy_title">Разреши HTTP прокси</string>
 	<string name="enable_proxy_descr">Конфигуриране на HTTP прокси за всички мрежови заявки</string>
@@ -1996,7 +1996,7 @@ OsmAnd е с отворен код и активно да се развива. �
     <string name="gpx_selection_route_points">%1$s
 \nТочки %2$s</string>
     <string name="speed_limit_exceed_message">Изберете толеранса на ограничението на скоростта, над което ще получите гласово предупреждение.</string>
-	<string name="fav_point_emoticons_message">Името на точката е променено на %1$ s с цел правилното записване на низ с емотикони във файл.</string>
+	<string name="fav_point_emoticons_message">Името на точката е променено на %1$s с цел правилното записване на низ с емотикони във файл.</string>
     <string name="osmo_gpx_track_downloaded">OsMo следата %1$s е изтеглена.</string>
     <string name="no_index_file_to_download">Списъкът за сваляне не е намерен, моля проверете Вашата интернет връзка.</string>
     <string name="gpx_selection_points">%1$s

--- a/OsmAnd/res/values-lt/strings.xml
+++ b/OsmAnd/res/values-lt/strings.xml
@@ -2037,7 +2037,7 @@
     <string name="local_indexes_cat_wiki">Vikipedija</string>
     <string name="shared_string_show_details">Rodyti detales</string>
     <string name="osm_edit_context_menu_delete">Ištrinti OSM taisymus</string>
-    <string name="local_recordings_delete_all_confirm">Ketinate ištrinti %1$ d pastabas. Ar tikrai to norite?</string>
+    <string name="local_recordings_delete_all_confirm">Ketinate ištrinti %1$d pastabas. Ar tikrai to norite?</string>
 	<string name="download_wikipedia_maps">Vikipedija</string>
     <string name="disable_recording_once_app_killed_descrp">Bus pristabdytas GPX įrašymas, jei programa bus išjungta (per Pastarosios programos). (OsmAnd Miego režimo piktograma dings iš Android pranešimų juostos.)</string>
 	<string name="download_wikipedia_files">Ar norite atsisiųsti papildomų Wikipedia duomenų (%1$s MB)?</string>

--- a/OsmAnd/res/values-pt-rBR/strings.xml
+++ b/OsmAnd/res/values-pt-rBR/strings.xml
@@ -264,7 +264,7 @@
     <string name="logged_as">Conectado como %1$s</string>
 	<string name="speed_limit_exceed">Tolerância do limite de velocidade</string>
 	<string name="speed_limit_exceed_message">Selecione a margem de tolerância de limite de velocidade, acima do qual você receberá um aviso de voz.</string>
-	<string name="fav_point_emoticons_message">O nome do favorito foi modificado para %1$ s para facilitar a salvar corretamente a seqüência de caracteres com emoticons para um arquivo.</string>
+	<string name="fav_point_emoticons_message">O nome do favorito foi modificado para %1$s para facilitar a salvar corretamente a seqüência de caracteres com emoticons para um arquivo.</string>
     <string name="speak_title">Anunciar…</string>
 	<string name="show_pedestrian_warnings">Faixas de pedestre</string>
     <string name="routing_attr_no_new_routing_description">Não use as regras de roteamento introduzidas na v1.9</string>


### PR DESCRIPTION
When you set the language to Bulgarian and then you go to Manage map files (Управление на карти) the application crashes.