### PR TITLE
Fix incorrect minimum precision logic for track recording

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/SavingTrackHelper.java
+++ b/OsmAnd/src/net/osmand/plus/activities/SavingTrackHelper.java
@@ -375,7 +375,7 @@ public class SavingTrackHelper extends SQLiteOpenHelper {
 					record = false;
 				}
 				float precision = settings.SAVE_TRACK_PRECISION.get();
-				if(precision > 0 && (!location.hasAccuracy() || location.getAccuracy() < precision)) {
+				if(precision > 0 && (!location.hasAccuracy() || location.getAccuracy() > precision)) {
 					record = false;
 				}
 				float minSpeed = settings.SAVE_TRACK_MIN_SPEED.get();


### PR DESCRIPTION
OsmAnd 2.5 introduced optional minimum precision for location when recording tracks. When enabled, track points are only recorded if the location accuracy at the time of sampling is within the minimum precision:

```java
float precision = settings.SAVE_TRACK_PRECISION.get();
if(precision > 0 && (!location.hasAccuracy() || location.getAccuracy() < precision)) {
    record = false;
}
```

Logic in this code was inverted: points with accuracy below (i.e. within) the minimum precision were rejected, and points with accuracy above the minimum precision were incorrectly accepted. 

For example, if the minimum precision was set to 20 metres, all points with an accuracy under 20 metres were incorrectly rejected, because `location.hasAccuracy()` is true, `location.getAccuracy()` returns (say) 10, and 10 is less than the minimum precision (20).

I suspect the confusion happened because the logic here is the opposite of the other checks in `updateLocation()`, and the Android API is slightly confusing in this case: lower `getAccuracy()` values indicate higher accuracy.