### PR TITLE
Android automatic refactor - ObsoleteLayoutParam

### DIFF
--- a/OsmAnd/res/layout/fragment_data_storage_place_dialog.xml
+++ b/OsmAnd/res/layout/fragment_data_storage_place_dialog.xml
@@ -1,226 +1,190 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:layout_gravity="bottom"
-              android:background="?attr/bottom_menu_view_bg"
-              android:orientation="horizontal"
-              tools:context="net.osmand.plus.download.ui.DataStoragePlaceDialogFragment">
+<?xml version='1.0' encoding='UTF-8'?>
+  <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:layout_gravity="bottom"
+  android:background="?attr/bottom_menu_view_bg"
+  android:orientation="horizontal"
+  tools:context="net.osmand.plus.download.ui.DataStoragePlaceDialogFragment">
 
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent">
+  <LinearLayout android:layout_width="wrap_content"
+    android:layout_height="match_parent">
 
-        <ImageView
-            android:id="@+id/folderIconImageView"
-            android:layout_width="56dp"
-            android:layout_height="56dp"
-            android:layout_marginRight="8dp"
-            android:layout_marginTop="4dp"
-            android:layout_row="0"
-            android:scaleType="center"
-            tools:background="@color/color_warning"
-            tools:src="@drawable/ic_action_folder"/>
+    <ImageView android:id="@+id/folderIconImageView"
+      android:layout_width="56dp"
+      android:layout_height="56dp"
+      android:layout_marginRight="8dp"
+      android:layout_marginTop="4dp"
+      android:scaleType="center"
+      tools:background="@color/color_warning"
+      tools:src="@drawable/ic_action_folder">
+      <!--Removed ObsoleteLayoutParam: layout_row-->
+    </ImageView>
+  </LinearLayout>
 
-    </LinearLayout>
+  <LinearLayout android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    android:layout_weight="1"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <LinearLayout android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="horizontal">
+
+      <TextView android:id="@+id/title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_gravity="fill_horizontal"
         android:layout_weight="1"
-        android:orientation="vertical">
+        android:paddingTop="22dp"
+        android:text="@string/application_dir"
+        android:textColor="?android:attr/textColorPrimary"
+        android:textSize="@dimen/dialog_header_text_size"/>
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/title"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="fill_horizontal"
-                android:layout_weight="1"
-                android:paddingTop="22dp"
-                android:text="@string/application_dir"
-                android:textColor="?android:attr/textColorPrimary"
-                android:textSize="@dimen/dialog_header_text_size"/>
-
-            <ImageButton
-                android:id="@+id/closeImageButton"
-                android:contentDescription="@string/shared_string_close"
-                style="@style/Widget.AppCompat.Button.Borderless"
-                android:layout_width="44dp"
-                android:layout_height="44dp"
-                android:src="@drawable/ic_action_remove_dark"
-                tools:background="@color/color_warning"/>
-
-        </LinearLayout>
-
-        <TextView
-            android:id="@+id/description"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="fill_horizontal"
-            android:layout_marginBottom="24dp"
-            android:layout_marginTop="4dp"
-            android:text="@string/application_dir_description"
-            android:textSize="16sp"/>
-
-        <ScrollView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
-
-                <LinearLayout
-                    android:id="@+id/deviceMemoryRow"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:background="?attr/selectableItemBackground"
-                    android:orientation="horizontal">
-
-                    <ImageView
-                        android:id="@+id/deviceMemoryImageView"
-                        android:layout_width="wrap_content"
-                        android:layout_height="56dp"
-                        android:paddingRight="16dp"
-                        android:scaleType="center"
-                        android:src="@drawable/ic_sdcard"
-                        tools:background="@color/color_warning"/>
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_vertical"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:id="@+id/deviceMemoryTitle"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="fill_horizontal"
-                            android:gravity="center_vertical"
-                            android:text="@string/storage_directory_external"
-                            android:textColor="?android:attr/textColorPrimary"
-                            />
-
-                        <TextView
-                            android:id="@+id/deviceMemoryDescription"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="fill_horizontal"
-                            android:textColor="?android:attr/textColorSecondary"
-                            tools:text="Free: 568 Mb"/>
-
-                    </LinearLayout>
-
-                </LinearLayout>
-
-                <View
-                    android:id="@+id/divSharedStorage"
-                    android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:layout_gravity="fill_horizontal"
-                    android:background="@color/divider_color"/>
-
-                <LinearLayout
-                    android:id="@+id/sharedMemoryRow"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:background="?attr/selectableItemBackground"
-                    android:orientation="horizontal">
-
-                    <ImageView
-                        android:id="@+id/sharedMemoryImageView"
-                        android:layout_width="wrap_content"
-                        android:layout_height="56dp"
-                        android:paddingRight="16dp"
-                        android:scaleType="center"
-                        android:src="@drawable/ic_sdcard"
-                        tools:background="@color/color_warning"/>
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_vertical"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:id="@+id/sharedMemoryTitle"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="fill_horizontal"
-                            android:text="@string/storage_directory_shared"
-                            android:textColor="?android:attr/textColorPrimary"/>
-
-                        <TextView
-                            android:id="@+id/sharedMemoryDescription"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="fill_horizontal"
-                            android:textColor="?android:attr/textColorSecondary"
-                            tools:text="Free: 9 Gb"/>
-
-                    </LinearLayout>
-                </LinearLayout>
-
-                <View
-                    android:id="@+id/divExtStorage"
-                    android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:layout_gravity="fill_horizontal"
-                    android:background="@color/divider_color"/>
-
-                <LinearLayout
-                    android:id="@+id/memoryStickRow"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:background="?attr/selectableItemBackground"
-                    android:orientation="horizontal">
-
-                    <ImageView
-                        android:id="@+id/memoryStickImageView"
-                        android:layout_width="wrap_content"
-                        android:layout_height="56dp"
-                        android:paddingRight="16dp"
-                        android:scaleType="center"
-                        android:src="@drawable/ic_sdcard"
-                        tools:background="@color/color_warning"/>
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_vertical"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:id="@+id/memoryStickTitle"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="fill_horizontal"
-                            android:text="@string/storage_directory_card"
-                            android:textColor="?android:attr/textColorPrimary"/>
-
-                        <TextView
-                            android:id="@+id/memoryStickDescription"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="fill_horizontal"
-                            android:textColor="?android:attr/textColorSecondary"
-                            tools:text="Free: 9 Gb"/>
-
-                    </LinearLayout>
-
-                </LinearLayout>
-
-            </LinearLayout>
-
-        </ScrollView>
-
+      <ImageButton android:id="@+id/closeImageButton"
+        android:contentDescription="@string/shared_string_close"
+        style="@style/Widget.AppCompat.Button.Borderless"
+        android:layout_width="44dp"
+        android:layout_height="44dp"
+        android:src="@drawable/ic_action_remove_dark"
+        tools:background="@color/color_warning"/>
     </LinearLayout>
 
