### PR TITLE
Always show gpx track settings

### DIFF
--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/other/RoutePreferencesMenu.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/other/RoutePreferencesMenu.java
@@ -562,10 +562,13 @@ public class RoutePreferencesMenu {
 		List<LocalRoutingParameter> list = new ArrayList<LocalRoutingParameter>();
 		RouteProvider.GPXRouteParamsBuilder rparams = mapActivity.getRoutingHelper().getCurrentGPXRoute();
 		boolean osmandRouter = settings.ROUTER_SERVICE.get() == RouteProvider.RouteService.OSMAND;
+		boolean bRouter = settings.ROUTER_SERVICE.get() == RouteProvider.RouteService.BROUTER;
 		if (!osmandRouter) {
-			list.add(new OtherLocalRoutingParameter(R.string.calculate_osmand_route_without_internet,
-					getString(R.string.calculate_osmand_route_without_internet), settings.GPX_ROUTE_CALC_OSMAND_PARTS
-					.get()));
+			if (!bRouter) {
+				list.add(new OtherLocalRoutingParameter(R.string.calculate_osmand_route_without_internet,
+						getString(R.string.calculate_osmand_route_without_internet), settings.GPX_ROUTE_CALC_OSMAND_PARTS
+						.get()));
+			}
 			list.add(new OtherLocalRoutingParameter(R.string.fast_route_mode, getString(R.string.fast_route_mode),
 					settings.FAST_ROUTE_MODE.get()));
 		}

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/other/RoutePreferencesMenu.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/other/RoutePreferencesMenu.java
@@ -568,7 +568,6 @@ public class RoutePreferencesMenu {
 					.get()));
 			list.add(new OtherLocalRoutingParameter(R.string.fast_route_mode, getString(R.string.fast_route_mode),
 					settings.FAST_ROUTE_MODE.get()));
-			return list;
 		}
 		if (rparams != null) {
 			GPXUtilities.GPXFile fl = rparams.getFile();
@@ -585,6 +584,9 @@ public class RoutePreferencesMenu {
 						getString(R.string.gpx_option_calculate_first_last_segment), rparams
 						.isCalculateOsmAndRouteParts()));
 			}
+		}
+		if (!osmandRouter) {
+			return list;
 		}
 		GeneralRouter rm = SettingsNavigationActivity.getRouter(app.getDefaultRoutingConfig(), am);
 		if (rm == null || (rparams != null && !rparams.isCalculateOsmAndRoute()) && !rparams.getFile().hasRtePt()) {


### PR DESCRIPTION
I've enabled the routing settings again when a different navigation service than osmand is used for gpx tracks, which are 'pass along entire track' and 'reverse GPX direction'. I think this is allowed as gpx navigation always uses osmand for calculating the first and last segments and recalculations when deviating from the gpx track.

I've also removed the option to 'calculate osmand route without internet' when brouter is used, as it is an offline service as well and should always succeed.

Please review carefully. I'm still familiarizing with the sources and I could have missed something when implementing these fixes.
