### PR TITLE
listener might be null

### DIFF
--- a/OsmAnd/src/net/osmand/plus/widgets/InterceptorFrameLayout.java
+++ b/OsmAnd/src/net/osmand/plus/widgets/InterceptorFrameLayout.java
@@ -56,7 +56,9 @@ public class InterceptorFrameLayout extends FrameLayout {
 		switch (action) {
 			case MotionEvent.ACTION_DOWN:
 				mDownX = ev.getRawX();
-				listener.onTouch(this, ev);
+				if(listener != null) {
+					listener.onTouch(this, ev);
+				}
 				return false;
 			case MotionEvent.ACTION_MOVE:
 				if (mIsScrolling) {


### PR DESCRIPTION
listener might be null if plugin method isDismissAllowed return false.
See DashBaseFragment.java line 62. It will create the SwipeDismissListeneer only in case of value is true.