+    <TextView android:id="@+id/description"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="fill_horizontal"
+      android:layout_marginBottom="24dp"
+      android:layout_marginTop="4dp"
+      android:text="@string/application_dir_description"
+      android:textSize="16sp"/>
+
+    <ScrollView android:layout_width="match_parent"
+      android:layout_height="match_parent">
+
+      <LinearLayout android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <LinearLayout android:id="@+id/deviceMemoryRow"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:background="?attr/selectableItemBackground"
+          android:orientation="horizontal">
+
+          <ImageView android:id="@+id/deviceMemoryImageView"
+            android:layout_width="wrap_content"
+            android:layout_height="56dp"
+            android:paddingRight="16dp"
+            android:scaleType="center"
+            android:src="@drawable/ic_sdcard"
+            tools:background="@color/color_warning"/>
+
+          <LinearLayout android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:orientation="vertical">
+
+            <TextView android:id="@+id/deviceMemoryTitle"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_gravity="fill_horizontal"
+              android:gravity="center_vertical"
+              android:text="@string/storage_directory_external"
+              android:textColor="?android:attr/textColorPrimary"/>
+
+            <TextView android:id="@+id/deviceMemoryDescription"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_gravity="fill_horizontal"
+              android:textColor="?android:attr/textColorSecondary"
+              tools:text="Free: 568 Mb"/>
+          </LinearLayout>
+        </LinearLayout>
+
+        <View android:id="@+id/divSharedStorage"
+          android:layout_width="match_parent"
+          android:layout_height="1dp"
+          android:layout_gravity="fill_horizontal"
+          android:background="@color/divider_color"/>
+
+        <LinearLayout android:id="@+id/sharedMemoryRow"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:background="?attr/selectableItemBackground"
+          android:orientation="horizontal">
+
+          <ImageView android:id="@+id/sharedMemoryImageView"
+            android:layout_width="wrap_content"
+            android:layout_height="56dp"
+            android:paddingRight="16dp"
+            android:scaleType="center"
+            android:src="@drawable/ic_sdcard"
+            tools:background="@color/color_warning"/>
+
+          <LinearLayout android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:orientation="vertical">
+
+            <TextView android:id="@+id/sharedMemoryTitle"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_gravity="fill_horizontal"
+              android:text="@string/storage_directory_shared"
+              android:textColor="?android:attr/textColorPrimary"/>
+
+            <TextView android:id="@+id/sharedMemoryDescription"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_gravity="fill_horizontal"
+              android:textColor="?android:attr/textColorSecondary"
+              tools:text="Free: 9 Gb"/>
+          </LinearLayout>
+        </LinearLayout>
+
+        <View android:id="@+id/divExtStorage"
+          android:layout_width="match_parent"
+          android:layout_height="1dp"
+          android:layout_gravity="fill_horizontal"
+          android:background="@color/divider_color"/>
+
+        <LinearLayout android:id="@+id/memoryStickRow"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:background="?attr/selectableItemBackground"
+          android:orientation="horizontal">
+
+          <ImageView android:id="@+id/memoryStickImageView"
+            android:layout_width="wrap_content"
+            android:layout_height="56dp"
+            android:paddingRight="16dp"
+            android:scaleType="center"
+            android:src="@drawable/ic_sdcard"
+            tools:background="@color/color_warning"/>
+
+          <LinearLayout android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:orientation="vertical">
+
+            <TextView android:id="@+id/memoryStickTitle"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_gravity="fill_horizontal"
+              android:text="@string/storage_directory_card"
+              android:textColor="?android:attr/textColorPrimary"/>
+
+            <TextView android:id="@+id/memoryStickDescription"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_gravity="fill_horizontal"
+              android:textColor="?android:attr/textColorSecondary"
+              tools:text="Free: 9 Gb"/>
+          </LinearLayout>
+        </LinearLayout>
+      </LinearLayout>
+    </ScrollView>
+  </LinearLayout>
 </LinearLayout>

