### PR TITLE
Open Location Code support

### DIFF
--- a/OsmAnd-java/src/com/google/openlocationcode/OpenLocationCode.java
+++ b/OsmAnd-java/src/com/google/openlocationcode/OpenLocationCode.java
@@ -1,0 +1,532 @@
+package com.google.openlocationcode;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Representation of open location code. https://github.com/google/open-location-code The
+ * OpenLocationCode class is a wrapper around String value {@code code}, which guarantees that the
+ * value is a valid Open Location Code.
+ *
+ * @author Jiri Semecky
+ */
+public final class OpenLocationCode {
+
+  private static final BigDecimal BD_0 = new BigDecimal(0);
+  private static final BigDecimal BD_5 = new BigDecimal(5);
+  private static final BigDecimal BD_4 = new BigDecimal(4);
+  private static final BigDecimal BD_20 = new BigDecimal(20);
+  private static final BigDecimal BD_90 = new BigDecimal(90);
+  private static final BigDecimal BD_180 = new BigDecimal(180);
+  private static final double LATITUDE_PRECISION_8_DIGITS = computeLatitudePrecision(8) / 4;
+  private static final double LATITUDE_PRECISION_6_DIGITS = computeLatitudePrecision(6) / 4;
+  private static final double LATITUDE_PRECISION_4_DIGITS = computeLatitudePrecision(4) / 4;
+
+  private static final char[] ALPHABET = "23456789CFGHJMPQRVWX".toCharArray();
+  private static final Map<Character, Integer> CHARACTER_TO_INDEX = new HashMap<>();
+
+  static {
+    int index = 0;
+    for (char character : ALPHABET) {
+      char lowerCaseCharacter = Character.toLowerCase(character);
+      CHARACTER_TO_INDEX.put(character, index);
+      CHARACTER_TO_INDEX.put(lowerCaseCharacter, index);
+      index++;
+    }
+  }
+
+  private static final char SEPARATOR = '+';
+  private static final char SEPARATOR_POSITION = 8;
+  private static final char SUFFIX_PADDING = '0';
+
+  /** Class providing information about area covered by Open Location Code. */
+  public class CodeArea {
+
+    private final BigDecimal southLatitude;
+    private final BigDecimal westLongitude;
+    private final BigDecimal northLatitude;
+    private final BigDecimal eastLongitude;
+
+    public CodeArea(
+        BigDecimal southLatitude,
+        BigDecimal westLongitude,
+        BigDecimal northLatitude,
+        BigDecimal eastLongitude) {
+      this.southLatitude = southLatitude;
+      this.westLongitude = westLongitude;
+      this.northLatitude = northLatitude;
+      this.eastLongitude = eastLongitude;
+    }
+
+    public double getSouthLatitude() {
+      return southLatitude.doubleValue();
+    }
+
+    public double getWestLongitude() {
+      return westLongitude.doubleValue();
+    }
+
+    public double getLatitudeHeight() {
+      return northLatitude.subtract(southLatitude).doubleValue();
+    }
+
+    public double getLongitudeWidth() {
+      return eastLongitude.subtract(westLongitude).doubleValue();
+    }
+
+    public double getCenterLatitude() {
+      return southLatitude.add(northLatitude).doubleValue() / 2;
+    }
+
+    public double getCenterLongitude() {
+      return westLongitude.add(eastLongitude).doubleValue() / 2;
+    }
+
+    public double getNorthLatitude() {
+      return northLatitude.doubleValue();
+    }
+
+    public double getEastLongitude() {
+      return eastLongitude.doubleValue();
+    }
+  }
+
+
+  /** The state of the OpenLocationCode. */
+  private final String code;
+
+  /** Creates Open Location Code for the provided code. */
+  public OpenLocationCode(String code) {
+    if (!isValidCode(code)) {
+      throw new IllegalArgumentException(
+          "The provided code '" + code + "' is not a valid Open Location Code.");
+    }
+    this.code = code.toUpperCase();
+  }
+
+  /** Creates Open Location Code from the provided latitude, longitude and desired code length. */
+  public OpenLocationCode(double latitude, double longitude, int codeLength)
+      throws IllegalArgumentException {
+    if (codeLength < 4 || (codeLength < 10 & codeLength % 2 == 1)) {
+      throw new IllegalArgumentException("Illegal code length " + codeLength);
+    }
+
+    latitude = clipLatitude(latitude);
+    longitude = normalizeLongitude(longitude);
+
+    // Latitude 90 needs to be adjusted to be just less, so the returned code can also be decoded.
+    if (latitude == 90) {
+      latitude = latitude - 0.9 * computeLatitudePrecision(codeLength);
+    }
+
+    StringBuilder codeBuilder = new StringBuilder();
+
+    // Ensure the latitude and longitude are within [0, 180] and [0, 360) respectively.
+    /* Note: double type can't be used because of the rounding arithmetic due to floating point
+     * implementation. Eg. "8.95 - 8" can give result 0.9499999999999 instead of 0.95 which
+     * incorrectly classify the points on the border of a cell.
+     */
+    BigDecimal remainingLongitude = new BigDecimal(longitude + 180);
+    BigDecimal remainingLatitude = new BigDecimal(latitude + 90);
+
+    // Create up to 10 significant digits from pairs alternating latitude and longitude.
+    int generatedDigits = 0;
+
+    while (generatedDigits < codeLength) {
+      // Always the integer part of the remaining latitude/longitude will be used for the following
+      // digit.
+      if (generatedDigits == 0) {
+        // First step World division: Map <0..400) to <0..20) for both latitude and longitude.
+        remainingLatitude = remainingLatitude.divide(BD_20);
+        remainingLongitude = remainingLongitude.divide(BD_20);
+      } else if (generatedDigits < 10) {
+        remainingLatitude = remainingLatitude.multiply(BD_20);
+        remainingLongitude = remainingLongitude.multiply(BD_20);
+      } else {
+        remainingLatitude = remainingLatitude.multiply(BD_5);
+        remainingLongitude = remainingLongitude.multiply(BD_4);
+      }
+      int latitudeDigit = remainingLatitude.intValue();
+      int longitudeDigit = remainingLongitude.intValue();
+      if (generatedDigits < 10) {
+        codeBuilder.append(ALPHABET[latitudeDigit]);
+        codeBuilder.append(ALPHABET[longitudeDigit]);
+        generatedDigits += 2;
+      } else {
+        codeBuilder.append(ALPHABET[4 * latitudeDigit + longitudeDigit]);
+        generatedDigits += 1;
+      }
+      remainingLatitude = remainingLatitude.subtract(new BigDecimal(latitudeDigit));
+      remainingLongitude = remainingLongitude.subtract(new BigDecimal(longitudeDigit));
+      if (generatedDigits == SEPARATOR_POSITION) {
+        codeBuilder.append(SEPARATOR);
+      }
+    }
+    if (generatedDigits < SEPARATOR_POSITION) {
+      for (; generatedDigits < SEPARATOR_POSITION; generatedDigits++) {
+        codeBuilder.append(SUFFIX_PADDING);
+      }
+      codeBuilder.append(SEPARATOR);
+    }
+    this.code = codeBuilder.toString();
+  }
+
+  /** Creates Open Location Code with code length 10 from the provided latitude, longitude. */
+  public OpenLocationCode(double latitude, double longitude) {
+    this(latitude, longitude, 10);
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  /**
+   * Encodes latitude/longitude into 10 digit Open Location Code. This method is equivalent to
+   * creating the OpenLocationCode object and getting the code from it.
+   */
+  public static String encode(double latitude, double longitude) {
+    return new OpenLocationCode(latitude, longitude).getCode();
+  }
+
+  /**
+   * Encodes latitude/longitude into Open Location Code of the provided length. This method is
+   * equivalent to creating the OpenLocationCode object and getting the code from it.
+   */
+  public static String encode(double latitude, double longitude, int codeLength) {
+    return new OpenLocationCode(latitude, longitude, codeLength).getCode();
+  }
+
+  /**
+   * Decodes {@link OpenLocationCode} object into {@link CodeArea} object encapsulating
+   * latitude/longitude bounding box.
+   */
+  public CodeArea decode() {
+    if (!isFullCode(code)) {
+      throw new IllegalStateException(
+          "Method decode() could only be called on valid full codes, code was " + code + ".");
+    }
+    String decoded = code.replaceAll("[0+]", "");
+    // Decode the lat/lng pair component.
+    BigDecimal southLatitude = BD_0;
+    BigDecimal westLongitude = BD_0;
+
+    int digit = 0;
+    double latitudeResolution = 400, longitudeResolution = 400;
+
+    // Decode pair.
+    while (digit < decoded.length()) {
+      if (digit < 10) {
+        latitudeResolution /= 20;
+        longitudeResolution /= 20;
+        southLatitude =
+            southLatitude.add(
+                new BigDecimal(latitudeResolution * CHARACTER_TO_INDEX.get(decoded.charAt(digit))));
+        westLongitude =
+            westLongitude.add(
+                new BigDecimal(
+                    longitudeResolution * CHARACTER_TO_INDEX.get(decoded.charAt(digit + 1))));
+        digit += 2;
+      } else {
+        latitudeResolution /= 5;
+        longitudeResolution /= 4;
+        southLatitude =
+            southLatitude.add(
+                new BigDecimal(
+                    latitudeResolution * (CHARACTER_TO_INDEX.get(decoded.charAt(digit)) / 4)));
+        westLongitude =
+            westLongitude.add(
+                new BigDecimal(
+                    longitudeResolution * (CHARACTER_TO_INDEX.get(decoded.charAt(digit)) % 4)));
+        digit += 1;
+      }
+    }
+    return new CodeArea(
+        southLatitude.subtract(BD_90),
+        westLongitude.subtract(BD_180),
+        southLatitude.subtract(BD_90).add(new BigDecimal(latitudeResolution)),
+        westLongitude.subtract(BD_180).add(new BigDecimal(longitudeResolution)));
+  }
+
+  /**
+   * Decodes code representing Open Location Code into {@link CodeArea} object encapsulating
+   * latitude/longitude bounding box.
+   *
+   * @param code Open Location Code to be decoded.
+   * @throws IllegalArgumentException if the provided code is not a valid Open Location Code.
+   */
+  public static CodeArea decode(String code) throws IllegalArgumentException {
+    return new OpenLocationCode(code).decode();
+  }
+
+  /** Returns whether this {@link OpenLocationCode} is a full Open Location Code. */
+  public boolean isFull() {
+    return code.indexOf(SEPARATOR) == SEPARATOR_POSITION;
+  }
+
+  /** Returns whether the provided Open Location Code is a full Open Location Code. */
+  public static boolean isFull(String code) throws IllegalArgumentException {
+    return new OpenLocationCode(code).isFull();
+  }
+
+  /** Returns whether this {@link OpenLocationCode} is a short Open Location Code. */
+  public boolean isShort() {
+    return code.indexOf(SEPARATOR) >= 0 && code.indexOf(SEPARATOR) < SEPARATOR_POSITION;
+  }
+
+  /** Returns whether the provided Open Location Code is a short Open Location Code. */
+  public static boolean isShort(String code) throws IllegalArgumentException {
+    return new OpenLocationCode(code).isShort();
+  }
+
+  /**
+   * Returns whether this {@link OpenLocationCode} is a padded Open Location Code, meaning that it
+   * contains less than 8 valid digits.
+   */
+  private boolean isPadded() {
+    return code.indexOf(SUFFIX_PADDING) >= 0;
+  }
+
+  /**
+   * Returns whether the provided Open Location Code is a padded Open Location Code, meaning that it
+   * contains less than 8 valid digits.
+   */
+  public static boolean isPadded(String code) throws IllegalArgumentException {
+    return new OpenLocationCode(code).isPadded();
+  }
+
+  /**
+   * Returns short {@link OpenLocationCode} from the full Open Location Code created by removing
+   * four or six digits, depending on the provided reference point.  It removes as many digits as
+   * possible.
+   */
+  public OpenLocationCode shorten(double referenceLatitude, double referenceLongitude) {
+    if (!isFull()) {
+      throw new IllegalStateException("shorten() method could only be called on a full code.");
+    }
+    if (isPadded()) {
+      throw new IllegalStateException("shorten() method can not be called on a padded code.");
+    }
+
+    CodeArea codeArea = decode();
+    double latitudeDiff = Math.abs(referenceLatitude - codeArea.getCenterLatitude());
+    double longitudeDiff = Math.abs(referenceLongitude - codeArea.getCenterLongitude());
+
+    if (latitudeDiff < LATITUDE_PRECISION_8_DIGITS && longitudeDiff < LATITUDE_PRECISION_8_DIGITS) {
+      return new OpenLocationCode(code.substring(8));
+    }
+    if (latitudeDiff < LATITUDE_PRECISION_6_DIGITS && longitudeDiff < LATITUDE_PRECISION_6_DIGITS) {
+      return new OpenLocationCode(code.substring(6));
+    }
+    if (latitudeDiff < LATITUDE_PRECISION_4_DIGITS && longitudeDiff < LATITUDE_PRECISION_4_DIGITS) {
+      return new OpenLocationCode(code.substring(4));
+    }
+    throw new IllegalArgumentException(
+        "Reference location is too far from the Open Location Code center.");
+  }
+
+  /**
+   * Returns an {@link OpenLocationCode} object representing a full Open Location Code from this
+   * (short) Open Location Code, given the reference location.
+   */
+  public OpenLocationCode recover(double referenceLatitude, double referenceLongitude) {
+    if (isFull()) {
+      // Note: each code is either full xor short, no other option.
+      return this;
+    }
+    referenceLatitude = clipLatitude(referenceLatitude);
+    referenceLongitude = normalizeLongitude(referenceLongitude);
+
+    int digitsToRecover = 8 - code.indexOf(SEPARATOR);
+    // The resolution (height and width) of the padded area in degrees.
+    double paddedAreaSize = Math.pow(20, 2 - (digitsToRecover / 2));
+
+    // Use the reference location to pad the supplied short code and decode it.
+    String recoveredPrefix =
+        new OpenLocationCode(referenceLatitude, referenceLongitude)
+            .getCode()
+            .substring(0, digitsToRecover);
+    OpenLocationCode recovered = new OpenLocationCode(recoveredPrefix + code);
+    CodeArea recoveredCodeArea = recovered.decode();
+    double recoveredLatitude = recoveredCodeArea.getCenterLatitude();
+    double recoveredLongitude = recoveredCodeArea.getCenterLongitude();
+
+    // Move the recovered latitude by one resolution up or down if it is too far from the reference.
+    double latitudeDiff = recoveredLatitude - referenceLatitude;
+    if (latitudeDiff > paddedAreaSize / 2) {
+      recoveredLatitude -= paddedAreaSize;
+    } else if (latitudeDiff < -paddedAreaSize / 2) {
+      recoveredLatitude += paddedAreaSize;
+    }
+
+    // Move the recovered longitude by one resolution up or down if it is too far from the
+    // reference.
+    double longitudeDiff = recoveredCodeArea.getCenterLongitude() - referenceLongitude;
+    if (longitudeDiff > paddedAreaSize / 2) {
+      recoveredLongitude -= paddedAreaSize;
+    } else if (longitudeDiff < -paddedAreaSize / 2) {
+      recoveredLongitude += paddedAreaSize;
+    }
+
+    return new OpenLocationCode(
+        recoveredLatitude, recoveredLongitude, recovered.getCode().length() - 1);
+  }
+
+  /**
+   * Returns whether the bounding box specified by the Open Location Code contains provided point.
+   */
+  public boolean contains(double latitude, double longitude) {
+    CodeArea codeArea = decode();
+    return codeArea.getSouthLatitude() <= latitude
+        && latitude < codeArea.getNorthLatitude()
+        && codeArea.getWestLongitude() <= longitude
+        && longitude < codeArea.getEastLongitude();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    OpenLocationCode that = (OpenLocationCode) o;
+    return hashCode() == that.hashCode();
+  }
+
+  @Override
+  public int hashCode() {
+    return code != null ? code.hashCode() : 0;
+  }
+
+  @Override
+  public String toString() {
+    return getCode();
+  }
+
+  // Exposed static helper methods.
+
+  /** Returns whether the provided string is a valid Open Location code. */
+  public static boolean isValidCode(String code) {
+    if (code == null || code.length() < 2) {
+      return false;
+    }
+
+    // There must be exactly one separator.
+    int separatorPosition = code.indexOf(SEPARATOR);
+    if (separatorPosition == -1) {
+      return false;
+    }
+    if (separatorPosition != code.lastIndexOf(SEPARATOR)) {
+      return false;
+    }
+
+    if (separatorPosition % 2 != 0) {
+      return false;
+    }
+
+    // Check first two characters: only some values from the alphabet are permitted.
+    if (separatorPosition == 8) {
+      // First latitude character can only have first 9 values.
+      Integer index0 = CHARACTER_TO_INDEX.get(code.charAt(0));
+      if (index0 == null || index0 > 8) {
+        return false;
+      }
+
+      // First longitude character can only have first 18 values.
+      Integer index1 = CHARACTER_TO_INDEX.get(code.charAt(1));
+      if (index1 == null || index1 > 17) {
+        return false;
+      }
+    }
+
+    // Check the characters before the separator.
+    boolean paddingStarted = false;
+    for (int i = 0; i < separatorPosition; i++) {
+      if (paddingStarted) {
+        // Once padding starts, there must not be anything but padding.
+        if (code.charAt(i) != SUFFIX_PADDING) {
+          return false;
+        }
+        continue;
+      }
+      if (CHARACTER_TO_INDEX.keySet().contains(code.charAt(i))) {
+        continue;
+      }
+      if (SUFFIX_PADDING == code.charAt(i)) {
+        paddingStarted = true;
+        // Padding can start on even character: 2, 4 or 6.
+        if (i != 2 && i != 4 && i != 6) {
+          return false;
+        }
+        continue;
+      }
+      return false;  // Illegal character.
+    }
+
+    // Check the characters after the separator.
+    if (code.length() > separatorPosition + 1) {
+      if (paddingStarted) {
+        return false;
+      }
+      // Only one character after separator is forbidden.
+      if (code.length() == separatorPosition + 2) {
+        return false;
+      }
+      for (int i = separatorPosition + 1; i < code.length(); i++) {
+        if (!CHARACTER_TO_INDEX.keySet().contains(code.charAt(i))) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  /** Returns if the code is a valid full Open Location Code. */
+  public static boolean isFullCode(String code) {
+    try {
+      return new OpenLocationCode(code).isFull();
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+  /** Returns if the code is a valid short Open Location Code. */
+  public static boolean isShortCode(String code) {
+    try {
+      return new OpenLocationCode(code).isShort();
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+  // Private static methods.
+
+  private static double clipLatitude(double latitude) {
+    return Math.min(Math.max(latitude, -90), 90);
+  }
+
+  private static double normalizeLongitude(double longitude) {
+    if (longitude < -180) {
+      longitude = (longitude % 360) + 360;
+    }
+    if (longitude >= 180) {
+      longitude = (longitude % 360) - 360;
+    }
+    return longitude;
+  }
+
+  /**
+   * Compute the latitude precision value for a given code length. Lengths <= 10 have the same
+   * precision for latitude and longitude, but lengths > 10 have different precisions due to the
+   * grid method having fewer columns than rows. Copied from the JS implementation.
+   */
+  private static double computeLatitudePrecision(int codeLength) {
+    if (codeLength <= 10) {
+      return Math.pow(20, Math.floor(codeLength / -2 + 2));
+    }
+    return Math.pow(20, -3) / Math.pow(5, codeLength - 10);
+  }
+}

--- a/OsmAnd-java/src/net/osmand/LocationConvert.java
+++ b/OsmAnd-java/src/net/osmand/LocationConvert.java
@@ -1,7 +1,12 @@
 package net.osmand;
 
+import com.google.openlocationcode.OpenLocationCode;
+
+import net.osmand.data.LatLon;
+
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.util.IllegalFormatException;
 import java.util.Locale;
 import java.util.StringTokenizer;
 
@@ -14,6 +19,7 @@ public class LocationConvert {
 	public static final int FORMAT_MINUTES = 1;
 	public static final int FORMAT_SECONDS = 2;
 	public static final int UTM_FORMAT = 3;
+	public static final int OLC_FORMAT = 4;
 	private static final char DELIM = ':';
 
 	
@@ -149,5 +155,4 @@ public class LocationConvert {
 		sb.append(df.format(coordinate));
 		return sb.toString();
 	}
-
 }

--- a/OsmAnd-java/src/net/osmand/search/core/SearchCoreFactory.java
+++ b/OsmAnd-java/src/net/osmand/search/core/SearchCoreFactory.java
@@ -1,5 +1,6 @@
 package net.osmand.search.core;
 
+import com.google.openlocationcode.OpenLocationCode;
 import com.jwetherell.openmap.common.LatLonPoint;
 import com.jwetherell.openmap.common.UTMPoint;
 
@@ -1031,6 +1032,15 @@ public class SearchCoreFactory {
 		
 		LatLon parseLocation(String s) {
 			s = s.trim();
+			// detect OLC first
+			// avoid throwing exceptions by carefully checking exceptions
+			if (s.length() > 0 && OpenLocationCode.isValidCode(s)) {
+				OpenLocationCode olc = new OpenLocationCode(s);
+				if (olc.isFull()) {
+					OpenLocationCode.CodeArea codeArea = olc.decode();
+					return new LatLon(codeArea.getCenterLatitude(), codeArea.getCenterLongitude());
+				}
+			}
 			if(s.length() == 0 || !(s.charAt(0) == '-' || Character.isDigit(s.charAt(0))
 					 || s.charAt(0) == 'S' || s.charAt(0) == 's' 
 					 || s.charAt(0) == 'N' || s.charAt(0) == 'n' 

--- a/OsmAnd/res/layout/search_advanced_coords.xml
+++ b/OsmAnd/res/layout/search_advanced_coords.xml
@@ -298,6 +298,74 @@
                 </LinearLayout>
 
                 <LinearLayout
+                    android:id="@+id/olcLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:paddingTop="16dp"
+                    android:visibility="gone">
+
+                    <FrameLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content">
+
+                        <android.support.design.widget.TextInputLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginLeft="54dp"
+                            android:layout_marginRight="16dp">
+
+                            <EditText
+                                android:id="@+id/olcEditText"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:hint="@string/navigate_point_olc"
+                                android:imeOptions="actionDone"
+                                android:inputType="textCapCharacters|textNoSuggestions"
+                                tools:text="6PH57VP3+PQ"/>
+
+                        </android.support.design.widget.TextInputLayout>
+
+                        <ImageButton
+                            android:id="@+id/olcClearButton"
+                            style="@style/Widget.AppCompat.ActionButton"
+                            android:layout_width="48dp"
+                            android:layout_height="48dp"
+                            android:layout_gravity="right"
+                            android:layout_marginRight="4dp"
+                            android:contentDescription="@string/shared_string_clear"
+                            android:src="@drawable/ic_action_remove_dark"/>
+
+                    </FrameLayout>
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/olcInfoLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:paddingTop="16dp"
+                    android:visibility="gone">
+
+                    <FrameLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="54dp"
+                        android:layout_marginRight="16dp">
+
+                        <TextView
+                            android:id="@+id/olcInfoTextView"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            tools:text="OLC area information"
+                            android:inputType="textMultiLine"/>
+
+                    </FrameLayout>
+
+                </LinearLayout>
+
+                <LinearLayout
                     android:id="@+id/formatLayout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -761,6 +761,10 @@
     <string name="rendering_attr_transportStops_name">Transport stops</string>
 
     <string name="navigate_point_zone">Zone</string>
+    <string name="navigate_point_olc">Open Location Code</string>
+    <string name="navigate_point_olc_info_invalid">Invalid OLC\n</string>
+    <string name="navigate_point_olc_info_short">Short OLC\nPlease provide a full code</string>
+    <string name="navigate_point_olc_info_area">Valid full OLC\nRepresents area: %1$s x %2$s</string>
     <string name="navigate_point_northing">Northing</string>
     <string name="navigate_point_easting">Easting</string>
     <string name="download_tab_downloads">All Downloads</string>

--- a/OsmAnd/src/net/osmand/data/PointDescription.java
+++ b/OsmAnd/src/net/osmand/data/PointDescription.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.google.openlocationcode.OpenLocationCode;
 import com.jwetherell.openmap.common.LatLonPoint;
 import com.jwetherell.openmap.common.UTMPoint;
 
@@ -156,6 +157,8 @@ public class PointDescription {
 			UTMPoint pnt = new UTMPoint(new LatLonPoint(lat, lon));
 			return pnt.zone_number + "" + pnt.zone_letter + " " + ((long) pnt.easting) + " "
 					+ ((long) pnt.northing);
+		} else if (f == PointDescription.OLC_FORMAT) {
+			return getLocationOlcName(lat, lon);
 		} else {
 			try {
 				return ctx.getString(sh ? R.string.short_location_on_map : R.string.location_on_map, LocationConvert.convert(lat, f),
@@ -174,6 +177,8 @@ public class PointDescription {
 			UTMPoint pnt = new UTMPoint(new LatLonPoint(lat, lon));
 			return pnt.zone_number + "" + pnt.zone_letter + " " + ((long) pnt.easting) + " "
 					+ ((long) pnt.northing);
+		} else if (f == PointDescription.OLC_FORMAT) {
+			return getLocationOlcName(lat, lon);
 		} else {
 			try {
 				return LocationConvert.convert(lat, f) + ", " + LocationConvert.convert(lon, f);
@@ -182,6 +187,10 @@ public class PointDescription {
 				return "0, 0";
 			}
 		}
+	}
+
+	public static String getLocationOlcName(double lat, double lon) {
+		return OpenLocationCode.encode(lat, lon);
 	}
 
 	public boolean contextMenuDisabled() {
@@ -338,6 +347,7 @@ public class PointDescription {
 	public static final int FORMAT_MINUTES = LocationConvert.FORMAT_MINUTES;
 	public static final int FORMAT_SECONDS = LocationConvert.FORMAT_SECONDS;
 	public static final int UTM_FORMAT = LocationConvert.UTM_FORMAT;
+	public static final int OLC_FORMAT = LocationConvert.OLC_FORMAT;
 	
 	public static String formatToHumanString(Context ctx, int format) {
 		switch (format) {
@@ -349,6 +359,8 @@ public class PointDescription {
 				return ctx.getString(R.string.navigate_point_format_DMS);
 			case LocationConvert.UTM_FORMAT:
 				return "UTM";
+			case LocationConvert.OLC_FORMAT:
+				return "OLC";
 			default:
 				return "Unknown format";
 		}

--- a/OsmAnd/src/net/osmand/plus/activities/SettingsGeneralActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/SettingsGeneralActivity.java
@@ -151,16 +151,18 @@ public class SettingsGeneralActivity extends SettingsBaseActivity implements OnR
 		}
 		registerListPreference(settings.METRIC_SYSTEM, screen, entries, mvls);
 
-		Integer[] cvls  = new Integer[4];
+		Integer[] cvls  = new Integer[5];
 		cvls[0] = PointDescription.FORMAT_DEGREES;
 		cvls[1] = PointDescription.FORMAT_MINUTES;
 		cvls[2] = PointDescription.FORMAT_SECONDS;
 		cvls[3] = PointDescription.UTM_FORMAT;
-		entries = new String[4];
+		cvls[4] = PointDescription.OLC_FORMAT;
+		entries = new String[5];
 		entries[0] = PointDescription.formatToHumanString(this, PointDescription.FORMAT_DEGREES);
 		entries[1] = PointDescription.formatToHumanString(this, PointDescription.FORMAT_MINUTES);
 		entries[2] = PointDescription.formatToHumanString(this, PointDescription.FORMAT_SECONDS);
 		entries[3] = PointDescription.formatToHumanString(this, PointDescription.UTM_FORMAT);
+		entries[4] = PointDescription.formatToHumanString(this, PointDescription.OLC_FORMAT);
 		registerListPreference(settings.COORDINATES_FORMAT, screen, entries, cvls);
 
 		// See language list and statistics at: https://hosted.weblate.org/projects/osmand/main/

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/MenuController.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/MenuController.java
@@ -22,6 +22,7 @@ import net.osmand.plus.GPXUtilities.WptPt;
 import net.osmand.plus.GpxSelectionHelper.GpxDisplayItem;
 import net.osmand.plus.MapMarkersHelper.MapMarker;
 import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.OsmandSettings;
 import net.osmand.plus.R;
 import net.osmand.plus.TargetPointsHelper.TargetPoint;
 import net.osmand.plus.activities.MapActivity;
@@ -203,8 +204,12 @@ public abstract class MenuController extends BaseMenuController {
 	}
 
 	protected void addMyLocationToPlainItems(LatLon latLon) {
+		OsmandSettings st = ((OsmandApplication) getMapActivity().getApplicationContext()).getSettings();
 		addPlainMenuItem(R.drawable.ic_action_get_my_location, PointDescription.getLocationName(getMapActivity(),
 				latLon.getLatitude(), latLon.getLongitude(), true).replaceAll("\n", " "), false, false, null);
+		if (st.COORDINATES_FORMAT.get() != PointDescription.OLC_FORMAT)
+			addPlainMenuItem(R.drawable.ic_action_get_my_location, PointDescription.getLocationOlcName(
+					latLon.getLatitude(), latLon.getLongitude()).replaceAll("\n", " "), false, false, null);
 	}
 
 	public PointDescription getPointDescription() {

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/AmenityMenuBuilder.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/AmenityMenuBuilder.java
@@ -24,6 +24,8 @@ import net.osmand.data.PointDescription;
 import net.osmand.osm.AbstractPoiType;
 import net.osmand.osm.MapPoiTypes;
 import net.osmand.osm.PoiType;
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.OsmandSettings;
 import net.osmand.plus.R;
 import net.osmand.plus.activities.MapActivity;
 import net.osmand.plus.mapcontextmenu.MenuBuilder;
@@ -464,9 +466,15 @@ public class AmenityMenuBuilder extends MenuBuilder {
 			buildAmenityRow(view, wikiInfo);
 		}
 
+		OsmandSettings st = ((OsmandApplication) mapActivity.getApplicationContext()).getSettings();
 		buildRow(view, R.drawable.ic_action_get_my_location, PointDescription.getLocationName(app,
 				amenity.getLocation().getLatitude(), amenity.getLocation().getLongitude(), true)
 				.replaceAll("\n", " "), 0, false, null, false, 0, false, null);
+		if (st.COORDINATES_FORMAT.get() != PointDescription.OLC_FORMAT)
+			buildRow(view, R.drawable.ic_action_get_my_location, PointDescription.getLocationOlcName(
+					amenity.getLocation().getLatitude(), amenity.getLocation().getLongitude())
+					.replaceAll("\n", " "), 0, false, null, false, 0, false, null);
+
 	}
 
 	public void buildAmenityRow(View view, AmenityInfoRow info) {

--- a/OsmAnd/src/net/osmand/plus/osmedit/EditPOIMenuBuilder.java
+++ b/OsmAnd/src/net/osmand/plus/osmedit/EditPOIMenuBuilder.java
@@ -5,6 +5,8 @@ import android.view.View;
 import net.osmand.data.PointDescription;
 import net.osmand.osm.MapPoiTypes;
 import net.osmand.osm.PoiType;
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.OsmandSettings;
 import net.osmand.plus.R;
 import net.osmand.plus.activities.MapActivity;
 import net.osmand.plus.mapcontextmenu.MenuBuilder;
@@ -71,8 +73,13 @@ public class EditPOIMenuBuilder extends MenuBuilder {
 			}
 		}
 
+		OsmandSettings st = ((OsmandApplication) mapActivity.getApplicationContext()).getSettings();
 		buildRow(view, R.drawable.ic_action_get_my_location, PointDescription.getLocationName(app,
 				osmPoint.getLatitude(), osmPoint.getLongitude(), true)
 				.replaceAll("\n", " "), 0, false, null, false, 0, false, null);
+		if (st.COORDINATES_FORMAT.get() != PointDescription.OLC_FORMAT)
+			buildRow(view, R.drawable.ic_action_get_my_location, PointDescription.getLocationOlcName(
+					osmPoint.getLatitude(), osmPoint.getLongitude())
+					.replaceAll("\n", " "), 0, false, null, false, 0, false, null);
 	}
 }


### PR DESCRIPTION
Hello! I have implemented the [Open Location Code](http://openlocationcode.com) (OLC, Plus Code) support in OsmAnd. It has been requested in #2740.

Could you please review and accept it?

**What is added**
- Added OpenLocationCode classes from official repository. It contains only one unchanged java file.
- Show OLC in point descriptions along with latitude/longitude.
- Support OLC positions in full-text search. If a full OLC is typed, it is shown as a coordinate.
- Support OLC in advanced coordinate search. It is an additional search mode. Also it shows information about specified OLC and how large is represented area.

**What is missing**
- Only full OLC is supported.
- No localization yet

**Notes about full vs short OLC**
Example of full OLC: `849VCWC8+R9`.
Example of short OLC (local): `CWC8+R9, Mountain View`
You can use [test application](https://plus.codes) or even google maps for displaying and parsing codes.
It is needed to add support for short OLC in future by parsing both short OLC and locality from a query string and then compose a full OLC. I can implement it later.