### PR TITLE
Remove resource_cereal from phrases.xml

### DIFF
--- a/OsmAnd/res/values/phrases.xml
+++ b/OsmAnd/res/values/phrases.xml
@@ -1872,7 +1872,6 @@
 	<string name="poi_resource_bauxite">Bauxite</string>
 	<string name="poi_resource_beryl">Beryl</string>
 	<string name="poi_resource_bismuth">Bismuth</string>
-	<string name="poi_resource_cereal">Cereal</string>
 	<string name="poi_resource_chromite">Chromite</string>
 	<string name="poi_resource_clay">Clay</string>
 	<string name="poi_resource_coal">Coal</string>


### PR DESCRIPTION
There is no resource_cereal in poi_types.xml (only crop_cereal) and it is not documented on the wiki for what it means.