### PR TITLE
Allow installation of OsmAnd-debug alongside released OsmAnd version

### DIFF
--- a/OsmAnd/AndroidManifest.xml
+++ b/OsmAnd/AndroidManifest.xml
@@ -61,7 +61,7 @@
         
         <provider
             android:name="android.support.v4.content.FileProvider"
-            android:authorities="net.osmand.fileprovider"
+            android:authorities="@string/authority"
             android:exported="false"
             android:grantUriPermissions="true" >
             <meta-data

--- a/OsmAnd/build.gradle
+++ b/OsmAnd/build.gradle
@@ -140,12 +140,15 @@ android {
 
 	buildTypes {
 		debug {
+                    applicationIdSuffix '.debug'
+                    resValue "string", "authority", "net.osmand.plus.debug.fileprovider"
 		    // proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt'
 		    // minifyEnabled true
 		    // proguardFiles 'proguard-project.txt'
 			signingConfig signingConfigs.development
 		}
 		release {
+                    resValue "string", "authority", "net.osmand.plus.fileprovider"
 		    // proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt'
 		    // minifyEnabled true
 		    //proguardFiles 'proguard-project.txt'


### PR DESCRIPTION
Hi,
Please consider this patch, which allows me to build/install a dev/debug version of Osmand alongside the official stable release on my smartphone. I used the method described at http://stackoverflow.com/a/22402658 to achieve this result.
Best,
Florent