### PR TITLE
Fix #2484 - GPX tracks not shown unless extension is .gpx

### DIFF
--- a/OsmAnd/src/net/osmand/plus/GpxSelectionHelper.java
+++ b/OsmAnd/src/net/osmand/plus/GpxSelectionHelper.java
@@ -92,7 +92,7 @@ public class GpxSelectionHelper {
 			if (i >= 0) {
 				name = name.substring(i + 1);
 			}
-			if (name.endsWith(".gpx")) {
+			if (name.toLowerCase().endsWith(".gpx")) {
 				name = name.substring(0, name.length() - 4);
 			}
 			name = name.replace('_', ' ');

--- a/OsmAnd/src/net/osmand/plus/myplaces/AvailableGPXFragment.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/AvailableGPXFragment.java
@@ -646,7 +646,7 @@ public class AvailableGPXFragment extends OsmandExpandableListFragment {
 					String sub = gpxSubfolder.length() == 0 ? gpxFile.getName() : gpxSubfolder + "/"
 							+ gpxFile.getName();
 					loadGPXFolder(gpxFile, result, loadTask, progress, sub);
-				} else if (gpxFile.isFile() && gpxFile.getName().endsWith(".gpx")) {
+				} else if (gpxFile.isFile() && gpxFile.getName().toLowerCase().endsWith(".gpx")) {
 					GpxInfo info = new GpxInfo();
 					info.subfolder = gpxSubfolder;
 					info.file = gpxFile;


### PR DESCRIPTION
Before this change, GPX tracks are not shown in "My Tracks" in "My Places"
unless they have a lowercase .gpx extension.

Such tracks are still shown in "Configure map", "GPX track..." but the
extension isn't removed like it is for tracks with a lowercase extension.
This has been fixed too.