--- a/OsmAnd/res/layout/open_time_list_item.xml
+++ b/OsmAnd/res/layout/open_time_list_item.xml
@@ -1,73 +1,63 @@
-<?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
+<?xml version='1.0' encoding='utf-8'?>
+  <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:orientation="vertical">
+
+  <LinearLayout android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:orientation="horizontal">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
+    <ImageView android:id="@+id/clockIconImageView"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_margin="16dp"
+      android:src="@drawable/ic_action_time"/>
 
-        <ImageView
-            android:id="@+id/clockIconImageView"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="16dp"
-            android:src="@drawable/ic_action_time"/>
+    <LinearLayout android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_marginLeft="16dp"
+      android:layout_marginTop="16dp"
+      android:layout_weight="1"
+      android:orientation="vertical">
 
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="16dp"
-            android:layout_marginTop="16dp"
-            android:layout_weight="1"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/daysTextView"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textColor="?android:textColorPrimary"
-                android:textSize="@dimen/default_list_text_size"
-                tools:text="Mo-We"/>
-
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="?android:textColorSecondary"/>
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/timeListContainer"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-            <!--<include layout="@layout/time_from_to_layout"/>-->
-
-        </LinearLayout>
-
-        <ImageButton
-            android:id="@+id/deleteItemImageButton"
-            android:contentDescription="@string/shared_string_delete"
-            style="@style/Widget.AppCompat.Button.Borderless"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:layout_gravity="top"
-            android:src="@drawable/ic_action_remove_dark"/>
-
-    </LinearLayout>
-    <Button
-        android:id="@+id/addTimeSpanButton"
+      <TextView android:id="@+id/daysTextView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="60dp"
-        android:text="@string/add_time_span"
-        android:layout_toRightOf="@id/clockIconImageView"
-        android:layout_below="@id/timeListContainer"
-        android:textColor="?attr/color_dialog_buttons"
-        style="@style/Widget.AppCompat.Button.Borderless"/>
+        android:textColor="?android:textColorPrimary"
+        android:textSize="@dimen/default_list_text_size"
+        tools:text="Mo-We"/>
 
+      <View android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="?android:textColorSecondary"/>
+    </LinearLayout>
+
+    <LinearLayout android:id="@+id/timeListContainer"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:orientation="vertical">
+      <!--<include layout="@layout/time_from_to_layout"/>-->
+    </LinearLayout>
+
+    <ImageButton android:id="@+id/deleteItemImageButton"
+      android:contentDescription="@string/shared_string_delete"
+      style="@style/Widget.AppCompat.Button.Borderless"
+      android:layout_width="48dp"
+      android:layout_height="48dp"
+      android:layout_gravity="top"
+      android:src="@drawable/ic_action_remove_dark"/>
+  </LinearLayout>
+
+  <Button android:id="@+id/addTimeSpanButton"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginLeft="60dp"
+    android:text="@string/add_time_span"
+    android:textColor="?attr/color_dialog_buttons"
+    style="@style/Widget.AppCompat.Button.Borderless">
+    <!--Removed ObsoleteLayoutParam: layout_toRightOf-->
+    <!--Removed ObsoleteLayoutParam: layout_below-->
+  </Button>
 </LinearLayout>


### PR DESCRIPTION
Hi (again),

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "ObsoleteLayoutParam".

While developing your application's views you might be specifying attributes in a view's artefact that are not necessary due to the nature of its parent. In this PR, those attributes were replaced by a comment.

I have made a previous validation of the changes and they seem correct.
Unfortunately, this tool is not able keep the original whitespace of the files, so comparison without ignoring whitespace might be confusing.
Please consider the changes and let me know if you agree with them.

Best,
Luis
