### PR TITLE
update link to latest version

### DIFF
--- a/OsmAnd/src/net/osmand/plus/AppInitializer.java
+++ b/OsmAnd/src/net/osmand/plus/AppInitializer.java
@@ -85,7 +85,7 @@ public class AppInitializer implements IProgress {
 	private static final String VERSION_INSTALLED = "VERSION_INSTALLED"; //$NON-NLS-1$
 	private static final String EXCEPTION_FILE_SIZE = "EXCEPTION_FS"; //$NON-NLS-1$
 
-	public static final String LATEST_CHANGES_URL = "http://osmand.net/blog?id=osmand-2-5-released";
+	public static final String LATEST_CHANGES_URL = "http://osmand.net/blog?id=osmand-2-6-released";
 //	public static final String LATEST_CHANGES_URL = null; // not enough to read
 	public static final int APP_EXIT_CODE = 4;
 	public static final String APP_EXIT_KEY = "APP_EXIT_KEY";


### PR DESCRIPTION
Currently, after the update (in my case to 2.6.2), a click on "More infos" still opens the detailed 2.5 description in the browser.