### PR TITLE
Fix idea dependency error.

### DIFF
--- a/OsmAnd/build.gradle
+++ b/OsmAnd/build.gradle
@@ -68,7 +68,6 @@ android {
 			jniLibs.srcDirs = ["libs"]
 			aidl.srcDirs = ["src"]
 			java.srcDirs = ["src"]
-			resources.srcDirs = ["src"]
 			renderscript.srcDirs = ["src"]
 			res.srcDirs = ["res"]
 			assets.srcDirs = ["assets"]

--- a/plugins/Osmand-ParkingPlugin/build.gradle
+++ b/plugins/Osmand-ParkingPlugin/build.gradle
@@ -36,7 +36,6 @@ android {
 			jniLibs.srcDirs = []
 			aidl.srcDirs = ["src"]
 			java.srcDirs = ["src"]
-			resources.srcDirs = ["src"]
 			renderscript.srcDirs = ["src"]
 			res.srcDirs = ["res"]
 			assets.srcDirs = ["assets"]

--- a/plugins/Osmand-SRTMPlugin/build.gradle
+++ b/plugins/Osmand-SRTMPlugin/build.gradle
@@ -36,7 +36,6 @@ android {
 			jniLibs.srcDirs = []
 			aidl.srcDirs = ["src"]
 			java.srcDirs = ["src"]
-			resources.srcDirs = ["src"]
 			renderscript.srcDirs = ["src"]
 			res.srcDirs = ["res"]
 			assets.srcDirs = ["assets"]


### PR DESCRIPTION
On dependency changes in File -> Project structure... I get following errors (for 3 projects):

{% for project in ['Osmand', 'Osmand-SRTMPlugin', 'Osmand-ParkingPlugin'] %}
  Module "{{ project }}"
  must not contain source root
  "~/osmand/android/plugins/{{ project }}/src".
  The root already belongs to module "{{ project }}"
{% endfor %}

This is due duplicate lines in "{{ project }}.iml" file that is
generated based on "build.gradle" files.

This commit fixes this situation.