### PR TITLE
Allow colours for GPX routes (not just tracks) to be specified in files

### DIFF
--- a/OsmAnd/src/net/osmand/plus/GPXUtilities.java
+++ b/OsmAnd/src/net/osmand/plus/GPXUtilities.java
@@ -725,10 +725,12 @@ public class GPXUtilities {
 			List<TrkSegment> tpoints = new ArrayList<TrkSegment>();
 			if (routes.size() > 0) {
 				for (Route r : routes) {
+					int routeColor = r.getColor(getColor(0));
 					if (r.points.size() > 0) {
 						TrkSegment sgmt = new TrkSegment();
 						tpoints.add(sgmt);
 						sgmt.points.addAll(r.points);
+						sgmt.setColor(routeColor);
 					}
 				}
 			}


### PR DESCRIPTION
GPX distinguishes between routes (where you should go) and tracks (where you've been).

OsmAnd can already use a colour specified in \<color\> in \<extensions\> for tracks, but not routes.

With this change, OsmAnd uses colour specified in GPX files for routes. This is very useful when viewing multiple routes or to emphasise a particular route.