### PR TITLE
Double parentheses in URL fix

### DIFF
--- a/OsmAnd-java/build.gradle
+++ b/OsmAnd-java/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'java'
+apply plugin:'application'
+mainClassName = "net.osmand.util.GeoPointParserUtil"
 
 sourceSets {
 	main {

--- a/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
+++ b/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
@@ -466,10 +466,11 @@ public class GeoPointParserUtil {
 
 		// http://maps.google.com/maps?lci=com.google.latitudepublicupdates&ll=34.99393%2C-106.61568&q=34.99393%2C-106.61568
                 z = GeoParsedPoint.NO_ZOOM;
-		url = "http://maps.google.com/maps?lci=com.google.latitudepublicupdates&ll=55.8063697%2C25.3749485&q=55.8063697%2C25.3749485((55.8063670%2C%2025.3749488))";
+		url = "http://maps.google.com/maps?lci=com.google.latitudepublicupdates&ll=" + dlat
+				+"%2C" + dlon + "&q=" + dlat + "%2C" + dlon + "((" + dlat + "%2C%20" + dlon + "))";
 		System.out.println("url: " + url);
 		actual = GeoPointParserUtil.parse(url);
-		assertGeoPoint(actual, new GeoParsedPoint(55.8063697, 25.3749485, z));
+		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
 		// https://www.google.com/maps/place/34%C2%B059'38.1%22N+106%C2%B036'56.5%22W/@34.99393,-106.61568,17z/data=!3m1!4b1!4m2!3m1!1s0x0:0x0
 		z = 17;

--- a/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
+++ b/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java
@@ -3,7 +3,6 @@ package net.osmand.util;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Locale;
@@ -465,6 +464,13 @@ public class GeoPointParserUtil {
 		actual = GeoPointParserUtil.parse(url);
 		assertGeoPoint(actual, new GeoParsedPoint(dlat, dlon, z));
 
+		// http://maps.google.com/maps?lci=com.google.latitudepublicupdates&ll=34.99393%2C-106.61568&q=34.99393%2C-106.61568
+                z = GeoParsedPoint.NO_ZOOM;
+		url = "http://maps.google.com/maps?lci=com.google.latitudepublicupdates&ll=55.8063697%2C25.3749485&q=55.8063697%2C25.3749485((55.8063670%2C%2025.3749488))";
+		System.out.println("url: " + url);
+		actual = GeoPointParserUtil.parse(url);
+		assertGeoPoint(actual, new GeoParsedPoint(55.8063697, 25.3749485, z));
+
 		// https://www.google.com/maps/place/34%C2%B059'38.1%22N+106%C2%B036'56.5%22W/@34.99393,-106.61568,17z/data=!3m1!4b1!4m2!3m1!1s0x0:0x0
 		z = 17;
 		url = "https://www.google.com/maps/place/34%C2%B059'38.1%22N+106%C2%B036'56.5%22W/@" + dlat + "," + dlon + "," + z + "z/data=!3m1!4b1!4m2!3m1!1s0x0:0x0";
@@ -785,7 +791,8 @@ public class GeoPointParserUtil {
             uri = URI.create(uriString.replaceAll("\\s+", "+")
                              .replaceAll("%20", "+")
                              .replaceAll("%2C", ",")
-                             .replaceAll("\\|", ";"));
+                             .replaceAll("\\|", ";")
+                             .replaceAll("\\(\\(\\S+\\)\\)", ""));
         } catch (IllegalArgumentException e) {
             return null;
         }

--- a/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
@@ -1,36 +1,5 @@
 package net.osmand.plus.activities.search;
 
-import android.widget.*;
-import gnu.trove.map.hash.TLongObjectHashMap;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-
-import net.osmand.ResultMatcher;
-import net.osmand.access.AccessibleToast;
-import net.osmand.data.Amenity;
-import net.osmand.data.City;
-import net.osmand.data.LatLon;
-import net.osmand.data.MapObject;
-import net.osmand.data.PointDescription;
-import net.osmand.data.Street;
-import net.osmand.plus.AppInitializer;
-import net.osmand.plus.OsmAndFormatter;
-import net.osmand.plus.OsmandApplication;
-import net.osmand.plus.OsmandSettings;
-import net.osmand.plus.R;
-import net.osmand.plus.AppInitializer.AppInitializeListener;
-import net.osmand.plus.AppInitializer.InitEvents;
-import net.osmand.plus.activities.MapActivity;
-import net.osmand.plus.activities.OsmandListActivity;
-import net.osmand.plus.resources.RegionAddressRepository;
-import net.osmand.plus.resources.ResourceManager;
-import net.osmand.util.GeoPointParserUtil;
-import net.osmand.util.MapUtils;
-import android.app.Dialog;
 import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnCancelListener;
@@ -41,9 +10,44 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import net.osmand.ResultMatcher;
+import net.osmand.access.AccessibleToast;
+import net.osmand.data.Amenity;
+import net.osmand.data.City;
+import net.osmand.data.LatLon;
+import net.osmand.data.MapObject;
+import net.osmand.data.PointDescription;
+import net.osmand.data.Street;
+import net.osmand.plus.AppInitializer;
+import net.osmand.plus.AppInitializer.AppInitializeListener;
+import net.osmand.plus.AppInitializer.InitEvents;
+import net.osmand.plus.OsmAndFormatter;
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.OsmandSettings;
+import net.osmand.plus.R;
+import net.osmand.plus.activities.MapActivity;
+import net.osmand.plus.activities.OsmandListActivity;
+import net.osmand.plus.resources.RegionAddressRepository;
+import net.osmand.plus.resources.ResourceManager;
+import net.osmand.util.GeoPointParserUtil;
+import net.osmand.util.MapUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import gnu.trove.map.hash.TLongObjectHashMap;
 
 public class GeoIntentActivity extends OsmandListActivity {
 
+	private static final String TAG = "GeoIntentActivity";
 	private ProgressDialog progressDlg;
 	private LatLon location;
 
@@ -206,7 +210,7 @@ public class GeoIntentActivity extends OsmandListActivity {
 	 * geo:0,0?q=34.99,-106.61(Treasure)<br/>
 	 * geo:0,0?q=1600+Amphitheatre+Parkway%2C+CA<br/>
 	 * 
-	 * @param data
+	 * @param uri
 	 *            The intent uri
 	 * @return
 	 */

--- a/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/search/GeoIntentActivity.java
@@ -47,7 +47,6 @@ import gnu.trove.map.hash.TLongObjectHashMap;
 
 public class GeoIntentActivity extends OsmandListActivity {
 
-	private static final String TAG = "GeoIntentActivity";
 	private ProgressDialog progressDlg;
 	private LatLon location;
 


### PR DESCRIPTION
* OsmAnd-java/build.gradle
  * modified gradle file for testing purposes
* GeoPointParserUtil.java
  * created test for URL from issue #1486
  * double parentheses and their content are now removed from URL
* GeoIntentActivity.java
  * imports and tiny Javadoc fix