### PR TITLE
Address search in landscape mode fixed, no more "extracted text UI" issue

### DIFF
--- a/OsmAnd/res/layout-land/search_by_name.xml
+++ b/OsmAnd/res/layout-land/search_by_name.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:orientation="vertical"
+    android:windowSoftInputMode="adjustResize"
+    android:isScrollContainer="true"
+    android:imeOptions="flagNoExtractUi" >
+    <!--
+        ppenguin 2016-03-07: apparently adjustResize and flagNoExtractUi have no effect here or below,
+        so SearchByNameAbstractActivity.java needed to be changed by setting the imeOptions in the code to always include
+        the necessary flag
+    -->
+
+    <LinearLayout
+        android:id="@+id/LinearLayout"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="3dp"
+        android:layout_marginRight="3dp"
+        android:layout_marginBottom="0dp"
+        android:layout_marginTop="0dp" >
+
+        <ProgressBar
+            android:id="@+id/ProgressBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="-5dp" />
+
+        <EditText
+            android:id="@+id/SearchText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:maxLines="1"
+            android:singleLine="true"
+            android:inputType="textNoSuggestions"
+            android:lines="1"
+            android:layout_weight="1"
+            android:layout_marginBottom="-5dp"
+            android:imeOptions="flagNoExtractUi" />
+
+        <Button
+            android:id="@+id/ResetButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="0"
+            android:layout_marginLeft="0dp"
+            android:layout_marginRight="0dp"
+            android:layout_marginBottom="-5dp"
+            android:layout_marginTop="0dp"
+            android:padding="0dp"
+            android:text="@string/shared_string_clear" />
+
+    </LinearLayout>
+
+    <ListView
+        android:id="@android:id/list"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:dividerHeight="1dp"
+        android:layout_marginLeft="3dp"
+        android:layout_marginRight="3dp"
+        android:layout_marginTop="0dp" />
+
+</LinearLayout>

--- a/OsmAnd/res/layout-land/searchbyname_list.xml
+++ b/OsmAnd/res/layout-land/searchbyname_list.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:paddingTop="1dp"
+    android:paddingBottom="1dp"
+    android:paddingLeft="16dp"
+    android:paddingRight="16dp">
+
+    <!--
+        ppenguin 2016-03-07: more compact layout (less padding) for landscape, to allow the maximum
+        number of lines when most area is taken up by the soft keyboard
+    -->
+
+    <TextView
+        android:id="@+id/NameLabel"
+        android:textSize="@dimen/default_list_text_size"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent" />
+</LinearLayout>

--- a/OsmAnd/src/net/osmand/plus/activities/search/SearchByNameAbstractActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/search/SearchByNameAbstractActivity.java
@@ -113,11 +113,14 @@ public abstract class SearchByNameAbstractActivity<T> extends OsmandListActivity
 		setListAdapter(namesAdapter);
 		
 		collator = OsmAndCollator.primaryCollator();
- 	    
-		
+
 		progress = (ProgressBar) findViewById(R.id.ProgressBar);
 			
 		searchText = (EditText) findViewById(R.id.SearchText);
+
+		// ppenguin 2016-03-07: try to avoid full screen input in landscape mode (when softKB too large)
+		searchText.setImeOptions(searchText.getImeOptions() | EditorInfo.IME_FLAG_NO_EXTRACT_UI | EditorInfo.IME_FLAG_NO_FULLSCREEN);
+
 		searchText.addTextChangedListener(new TextWatcher(){
 
 			@Override
@@ -145,7 +148,9 @@ public abstract class SearchByNameAbstractActivity<T> extends OsmandListActivity
 //		filter.setOnClickListener(new OnClickListener() {
 //			}
 //		});
-		searchText.setImeOptions(EditorInfo.IME_ACTION_DONE);
+
+        // ppenguin 2016-03-07: try to avoid full screen input in landscape mode (when softKB too large) => IME-flags necessary here too!
+		searchText.setImeOptions(EditorInfo.IME_ACTION_DONE | EditorInfo.IME_FLAG_NO_EXTRACT_UI | EditorInfo.IME_FLAG_NO_FULLSCREEN);
 		searchText.requestFocus();
 		searchText.setOnEditorActionListener(new OnEditorActionListener() {
 	        @Override


### PR DESCRIPTION
Avoid blocking of street list (during address search) in landscape mode with large soft-keyboard by changing imeOptions, thereby avoiding the "extracted text UI" issue.

!!! **This makes address search finally more usable on e.g. in-car head units** !!!

 Additionally added minor layout changes to squeeze the street list in landscape mode (less line separator height and margin).