### PR TITLE
GPX tracks - Altitude and speed and distance along track

### DIFF
--- a/OsmAnd/src/net/osmand/plus/GPXUtilities.java
+++ b/OsmAnd/src/net/osmand/plus/GPXUtilities.java
@@ -1036,17 +1036,17 @@ public class GPXUtilities {
 							if (parser.getName().equals("gpx")) {
 								((GPXFile) parse).author = parser.getAttributeValue("", "creator");
 							}
-							if (parser.getName().equals("trk")) {
+							else if (parser.getName().equals("trk")) {
 								Track track = new Track();
 								((GPXFile) parse).tracks.add(track);
 								parserState.push(track);
 							}
-							if (parser.getName().equals("rte")) {
+							else if (parser.getName().equals("rte")) {
 								Route route = new Route();
 								((GPXFile) parse).routes.add(route);
 								parserState.push(route);
 							}
-							if (parser.getName().equals("wpt")) {
+							else if (parser.getName().equals("wpt")) {
 								WptPt wptPt = parseWptAttributes(parser);
 								((GPXFile) parse).points.add(wptPt);
 								parserState.push(wptPt);
@@ -1055,10 +1055,10 @@ public class GPXUtilities {
 							if (parser.getName().equals("name")) {
 								((Route) parse).name = readText(parser, "name");
 							}
-							if (parser.getName().equals("desc")) {
+							else if (parser.getName().equals("desc")) {
 								((Route) parse).desc = readText(parser, "desc");
 							}
-							if (parser.getName().equals("rtept")) {
+							else if (parser.getName().equals("rtept")) {
 								WptPt wptPt = parseWptAttributes(parser);
 								((Route) parse).points.add(wptPt);
 								parserState.push(wptPt);
@@ -1067,10 +1067,10 @@ public class GPXUtilities {
 							if (parser.getName().equals("name")) {
 								((Track) parse).name = readText(parser, "name");
 							}
-							if (parser.getName().equals("desc")) {
+							else if (parser.getName().equals("desc")) {
 								((Track) parse).desc = readText(parser, "desc");
 							}
-							if (parser.getName().equals("trkseg")) {
+							else if (parser.getName().equals("trkseg")) {
 								TrkSegment trkSeg = new TrkSegment();
 								((Track) parse).segments.add(trkSeg);
 								parserState.push(trkSeg);

--- a/OsmAnd/src/net/osmand/plus/GPXUtilities.java
+++ b/OsmAnd/src/net/osmand/plus/GPXUtilities.java
@@ -2,15 +2,12 @@
 package net.osmand.plus;
 
 import android.content.Context;
-import android.graphics.Canvas;
 import android.graphics.Color;
-import android.graphics.Paint;
 
 import net.osmand.Location;
 import net.osmand.PlatformUtil;
 import net.osmand.data.LocationPoint;
 import net.osmand.data.PointDescription;
-import net.osmand.data.RotatedTileBox;
 import net.osmand.plus.views.OsmandMapTileView;
 import net.osmand.plus.views.Renderable;
 import net.osmand.util.Algorithms;
@@ -32,7 +29,6 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.lang.reflect.Array;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
@@ -40,7 +36,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -105,8 +100,8 @@ public class GPXUtilities {
 		public double speed = 0;
 		public double hdop = Double.NaN;
 		public boolean deleted = false;
-		public int colourARGB = 0;					// point colour (used for altitude/speed colouring)
-		public double distance = 0.0;				// cumulative distance, if in a track
+	//	public int colourARGB = 0;					// point colour (used for altitude/speed colouring)
+	//	public double distance = 0.0;				// cumulative distance, if in a track
 
 		public WptPt() {
 		}
@@ -132,13 +127,13 @@ public class GPXUtilities {
 //			this.distance = toCopy.distance;
 //		}
 
-		public void setDistance(double dist) {
-			distance = dist;
-		}
+		//public void setDistance(double dist) {
+		//	distance = dist;
+		//}
 
-		public double getDistance() {
-			return distance;
-		}
+		//public double getDistance() {
+		//	return distance;
+		//}
 
 		@Override
 		public int getColor() {
@@ -206,7 +201,7 @@ public class GPXUtilities {
 		public List<WptPt> points = new ArrayList<WptPt>();
 		private OsmandMapTileView view;
 
-		public List<Renderable.RenderableSegment> renders = new ArrayList<>();
+		public List<Renderable> renders = new ArrayList<>();
 
 		public List<GPXTrackAnalysis> splitByDistance(double meters) {
 			return split(getDistanceMetric(), getTimeSplit(), meters);
@@ -223,7 +218,7 @@ public class GPXUtilities {
 		}
 
 //		public void drawRenderers(double zoom, Paint p, Canvas c, RotatedTileBox tb) {
-//			for (Renderable.RenderableSegment rs : renders) {
+//			for (Renderable.Renderable rs : renders) {
 //				rs.drawSegment(zoom, p, c, tb);
 //			}
 //		}

--- a/OsmAnd/src/net/osmand/plus/views/AsynchronousResampler.java
+++ b/OsmAnd/src/net/osmand/plus/views/AsynchronousResampler.java
@@ -218,7 +218,7 @@ public abstract class AsynchronousResampler extends AsyncTask<String,Integer,Str
                     WptPt2 pt = culled.get(i);
                     double delta = pt.time - lastPt.time;
                     pt.speed = delta > 0 ? MapUtils.getDistance(pt.lat, pt.lon,
-                            lastPt.lat, lastPt.lon) / delta : 0;
+                            lastPt.lat, lastPt.lon) / delta * 3600 : 0;             // units:  km/h
                     lastPt = pt;
                 }
 

--- a/OsmAnd/src/net/osmand/plus/views/AsynchronousResampler.java
+++ b/OsmAnd/src/net/osmand/plus/views/AsynchronousResampler.java
@@ -32,15 +32,14 @@ public abstract class AsynchronousResampler extends AsyncTask<String,Integer,Str
 
 
     private WptPt2 createIntermediatePoint(WptPt lastPt, WptPt pt, double partial, double dist) {
-        double inpartial = 1.0 - partial;
-        WptPt2 newPt = new WptPt2(
-                lastPt.getLatitude() * inpartial + pt.getLatitude() * partial,
-                lastPt.getLongitude() * inpartial + pt.getLongitude() * partial,
-                (long) (lastPt.time * inpartial + pt.time * partial),
-                lastPt.ele * inpartial + pt.ele * partial,
-                lastPt.speed * inpartial + pt.speed * partial,
-                dist);
-        return newPt;
+        double angle = Math.atan2(lastPt.lat - pt.lat, lastPt.lon - pt.lon);    // kludge
+        return new WptPt2(
+                lastPt.lat + (pt.lat - lastPt.lat) * partial,
+                lastPt.lon + (pt.lon - lastPt.lon) * partial,
+                (long) (lastPt.time + (pt.time - lastPt.time) * partial),
+                lastPt.ele + (pt.ele - lastPt.ele) * partial,
+                lastPt.speed + (pt.speed - lastPt.speed) * partial,
+                dist, angle);
     }
 
     public List<WptPt2> resampleTrack(List<WptPt> pts, double dist) {
@@ -55,11 +54,10 @@ public abstract class AsynchronousResampler extends AsyncTask<String,Integer,Str
             double cumDist = 0;
             for (int i = 1; i < size && !isCancelled(); i++) {
                 WptPt pt = pts.get(i);
-                double segLength = MapUtils.getDistance(pt.getLatitude(), pt.getLongitude(), lastPt.getLatitude(), lastPt.getLongitude());
+                double segLength = MapUtils.getDistance(pt.lat, pt.lon, lastPt.lat, lastPt.lon);
                 while (segSub < segLength) {
                     double partial = segSub / segLength;
-                    WptPt2 nPt = createIntermediatePoint(lastPt, pt, segSub / segLength, cumDist + segLength * partial);
-                    newPts.add(nPt);
+                    newPts.add(createIntermediatePoint(lastPt, pt, partial, cumDist + segLength * partial));
                     segSub += dist;
                 }
                 segSub -= segLength;

--- a/OsmAnd/src/net/osmand/plus/views/AsynchronousResampler.java
+++ b/OsmAnd/src/net/osmand/plus/views/AsynchronousResampler.java
@@ -3,6 +3,7 @@ package net.osmand.plus.views;
 import android.os.AsyncTask;
 
 import net.osmand.plus.GPXUtilities.WptPt;
+import net.osmand.util.Algorithms;
 import net.osmand.util.MapUtils;
 
 import java.util.ArrayList;
@@ -12,11 +13,13 @@ public abstract class AsynchronousResampler extends AsyncTask<String,Integer,Str
 
     protected Renderable.RenderableSegment rs;
     protected List<WptPt> culled = null;
+    protected double epsilon;
 
-    AsynchronousResampler(Renderable.RenderableSegment rs) {
+    AsynchronousResampler(Renderable.RenderableSegment rs, double epsilon) {
         assert rs != null;
         assert rs.points != null;
         this.rs = rs;
+        this.epsilon = epsilon;
     }
 
     @Override protected void onPostExecute(String result) {
@@ -25,56 +28,185 @@ public abstract class AsynchronousResampler extends AsyncTask<String,Integer,Str
         }
     }
 
+    private WptPt createIntermediatePoint(WptPt lastPt, WptPt pt, double partial, double dist) {
+        double inpartial = 1.0 - partial;
+        WptPt newPt = new WptPt(
+                lastPt.getLatitude() * inpartial + pt.getLatitude() * partial,
+                lastPt.getLongitude() * inpartial + pt.getLongitude() * partial,
+                (long) (lastPt.time * inpartial + pt.time * partial),
+                lastPt.ele * inpartial + pt.ele * partial,
+                lastPt.speed * inpartial + pt.speed * partial,
+                lastPt.hdop * inpartial + pt.hdop * partial);
+        newPt.setDistance(dist);
+        return newPt;
+    }
+
+    protected List<WptPt> resampleTrack(List<WptPt> pts, double dist) {
+
+        List<WptPt> newPts = new ArrayList<>();
+
+        int size = pts.size();
+        if (size > 0) {
+            WptPt lastPt = pts.get(0);
+
+            double segSub = 0;
+            double cumDist = 0;
+            for (int i = 1; i < size && !isCancelled(); i++) {
+                WptPt pt = pts.get(i);
+                double segLength = MapUtils.getDistance(pt.getLatitude(), pt.getLongitude(), lastPt.getLatitude(), lastPt.getLongitude());
+                while (segSub < segLength) {
+                    double partial = segSub / segLength;
+                    WptPt nPt = createIntermediatePoint(lastPt, pt, segSub / segLength, cumDist + segLength * partial);
+                    newPts.add(nPt);
+                    segSub += dist;
+                }
+                segSub -= segLength;
+                cumDist += segLength;
+                lastPt = pt;
+            }
+            newPts.add(createIntermediatePoint(lastPt, lastPt, 0, cumDist));
+        }
+        return newPts;
+    }
+
+    protected List<WptPt> doRamerDouglasPeucerSimplification(List<WptPt> pts) {
+        List<WptPt> rdpTrack = null;
+        int nsize = pts.size();
+        if (nsize > 0) {
+            boolean survivor[] = new boolean[nsize];
+            cullRamerDouglasPeucer(survivor, 0, nsize - 1);
+            if (!isCancelled()) {
+                rdpTrack = new ArrayList<>();
+                survivor[0] = true;
+                for (int i = 0; i < nsize; i++) {
+                    if (survivor[i]) {
+                        rdpTrack.add(pts.get(i));
+                    }
+                }
+            }
+        }
+        return rdpTrack;
+    }
+
+    private void cullRamerDouglasPeucer(boolean survivor[], int start, int end) {
+
+        double dmax = Double.NEGATIVE_INFINITY;
+        int index = -1;
+
+        WptPt startPt = rs.points.get(start);
+        WptPt endPt = rs.points.get(end);
+
+        for (int i = start + 1; i < end && !isCancelled(); i++) {
+            WptPt pt = rs.points.get(i);
+            double d = MapUtils.getOrthogonalDistance(pt.lat, pt.lon, startPt.lat, startPt.lon, endPt.lat, endPt.lon);
+            if (d > dmax) {
+                dmax = d;
+                index = i;
+            }
+        }
+        if (dmax > epsilon) {
+            cullRamerDouglasPeucer(survivor, start, index);
+            cullRamerDouglasPeucer(survivor, index, end);
+        } else {
+            survivor[end] = true;
+        }
+    }
+
+    //----------------------------------------------------------------------------------------------
+
     public static class RamerDouglasPeucer extends AsynchronousResampler {
 
-        private double epsilon;
-
         public RamerDouglasPeucer(Renderable.RenderableSegment rs, double epsilon) {
-            super(rs);
-            this.epsilon = epsilon;
+            super(rs, epsilon);
+        }
+
+        @Override protected String doInBackground(String... params) {
+            culled = doRamerDouglasPeucerSimplification(rs.points);
+            return null;
+        }
+    }
+
+    //----------------------------------------------------------------------------------------------
+
+    public static class ResampleAltitude extends AsynchronousResampler {
+
+        ResampleAltitude(Renderable.RenderableSegment rs, double epsilon) {
+            super(rs, epsilon);
+        }
+
+        @Override protected String doInBackground(String... params) {
+            culled = doRamerDouglasPeucerSimplification(rs.points); //resampleTrack(rs.points, epsilon);
+            if (!isCancelled() && !culled.isEmpty()) {
+
+                int halfC = Algorithms.getRainbowColor(0.5);
+
+                // Calculate the absolutes of the altitude variations
+                Double max = culled.get(0).ele;
+                Double min = max;
+                for (WptPt pt : culled) {
+                    max = Math.max(max, pt.ele);
+                    min = Math.min(min, pt.ele);
+                    pt.colourARGB = halfC;                  // default, in case there are no 'ele' in GPX
+                }
+
+                Double elevationRange = max - min;
+                if (elevationRange > 0)
+                    for (WptPt pt : culled)
+                        pt.colourARGB = Algorithms.getRainbowColor((pt.ele - min) / elevationRange);
+            }
+
+            return null;
+        }
+    }
+
+    //----------------------------------------------------------------------------------------------
+
+    public static class ResampleSpeed extends AsynchronousResampler {
+
+        ResampleSpeed(Renderable.RenderableSegment rs, double epsilon) {
+            super(rs, epsilon);
         }
 
         @Override protected String doInBackground(String... params) {
 
-            int nsize = rs.points.size();
-            if (nsize > 0) {
-                boolean survivor[] = new boolean[nsize];
-                cullRamerDouglasPeucer(survivor, 0, nsize - 1);
-                if (!isCancelled()) {
-                    culled = new ArrayList<>();
-                    survivor[0] = true;
-                    for (int i = 0; i < nsize; i++) {
-                        if (survivor[i]) {
-                            culled.add(rs.points.get(i));
-                        }
-                    }
+            // Resample track, then analyse speeds and set colours for each point
+
+            culled = doRamerDouglasPeucerSimplification(rs.points); //resampleTrack(rs.points, epsilon);
+            if (!isCancelled() && !culled.isEmpty()) {
+
+                WptPt lastPt = culled.get(0);
+                lastPt.speed = 0;
+
+                int size = culled.size();
+                for (int i = 1; i < size; i++) {
+                    WptPt pt = culled.get(i);
+                    double delta = pt.time - lastPt.time;
+                    pt.speed = delta > 0 ? MapUtils.getDistance(pt.getLatitude(), pt.getLongitude(),
+                            lastPt.getLatitude(), lastPt.getLongitude()) / delta : 0;
+                    lastPt = pt;
+                }
+
+                if (size > 1) {
+                    culled.get(0).speed = culled.get(1).speed;      // fixup 1st speed
+                }
+
+                double max = lastPt.speed;
+                double min = max;
+
+                int halfC = Algorithms.getRainbowColor(0.5);
+
+                for (WptPt pt : culled) {
+                    max = Math.max(max, pt.speed);
+                    min = Math.min(min, pt.speed);
+                    pt.colourARGB = halfC;                  // default, in case there are no 'time' in GPX
+                }
+                double speedRange = max - min;
+                if (speedRange > 0) {
+                    for (WptPt pt : culled)
+                        pt.colourARGB = Algorithms.getRainbowColor((pt.speed - min) / speedRange);
                 }
             }
             return null;
-        }
-
-        private void cullRamerDouglasPeucer(boolean survivor[], int start, int end) {
-
-            double dmax = Double.NEGATIVE_INFINITY;
-            int index = -1;
-
-            WptPt startPt = rs.points.get(start);
-            WptPt endPt = rs.points.get(end);
-
-            for (int i = start + 1; i < end && !isCancelled(); i++) {
-                WptPt pt = rs.points.get(i);
-                double d = MapUtils.getOrthogonalDistance(pt.lat, pt.lon, startPt.lat, startPt.lon, endPt.lat, endPt.lon);
-                if (d > dmax) {
-                    dmax = d;
-                    index = i;
-                }
-            }
-            if (dmax > epsilon) {
-                cullRamerDouglasPeucer(survivor, start, index);
-                cullRamerDouglasPeucer(survivor, index, end);
-            } else {
-                survivor[end] = true;
-            }
         }
     }
 }

--- a/OsmAnd/src/net/osmand/plus/views/GPXLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/GPXLayer.java
@@ -359,15 +359,16 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 				if (ts.renders.isEmpty()) {
 
 					if (g.isShowCurrentTrack()) {
-						ts.renders.add(new Renderable.CurrentTrack(ts.points, 0));
+						ts.renders.add(new Renderable.CurrentTrack(view, ts.points, 0));
 					} else {
 
 						double epsilon = 16.5;                // Increase for less quality.
 
-						ts.renders.add(new Renderable.StandardTrack(ts.points, epsilon));
-						ts.renders.add(new Renderable.Altitude(ts.points, epsilon, 2.5));
-						//ts.renders.add(new Renderable.Speed(ts.points, epsilon, 4));
-						ts.renders.add(new Renderable.Distance(ts.points, Renderable.Distance.unit.KILOMETERS));
+						ts.renders.add(new Renderable.StandardTrack(view, ts.points, epsilon));
+						ts.renders.add(new Renderable.Altitude(view, ts.points, epsilon, 2.5));
+						//ts.renders.add(new Renderable.Speed(view, ts.points, epsilon, 4));
+						ts.renders.add(new Renderable.Distance(view, ts.points, Renderable.Distance.unit.KILOMETERS));
+						//ts.renders.add(new Renderable.Arrows(view, ts.points, view, 20, 500));
 					}
 				}
 				// END OF SECTION TO BE MOVED TO UI

--- a/OsmAnd/src/net/osmand/plus/views/GPXLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/GPXLayer.java
@@ -365,8 +365,17 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 						double epsilon = 16.5;                // Increase for less quality.
 
 						ts.renders.add(new Renderable.StandardTrack(view, ts.points, epsilon));
-						ts.renders.add(new Renderable.Altitude(view, ts.points, epsilon, 2.5));
-						//ts.renders.add(new Renderable.Speed(view, ts.points, epsilon, 4));
+
+						Renderable.Altitude alt = new Renderable.Altitude(view, ts.points, epsilon, 2.5);
+						alt.setRange(0,500);	// optional  - set colour range 0m to 500m
+						ts.renders.add(alt);
+
+						//Renderable.Speed speed = new Renderable.Speed(view, ts.points, epsilon, 4);
+						//speed.setRange(0,80/3600.);	// optional (0 km/h to 80 km/h range)
+						//ts.renders.add(speed);
+
+
+
 						ts.renders.add(new Renderable.Distance(view, ts.points, Renderable.Distance.unit.KILOMETERS));
 						//ts.renders.add(new Renderable.Arrows(view, ts.points, view, 20, 500));
 					}

--- a/OsmAnd/src/net/osmand/plus/views/GPXLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/GPXLayer.java
@@ -371,7 +371,7 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 //						ts.renders.add(alt);
 
 						Renderable.Speed speed = new Renderable.Speed(view, ts.points, epsilon, 4);
-						speed.setRange(0,80);	// optional (0 km/h to 80 km/h range)
+						//speed.setRange(0,80);	// optional (0 km/h to 80 km/h range)
 						ts.renders.add(speed);
 
 

--- a/OsmAnd/src/net/osmand/plus/views/GPXLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/GPXLayer.java
@@ -366,13 +366,13 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 
 						ts.renders.add(new Renderable.StandardTrack(view, ts.points, epsilon));
 
-						Renderable.Altitude alt = new Renderable.Altitude(view, ts.points, epsilon, 2.5);
-						alt.setRange(0,500);	// optional  - set colour range 0m to 500m
-						ts.renders.add(alt);
+//						Renderable.Altitude alt = new Renderable.Altitude(view, ts.points, epsilon, 2.5);
+//						alt.setRange(0,500);	// optional  - set colour range 0m to 500m
+//						ts.renders.add(alt);
 
-						//Renderable.Speed speed = new Renderable.Speed(view, ts.points, epsilon, 4);
-						//speed.setRange(0,80/3600.);	// optional (0 km/h to 80 km/h range)
-						//ts.renders.add(speed);
+						Renderable.Speed speed = new Renderable.Speed(view, ts.points, epsilon, 4);
+						speed.setRange(0,80);	// optional (0 km/h to 80 km/h range)
+						ts.renders.add(speed);
 
 
 

--- a/OsmAnd/src/net/osmand/plus/views/GPXLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/GPXLayer.java
@@ -37,13 +37,15 @@ import net.osmand.render.RenderingRulesStorage;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
-public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContextMenuProvider, 
+public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContextMenuProvider,
 			MapTextProvider<WptPt> {
-	
+
 	private OsmandMapTileView view;
-	
+
 	private Paint paint;
 	private Paint paint2;
 	private boolean isPaint2;
@@ -58,7 +60,7 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 
 	private static final int startZoom = 7;
 
-	
+
 	private GpxSelectionHelper selectedGpxHelper;
 	private Paint paintBmp;
 	private List<WptPt> cache = new ArrayList<WptPt>();
@@ -76,7 +78,7 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 	private List<TrkSegment> points;
 	private GPXFile gpx;
 
-	
+
 	private void initUI() {
 		paint = new Paint();
 		paint.setStyle(Style.STROKE);
@@ -90,21 +92,21 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 		paint_1 = new Paint();
 		paint_1.setStyle(Style.STROKE);
 		paint_1.setAntiAlias(true);
-		
 
-		
+
+
 		paintBmp = new Paint();
 		paintBmp.setAntiAlias(true);
 		paintBmp.setFilterBitmap(true);
 		paintBmp.setDither(true);
-		
+
 		paintTextIcon = new Paint();
 		paintTextIcon.setTextSize(10 * view.getDensity());
 		paintTextIcon.setTextAlign(Align.CENTER);
 		paintTextIcon.setFakeBoldText(true);
 		paintTextIcon.setColor(Color.BLACK);
 		paintTextIcon.setAntiAlias(true);
-		
+
 		textLayer = view.getLayerByClass(MapTextLayer.class);
 
 		paintOuter = new Paint();
@@ -119,7 +121,7 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 		paintIcon = new Paint();
 		pointSmall = BitmapFactory.decodeResource(view.getResources(), R.drawable.map_white_shield_small);
 	}
-	
+
 
 	@Override
 	public void initLayer(OsmandMapTileView view) {
@@ -129,11 +131,11 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 		initUI();
 	}
 
-	
+
 	public void updateLayerStyle() {
 		cachedHash = -1;
 	}
-	
+
 	private int updatePaints(int color, boolean routePoints, boolean currentTrack, DrawSettings nightMode, RotatedTileBox tileBox){
 		RenderingRulesStorage rrs = view.getApplication().getRendererRegistry().getCurrentSelectedRenderer();
 		final boolean isNight = nightMode != null && nightMode.isNightMode();
@@ -194,7 +196,7 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 		paint.setColor(color == 0 ? cachedColor : color);
 		return cachedColor;
 	}
-	
+
 	private int calculateHash(Object... o) {
 		return Arrays.hashCode(o);
 	}
@@ -204,8 +206,11 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 	public void onPrepareBufferImage(Canvas canvas, RotatedTileBox tileBox, DrawSettings settings) {
 		if(points != null) {
 			updatePaints(0, false, false, settings, tileBox);
-			for (TrkSegment ts : points)
-				ts.drawRenderers(view.getZoom(), paint, canvas, tileBox);
+			for (TrkSegment ts : points) {
+				for (Renderable.RenderableSegment rs : ts.renders) {
+					rs.drawSegment(view.getZoom(), paint, canvas, tileBox);		// unsorted
+				}
+			}
 		} else {
 			List<SelectedGpxFile> selectedGPXFiles = selectedGpxHelper.getSelectedGPXFiles();
 			cache.clear();
@@ -220,8 +225,8 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 			}
 		}
 	}
-	
-	private void drawSelectedFilesSplits(Canvas canvas, RotatedTileBox tileBox, List<SelectedGpxFile> selectedGPXFiles, 
+
+	private void drawSelectedFilesSplits(Canvas canvas, RotatedTileBox tileBox, List<SelectedGpxFile> selectedGPXFiles,
 			DrawSettings settings) {
 		if (tileBox.getZoom() >= startZoom) {
 			// request to load
@@ -240,7 +245,7 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 	private void drawSplitItems(Canvas canvas, RotatedTileBox tileBox, List<GpxDisplayItem> items, DrawSettings settings) {
 		final QuadRect latLonBounds = tileBox.getLatLonBounds();
 		int r = (int) (12 * tileBox.getDensity());
-		int dr = r * 3 / 2; 
+		int dr = r * 3 / 2;
 		int px = -1;
 		int py = -1;
 		for(int k = 0; k < items.size(); k++) {
@@ -321,29 +326,66 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 		}
 	}
 
+	private class Rend {
+		Renderable.RenderableSegment rs;
+		public int color;
+		public boolean routePoints;
+		public boolean showCurrentTrack;
+		public DrawSettings settings;
+		public RotatedTileBox tileBox;
+
+		Rend(Renderable.RenderableSegment r, int col, boolean rp, boolean ct, DrawSettings ds, RotatedTileBox tb) {
+			rs = r;
+			color = col;
+			routePoints = rp;
+			showCurrentTrack = ct;
+			settings = ds;
+			tileBox = tb;
+		}
+	}
+
 	private void drawSelectedFilesSegments(Canvas canvas, RotatedTileBox tileBox,
 			List<SelectedGpxFile> selectedGPXFiles, DrawSettings settings) {
+
+		List<Rend> rend = new ArrayList<>();
 
 		for (SelectedGpxFile g : selectedGPXFiles) {
 			List<TrkSegment> segments = g.getPointsToDisplay();
 			for (TrkSegment ts : segments) {
 
-				if (ts.renders.isEmpty()				// only do once (CODE HERE NEEDS TO BE UI INSTEAD)
-						&& !ts.points.isEmpty()) {		// hmmm. 0-point tracks happen, but.... how?
+				if (ts.renders.isEmpty()) {                // only do once (CODE HERE NEEDS TO BE UI INSTEAD)
 
-					if (g.isShowCurrentTrack()) {
-						ts.renders.add(new Renderable.CurrentTrack(ts.points));
-					} else {
-						ts.renders.add(new Renderable.StandardTrack(ts.points, 17.2));
-					}
+					// Note: CurrentTrack - it is no longer necessary to identify this; it is auto-detected
+					// so always just use 'StandardTrack' for all tracks and add on the other renderers as required
+
+					double epsilon = 16.5;                // aggressiveness (zoom) of line simiplification. Increase for less quality.
+
+					ts.renders.add(new Renderable.StandardTrack(100, ts.points, epsilon));
+					ts.renders.add(new Renderable.Altitude(0, ts.points, epsilon, 5));
+					//ts.renders.add(new Renderable.Speed(1,ts.points, epsilon, 5));
 				}
 
-				updatePaints(ts.getColor(cachedColor), g.isRoutePoints(), g.isShowCurrentTrack(), settings, tileBox);
-				ts.drawRenderers(view.getZoom(), paint, canvas, tileBox);
+				for (Renderable.RenderableSegment r : ts.renders) {
+					rend.add(new Rend(r, ts.getColor(cachedColor), g.isRoutePoints(), g.isShowCurrentTrack(), settings, tileBox));
+				}
+
 			}
+		}
+
+		// Draw renderers in sorted priority order
+		Collections.sort(rend, new CustomComparator());
+		for (Rend r : rend) {
+			updatePaints(r.color, r.routePoints, r.showCurrentTrack, r.settings, r.tileBox );
+			r.rs.drawSegment(view.getZoom(), paint, canvas, tileBox);
 		}
 	}
 
+	public class CustomComparator implements Comparator<Rend> {
+		@Override
+		public int compare(Rend o1, Rend o2) {
+			return o1.rs.getPriority() - o2.rs.getPriority();
+		}
+	}
 
 	private boolean isPointVisited(WptPt o) {
 		boolean visit = false;
@@ -367,7 +409,7 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 	@Override
 	public void onDraw(Canvas canvas, RotatedTileBox tileBox, DrawSettings settings) {
 	}
-	
+
 	private boolean calculateBelongs(int ex, int ey, int objx, int objy, int radius) {
 		return (Math.abs(objx - ex) <= radius * 2 && Math.abs(objy - ey) <= radius * 2) ;
 //		return Math.abs(objx - ex) <= radius && (ey - objy) <= radius / 2 && (objy - ey) <= 3 * radius ;
@@ -397,7 +439,7 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 		}
 		return null;
 	}
-	
+
 	@Override
 	public PointDescription getObjectName(Object o) {
 		if(o instanceof WptPt){
@@ -435,11 +477,11 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 		}
 		return null;
 	}
-	
-	
+
+
 	@Override
 	public void destroyLayer() {
-		
+
 	}
 	@Override
 	public boolean drawInScreenPixels() {

--- a/OsmAnd/src/net/osmand/plus/views/Renderable.java
+++ b/OsmAnd/src/net/osmand/plus/views/Renderable.java
@@ -1,193 +1,232 @@
 package net.osmand.plus.views;
 
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.Paint;
+import android.graphics.Rect;
 import android.os.AsyncTask;
 
 import net.osmand.data.QuadRect;
 import net.osmand.data.RotatedTileBox;
-import net.osmand.plus.GPXUtilities.WptPt;
+import net.osmand.plus.GPXUtilities;
 
 import java.util.ArrayList;
 import java.util.List;
 
+public abstract class Renderable {
 
-public class Renderable {
+    public enum Priority {
 
-    public static abstract class RenderableSegment {
+        CURRENT(1000),
+        ALTITUDE(1),
+        SPEED(0),
+        DISTANCE(500),
+        STANDARD(300);
 
-        public List<WptPt> points = null;                           // Original list of points
-        protected List<WptPt> culled = new ArrayList<>();           // Reduced/resampled list of points
-        protected int pointSize;
-        protected double segmentSize;
-
-        protected QuadRect trackBounds;
-        protected double zoom = -1;
-        protected AsynchronousResampler culler = null;                        // The currently active resampler
-        protected Paint paint = null;                               // MUST be set by 'updateLocalPaint' before use
-        protected int priority;
-
-        public RenderableSegment(int priority, List <WptPt> points, double segmentSize) {
+        int priority;
+        Priority(int priority) {
             this.priority = priority;
-            this.points = points;
-            this.segmentSize = segmentSize;
-
-            trackBounds = new QuadRect(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY,
-                    Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
-            updateBounds(points, 0);
-        }
-
-        protected void updateLocalPaint(Paint p) {
-            if (paint == null) {
-                paint = new Paint(p);
-                paint.setStrokeCap(Paint.Cap.ROUND);
-                paint.setStrokeJoin(Paint.Join.ROUND);
-                paint.setStyle(Paint.Style.STROKE); //.Style.FILL);
-            }
-            paint.setColor(p.getColor()|0xFF000000);        // no transparency
-            paint.setStrokeWidth(p.getStrokeWidth());
-        }
-
-        protected abstract void startCuller(double newZoom);
-
-        protected void drawSingleSegment(Paint p, Canvas canvas, RotatedTileBox tileBox) {}
-
-        public void drawSegment(double zoom, Paint p, Canvas canvas, RotatedTileBox tileBox) {
-
-            if (pointSize != points.size()) {
-                for (int i = pointSize; i < points.size(); i++) {
-                    culled.add(points.get(i));
-                }
-                updateBounds(points, pointSize);
-            }
-
-            if (QuadRect.trivialOverlap(tileBox.getLatLonBounds(), trackBounds)) { // is visible?
-                startCuller(zoom);
-                drawSingleSegment(p, canvas, tileBox);
-            }
-        }
-
-        public int getPriority() {
-            return priority;
-        }
-
-        protected void updateBounds(List<WptPt> pts, int startIndex) {
-            for (int i = startIndex; i < pts.size(); i++) {
-                WptPt pt = pts.get(i);
-                trackBounds.right = Math.max(trackBounds.right, pt.lon);
-                trackBounds.left = Math.min(trackBounds.left, pt.lon);
-                trackBounds.top = Math.max(trackBounds.top, pt.lat);
-                trackBounds.bottom = Math.min(trackBounds.bottom, pt.lat);
-            }
-            pointSize = pts.size();
-        }
-
-        public void setRDP(List<WptPt> cull) {
-            culled = cull;
-        }
-
-        protected void draw(List<WptPt> pts, Paint p, Canvas canvas, RotatedTileBox tileBox) {
-
-            if (pts.size() > 1) {
-
-                updateLocalPaint(p);
-                canvas.rotate(-tileBox.getRotate(), tileBox.getCenterPixelX(), tileBox.getCenterPixelY());
-                QuadRect tileBounds = tileBox.getLatLonBounds();
-
-                WptPt lastPt = pts.get(0);
-                float lastx = 0;
-                float lasty = 0;
-                boolean reCalculateLastXY = true;
-
-                int size = pts.size();
-                for (int i = 1; i < size; i++) {
-                    WptPt pt = pts.get(i);
-
-                    if (Math.min(pt.lon, lastPt.lon) < tileBounds.right && Math.max(pt.lon, lastPt.lon) > tileBounds.left
-                            && Math.min(pt.lat, lastPt.lat) < tileBounds.top && Math.max(pt.lat, lastPt.lat) > tileBounds.bottom) {
-
-                        if (reCalculateLastXY) {
-                            lastx = tileBox.getPixXFromLatLon(lastPt.lat, lastPt.lon);
-                            lasty = tileBox.getPixYFromLatLon(lastPt.lat, lastPt.lon);
-                            reCalculateLastXY = false;
-                        }
-
-                        float x = tileBox.getPixXFromLatLon(pt.lat, pt.lon);
-                        float y = tileBox.getPixYFromLatLon(pt.lat, pt.lon);
-
-                        canvas.drawLine(lastx, lasty, x, y, paint);
-
-                        lastx = x;
-                        lasty = y;
-
-                    } else {
-                        reCalculateLastXY = true;
-                    }
-                    lastPt = pt;
-                }
-                canvas.rotate(tileBox.getRotate(), tileBox.getCenterPixelX(), tileBox.getCenterPixelY());
-            }
         }
     }
 
-    public static class StandardTrack extends RenderableSegment {
+    public List<GPXUtilities.WptPt> points = null;               // Original list of points
+    protected List<WptPt2> culled;                               // Reduced/resampled list of points
+    protected int pointSize;
+    protected double epsilon;
 
-        public StandardTrack(int priority, List<WptPt> pt, double base) {
-            super(priority, pt, base);
+    protected QuadRect trackBounds;
+    protected double zoom = -1;
+    protected AsynchronousResampler culler = null;              // The currently active resampler
+    protected Paint paint = null;                               // MUST be set by 'updateLocalPaint' before use
+    protected int priority;
+
+    public Renderable(Priority priority, List<GPXUtilities.WptPt> points, double epsilon) {
+        this.priority = priority.priority;
+        this.points = points;
+        this.epsilon = epsilon;
+
+        culled = new ArrayList<>();
+        for (GPXUtilities.WptPt pt : points) {
+            culled.add(new WptPt2(pt));
         }
 
-        @Override public void startCuller(double newZoom) {
+        trackBounds = new QuadRect(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY,
+                Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+        updateBounds(points, 0);
+    }
 
-            if ((pointSize != points.size() && culler != null && culler.getStatus() == AsyncTask.Status.FINISHED)
-                    || zoom != newZoom) {
+    protected void updateLocalPaint(Paint p) {
+        if (paint == null) {
+            paint = new Paint(p);
+            paint.setStrokeCap(Paint.Cap.ROUND);
+            paint.setStrokeJoin(Paint.Join.ROUND);
+            paint.setStyle(Paint.Style.FILL);
+        }
+        paint.setColor(p.getColor() | 0xFF000000);
+        paint.setStrokeWidth(p.getStrokeWidth());
+    }
 
-                if (culler != null) {
-                    culler.cancel(true);
+    protected abstract void startCuller(double newZoom);
+
+    protected void drawSingleSegment(Paint p, Canvas canvas, RotatedTileBox tileBox) {}
+
+    public void drawSegment(double zoom, Paint p, Canvas canvas, RotatedTileBox tileBox) {
+        if (QuadRect.trivialOverlap(tileBox.getLatLonBounds(), trackBounds)) { // is visible?
+            startCuller(zoom);
+            drawSingleSegment(p, canvas, tileBox);
+        }
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    protected void updateBounds(List<GPXUtilities.WptPt> pts, int startIndex) {
+        for (int i = startIndex; i < pts.size(); i++) {
+            GPXUtilities.WptPt pt = pts.get(i);
+            trackBounds.right = Math.max(trackBounds.right, pt.lon);
+            trackBounds.left = Math.min(trackBounds.left, pt.lon);
+            trackBounds.top = Math.max(trackBounds.top, pt.lat);
+            trackBounds.bottom = Math.min(trackBounds.bottom, pt.lat);
+        }
+        pointSize = pts.size();
+    }
+
+    public void setRDP(List<WptPt2> cull) {
+        culled = cull;
+    }
+
+    protected void draw(List<WptPt2> pts, Paint p, Canvas canvas, RotatedTileBox tileBox) {
+
+        if (pts.size() > 1) {
+
+            updateLocalPaint(p);
+            canvas.rotate(-tileBox.getRotate(), tileBox.getCenterPixelX(), tileBox.getCenterPixelY());
+            QuadRect tileBounds = tileBox.getLatLonBounds();
+
+            WptPt2 lastPt = pts.get(0);
+            float lastx = 0;
+            float lasty = 0;
+            boolean reCalculateLastXY = true;
+
+            int size = pts.size();
+            for (int i = 1; i < size; i++) {
+                WptPt2 pt = pts.get(i);
+
+                if (Math.min(pt.lon, lastPt.lon) < tileBounds.right && Math.max(pt.lon, lastPt.lon) > tileBounds.left
+                        && Math.min(pt.lat, lastPt.lat) < tileBounds.top && Math.max(pt.lat, lastPt.lat) > tileBounds.bottom) {
+
+                    if (reCalculateLastXY) {
+                        lastx = tileBox.getPixXFromLatLon(lastPt.lat, lastPt.lon);
+                        lasty = tileBox.getPixYFromLatLon(lastPt.lat, lastPt.lon);
+                        reCalculateLastXY = false;
+                    }
+
+                    float x = tileBox.getPixXFromLatLon(pt.lat, pt.lon);
+                    float y = tileBox.getPixYFromLatLon(pt.lat, pt.lon);
+
+                    canvas.drawLine(lastx, lasty, x, y, paint);
+
+                    lastx = x;
+                    lasty = y;
+
+                } else {
+                    reCalculateLastXY = true;
                 }
-                if (zoom < newZoom) {            // if line would look worse (we're zooming in) then...
-                    culled.clear();              // use full-resolution until re-cull complete
-                }
-                zoom = newZoom;
-
-                double cullDistance = Math.pow(2.0, segmentSize - zoom);    // segmentSize == epsilon
-                culler = new AsynchronousResampler.RamerDouglasPeucer(this, cullDistance);
-                culler.execute("");
+                lastPt = pt;
             }
-        }
-
-        @Override public void drawSingleSegment(Paint p, Canvas canvas, RotatedTileBox tileBox) {
-            draw(culled.isEmpty() ? points : culled, p, canvas, tileBox);
+            canvas.rotate(tileBox.getRotate(), tileBox.getCenterPixelX(), tileBox.getCenterPixelY());
         }
     }
 
     //----------------------------------------------------------------------------------------------
 
-    public static class Altitude extends RenderableSegment {
+    public static class StandardTrack extends Renderable {
 
-        double widthZoom;
-
-        public Altitude(int priority, List<WptPt> pt, double epsilon, double widthZoom) {
-            super(priority, pt, epsilon);
-            this.widthZoom = widthZoom;
+        public StandardTrack(List<GPXUtilities.WptPt> pt, double epsilon) {
+            super(Priority.STANDARD, pt, epsilon);
         }
 
-        @Override public void startCuller(double newZoom) {
+        @Override protected void startCuller(double newZoom) {
+
             if (zoom != newZoom) {
                 if (culler != null) {
                     culler.cancel(true);
                 }
-                //if (zoom < newZoom) {            // if line would look worse (we're zooming in) then...
-                    culled.clear();              // use NOTHING until re-cull complete
-                //}
                 zoom = newZoom;
-
-                double epsilon = Math.pow(2.0, 16 - zoom);
-                culler = new AsynchronousResampler.ResampleAltitude(this, epsilon);     // once only!
+                culler = new AsynchronousResampler.RamerDouglasPeucer(this, Math.pow(2.0, epsilon - zoom));
                 culler.execute("");
             }
         }
 
-        @Override public void drawSingleSegment(Paint p, Canvas canvas, RotatedTileBox tileBox) {
+        @Override protected void drawSingleSegment(Paint p, Canvas canvas, RotatedTileBox tileBox) {
+            draw(culled, p, canvas, tileBox);
+        }
+    }
+
+    //----------------------------------------------------------------------------------------------
+
+    public static class CurrentTrack extends Renderable {
+
+        private boolean forceCull = false;
+
+        public CurrentTrack(List<GPXUtilities.WptPt> pt, double base) {
+            super(Priority.CURRENT, pt, base);
+        }
+
+        @Override protected void startCuller(double newZoom) {
+
+            if ((forceCull && culler != null && culler.getStatus() == AsyncTask.Status.FINISHED)
+                    || zoom != newZoom) {
+                forceCull = false;
+                zoom = newZoom;
+                culler = new AsynchronousResampler.RamerDouglasPeucer(this, Math.pow(2.0, epsilon - zoom));
+                culler.execute("");
+            }
+        }
+
+        @Override public void drawSegment(double zoom, Paint p, Canvas canvas, RotatedTileBox tileBox) {
+
+            if (pointSize != points.size()) {
+                for (int i = pointSize; i < points.size(); i++) {
+                    culled.add(new WptPt2(points.get(i)));
+                }
+                updateBounds(points, pointSize);
+                forceCull = true;
+            }
+
+            if (QuadRect.trivialOverlap(tileBox.getLatLonBounds(), trackBounds)) { // is visible?
+                startCuller(zoom);
+                draw(culled, p, canvas, tileBox);
+            }
+        }
+    }
+
+    //----------------------------------------------------------------------------------------------
+
+    private abstract static class ColourBand extends Renderable {
+
+        protected double widthZoom;
+
+        public ColourBand(Priority priority, List<GPXUtilities.WptPt> pt, double epsilon, double widthZoom) {
+            super(priority, pt, epsilon);
+            this.widthZoom = widthZoom;
+        }
+
+        protected abstract AsynchronousResampler Factory();
+
+        @Override protected void startCuller(double newZoom) {
+            if (zoom != newZoom) {
+                if (culler != null) {
+                    culler.cancel(true);
+                }
+                zoom = newZoom;
+                culler = Factory();
+                culler.execute("");
+            }
+        }
+
+        @Override protected void drawSingleSegment(Paint p, Canvas canvas, RotatedTileBox tileBox) {
 
             if (culled.size() > 1
                     && QuadRect.trivialOverlap(tileBox.getLatLonBounds(), trackBounds)) {
@@ -203,7 +242,7 @@ public class Renderable {
                 float clipT = canvas.getHeight() + bandWidth / 2;
                 float clipR = canvas.getWidth() + bandWidth / 2;
 
-                WptPt pt = culled.get(0);
+                WptPt2 pt = culled.get(0);
                 float lastx = tileBox.getPixXFromLatLon(pt.lat, pt.lon);
                 float lasty = tileBox.getPixYFromLatLon(pt.lat, pt.lon);
 
@@ -229,27 +268,113 @@ public class Renderable {
 
     //----------------------------------------------------------------------------------------------
 
-    public static class Speed extends Altitude {
+    public static class Speed extends ColourBand {
 
-        public Speed(int priority, List<WptPt> pt, double segmentSize, double widthZoom) {
-            super(priority, pt, segmentSize, widthZoom);
+        public Speed(List<GPXUtilities.WptPt> pt, double epsilon, double widthZoom) {
+            super(Priority.SPEED, pt, epsilon, widthZoom);
         }
 
-        @Override public void startCuller(double newZoom) {
-            if (zoom != newZoom) {
-                if (culler != null) {
-                    culler.cancel(true);
-                }
-                //if (zoom < newZoom) {            // if line would look worse (we're zooming in) then...
-                    culled.clear();              // use nothing until cull finished
-                //}
-                zoom = newZoom;
-
-                double epsilon = Math.pow(2.0, 16 - zoom);
-                culler = new AsynchronousResampler.ResampleSpeed(this, epsilon);        // TODO: convert to same as altitude once only!
-                culler.execute("");
-            }
+        @Override protected AsynchronousResampler Factory() {
+            return new AsynchronousResampler.Speed(this, Math.pow(2.0, epsilon - zoom));
         }
     }
 
+    //----------------------------------------------------------------------------------------------
+
+    public static class Altitude extends ColourBand {
+
+        public Altitude(List<GPXUtilities.WptPt> pt, double epsilon, double widthZoom) {
+            super(Priority.ALTITUDE, pt, epsilon, widthZoom);
+        }
+
+        @Override protected AsynchronousResampler Factory() {
+            return new AsynchronousResampler.Altitude(this, Math.pow(2.0, epsilon - zoom));
+        }
+    }
+
+    //----------------------------------------------------------------------------------------------
+
+    public static class Distance extends Renderable {
+
+        public enum unit {
+            METRES (1, "m", 21),
+            METERS (1, "m", 21),
+            KILOMETRES (1000, "km", 12),
+            KILOMETERS (1000, "km", 12),
+            MILES (1609.344, "mi.", 11),
+            YARDS (0.9144, "yd.", 21),
+            FEET (0.3048, "ft.", 21);
+
+            double value;
+            String abbreviation;
+            int visible;
+
+            unit(double value, String abbreviation, int visible) {
+                this.value = value;
+                this.abbreviation = abbreviation;
+                this.visible = visible;
+            }
+        }
+
+        private unit option;
+
+        public Distance(List<GPXUtilities.WptPt> pt, unit segment) {
+            super(Priority.DISTANCE, pt, segment.value);
+            this.option = segment;
+        }
+
+        @Override protected void startCuller(double zoom) {
+            this.zoom = zoom;
+            if (culler == null) {
+                culler = new AsynchronousResampler.Generic(this, option.value);       // once
+                culler.execute("");
+            }
+        }
+
+        @Override protected void drawSingleSegment(Paint p, Canvas canvas, RotatedTileBox tileBox) {
+
+            if (!culled.isEmpty() && zoom > option.visible
+                    && QuadRect.trivialOverlap(tileBox.getLatLonBounds(), trackBounds)) {
+
+                updateLocalPaint(p);
+                canvas.rotate(-tileBox.getRotate(), tileBox.getCenterPixelX(), tileBox.getCenterPixelY());
+
+                float scale = 11 * tileBox.getDensity();
+                paint.setTextSize(scale);
+
+                float stroke = paint.getStrokeWidth();
+
+                for (int i = culled.size()-1; --i >= 0;) {
+
+                    WptPt2 pt = culled.get(i);
+                    float x = tileBox.getPixXFromLatLon(pt.lat, pt.lon);
+                    float y = tileBox.getPixYFromLatLon(pt.lat, pt.lon);
+
+                    Rect bounds = new Rect();
+                    String lab = String.format("  %d %s", (int) ((pt.distance / option.value) + 0.5), option.abbreviation);
+                    paint.getTextBounds(lab, 0, lab.length(), bounds);
+
+                    int rectH =  bounds.height();
+                    int rectW =  bounds.width();
+
+                    if (x < canvas.getWidth() + rectW && x > -rectW
+                            && y < canvas.getHeight() + rectH/2f && y > -rectH/2f) {
+
+                        paint.setStrokeWidth(2f * tileBox.getDensity());
+                        paint.setStyle(Paint.Style.STROKE);
+                        paint.setColor(Color.WHITE);
+                        canvas.drawText(lab, x, y + rectH / 2, paint);
+                        paint.setStyle(Paint.Style.FILL);
+                        paint.setStrokeWidth(1.5f * tileBox.getDensity());
+                        paint.setColor(Color.BLACK);
+                        canvas.drawText(lab, x, y + rectH / 2, paint);
+
+                        paint.setStrokeWidth(stroke * 2);
+                        canvas.drawPoint(x, y, paint);
+                    }
+                    canvas.rotate(tileBox.getRotate(), tileBox.getCenterPixelX(), tileBox.getCenterPixelY());
+                }
+            }
+        }
+    }
 }

--- a/OsmAnd/src/net/osmand/plus/views/Renderable.java
+++ b/OsmAnd/src/net/osmand/plus/views/Renderable.java
@@ -165,4 +165,7 @@ public class Renderable {
             draw(points, p, canvas, tileBox);
         }
     }
+
+
+
 }

--- a/OsmAnd/src/net/osmand/plus/views/Renderable.java
+++ b/OsmAnd/src/net/osmand/plus/views/Renderable.java
@@ -393,8 +393,8 @@ public abstract class Renderable {
                         paint.setStrokeWidth(stroke * 2);
                         canvas.drawPoint(x, y, paint);
                     }
-                    canvas.rotate(tileBox.getRotate(), tileBox.getCenterPixelX(), tileBox.getCenterPixelY());
                 }
+                canvas.rotate(tileBox.getRotate(), tileBox.getCenterPixelX(), tileBox.getCenterPixelY());
             }
         }
     }

--- a/OsmAnd/src/net/osmand/plus/views/Renderable.java
+++ b/OsmAnd/src/net/osmand/plus/views/Renderable.java
@@ -2,6 +2,7 @@ package net.osmand.plus.views;
 
 import android.graphics.Canvas;
 import android.graphics.Paint;
+import android.os.AsyncTask;
 
 import net.osmand.data.QuadRect;
 import net.osmand.data.RotatedTileBox;
@@ -24,11 +25,16 @@ public class Renderable {
         protected double zoom = -1;
         protected AsynchronousResampler culler = null;                        // The currently active resampler
         protected Paint paint = null;                               // MUST be set by 'updateLocalPaint' before use
+        protected int priority;
 
-        public RenderableSegment(List <WptPt> points, double segmentSize) {
+        public RenderableSegment(int priority, List <WptPt> points, double segmentSize) {
+            this.priority = priority;
             this.points = points;
-            calculateBounds(points);
             this.segmentSize = segmentSize;
+
+            trackBounds = new QuadRect(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY,
+                    Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+            updateBounds(points, 0);
         }
 
         protected void updateLocalPaint(Paint p) {
@@ -36,38 +42,41 @@ public class Renderable {
                 paint = new Paint(p);
                 paint.setStrokeCap(Paint.Cap.ROUND);
                 paint.setStrokeJoin(Paint.Join.ROUND);
-                paint.setStyle(Paint.Style.FILL);
+                paint.setStyle(Paint.Style.STROKE); //.Style.FILL);
             }
-            paint.setColor(p.getColor());
+            paint.setColor(p.getColor()|0xFF000000);        // no transparency
             paint.setStrokeWidth(p.getStrokeWidth());
         }
 
         protected abstract void startCuller(double newZoom);
 
-        protected void drawSingleSegment(double zoom, Paint p, Canvas canvas, RotatedTileBox tileBox) {}
+        protected void drawSingleSegment(Paint p, Canvas canvas, RotatedTileBox tileBox) {}
 
         public void drawSegment(double zoom, Paint p, Canvas canvas, RotatedTileBox tileBox) {
+
+            if (pointSize != points.size()) {
+                updateBounds(points, pointSize);
+            }
+
             if (QuadRect.trivialOverlap(tileBox.getLatLonBounds(), trackBounds)) { // is visible?
                 startCuller(zoom);
-                drawSingleSegment(zoom, p, canvas, tileBox);
+                drawSingleSegment(p, canvas, tileBox);
             }
         }
 
-        private void calculateBounds(List<WptPt> pts) {
-            trackBounds = new QuadRect(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY,
-                    Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
-            updateBounds(pts, 0);
+        public int getPriority() {
+            return priority;
         }
 
         protected void updateBounds(List<WptPt> pts, int startIndex) {
-            pointSize = pts.size();
-            for (int i = startIndex; i < pointSize; i++) {
+            for (int i = startIndex; i < pts.size(); i++) {
                 WptPt pt = pts.get(i);
                 trackBounds.right = Math.max(trackBounds.right, pt.lon);
                 trackBounds.left = Math.min(trackBounds.left, pt.lon);
                 trackBounds.top = Math.max(trackBounds.top, pt.lat);
                 trackBounds.bottom = Math.min(trackBounds.bottom, pt.lat);
             }
+            pointSize = pts.size();
         }
 
         public void setRDP(List<WptPt> cull) {
@@ -120,13 +129,15 @@ public class Renderable {
 
     public static class StandardTrack extends RenderableSegment {
 
-        public StandardTrack(List<WptPt> pt, double base) {
-            super(pt, base);
+        public StandardTrack(int priority, List<WptPt> pt, double base) {
+            super(priority, pt, base);
         }
 
         @Override public void startCuller(double newZoom) {
 
-            if (zoom != newZoom) {
+            if ((pointSize != points.size() && culler != null && culler.getStatus() == AsyncTask.Status.FINISHED)
+                    || zoom != newZoom) {
+
                 if (culler != null) {
                     culler.cancel(true);
                 }
@@ -141,31 +152,101 @@ public class Renderable {
             }
         }
 
-        @Override public void drawSingleSegment(double zoom, Paint p, Canvas canvas, RotatedTileBox tileBox) {
+        @Override public void drawSingleSegment(Paint p, Canvas canvas, RotatedTileBox tileBox) {
             draw(culled.isEmpty() ? points : culled, p, canvas, tileBox);
         }
     }
 
-    public static class CurrentTrack extends RenderableSegment {
+    //----------------------------------------------------------------------------------------------
 
-        public CurrentTrack(List<WptPt> pt) {
-            super(pt, 0);
+    public static class Altitude extends RenderableSegment {
+
+        double widthZoom;
+
+        public Altitude(int priority, List<WptPt> pt, double epsilon, double widthZoom) {
+            super(priority, pt, epsilon);
+            this.widthZoom = widthZoom;
         }
 
-        @Override public void drawSegment(double zoom, Paint p, Canvas canvas, RotatedTileBox tileBox) {
-            if (points.size() != pointSize) {
-                updateBounds(points, pointSize);
+        @Override public void startCuller(double newZoom) {
+            if (zoom != newZoom) {
+                if (culler != null) {
+                    culler.cancel(true);
+                }
+                //if (zoom < newZoom) {            // if line would look worse (we're zooming in) then...
+                    culled.clear();              // use NOTHING until re-cull complete
+                //}
+                zoom = newZoom;
+
+                double epsilon = Math.pow(2.0, 16 - zoom);
+                culler = new AsynchronousResampler.ResampleAltitude(this, epsilon);     // once only!
+                culler.execute("");
             }
-            drawSingleSegment(zoom, p, canvas, tileBox);
         }
 
-        @Override protected void startCuller(double newZoom) {}
+        @Override public void drawSingleSegment(Paint p, Canvas canvas, RotatedTileBox tileBox) {
 
-        @Override public void drawSingleSegment(double zoom, Paint p, Canvas canvas, RotatedTileBox tileBox) {
-            draw(points, p, canvas, tileBox);
+            if (culled.size() > 1
+                    && QuadRect.trivialOverlap(tileBox.getLatLonBounds(), trackBounds)) {
+
+                updateLocalPaint(p);
+                canvas.rotate(-tileBox.getRotate(), tileBox.getCenterPixelX(), tileBox.getCenterPixelY());
+
+                float bandWidth = paint.getStrokeWidth() * (float)widthZoom;
+                paint.setStrokeWidth(bandWidth);
+
+                float clipL = -bandWidth / 2;
+                float clipB = -bandWidth / 2;
+                float clipT = canvas.getHeight() + bandWidth / 2;
+                float clipR = canvas.getWidth() + bandWidth / 2;
+
+                WptPt pt = culled.get(0);
+                float lastx = tileBox.getPixXFromLatLon(pt.lat, pt.lon);
+                float lasty = tileBox.getPixYFromLatLon(pt.lat, pt.lon);
+
+                int size = culled.size();
+                for (int i = 1; i < size; i++) {
+                    pt = culled.get(i);
+
+                    float x = tileBox.getPixXFromLatLon(pt.lat, pt.lon);
+                    float y = tileBox.getPixYFromLatLon(pt.lat, pt.lon);
+
+                    if (Math.min(x, lastx) < clipR && Math.max(x, lastx) > clipL
+                            && Math.min(y, lasty) < clipT && Math.max(y, lasty) > clipB) {
+                        paint.setColor(pt.colourARGB);
+                        canvas.drawLine(lastx, lasty, x, y, paint);
+                    }
+                    lastx = x;
+                    lasty = y;
+                }
+                canvas.rotate(tileBox.getRotate(), tileBox.getCenterPixelX(), tileBox.getCenterPixelY());
+            }
         }
     }
 
+    //----------------------------------------------------------------------------------------------
 
+    public static class Speed extends Altitude {
+
+        public Speed(int priority, List<WptPt> pt, double segmentSize, double widthZoom) {
+            super(priority, pt, segmentSize, widthZoom);
+        }
+
+        @Override public void startCuller(double newZoom) {
+            if (zoom != newZoom) {
+                if (culler != null) {
+                    culler.cancel(true);
+                }
+                //if (zoom < newZoom) {            // if line would look worse (we're zooming in) then...
+                    culled.clear();              // use nothing until cull finished
+                //}
+                zoom = newZoom;
+
+                double epsilon = Math.pow(2.0, 16 - zoom);
+                culler = new AsynchronousResampler.ResampleSpeed(this, epsilon);        // TODO: convert to same as altitude once only!
+                culler.execute("");
+            }
+        }
+    }
 
 }

--- a/OsmAnd/src/net/osmand/plus/views/Renderable.java
+++ b/OsmAnd/src/net/osmand/plus/views/Renderable.java
@@ -55,6 +55,9 @@ public class Renderable {
         public void drawSegment(double zoom, Paint p, Canvas canvas, RotatedTileBox tileBox) {
 
             if (pointSize != points.size()) {
+                for (int i = pointSize; i < points.size(); i++) {
+                    culled.add(points.get(i));
+                }
                 updateBounds(points, pointSize);
             }
 

--- a/OsmAnd/src/net/osmand/plus/views/Renderable.java
+++ b/OsmAnd/src/net/osmand/plus/views/Renderable.java
@@ -229,12 +229,7 @@ public abstract class Renderable {
 
         }
 
-        // Set the extent of values for colour band calculations. Values are clampted to min...max for band display
-        // Notes: Altitude range in metres
-        // Speed range in metres per millisecond.
-        // To convert to km/h, divide by 3600
-        //  100/3600  = 100 km/h
-
+        // Speed range in km/h, altitude is in m.
         public void setRange(double clampMin, double clampMax) {
             this.clampMin = clampMin;
             this.clampMax = clampMax;
@@ -288,6 +283,12 @@ public abstract class Renderable {
 
         public Speed(OsmandMapTileView view, List<GPXUtilities.WptPt> pt, double epsilon, double widthZoom) {
             super(Priority.SPEED, view, pt, epsilon, widthZoom);
+        }
+
+        public void setRangeMilesPerHour(double clampMin, double clampMax) {
+            this.clampMin = clampMin / 1.60934;
+            this.clampMax = clampMax / 1.60934;
+            this.clamp = true;
         }
 
         @Override protected AsynchronousResampler Factory() {

--- a/OsmAnd/src/net/osmand/plus/views/WptPt2.java
+++ b/OsmAnd/src/net/osmand/plus/views/WptPt2.java
@@ -7,8 +7,8 @@ public class WptPt2 {
     public double lat;
     public double lon;
     public long time = 0;
-    public double ele = Double.NaN;
-    public double speed = 0;
+    public double ele = Double.NaN;             // m
+    public double speed = 0;                    // km/h
     public int colourARGB = 0;					// point colour (used for altitude/speed colouring)
     public double distance = 0.0;				// cumulative distance, if in a track
     public double angle = 0;

--- a/OsmAnd/src/net/osmand/plus/views/WptPt2.java
+++ b/OsmAnd/src/net/osmand/plus/views/WptPt2.java
@@ -11,6 +11,12 @@ public class WptPt2 {
     public double speed = 0;
     public int colourARGB = 0;					// point colour (used for altitude/speed colouring)
     public double distance = 0.0;				// cumulative distance, if in a track
+    public double angle = 0;
+
+    public WptPt2(double lat, double lon) {
+        this.lat = lat;
+        this.lon = lon;
+    }
 
     public WptPt2(GPXUtilities.WptPt pt)  {
         lat = pt.lat;
@@ -18,14 +24,16 @@ public class WptPt2 {
         time = pt.time;
         ele = pt.ele;
         speed = pt.speed;
+        angle = 0;
     }
 
-    public WptPt2(double lat, double lon, long time, double ele, double speed, double distance) {
+    public WptPt2(double lat, double lon, long time, double ele, double speed, double distance, double angle) {
         this.lat = lat;
         this.lon = lon;
         this.time = time;
         this.ele = ele;
         this.speed = speed;
         this.distance = distance;
+        this.angle = angle;
     }
 }

--- a/OsmAnd/src/net/osmand/plus/views/WptPt2.java
+++ b/OsmAnd/src/net/osmand/plus/views/WptPt2.java
@@ -1,0 +1,31 @@
+package net.osmand.plus.views;
+
+import net.osmand.plus.GPXUtilities;
+
+public class WptPt2 {
+
+    public double lat;
+    public double lon;
+    public long time = 0;
+    public double ele = Double.NaN;
+    public double speed = 0;
+    public int colourARGB = 0;					// point colour (used for altitude/speed colouring)
+    public double distance = 0.0;				// cumulative distance, if in a track
+
+    public WptPt2(GPXUtilities.WptPt pt)  {
+        lat = pt.lat;
+        lon = pt.lon;
+        time = pt.time;
+        ele = pt.ele;
+        speed = pt.speed;
+    }
+
+    public WptPt2(double lat, double lon, long time, double ele, double speed, double distance) {
+        this.lat = lat;
+        this.lon = lon;
+        this.time = time;
+        this.ele = ele;
+        this.speed = speed;
+        this.distance = distance;
+    }
+}


### PR DESCRIPTION
All these are optimised with asynchronous line culling to reduce the number of points to display.
Also handles 'current track' with addition of points being gracefully catered and resampled in the background. Lots of options;  band width for speed and altitude, and the distance renderer has inbuilt units conversion/display for metres, kilometres, miles, yards and feet.  Display of markers is limited to sensible zoom ranges where they will not clutter the display.