### PR TITLE
Display all segments of the current recording track in the same colour

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/SavingTrackHelper.java
+++ b/OsmAnd/src/net/osmand/plus/activities/SavingTrackHelper.java
@@ -417,13 +417,14 @@ public class SavingTrackHelper extends SQLiteOpenHelper {
 	
 	private void addTrackPoint(WptPt pt, boolean newSegment, long time) {
 		List<TrkSegment> points = currentTrack.getModifiablePointsToDisplay();
-		Track track = currentTrack.getGpxFile().tracks.get(0);
+		Track track = currentTrack.getModifiableGpxFile().tracks.get(0);
 		assert track.segments.size() == points.size(); 
 		if (points.size() == 0 || newSegment) {
 			points.add(new TrkSegment());
 		}
 		if(track.segments.size() == 0 || newSegment) {
 			track.segments.add(new TrkSegment());
+			currentTrack.processPoints();
 		}
 		if (pt != null) {
 			int ind = points.size() - 1;


### PR DESCRIPTION
Previously, when selecting a custom colour for the current recording track, any new track segments after the first one were displayed in the default GPX colour, not the custom colour.