### PR TITLE
Support three turn options for one segment in the result route description

### DIFF
--- a/OsmAnd-java/src/net/osmand/router/RouteResultPreparation.java
+++ b/OsmAnd-java/src/net/osmand/router/RouteResultPreparation.java
@@ -1006,6 +1006,7 @@ public class RouteResultPreparation {
 		int[] lanes = new int[splitLaneOptions.length];
 		for (int i = 0; i < splitLaneOptions.length; i++) {
 			String[] laneOptions = splitLaneOptions[i].split(";");
+			boolean isTertiaryTurn = false;
 
 			for (int j = 0; j < laneOptions.length; j++) {
 				int turn;
@@ -1039,10 +1040,13 @@ public class RouteResultPreparation {
                     	(TurnType.isLeftTurn(calcTurnType) && TurnType.isLeftTurn(turn)) 
                     	) {
                     	TurnType.setPrimaryTurnShiftOthers(lanes, i, turn);
-                    } else {
+                    } else if (!isTertiaryTurn) {
                     	TurnType.setSecondaryTurnShiftOthers(lanes, i, turn);
+						isTertiaryTurn = true;
+                    } else {
+						TurnType.setTertiaryTurn(lanes, i, turn);
+						break;
                     }
-					break; // Move on to the next lane
 				}
 			}
 		}

--- a/OsmAnd-java/src/net/osmand/router/TurnType.java
+++ b/OsmAnd-java/src/net/osmand/router/TurnType.java
@@ -180,7 +180,7 @@ public class TurnType {
 	}
 
 	public static int getSecondaryTurn(int laneValue) {
-		// Get the primary turn modifier for the lane
+		// Get the secondary turn modifier for the lane
 		return (laneValue >> 5);
 	}
 	
@@ -206,7 +206,7 @@ public class TurnType {
 	}
 
 	public static int getTertiaryTurn(int laneValue) {
-		// Get the primary turn modifier for the lane
+		// Get the tertiary turn modifier for the lane
 		return (laneValue >> 10);
 	}
 

--- a/OsmAnd-java/test/resources/test_turn_lanes.json
+++ b/OsmAnd-java/test/resources/test_turn_lanes.json
@@ -216,6 +216,21 @@
     "expectedResults": {
       "14418": "TL, +TL, C, C, TR"
    }
+  },
+  {
+    "testName": "11.Figure 8 TL",
+    "startPoint": {
+      "latitude": 45.69816447596442,
+      "longitude": 35.74885922431952
+    },
+    "endPoint": {
+      "latitude": 45.700075267731705,
+      "longitude": 35.7467134571076
+    },
+    "expectedResults": {
+      "43906": null,
+      "43905": "+TL;C;TR"
+    }
   }
 
 ]


### PR DESCRIPTION
I don't like this solution because it's still limited. `TurnType` supports only 3 turn options. Here (https://www.openstreetmap.org/#map=19/55.71127/37.62080), for example, we have 4 different turn options, so I'm proposing to rewrite `TurnType` to support arbitrary number of turn options by using an `AbstractList` interface. What do you think?

Illustration of a bug:
![Image with wrong behaviour](https://dl.dropboxusercontent.com/u/4624786/osm/Screenshots/Screenshot%20from%202016-04-04%2016%3A23%3A15.png)