### PR TITLE
Added explicit encoding for Java source code

### DIFF
--- a/OsmAnd-java/build.gradle
+++ b/OsmAnd-java/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'application'
 mainClassName = "net.osmand.util.GeoPointParserUtil"
-
+compileJava.options.encoding = 'UTF-8'
 
 tasks.withType(JavaCompile) {
 	sourceCompatibility = "1.7"


### PR DESCRIPTION
On Windows 10 x64 Russian with Java 8.0.1210.13 compiler uses cyrillic encoding "cp1251" by default. That's why gradle fails with error
```
Validating translations
Incremental java compilation is an incubating feature.
:OsmAnd-java:compileJavawarning: [options] bootstrap class path not set in conjunction with -source 1.7
E:\projects\Android\osmand_project\osmandapp\android\OsmAnd-java\src\net\osmand\data\MapObject.java:26: error: unmappable character for encoding Cp1251
	 * Looks like: {ru=ÐœÐ¾ÑÐºÐ²Ð°, dz=à½?à½¼à½¦à½²à¼‹à½€à½¼...} and does not contain values of OSM tags "name" and "name:en",
	                                      ^
E:\projects\Android\osmand_project\osmandapp\android\OsmAnd-java\src\net\osmand\Reshaper.java:98: error: unmappable character for encoding Cp1251
		String s = "Ú¯Ú† Ù¾Ú? Ù†Ù…Ú©ÛŒ Ø¨Ø§Ù„Ù„ØºØ© Ø§Ù„Ø¹Ø±Ø¨ÙŠ";
		                    ^
E:\projects\Android\osmand_project\osmandapp\android\OsmAnd-java\src\net\osmand\Reshaper.java:101: error: unmappable character for encoding Cp1251
		if (!reshape.equals("ï»²ïº‘ïº®ï»Œï»Ÿïº ïº”ï»ï» ï»ŸïºŽïº‘ ï¯½ï®‘ï»¤ï»§ ï®‹ï­? ï­»ï®”")) {
		                                                                             ^
E:\projects\Android\osmand_project\osmandapp\android\OsmAnd-java\src\net\osmand\Reshaper.java:89: error: unclosed character literal
		char[] c = new char[] {'×', '×“','×'} ;
		                       ^
E:\projects\Android\osmand_project\osmandapp\android\OsmAnd-java\src\net\osmand\Reshaper.java:89: error: ';' expected
		char[] c = new char[] {'×', '×“','×'} ;
		                         ^
E:\projects\Android\osmand_project\osmandapp\android\OsmAnd-java\src\net\osmand\Reshaper.java:89: error: unclosed character literal
		char[] c = new char[] {'×', '×“','×'} ;
		                          ^
E:\projects\Android\osmand_project\osmandapp\android\OsmAnd-java\src\net\osmand\Reshaper.java:89: error: unclosed character literal
		char[] c = new char[] {'×', '×“','×'} ;
		                             ^
E:\projects\Android\osmand_project\osmandapp\android\OsmAnd-java\src\net\osmand\Reshaper.java:89: error: illegal character: '\u201c'
		char[] c = new char[] {'×', '×“','×'} ;
		                               ^
E:\projects\Android\osmand_project\osmandapp\android\OsmAnd-java\src\net\osmand\Reshaper.java:89: error: ';' expected
		char[] c = new char[] {'×', '×“','×'} ;
		                                ^
E:\projects\Android\osmand_project\osmandapp\android\OsmAnd-java\src\net\osmand\Reshaper.java:89: error: unclosed character literal
		char[] c = new char[] {'×', '×“','×'} ;
		                                     ^
E:\projects\Android\osmand_project\osmandapp\android\OsmAnd-java\src\net\osmand\Reshaper.java:89: error: not a statement
		char[] c = new char[] {'×', '×“','×'} ;
		                                   ^
8 errors
1 warning
 FAILED

FAILURE: Build failed with an exception.
```

I've added expllicit encoding setting for Java compiler.