### PR TITLE
fix database cursor leak in GpxImportHelper.java

### DIFF
--- a/OsmAnd/src/net/osmand/plus/helpers/GpxImportHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/GpxImportHelper.java
@@ -81,9 +81,11 @@ public class GpxImportHelper {
 		final Cursor returnCursor = application.getContentResolver().query(contentUri, null, null, null, null);
 		if (returnCursor != null && returnCursor.moveToFirst()) {
 			name = returnCursor.getString(returnCursor.getColumnIndex(OpenableColumns.DISPLAY_NAME));
-			returnCursor.close();
 		} else {
 			name = null;
+		}
+		if (returnCursor != null && !returnCursor.isClosed()) {
+			returnCursor.close();
 		}
 		return name;
 	}


### PR DESCRIPTION
Dear developers,

I moved the database cursor closing code outside the if block to fix the potential leak of empty database cursor (when moveToFirst() returns false). Issue #3135 

@vshcherb please let me know if there are any problems. Thanks!