### PR TITLE
Dialog for issue #1291

### DIFF
--- a/OsmAnd/res/layout/osm_edit_list_item.xml
+++ b/OsmAnd/res/layout/osm_edit_list_item.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:layout_width="fill_parent"
+              android:layout_height="wrap_content"
+              android:minHeight="@dimen/list_item_height">
+
+    <TextView
+        android:id="@+id/nameTextView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_marginLeft="@dimen/dialog_elements_vertical_margin"
+        android:layout_marginRight="@dimen/dialog_elements_vertical_margin"
+        android:layout_weight="1"
+        android:gravity="center_vertical"
+        android:textSize="@dimen/default_list_text_size"
+        tools:text="@string/lorem_ipsum"/>
+
+    <ImageView
+        android:id="@+id/iconImageView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_marginLeft="3dp"
+        android:layout_marginRight="@dimen/dialog_elements_vertical_margin"
+        android:gravity="center_vertical"
+        android:maxLines="2"
+        android:src="@drawable/ic_action_remove_dark"
+        android:textSize="@dimen/default_desc_text_size"/>
+
+</LinearLayout>

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -2221,4 +2221,9 @@ Afghanistan, Albania, Algeria, Andorra, Angola, Anguilla, Antigua and Barbuda, A
 	<string name="rate_this_app_long">Please give OsmAnd a score on Google Play</string>
 	<string name="user_hates_app_get_feedback">Tell us why.</string>
 	<string name="user_hates_app_get_feedback_long">Please tell us what would you want to change in this app.</string>
+	<string name="failed_to_upload">Failed to upload</string>
+	<string name="delete_change">Delete change</string>
+	<string name="successfully_uploaded_pattern">Successfully uploaded {0}/{1}</string>
+	<string name="try_again">Try again</string>
+	<string name="error_message_pattern">Error: {0}</string>
 </resources>

