### PR TITLE
"show on start" string not translatable

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -2237,6 +2237,7 @@ Afghanistan, Albania, Algeria, Andorra, Angola, Anguilla, Antigua and Barbuda, A
 	<string name="try_again">Try again</string>
 	<string name="error_message_pattern">Error: {0}</string>
 	<string name="dahboard_options_dialog_title">Configure dashboard</string>
+	<string name="show_on_start">Show on start</string>
 	<string name="shared_string_card_was_hidden">Card was hidden</string>
 	<string name="shared_string_undo">UNDO</string>
 	<string name="shared_string_skip">Skip</string>

--- a/OsmAnd/src/net/osmand/plus/dashboard/tools/DashboardSettingsDialogFragment.java
+++ b/OsmAnd/src/net/osmand/plus/dashboard/tools/DashboardSettingsDialogFragment.java
@@ -65,7 +65,7 @@ public class DashboardSettingsDialogFragment extends DialogFragment {
 		View view = LayoutInflater.from(getActivity()).inflate(
 				R.layout.dashboard_settings_dialog_item, null, false);
 		final TextView textView = (TextView) view.findViewById(R.id.text);
-		textView.setText("Show on start");
+		textView.setText(R.string.show_on_start);
 		final OsmandSettings.CommonPreference<Boolean> shouldShowDashboardOnStart =
 				settings.registerBooleanPreference(MapActivity.SHOULD_SHOW_DASHBOARD_ON_START, true);
 		final CompoundButton compoundButton = (CompoundButton) view.findViewById(R.id.check_item);


### PR DESCRIPTION
The "show on start" string in dashboard configuration is hardcoded in DashboardSettingsDialogFragment.java.