### PR TITLE
Reworked GPX display.

### DIFF
--- a/OsmAnd/src/net/osmand/plus/GPXUtilities.java
+++ b/OsmAnd/src/net/osmand/plus/GPXUtilities.java
@@ -1009,44 +1009,87 @@ public class GPXUtilities {
 					} else if (parse instanceof GPXExtensions && tag.equals("extensions")) {
 						extensionReadMode = true;
 					} else {
-
-						if (parse instanceof TrkSegment) {						// 1st for speed
-							if (tag.equals("trkpt")) {
+						if (parse instanceof GPXFile) {
+							if (parser.getName().equals("gpx")) {
+								((GPXFile) parse).author = parser.getAttributeValue("", "creator");
+							}
+							if (parser.getName().equals("trk")) {
+								Track track = new Track();
+								((GPXFile) parse).tracks.add(track);
+								parserState.push(track);
+							}
+							if (parser.getName().equals("rte")) {
+								Route route = new Route();
+								((GPXFile) parse).routes.add(route);
+								parserState.push(route);
+							}
+							if (parser.getName().equals("wpt")) {
+								WptPt wptPt = parseWptAttributes(parser);
+								((GPXFile) parse).points.add(wptPt);
+								parserState.push(wptPt);
+							}
+						} else if (parse instanceof Route) {
+							if (parser.getName().equals("name")) {
+								((Route) parse).name = readText(parser, "name");
+							}
+							if (parser.getName().equals("desc")) {
+								((Route) parse).desc = readText(parser, "desc");
+							}
+							if (parser.getName().equals("rtept")) {
+								WptPt wptPt = parseWptAttributes(parser);
+								((Route) parse).points.add(wptPt);
+								parserState.push(wptPt);
+							}
+						} else if (parse instanceof Track) {
+							if (parser.getName().equals("name")) {
+								((Track) parse).name = readText(parser, "name");
+							}
+							if (parser.getName().equals("desc")) {
+								((Track) parse).desc = readText(parser, "desc");
+							}
+							if (parser.getName().equals("trkseg")) {
+								TrkSegment trkSeg = new TrkSegment();
+								((Track) parse).segments.add(trkSeg);
+								parserState.push(trkSeg);
+							}
+						} else if (parse instanceof TrkSegment) {
+							if (parser.getName().equals("trkpt")) {
 								WptPt wptPt = parseWptAttributes(parser);
 								((TrkSegment) parse).points.add(wptPt);
 								parserState.push(wptPt);
 							}
+							// main object to parse
 						} else if (parse instanceof WptPt) {
-							if (tag.equals("name")) {
-								((WptPt) parse).name = readText(parser, tag);
-							} else if (tag.equals("desc")) {
-								((WptPt) parse).desc = readText(parser, tag);
-							} else if (tag.equals("link")) {
+							if (parser.getName().equals("name")) {
+								((WptPt) parse).name = readText(parser, "name");
+							} else if (parser.getName().equals("desc")) {
+								((WptPt) parse).desc = readText(parser, "desc");
+							} else if (parser.getName().equals("link")) {
 								((WptPt) parse).link = parser.getAttributeValue("", "href");
-							} else if (tag.equals("category")) {
-								((WptPt) parse).category = readText(parser, tag);
-							} else if (tag.equals("type")) {
+							} else if (tag.equals("category")) {								//TODO: is this a bug?  should be parser.getName() not tag
+								((WptPt) parse).category = readText(parser, "category");
+							} else if (tag.equals("type")) {									//TODO: is this a bug?  should be parser.getName() not tag
 								if(((WptPt) parse).category == null) {
-									((WptPt) parse).category = readText(parser, tag);
+									((WptPt) parse).category = readText(parser, "type");
 								}
-							} else if (tag.equals("ele")) {
-								String text = readText(parser, tag);
+							} else if (parser.getName().equals("ele")) {
+								String text = readText(parser, "ele");
 								if (text != null) {
 									try {
 										((WptPt) parse).ele = Float.parseFloat(text);
 									} catch (NumberFormatException e) {
 									}
 								}
-							} else if (tag.equals("hdop")) {
-								String text = readText(parser, tag);
+							} else if (parser.getName().equals("hdop")) {
+								String text = readText(parser, "hdop");
 								if (text != null) {
 									try {
 										((WptPt) parse).hdop = Float.parseFloat(text);
 									} catch (NumberFormatException e) {
 									}
 								}
-							} else if (tag.equals("time")) {
-								String text = readText(parser, tag);
+							} else if (parser.getName().equals("time")) {
+								String text = readText(parser, "time");
 								if (text != null) {
 									try {
 										((WptPt) parse).time = format.parse(text).getTime();
@@ -1054,48 +1097,17 @@ public class GPXUtilities {
 									}
 								}
 							}
-						} else if (parse instanceof GPXFile) {
-							if (tag.equals("wpt")) {							// moved 1st for speed
-								WptPt wptPt = parseWptAttributes(parser);
-								((GPXFile) parse).points.add(wptPt);
-								parserState.push(wptPt);
-							} else if (tag.equals("gpx")) {
-								((GPXFile) parse).author = parser.getAttributeValue("", "creator");
-							} else if (tag.equals("trk")) {
-								Track track = new Track();
-								((GPXFile) parse).tracks.add(track);
-								parserState.push(track);
-							} else if (tag.equals("rte")) {
-								Route route = new Route();
-								((GPXFile) parse).routes.add(route);
-								parserState.push(route);
-							}
-						} else if (parse instanceof Route) {
-							if (tag.equals("name")) {
-								((Route) parse).name = readText(parser, tag);
-							} else if (tag.equals("desc")) {
-								((Route) parse).desc = readText(parser, tag);
-							} else if (tag.equals("rtept")) {
-								WptPt wptPt = parseWptAttributes(parser);
-								((Route) parse).points.add(wptPt);
-								parserState.push(wptPt);
-							}
-						} else if (parse instanceof Track) {
-							if (tag.equals("name")) {
-								((Track) parse).name = readText(parser, tag);
-							} else if (tag.equals("desc")) {
-								((Track) parse).desc = readText(parser, tag);
-							} else if (tag.equals("trkseg")) {
-								TrkSegment trkSeg = new TrkSegment();
-								((Track) parse).segments.add(trkSeg);
-								parserState.push(trkSeg);
-							}
 						}
 					}
 
 				} else if (tok == XmlPullParser.END_TAG) {
+					Object parse = parserState.peek();
 					String tag = parser.getName();
-					if (tag.equals("trkpt")) {					// moved first for speed!
+					if (parse instanceof GPXExtensions && tag.equals("extensions")) {
+						extensionReadMode = false;
+					}
+
+					if (tag.equals("trkpt")) {
 						Object pop = parserState.pop();
 						assert pop instanceof WptPt;
 					} else if (tag.equals("wpt")) {
@@ -1113,9 +1125,6 @@ public class GPXUtilities {
 					} else if (tag.equals("trkseg")) {
 						Object pop = parserState.pop();
 						assert pop instanceof TrkSegment;
-					} else if (tag.equals("extensions")) {
-						if (parserState.peek() instanceof GPXExtensions)
-							extensionReadMode = false;
 					}
 				}
 			}

--- a/OsmAnd/src/net/osmand/plus/GpxSelectionHelper.java
+++ b/OsmAnd/src/net/osmand/plus/GpxSelectionHelper.java
@@ -89,7 +89,12 @@ public class GpxSelectionHelper {
 			for (Track t : g.tracks) {
 				GpxDisplayGroup group = new GpxDisplayGroup(g);
 				group.gpxName = name;
+
+				// Set colour/zoom, using parent's data if not explicitly defined in the track...
+				// (and using defaults if not defined in the parent)
 				group.color = t.getColor(g.getColor(0));
+				group.gpxZoom = t.getGpxZoom(g.getGpxZoom(1.0f));
+
 				group.setType(GpxDisplayItemType.TRACK_SEGMENT);
 				group.setTrack(t);
 				String ks = (k++) + "";
@@ -414,6 +419,7 @@ public class GpxSelectionHelper {
 		private boolean showCurrentTrack;
 		private GPXFile gpxFile;
 		private int color;
+		private float gpxZoom; // custom zoom magnifier for GPX track drawing from .gpx file. 1.0 = 100%
 		private GPXTrackAnalysis trackAnalysis;
 		private long modifiedTime = -1;
 		private List<TrkSegment> processedPointsToDisplay = new ArrayList<TrkSegment>();
@@ -423,9 +429,13 @@ public class GpxSelectionHelper {
 		
 		public void setGpxFile(GPXFile gpxFile) {
 			this.gpxFile = gpxFile;
-			if(gpxFile.tracks.size() > 0) {
-				this.color = gpxFile.tracks.get(0).getColor(0);
-			}
+
+			// Set default zoom/colour to top-level zoom/colour from the .gpx
+			// It's possible that there are none, and that these are defined for individual tracks
+			//
+			this.gpxZoom = gpxFile.getGpxZoom(1.0f);
+			this.color = gpxFile.getColor(0);
+
 			processPoints();
 		}
 
@@ -486,6 +496,8 @@ public class GpxSelectionHelper {
 			return color;
 		}
 
+		public float getGpxZoom() { return gpxZoom; }
+
 		public List<GpxDisplayGroup> getDisplayGroups() {
 			if(modifiedTime != gpxFile.modifiedTime) {
 				update();
@@ -521,6 +533,7 @@ public class GpxSelectionHelper {
 		private double splitDistance = -1;
 		private int splitTime = -1;
 		private int color;
+		private float gpxZoom = 1.0f; //boo - resizes width of GPX tracks. 1.0 = 100%
 		
 		public GpxDisplayGroup(GPXFile gpx) {
 			this.gpx = gpx;
@@ -624,6 +637,7 @@ public class GpxSelectionHelper {
 		public int getColor() {
 			return color;
 		}
+		public float getGpxZoom() { return gpxZoom; }
 	}
 	
 	public static class GpxDisplayItem {

--- a/OsmAnd/src/net/osmand/plus/render/OsmandRenderer.java
+++ b/OsmAnd/src/net/osmand/plus/render/OsmandRenderer.java
@@ -52,6 +52,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.DisplayMetrics;
 import android.view.WindowManager;
+import java.util.HashMap;
 
 public class OsmandRenderer {
 	private static final Log log = PlatformUtil.getLog(OsmandRenderer.class);
@@ -59,12 +60,18 @@ public class OsmandRenderer {
 	private Paint paint;
 	private Paint paintIcon;
 
-	private float cachedStrokeWidth;
-	private float defaultStrokeWidth;
-	public float getStrokeWidth() {
-		return cachedStrokeWidth;
-	}
+	private Map paintStrokes = new HashMap();
 
+	// Given a paint context, use the hashmap ORIGINAL stroke width and scale it by the given value.
+	// Set that to the new stroke width for the paint context. This gives us our scaling of GPX tracks!
+
+	public void fixupStrokeWidth(Paint p, double rescale) {
+		Float originalWidth = (Float) paintStrokes.get(p.hashCode());
+		if (originalWidth != null) {
+			float scaledWidth = originalWidth.floatValue() * (float) rescale;
+			p.setStrokeWidth(scaledWidth);										// even if 0
+		}
+	}
 
 	public static final int TILE_SIZE = 256; 
 	private static final int MAX_V = 75;
@@ -717,6 +724,7 @@ public class OsmandRenderer {
 			p.setColorFilter(null);
 			p.clearShadowLayer();
 			p.setStyle(Style.FILL_AND_STROKE);
+			paintStrokes.put(p.hashCode(),new Float(0));
 			p.setStrokeWidth(0);
 		} else {
 			if(!req.isSpecified(rStrokeW)){
@@ -726,8 +734,8 @@ public class OsmandRenderer {
 			p.setColorFilter(null);
 			p.clearShadowLayer();
 			p.setStyle(Style.STROKE);
-			p.setStrokeWidth(rc.getComplexValue(req, rStrokeW));
-			cachedStrokeWidth = p.getStrokeWidth();
+			paintStrokes.put(p.hashCode(),new Float(rc.getComplexValue(req, rStrokeW)));
+			p.setStrokeWidth((float)paintStrokes.get(p.hashCode()));
 
 			String cap = req.getStringPropertyValue(rCap);
 			if(!Algorithms.isEmpty(cap)){
@@ -851,7 +859,6 @@ public class OsmandRenderer {
 		if (rc.shadowRenderingMode == 3 && shadowRadius > 0) {
 			paint.clearShadowLayer();
 			paint.setStrokeWidth(paint.getStrokeWidth() + shadowRadius * 2);
-			cachedStrokeWidth = paint.getStrokeWidth();
 
 			ColorFilter cf = new PorterDuffColorFilter(shadowColor, Mode.SRC_IN);
 			paint.setColorFilter(cf);

--- a/OsmAnd/src/net/osmand/plus/render/OsmandRenderer.java
+++ b/OsmAnd/src/net/osmand/plus/render/OsmandRenderer.java
@@ -57,8 +57,14 @@ public class OsmandRenderer {
 	private static final Log log = PlatformUtil.getLog(OsmandRenderer.class);
 
 	private Paint paint;
-
 	private Paint paintIcon;
+
+	private float cachedStrokeWidth;
+	private float defaultStrokeWidth;
+	public float getStrokeWidth() {
+		return cachedStrokeWidth;
+	}
+
 
 	public static final int TILE_SIZE = 256; 
 	private static final int MAX_V = 75;
@@ -721,6 +727,8 @@ public class OsmandRenderer {
 			p.clearShadowLayer();
 			p.setStyle(Style.STROKE);
 			p.setStrokeWidth(rc.getComplexValue(req, rStrokeW));
+			cachedStrokeWidth = p.getStrokeWidth();
+
 			String cap = req.getStringPropertyValue(rCap);
 			if(!Algorithms.isEmpty(cap)){
 				p.setStrokeCap(Cap.valueOf(cap.toUpperCase()));
@@ -843,6 +851,8 @@ public class OsmandRenderer {
 		if (rc.shadowRenderingMode == 3 && shadowRadius > 0) {
 			paint.clearShadowLayer();
 			paint.setStrokeWidth(paint.getStrokeWidth() + shadowRadius * 2);
+			cachedStrokeWidth = paint.getStrokeWidth();
+
 			ColorFilter cf = new PorterDuffColorFilter(shadowColor, Mode.SRC_IN);
 			paint.setColorFilter(cf);
 //			 paint.setColor(0xffbababa);

--- a/OsmAnd/src/net/osmand/plus/views/GPXLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/GPXLayer.java
@@ -139,13 +139,14 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 	public void updateLayerStyle() {
 		cachedHash = -1;
 	}
-	
+
 	private int updatePaints(int color, boolean routePoints, boolean currentTrack, DrawSettings nightMode, RotatedTileBox tileBox){
 		RenderingRulesStorage rrs = view.getApplication().getRendererRegistry().getCurrentSelectedRenderer();
 		final boolean isNight = nightMode != null && nightMode.isNightMode();
 		int hsh = calculateHash(rrs, routePoints, isNight, tileBox.getMapDensity());
 		if (hsh != cachedHash) {
 			cachedHash = hsh;
+
 			cachedColor = view.getResources().getColor(R.color.gpx_track);
 			if (rrs != null) {
 				RenderingRuleSearchRequest req = new RenderingRuleSearchRequest(rrs);
@@ -191,7 +192,7 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 					}
 				} else {
 					System.err.println("Rendering attribute gpx is not found !");
-					paint.setStrokeWidth(7 * view.getDensity());
+					//paint.setStrokeWidth(7 * view.getDensity());					Handled by new auto-sizing code
 				}
 			}
 		}
@@ -420,8 +421,15 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 				// If width becomes 0, then track is not displayed.
 				double gpxTrackWidth = ts.getGpxZoom(g.getGpxZoom()) * getScale(viewZoom);
 				if (gpxTrackWidth > 0) {
+
+					// Set "ideal" track width first. Shadows, etc., appear to use the current paint's track width as a starting
+					// point, so this should be compatible with those additional effects.
 					paint.setStrokeWidth((float) gpxTrackWidth);
+
 					updatePaints(ts.getColor(g.getColor()), g.isRoutePoints(), g.isShowCurrentTrack(), settings, tileBox);
+
+
+
 
 					// Create a transient track/segment for display purposes only
 					TrkSegment tsCulled = new TrkSegment();
@@ -483,7 +491,7 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 					if (endIndex == i - 1 && startIndex != -1) {
 						// continue previous line
 					} else {
-						// draw previous segment and start a new segment
+						// draw previous segment and start new segment
 						if (startIndex >= 0) {
 							drawSegment(canvas, tileBox, l, startIndex, endIndex);
 						}


### PR DESCRIPTION
1. GPX track colour can come from .gpx file (as before) via \<extensions> block. However, this was previously
 on an entire-track basis. Since the reader code also worked when an \<extensions> block was placed inside a \<trk> or
\<trkseg> block, I have honoured this implicit arrangement.  So, if an extension containing \<color> is inside a \<trkseg>
then that segment will be drawn in the selected colour. If there is no colour specified for a segment, it will draw
in it's parent track's colour. If the parent's colour is not specified, it will draw in the GPX file's colour. If
none is specified then the default OsmAnd colour is used.

2. Track width is also configurable on per-segment. I added \<zoom>1.0\</zoom> into the \<extensions>, so if you put
that in either a gpx \<trk\> or \<trkseg> then you will get scaling of the width of the drawn segments. The zoom is
relative to default size, so 1.0 is 100%. To draw double-thick lines, use 2.0, or half-width 0.5.

With (1) and (2) you can use one or both inside the \<extensions> block.

The reasoning for the above is that you may wish to have some tracks marked with easy and difficult sections, or
by different surface types, etc., By putting colouring capability in segments you can do all of that.

3) Reduced points for speedups.  Huge GPX files with hundreds of thousands of points could potentially slow the UI down.
I have implemented point-reduction at runtime so that tracks are displayed using the minimum number of points required
to maintain visual integrity. Code is inside GPXLayer.java and uses Ramer-Douglas-Peucer algorithm. Selection criteria
for culling points is based on view zoom level.  The culled point set is cached, so the line reduction only happens when
there is a change in zoom, or number of points in the original line. The reduction could theoretically replace the
"offscreen" culling code, because that code has a number of bugs;

  - e.g., 1) lines just offscreen are clipped but you can see curved ends on them when they shouldn't be.
  2) some lines that should be onsceen are totally culled. I have a sample track demonstrating this bug.

My preference would be to simply rely on the point culling to give great perfomance and drop the segment onscreen checks.

4) Scaling based on view zoom - the line widths are modified according to the view zoom modified by (2) the track
zoom. Now when you zoom right out, you don't get a large block of "mess" - in fact tracks are legible right down to very
small sizes (zooming right out).  It's a lovely thing.

Andrew Davie
andrew@taswegian.com