### PR TITLE
Show paused state more clearly on track recording notification

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -129,6 +129,7 @@
     <string name="shared_string_notifications">Notifications</string>
     <string name="shared_string_continue">Continue</string>
     <string name="shared_string_pause">Pause</string>
+    <string name="shared_string_paused">Paused</string>
     <string name="shared_string_trip">Trip</string>
     <string name="shared_string_recorded">Recorded</string>
     <string name="shared_string_record">Record</string>

--- a/OsmAnd/src/net/osmand/plus/notifications/GpxNotification.java
+++ b/OsmAnd/src/net/osmand/plus/notifications/GpxNotification.java
@@ -108,20 +108,20 @@ public class GpxNotification extends OsmandNotification {
 		color = 0;
 		icon = R.drawable.ic_action_polygom_dark;
 		boolean isGpxRecording = app.getSavingTrackHelper().getIsRecording();
-		float recordedDistane = app.getSavingTrackHelper().getDistance();
+		float recordedDistance = app.getSavingTrackHelper().getDistance();
 		ongoing = true;
 		if (isGpxRecording) {
 			color = app.getResources().getColor(R.color.osmand_orange);
 			notificationTitle = app.getString(R.string.shared_string_trip) + " • "
 					+ Algorithms.formatDuration((int) (app.getSavingTrackHelper().getDuration() / 1000), true);
 			notificationText = app.getString(R.string.shared_string_recorded)
-					+ ": " + OsmAndFormatter.getFormattedDistance(recordedDistane, app);
+					+ ": " + OsmAndFormatter.getFormattedDistance(recordedDistance, app);
 		} else {
-			if (recordedDistane > 0) {
-				notificationTitle = app.getString(R.string.shared_string_pause) + " • "
+			if (recordedDistance > 0) {
+				notificationTitle = app.getString(R.string.shared_string_paused) + " • "
 						+ Algorithms.formatDuration((int) (app.getSavingTrackHelper().getDuration() / 1000), true);
 				notificationText = app.getString(R.string.shared_string_recorded)
-						+ ": " + OsmAndFormatter.getFormattedDistance(recordedDistane, app);
+						+ ": " + OsmAndFormatter.getFormattedDistance(recordedDistance, app);
 			} else {
 				ongoing = false;
 				notificationTitle = app.getString(R.string.shared_string_trip_recording);
@@ -157,7 +157,7 @@ public class GpxNotification extends OsmandNotification {
 			Intent startIntent = new Intent(OSMAND_START_GPX_SERVICE_ACTION);
 			PendingIntent startPendingIntent = PendingIntent.getBroadcast(app, 0, startIntent,
 					PendingIntent.FLAG_UPDATE_CURRENT);
-			if (recordedDistane > 0) {
+			if (recordedDistance > 0) {
 				notificationBuilder.addAction(R.drawable.ic_action_rec_start,
 						app.getString(R.string.shared_string_continue), startPendingIntent);
 				notificationBuilder.addAction(R.drawable.ic_action_save, app.getString(R.string.shared_string_save),


### PR DESCRIPTION
Previously, the track recording notification displayed "Pause" when recording was paused. This was confusing because when recording, the notification also shows "Pause" to allow recording to be paused.

With this change, "Paused" (rather than "Pause") is shown in the notification when recording is paused.