### PR TITLE
Fix bug causing first segment of drawn path to be not drawn

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/OsmandMapLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/OsmandMapLayer.java
@@ -165,6 +165,11 @@ public abstract class OsmandMapLayer {
 				long intersection = MapAlgorithms.calculateIntersection(x, y,
 						px, py, 0, w, h, 0);
 				if (intersection != -1) {
+					if (pin && (i == 1)) {
+						cnt++;
+						path.moveTo(px, py);
+						start = true;
+					}
 					px = (int) (intersection >> 32);
 					py = (int) (intersection & 0xffffffff);
 					draw = true;


### PR DESCRIPTION
When a new segment of a path is drawn the first line was not drawn when the start coordinates were visible but the second set was not.

Screenshot with navigation path not being drawn:
![device-2016-05-11-195708](https://cloud.githubusercontent.com/assets/9898357/15191397/cd1d5fd4-17b4-11e6-8fa3-77aa0f3f7f2f.png)

Screenshot after fix:
![device-2016-05-11-200244](https://cloud.githubusercontent.com/assets/9898357/15191398/cd1f9cd6-17b4-11e6-9f4e-696c815c60a8.png)