--- a/OsmAnd/src/net/osmand/plus/osmedit/DashOsmEditsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/osmedit/DashOsmEditsFragment.java
@@ -133,7 +133,7 @@ public class DashOsmEditsFragment extends DashBaseFragment {
 		ProgressDialog dialog = ProgressImplementation.createProgressDialog(getActivity(),
 				getString(R.string.uploading), getString(R.string.local_openstreetmap_uploading),
 				ProgressDialog.STYLE_HORIZONTAL).getDialog();
-		OsmEditsUploadListener listener = new OsmEditUploadListenerHelper(getActivity(),
+		OsmEditsUploadListener listener = new OsmEditsUploadListenerHelper(getActivity(),
 				getString(R.string.local_openstreetmap_were_uploaded)) {
 			@Override
 			public void uploadUpdated(OsmPoint point) {

--- a/OsmAnd/src/net/osmand/plus/osmedit/OpenstreetmapPoint.java
+++ b/OsmAnd/src/net/osmand/plus/osmedit/OpenstreetmapPoint.java
@@ -1,11 +1,9 @@
 package net.osmand.plus.osmedit;
 
-import java.io.Serializable;
-
 import net.osmand.osm.edit.Node;
 import net.osmand.osm.edit.OSMSettings.OSMTagKey;
 
-public class OpenstreetmapPoint extends OsmPoint implements Serializable {
+public class OpenstreetmapPoint extends OsmPoint {
 	private static final long serialVersionUID = 729654300829771467L;
 	private Node entity;
 	private String comment;

--- a/OsmAnd/src/net/osmand/plus/osmedit/OpenstreetmapRemoteUtil.java
+++ b/OsmAnd/src/net/osmand/plus/osmedit/OpenstreetmapRemoteUtil.java
@@ -1,20 +1,8 @@
 package net.osmand.plus.osmedit;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.StringWriter;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.text.MessageFormat;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import android.content.Context;
+import android.util.Xml;
+import android.widget.Toast;
 
 import net.osmand.PlatformUtil;
 import net.osmand.access.AccessibleToast;
@@ -37,9 +25,21 @@ import org.apache.commons.logging.Log;
 import org.xml.sax.SAXException;
 import org.xmlpull.v1.XmlSerializer;
 
-import android.content.Context;
-import android.util.Xml;
-import android.widget.Toast;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.StringWriter;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.text.MessageFormat;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 public class OpenstreetmapRemoteUtil implements OpenstreetmapUtil {
 
@@ -335,11 +335,7 @@ public class OpenstreetmapRemoteUtil implements OpenstreetmapUtil {
 				return entityInfo;
 			}
 
-		} catch (IOException e) {
-			log.error("Loading node failed " + nodeId, e); //$NON-NLS-1$
-			AccessibleToast.makeText(ctx, ctx.getResources().getString(R.string.shared_string_io_error),
-					Toast.LENGTH_LONG).show();
-		} catch (SAXException e) {
+		} catch (IOException | SAXException e) {
 			log.error("Loading node failed " + nodeId, e); //$NON-NLS-1$
 			AccessibleToast.makeText(ctx, ctx.getResources().getString(R.string.shared_string_io_error),
 					Toast.LENGTH_LONG).show();

--- a/OsmAnd/src/net/osmand/plus/osmedit/OsmBugsRemoteUtil.java
+++ b/OsmAnd/src/net/osmand/plus/osmedit/OsmBugsRemoteUtil.java
@@ -1,14 +1,5 @@
 package net.osmand.plus.osmedit;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLEncoder;
-
 import net.osmand.PlatformUtil;
 import net.osmand.osm.io.Base64;
 import net.osmand.osm.io.NetworkUtils;
@@ -19,36 +10,42 @@ import net.osmand.plus.Version;
 
 import org.apache.commons.logging.Log;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URLEncoder;
+
 public class OsmBugsRemoteUtil implements OsmBugsUtil {
 
 	private static final Log log = PlatformUtil.getLog(OsmBugsRemoteUtil.class);
-	
-	static String getNotesApi()
-	{
+
+	static String getNotesApi() {
 		final int deviceApiVersion = android.os.Build.VERSION.SDK_INT;
-		
+
 		String RETURN_API;
-		
+
 		if (deviceApiVersion >= android.os.Build.VERSION_CODES.GINGERBREAD) {
 			RETURN_API = "https://api.openstreetmap.org/api/0.6/notes";
-		}
-		else {
+		} else {
 			RETURN_API = "http://api.openstreetmap.org/api/0.6/notes";
 		}
-	
+
 		return RETURN_API;
 	}
 
 	private OsmandApplication app;
 	private OsmandSettings settings;
-	
+
 	public OsmBugsRemoteUtil(OsmandApplication app) {
 		this.app = app;
 		settings = app.getSettings();
 	}
 
 	@Override
-	public String createNewBug(double latitude, double longitude, String text, String author){
+	public String createNewBug(double latitude, double longitude, String text, String author) {
 		StringBuilder b = new StringBuilder();
 		b.append(getNotesApi()).append("?"); //$NON-NLS-1$
 		b.append("lat=").append(latitude); //$NON-NLS-1$
@@ -58,21 +55,21 @@ public class OsmBugsRemoteUtil implements OsmBugsUtil {
 	}
 
 	@Override
-	public String addingComment(long id, String text, String author){
+	public String addingComment(long id, String text, String author) {
 		StringBuilder b = new StringBuilder();
-		b.append(getNotesApi()).append("/"); 
+		b.append(getNotesApi()).append("/");
 		b.append(id); //$NON-NLS-1$
 		b.append("/comment?text=").append(URLEncoder.encode(text)); //$NON-NLS-1$
 		return editingPOI(b.toString(), "POST", "adding comment"); //$NON-NLS-1$
 	}
 
 	@Override
-	public String closingBug(long id, String text, String author){
+	public String closingBug(long id, String text, String author) {
 		StringBuilder b = new StringBuilder();
-		b.append(getNotesApi()).append("/"); 
+		b.append(getNotesApi()).append("/");
 		b.append(id); //$NON-NLS-1$
 		b.append("/close?text=").append(URLEncoder.encode(text)); //$NON-NLS-1$
-		return editingPOI(b.toString(), "POST", "close bug") ; //$NON-NLS-1$
+		return editingPOI(b.toString(), "POST", "close bug"); //$NON-NLS-1$
 	}
 
 	private String editingPOI(String url, String requestMethod, String userOperation) {
@@ -104,26 +101,24 @@ public class OsmBugsRemoteUtil implements OsmBugsUtil {
 			boolean ok = connection.getResponseCode() == HttpURLConnection.HTTP_OK;
 			log.info(msg); //$NON-NLS-1$
 			// populate return fields.
-			
+
 			StringBuilder responseBody = new StringBuilder();
-			if (true) {
-				responseBody.setLength(0);
-				InputStream i = connection.getInputStream();
-				if (i != null) {
-					BufferedReader in = new BufferedReader(new InputStreamReader(i, "UTF-8"), 256); //$NON-NLS-1$
-					String s;
-					boolean f = true;
-					while ((s = in.readLine()) != null) {
-						if (!f) {
-							responseBody.append("\n"); //$NON-NLS-1$
-						} else {
-							f = false;
-						}
-						responseBody.append(s);
+			responseBody.setLength(0);
+			InputStream i = connection.getInputStream();
+			if (i != null) {
+				BufferedReader in = new BufferedReader(new InputStreamReader(i, "UTF-8"), 256); //$NON-NLS-1$
+				String s;
+				boolean f = true;
+				while ((s = in.readLine()) != null) {
+					if (!f) {
+						responseBody.append("\n"); //$NON-NLS-1$
+					} else {
+						f = false;
 					}
+					responseBody.append(s);
 				}
-				log.info("Response : " + responseBody); //$NON-NLS-1$
 			}
+			log.info("Response : " + responseBody); //$NON-NLS-1$
 			connection.disconnect();
 			if (!ok) {
 				return msg + "\n" + responseBody;
@@ -138,7 +133,7 @@ public class OsmBugsRemoteUtil implements OsmBugsUtil {
 			return e.getMessage() + "";
 		} catch (IOException e) {
 			log.error(userOperation + " " + app.getString(R.string.failed_op), e); //$NON-NLS-1$
-			return e.getMessage() + "";
+			return e.getMessage() + " link unavailable";
 		}
 		return null;
 	}

--- a/OsmAnd/src/net/osmand/plus/osmedit/OsmEditsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/osmedit/OsmEditsFragment.java
@@ -500,7 +500,7 @@ public class OsmEditsFragment extends OsmAndListFragment {
 				getString(R.string.uploading),
 				getString(R.string.local_openstreetmap_uploading),
 				ProgressDialog.STYLE_HORIZONTAL).getDialog();
-		OsmEditsUploadListener listener = new OsmEditUploadListenerHelper(getActivity(),
+		OsmEditsUploadListener listener = new OsmEditsUploadListenerHelper(getActivity(),
 				getString(R.string.local_openstreetmap_were_uploaded));
 		UploadOpenstreetmapPointAsyncTask uploadTask = new UploadOpenstreetmapPointAsyncTask(
 				dialog, listener, plugin, remotepoi, remotebug, toUpload.length);

--- a/OsmAnd/src/net/osmand/plus/osmedit/OsmEditsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/osmedit/OsmEditsFragment.java
@@ -1,12 +1,29 @@
 package net.osmand.plus.osmedit;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import android.app.AlertDialog;
+import android.app.ProgressDialog;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.support.v4.view.MenuItemCompat;
+import android.support.v7.view.ActionMode;
+import android.support.v7.widget.PopupMenu;
+import android.util.Xml;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.AdapterView.OnItemClickListener;
+import android.widget.ArrayAdapter;
+import android.widget.CheckBox;
+import android.widget.ImageView;
+import android.widget.TextView;
+import android.widget.Toast;
 
 import net.osmand.access.AccessibleToast;
 import net.osmand.data.PointDescription;
@@ -25,37 +42,18 @@ import net.osmand.plus.myplaces.FavoritesActivity;
 
 import org.xmlpull.v1.XmlSerializer;
 
-import android.app.AlertDialog;
-import android.app.ProgressDialog;
-import android.content.DialogInterface;
-import android.content.Intent;
-import android.net.Uri;
-import android.os.AsyncTask;
-import android.os.Bundle;
-import android.support.v4.view.MenuItemCompat;
-import android.support.v7.app.ActionBarActivity;
-import android.support.v7.view.ActionMode;
-import android.support.v7.widget.PopupMenu;
-import android.util.Xml;
-import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.AdapterView;
-import android.widget.AdapterView.OnItemClickListener;
-import android.widget.ArrayAdapter;
-import android.widget.CheckBox;
-import android.widget.ImageView;
-import android.widget.TextView;
-import android.widget.Toast;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Created by Denis
  * on 06.03.2015.
  */
-public class OsmEditsFragment extends OsmAndListFragment implements OsmEditsUploadListener {
+public class OsmEditsFragment extends OsmAndListFragment {
 	OsmEditingPlugin plugin;
 	private ArrayList<OsmPoint> dataPoints;
 	private OsmEditsAdapter listAdapter;
@@ -100,17 +98,17 @@ public class OsmEditsFragment extends OsmAndListFragment implements OsmEditsUplo
 		return view;
 	}
 
-	private void selectAll(){
-		for(int i =0 ;i < listAdapter.getCount(); i++){
+	private void selectAll() {
+		for (int i = 0; i < listAdapter.getCount(); i++) {
 			OsmPoint point = listAdapter.getItem(i);
-			if (!osmEditsSelected.contains(point)){
+			if (!osmEditsSelected.contains(point)) {
 				osmEditsSelected.add(point);
 			}
 		}
 		listAdapter.notifyDataSetInvalidated();
 	}
 
-	private void deselectAll(){
+	private void deselectAll() {
 		osmEditsSelected.clear();
 		listAdapter.notifyDataSetInvalidated();
 	}
@@ -199,8 +197,8 @@ public class OsmEditsFragment extends OsmAndListFragment implements OsmEditsUplo
 		});
 	}
 
-	private void enterSelectionMode(int type){
-		switch (type){
+	private void enterSelectionMode(int type) {
+		switch (type) {
 			case MODE_DELETE:
 				enterDeleteMode();
 				break;
@@ -256,10 +254,10 @@ public class OsmEditsFragment extends OsmAndListFragment implements OsmEditsUplo
 		refreshSelectAll();
 	}
 
-	private void updateSelectionTitle(ActionMode m){
-		if(osmEditsSelected.size() > 0) {
+	private void updateSelectionTitle(ActionMode m) {
+		if (osmEditsSelected.size() > 0) {
 			m.setTitle(osmEditsSelected.size() + " " + getMyApplication().getString(R.string.shared_string_selected_lowercase));
-		} else{
+		} else {
 			m.setTitle("");
 		}
 	}
@@ -282,8 +280,8 @@ public class OsmEditsFragment extends OsmAndListFragment implements OsmEditsUplo
 
 	private void enableSelectionMode(boolean selectionMode) {
 		this.selectionMode = selectionMode;
-		getView().findViewById(R.id.select_all).setVisibility(selectionMode? View.VISIBLE : View.GONE);
-		((FavoritesActivity)getActivity()).setToolbarVisibility(!selectionMode);
+		getView().findViewById(R.id.select_all).setVisibility(selectionMode ? View.VISIBLE : View.GONE);
+		((FavoritesActivity) getActivity()).setToolbarVisibility(!selectionMode);
 	}
 
 	public OsmandActionBarActivity getActionBarActivity() {
@@ -389,7 +387,7 @@ public class OsmEditsFragment extends OsmAndListFragment implements OsmEditsUplo
 
 			final CheckBox ch = (CheckBox) v.findViewById(R.id.check_local_index);
 			View options = v.findViewById(R.id.options);
-			if(selectionMode) {
+			if (selectionMode) {
 				options.setVisibility(View.GONE);
 				ch.setVisibility(View.VISIBLE);
 				ch.setChecked(osmEditsSelected.contains(child));
@@ -482,7 +480,7 @@ public class OsmEditsFragment extends OsmAndListFragment implements OsmEditsUplo
 		return (OsmandApplication) getActivity().getApplication();
 	}
 
-	private void uploadItems(final OsmPoint[] items){
+	private void uploadItems(final OsmPoint[] items) {
 		AlertDialog.Builder b = new AlertDialog.Builder(getActivity());
 		b.setMessage(getString(R.string.local_osm_changes_upload_all_confirm, items.length));
 		b.setPositiveButton(R.string.shared_string_yes, new DialogInterface.OnClickListener() {
@@ -502,8 +500,10 @@ public class OsmEditsFragment extends OsmAndListFragment implements OsmEditsUplo
 				getString(R.string.uploading),
 				getString(R.string.local_openstreetmap_uploading),
 				ProgressDialog.STYLE_HORIZONTAL).getDialog();
-		UploadOpenstreetmapPointAsyncTask uploadTask = new UploadOpenstreetmapPointAsyncTask(dialog, this, plugin, remotepoi,
-				remotebug, toUpload.length);
+		OsmEditsUploadListener listener = new OsmEditUploadListenerHelper(getActivity(),
+				getString(R.string.local_openstreetmap_were_uploaded));
+		UploadOpenstreetmapPointAsyncTask uploadTask = new UploadOpenstreetmapPointAsyncTask(
+				dialog, listener, plugin, remotepoi, remotebug, toUpload.length);
 		uploadTask.execute(toUpload);
 
 		dialog.show();
@@ -614,21 +614,6 @@ public class OsmEditsFragment extends OsmAndListFragment implements OsmEditsUplo
 		}
 	}
 
-	@Override
-	public void uploadUpdated(OsmPoint point) {
-		listAdapter.delete(point);
-	}
-
-	@Override
-	public void uploadEnded(Integer result) {
-		listAdapter.notifyDataSetChanged();
-		if (result != null) {
-			AccessibleToast.makeText(getActivity(),
-					MessageFormat.format(getString(R.string.local_openstreetmap_were_uploaded), result), Toast.LENGTH_LONG)
-					.show();
-		}
-	}
-
 	private void showOnMap(OsmPoint osmPoint) {
 		boolean isOsmPoint = osmPoint instanceof OpenstreetmapPoint;
 		String type = osmPoint.getGroup() == OsmPoint.Group.POI ? PointDescription.POINT_TYPE_POI : PointDescription.POINT_TYPE_OSM_BUG;
@@ -637,6 +622,4 @@ public class OsmEditsFragment extends OsmAndListFragment implements OsmEditsUplo
 				new PointDescription(type, name), true, osmPoint); //$NON-NLS-1$
 		MapActivity.launchMapActivityMoveToTop(getActivity());
 	}
-
-
 }

--- a/OsmAnd/src/net/osmand/plus/osmedit/OsmEditsUploadListener.java
+++ b/OsmAnd/src/net/osmand/plus/osmedit/OsmEditsUploadListener.java
@@ -1,12 +1,12 @@
 package net.osmand.plus.osmedit;
 
+import java.util.Map;
+
 /**
  * Created by Denis
  * on 11.03.2015.
  */
 public interface OsmEditsUploadListener {
-
-	public void uploadUpdated(OsmPoint point);
-
-	public void uploadEnded(Integer result);
+	void uploadUpdated(OsmPoint point);
+	void uploadEnded(Map<OsmPoint, String> loadErrorsMap);
 }

--- a/OsmAnd/src/net/osmand/plus/osmedit/OsmEditsUploadListenerHelper.java
+++ b/OsmAnd/src/net/osmand/plus/osmedit/OsmEditsUploadListenerHelper.java
@@ -34,12 +34,12 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Map;
 
-public class OsmEditUploadListenerHelper implements OsmEditsUploadListener {
+public class OsmEditsUploadListenerHelper implements OsmEditsUploadListener {
 	public static final String TAG = "OsmEditUploadListenerHe";
 	private final FragmentActivity activity;
 	private final String numberFormat;
 
-	public OsmEditUploadListenerHelper(FragmentActivity activity, String numberFormat) {
+	public OsmEditsUploadListenerHelper(FragmentActivity activity, String numberFormat) {
 		this.activity = activity;
 		this.numberFormat = numberFormat;
 	}
@@ -103,7 +103,7 @@ public class OsmEditUploadListenerHelper implements OsmEditsUploadListener {
 		OpenstreetmapRemoteUtil remotepoi = new OpenstreetmapRemoteUtil(activity);
 		OsmBugsRemoteUtil remotebug = new OsmBugsRemoteUtil((OsmandApplication) activity.getApplication());
 
-		OsmEditUploadListenerHelper helper = new OsmEditUploadListenerHelper(activity,
+		OsmEditsUploadListenerHelper helper = new OsmEditsUploadListenerHelper(activity,
 				activity.getResources().getString(R.string.local_openstreetmap_were_uploaded));
 
 		Resources resources = activity.getResources();
@@ -191,7 +191,7 @@ public class OsmEditUploadListenerHelper implements OsmEditsUploadListener {
 							new DialogInterface.OnClickListener() {
 								@Override
 								public void onClick(DialogInterface dialog, int which) {
-									OsmEditUploadListenerHelper
+									OsmEditsUploadListenerHelper
 											.showUploadItemsProgressDialog(
 													UploadingMultipleErrorDialogFragment.this,
 													points);

--- a/OsmAnd/src/net/osmand/plus/osmedit/OsmNotesPoint.java
+++ b/OsmAnd/src/net/osmand/plus/osmedit/OsmNotesPoint.java
@@ -1,8 +1,6 @@
 package net.osmand.plus.osmedit;
 
-import java.io.Serializable;
-
-public class OsmNotesPoint extends OsmPoint implements Serializable {
+public class OsmNotesPoint extends OsmPoint {
 	private static final long serialVersionUID = 729654300829771468L;
 
 	private long id;

--- a/OsmAnd/src/net/osmand/plus/osmedit/OsmPoint.java
+++ b/OsmAnd/src/net/osmand/plus/osmedit/OsmPoint.java
@@ -1,9 +1,10 @@
 package net.osmand.plus.osmedit;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class OsmPoint {
+public abstract class OsmPoint  implements Serializable {
 
 	public static enum Group {BUG, POI};
 

--- a/OsmAnd/src/net/osmand/plus/osmedit/UploadOpenstreetmapPointAsyncTask.java
+++ b/OsmAnd/src/net/osmand/plus/osmedit/UploadOpenstreetmapPointAsyncTask.java
@@ -3,47 +3,44 @@ package net.osmand.plus.osmedit;
 import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.os.AsyncTask;
-import android.support.v4.app.Fragment;
 
 import net.osmand.osm.edit.EntityInfo;
 import net.osmand.osm.edit.Node;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Created by Denis
  * on 11.03.2015.
  */
-public class UploadOpenstreetmapPointAsyncTask extends AsyncTask<OsmPoint, OsmPoint, Integer> {
-
+public class UploadOpenstreetmapPointAsyncTask
+		extends AsyncTask<OsmPoint, OsmPoint, Map<OsmPoint, String>> {
 	private ProgressDialog progress;
-
 	private OpenstreetmapRemoteUtil remotepoi;
-
 	private OsmBugsRemoteUtil remotebug;
-
-
 	private int listSize = 0;
-
 	private boolean interruptUploading = false;
-
-	private Fragment ctx;
-
+	private OsmEditsUploadListener listener;
 	private OsmEditingPlugin plugin;
 
-	public UploadOpenstreetmapPointAsyncTask(ProgressDialog progress,Fragment ctx,
-			OsmEditingPlugin plugin, 
-			OpenstreetmapRemoteUtil remotepoi, OsmBugsRemoteUtil remotebug,
+	public UploadOpenstreetmapPointAsyncTask(ProgressDialog progress,
+											 OsmEditsUploadListener listener,
+											 OsmEditingPlugin plugin,
+											 OpenstreetmapRemoteUtil remotepoi,
+											 OsmBugsRemoteUtil remotebug,
 											 int listSize) {
 		this.progress = progress;
 		this.plugin = plugin;
 		this.remotepoi = remotepoi;
 		this.remotebug = remotebug;
 		this.listSize = listSize;
-		this.ctx = ctx;
+		this.listener = listener;
 	}
 
 	@Override
-	protected Integer doInBackground(OsmPoint... points) {
-		int uploaded = 0;
+	protected Map<OsmPoint, String> doInBackground(OsmPoint... points) {
+		Map<OsmPoint, String> loadErrorsMap = new HashMap<>();
 
 		for (OsmPoint point : points) {
 			if (interruptUploading)
@@ -57,31 +54,29 @@ public class UploadOpenstreetmapPointAsyncTask extends AsyncTask<OsmPoint, OsmPo
 				}
 				Node n = remotepoi.commitNodeImpl(p.getAction(), p.getEntity(), entityInfo, p.getComment(), false);
 				if (n != null) {
-					
 					plugin.getDBPOI().deletePOI(p);
 					publishProgress(p);
-					uploaded++;
 				}
+				loadErrorsMap.put(point, n != null ? null : "Unknown problem");
 			} else if (point.getGroup() == OsmPoint.Group.BUG) {
 				OsmNotesPoint p = (OsmNotesPoint) point;
-				boolean success = false;
+				String errorMessage = null;
 				if (p.getAction() == OsmPoint.Action.CREATE) {
-					success = remotebug.createNewBug(p.getLatitude(), p.getLongitude(), p.getText(), p.getAuthor()) == null;
+					errorMessage = remotebug.createNewBug(p.getLatitude(), p.getLongitude(), p.getText(), p.getAuthor());
 				} else if (p.getAction() == OsmPoint.Action.MODIFY) {
-					success = remotebug.addingComment(p.getId(), p.getText(), p.getAuthor()) == null;
+					errorMessage = remotebug.addingComment(p.getId(), p.getText(), p.getAuthor());
 				} else if (p.getAction() == OsmPoint.Action.DELETE) {
-					success = remotebug.closingBug(p.getId(), p.getText(), p.getAuthor()) == null;
+					errorMessage = remotebug.closingBug(p.getId(), p.getText(), p.getAuthor());
 				}
-				if (success) {
+				if (errorMessage == null) {
 					plugin.getDBBug().deleteAllBugModifications(p);
-					uploaded++;
 					publishProgress(p);
 				}
-
+				loadErrorsMap.put(point, errorMessage);
 			}
 		}
 
-		return uploaded;
+		return loadErrorsMap;
 	}
 
 	@Override
@@ -100,11 +95,9 @@ public class UploadOpenstreetmapPointAsyncTask extends AsyncTask<OsmPoint, OsmPo
 	}
 
 	@Override
-	protected void onPostExecute(Integer result) {
+	protected void onPostExecute(Map<OsmPoint, String> loadErrorsMap) {
 		progress.dismiss();
-		if (ctx instanceof OsmEditsUploadListener){
-			((OsmEditsUploadListener)ctx).uploadEnded(result);
-		}
+		listener.uploadEnded(loadErrorsMap);
 	}
 
 	public void setInterruptUploading(boolean b) {
@@ -113,10 +106,8 @@ public class UploadOpenstreetmapPointAsyncTask extends AsyncTask<OsmPoint, OsmPo
 
 	@Override
 	protected void onProgressUpdate(OsmPoint... points) {
-		for(OsmPoint p : points) {
-			if (ctx instanceof OsmEditsUploadListener){
-				((OsmEditsUploadListener)ctx).uploadUpdated(p);
-			}
+		for (OsmPoint p : points) {
+			listener.uploadUpdated(p);
 			progress.incrementProgressBy(1);
 		}
 	}


### PR DESCRIPTION
Created dialog as a visual representation of unsuccessful upload of OSM edit operation. Issue #1291.
* Created default implementation of `OsmEditsUploadListener`
* DashOsmEditsFragment
  * Removed implementation of `OsmEditsUploadListener` and replaced it with customized default
* OsmPoint now implements `Serializeble` implementation removed from subclasses.
* OpenstreetmapRemoteUtil
  * Removed silly `if(true)` check. Made IOExecption message little bit more descriptive.
* OsmEditUploadListenerHelper new general implementation of `OsmEditsUploadListener`
  * UploadingErrorDialogFragment - dialog if one item failed to load
  * UploadingMultipleErrorDialogFragment - dialog if there were multiple items
  * PointsWithErrorsAdapter - adapter for list items of UploadingMultipleErrorDialogFragment
    * osm_edit_list_item - item layout
* OsmEditsFragment - changes mainly the same as in DashOsmEditsFragment
* OsmEditsUploadListener - changed interface to make possible to work with error messages.