### PR TITLE
Waypoints announcement initialization fix

### DIFF
--- a/OsmAnd/src/net/osmand/plus/helpers/WaypointHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/WaypointHelper.java
@@ -443,7 +443,7 @@ public class WaypointHelper {
 	}
 
 	public void clearAllVisiblePoints() {
-		//this.locationPointsStates.clear();
+		this.locationPointsStates.clear();
 		this.locationPoints = new ArrayList<List<LocationPointWrapper>>();
 	}
 
@@ -532,7 +532,7 @@ public class WaypointHelper {
 
 	protected synchronized void setLocationPoints(List<List<LocationPointWrapper>> locationPoints, RouteCalculationResult route) {
 		this.locationPoints = locationPoints;
-		//this.locationPointsStates.clear();
+		this.locationPointsStates.clear();
 		TIntArrayList list = new TIntArrayList(locationPoints.size());
 		list.fill(0, locationPoints.size(), 0);
 		this.pointsProgress = list;


### PR DESCRIPTION
I cannot imagine the reason these strings should be commented out for,
but not having the list properly initialized it is impossible to go
through the same route again hearing the announcements without force
reload.
