### PR TITLE
Add 'Postcode' to address search

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -1997,7 +1997,7 @@ Afghanistan, Albania, Algeria, Andorra, Angola, Anguilla, Antigua and Barbuda, A
     <string name="navigate_point_format_DMS">DDD MM SS.SS</string>
     <string name="search_address_top_text">Select address</string>
     <string name="search_address_region">Region</string>
-    <string name="search_address_city">City / \nPostcode</string>
+    <string name="search_address_city">City /\nPostcode</string>
     <string name="search_address_street">Street</string>
     <string name="search_address_building">Building</string>
     <string name="search_address_building_option">Building</string>

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -1997,7 +1997,7 @@ Afghanistan, Albania, Algeria, Andorra, Angola, Anguilla, Antigua and Barbuda, A
     <string name="navigate_point_format_DMS">DDD MM SS.SS</string>
     <string name="search_address_top_text">Select address</string>
     <string name="search_address_region">Region</string>
-    <string name="search_address_city">City</string>
+    <string name="search_address_city">City / \nPostcode</string>
     <string name="search_address_street">Street</string>
     <string name="search_address_building">Building</string>
     <string name="search_address_building_option">Building</string>


### PR DESCRIPTION
After some searching on the website I figured out that search based on postcode *is* possible. Rather than giving explanation on the website, it's more convenient to novice users to just print the info in the search screen.