### PR TITLE
add more variants of times into testing voice commands

### DIFF
--- a/OsmAnd/src/net/osmand/plus/development/TestVoiceActivity.java
+++ b/OsmAnd/src/net/osmand/plus/development/TestVoiceActivity.java
@@ -167,14 +167,14 @@ public class TestVoiceActivity extends OsmandActionBarActivity {
 	}
 	
 	private void addButtons(final LinearLayout ll, CommandPlayer p) {
-		addButton(ll, "New route has been calculated (11350m & 2h30m5sec)", builder(p).newRouteCalculated(11350, 9005));
-		addButton(ll, "New route has been calculated (150m & 2m5sec)", builder(p).newRouteCalculated(150, 125));
+		addButton(ll, "New route has been calculated (11350m & 2h3m5sec)", builder(p).newRouteCalculated(11350, 7385));
+		addButton(ll, "New route has been calculated (150m & 1m5sec)", builder(p).newRouteCalculated(150, 65));
 		addButton(ll, "Route recalculated (23150m & 350sec)", builder(p).routeRecalculated(23150, 350));
 
 		addButton(ll, "After 1520m turn slightly left", builder(p).prepareTurn(AbstractPrologCommandPlayer.A_LEFT_SL, 1520, street(p, "")));
 		addButton(ll, "In 450m turn sharply left onto 'Hauptstra"+"\u00df"+"e', then bear right", builder(p).turn(AbstractPrologCommandPlayer.A_LEFT_SH, 450, street(p, "Hauptstra�e")).then().bearRight(street(p, "")));
 		addButton(ll, "Turn left, then in 100m turn slightly right", builder(p).turn(AbstractPrologCommandPlayer.A_LEFT, street(p, "")).then().turn(AbstractPrologCommandPlayer.A_RIGHT_SL, 100, street(p, "")));
-		addButton(ll, "After 3100 turn right onto 'SR 80'", builder(p).prepareTurn(AbstractPrologCommandPlayer.A_RIGHT, 3100, street(p, "SR 80")));
+		addButton(ll, "After 3100m turn right onto 'SR 80'", builder(p).prepareTurn(AbstractPrologCommandPlayer.A_RIGHT, 3100, street(p, "SR 80")));
 		addButton(ll, "In 370m turn slightly right onto 'F23' 'Main Street', then bear left", builder(p).turn(AbstractPrologCommandPlayer.A_RIGHT_SL, 370, street(p, "Main Street", "F23")).then().bearLeft(street(p, "")));
 		addButton(ll, "Turn sharply right onto 'Main Street'", builder(p).turn(AbstractPrologCommandPlayer.A_RIGHT_SH, street(p, "Main Street")));
 


### PR DESCRIPTION
I try to update sk/ttsconfig.p to support more of the existing features of voice commands. As there are several forms of plurals, I update the route times to be more different.

I still do not understand why in the phrase "onto 'Market Square'", the internal command is 'street(p,"", "", "Market Square")' (market square as 3rd argument to street()).
In the phrase "onto 'Bridge Avenue'" the internal command is 'street(p, "Bridge Avenue")' (Bridge avenue is first argument).
What is the difference? It seems to me the 2nd argument is road ref, first could be the street name. 3rd could be the destination (something a bit away, not current street/road). But these assumptions are not true at these commands, and also at the "onto 'SR 80'" (it looks like a ref, but is used in 1st argument). So what are the rules?

Also I'd like if there was an example using e.g. bearLeft() including a street name. I don't know how the street name is used, in which context. Is it the street on which you should be keeping left, or is it the one where you get after you turn left (bearing on left before that)?