### PR TITLE
Android automatic refactor - Recycle

### DIFF
--- a/OsmAnd/src/net/osmand/view/ExpandableButton.java
+++ b/OsmAnd/src/net/osmand/view/ExpandableButton.java
@@ -15,6 +15,9 @@ public class ExpandableButton extends Button {
 		if(attrs != null) {
 			TypedArray ar = context.obtainStyledAttributes(attrs, R.styleable.ExpandableView);
 			maxWidth = ar.getDimension(R.styleable.ExpandableView_maxVisibleWidth, 0);
+			if (ar != null) {
+				ar.recycle();
+			}
 		}
 	}
 	
@@ -23,6 +26,9 @@ public class ExpandableButton extends Button {
         if(attrs != null) {
 			TypedArray ar = context.obtainStyledAttributes(attrs, R.styleable.ExpandableView);
 			maxWidth = ar.getDimension(R.styleable.ExpandableView_maxVisibleWidth, 0);
+			if (ar != null) {
+				ar.recycle();
+			}
 		}
     }
 

--- a/OsmAnd/src/net/osmand/view/ExpandableLinearLayout.java
+++ b/OsmAnd/src/net/osmand/view/ExpandableLinearLayout.java
@@ -15,6 +15,9 @@ public class ExpandableLinearLayout extends LinearLayout {
 		if(attrs != null) {
 			TypedArray ar = context.obtainStyledAttributes(attrs, R.styleable.ExpandableView);
 			maxWidth = ar.getDimension(R.styleable.ExpandableView_maxVisibleWidth, 0);
+			if (ar != null) {
+				ar.recycle();
+			}
 		}
 	}
 	


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "Recycle".

Some resources (e.g., ```Cursor``` instances) should be closed when they are no longer necessary. 

I have made a previous validation of the changes and they seem correct.
Please consider them and let me know if you agree with them.

Best,
Luis