### PR TITLE
support diacritics symbols also with czech language

### DIFF
--- a/OsmAnd-java/src/net/osmand/OsmAndCollator.java
+++ b/OsmAnd-java/src/net/osmand/OsmAndCollator.java
@@ -7,6 +7,7 @@ public class OsmAndCollator {
 	public static net.osmand.Collator primaryCollator() {
 		// romanian locale encounters diacritics as differnet symbols
 		final java.text.Collator instance = Locale.getDefault().getLanguage().equals("ro")  ||
+				Locale.getDefault().getLanguage().equals("cs") ||
 				Locale.getDefault().getLanguage().equals("sk")? java.text.Collator.getInstance(Locale.US)
 				: java.text.Collator.getInstance();
 		instance.setStrength(java.text.Collator.PRIMARY);


### PR DESCRIPTION
Search without diacritics will work properly in Czech Republic, Slovakia or Romania only when phone UI is set to these languages.

This is temporary solution.This should be handled better.

Addition to bug: https://github.com/osmandapp/Osmand/issues/2193
