### PR TITLE
 Fix SQLite open flags

### DIFF
--- a/OsmAnd/src/net/osmand/plus/api/SQLiteAPIImpl.java
+++ b/OsmAnd/src/net/osmand/plus/api/SQLiteAPIImpl.java
@@ -14,8 +14,9 @@ public class SQLiteAPIImpl implements SQLiteAPI {
 
 	@Override
 	public SQLiteConnection getOrCreateDatabase(String name, boolean readOnly) {
-		android.database.sqlite.SQLiteDatabase db = app.openOrCreateDatabase(name,
-				readOnly? SQLiteDatabase.OPEN_READONLY : (SQLiteDatabase.OPEN_READWRITE | SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING), null);
+		android.database.sqlite.SQLiteDatabase db = SQLiteDatabase.openDatabase(app.getDatabasePath(name).getAbsolutePath(), null,
+				(readOnly? SQLiteDatabase.OPEN_READONLY : (SQLiteDatabase.OPEN_READWRITE | SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING))
+				| SQLiteDatabase.CREATE_IF_NECESSARY);
 		if(db == null) {
 			return null;
 		}


### PR DESCRIPTION
app.openOrCreateDatabase expects flags from android.content.Context
which are completely different