### PR TITLE
Fix loading of custom rendering files containing dashes and underscores (regression)

### DIFF
--- a/OsmAnd/src/net/osmand/plus/render/RendererRegistry.java
+++ b/OsmAnd/src/net/osmand/plus/render/RendererRegistry.java
@@ -218,7 +218,7 @@ public class RendererRegistry {
 					if (f != null && f.getName().endsWith(IndexConstants.RENDERER_INDEX_EXT)) {
 						if(!internalRenderers.containsValue(f.getName())) {
 							String name = f.getName().substring(0, f.getName().length() - IndexConstants.RENDERER_INDEX_EXT.length());
-							externalRenderers.put(name, f);							
+							externalRenderers.put(name.replace('_', ' ').replace('-', ' '), f);
 						}
 					}
 				}


### PR DESCRIPTION
After I upgraded to OsmAnd+ 2.5.3, I noticed that my custom rendering file could not be selected. I got this toast: "Exception occurred: renderer was not loaded". Several people on the [forum](https://groups.google.com/forum/#!topic/osmand/w9111YDV_r8) reported the same problem.

I couldn't see any exception in logcat, so I investigated in more detail. In src/net/osmand/plus/dialogs/ConfigureMapMenu.java I could see that the toast is generated if this code returns null:

```java
app.getRendererRegistry().getRenderer(renderer);
```

`getRenderer()` only returns null if the specified renderer cannot be found, or an exception occurs. I added some debug code and found that the specified renderer could not be found, so null was being returned here:

```java
    if(!hasRender(name)){
      return null;
    }
```

`hasRender()` just checks that the supplied name exists in one of two collections: `externalRenderers` and `internalRenderers`. My custom renderer was an external one so I dumped `externalRenderers`:

```
externalRenderers: {GPX_routes_without_dashes=/storage/emulated/0/osmand/rendering/GPX_routes_without_dashes.render.xml}
```

Immediately I realised the problem. My custom rendering file is named GPX_routes_without_dashes.render.xml. Its entry in `externalRenderers` is `GPX_routes_without_dashes` but OsmAnd is looking for `GPX routes without dashes` (spaces instead of underscores).

This used to work. I think it was regressed in 7fc7b5aa373c8fdd8d65429de4c168a2b2bd4f59.

The fix is to apply the same processing to each renderer name when inserting into `externalRenderers` as when creating `visibleNamesList`.