### PR TITLE
Only show "find parking" if destination is reached by car-derived modes

### DIFF
--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/other/DestinationReachedMenuFragment.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/other/DestinationReachedMenuFragment.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 
 import net.osmand.AndroidUtils;
 import net.osmand.data.LatLon;
+import net.osmand.plus.ApplicationMode;
 import net.osmand.plus.IconsCache;
 import net.osmand.plus.R;
 import net.osmand.plus.TargetPointsHelper;
@@ -99,8 +100,14 @@ public class DestinationReachedMenuFragment extends Fragment {
 			}
 		});
 
-
 		Button findParkingButton = (Button) view.findViewById(R.id.findParkingButton);
+
+		ApplicationMode appMode = getMapActivity().getMyApplication().getRoutingHelper().getAppMode();
+
+		if (!appMode.isDerivedRoutingFrom(appMode.CAR)) {
+			findParkingButton.setVisibility(View.GONE);
+		}
+
 		findParkingButton.setCompoundDrawablesWithIntrinsicBounds(
 				iconsCache.getIcon(R.drawable.ic_action_parking_dark, menu.isLight()), null, null, null);
 		AndroidUtils.setTextPrimaryColor(view.getContext(), findParkingButton, !menu.isLight());


### PR DESCRIPTION
When reaching your destination in OsmAnd, the context menu shows a "find
parking" button to help you find a parking space. This might be useful if
you're driving (or using an application mode derived from car) but isn't
useful if you've just walked up to the top of a hill or you're cycling.

With this change, the button is shown only if you've reached the
destination by car (or a car-derived mode).