### PR TITLE
Calculate speed for GPX tracks which don't contain speed

### DIFF
--- a/OsmAnd/src/net/osmand/plus/GPXUtilities.java
+++ b/OsmAnd/src/net/osmand/plus/GPXUtilities.java
@@ -312,6 +312,7 @@ public class GPXUtilities {
 
 		public boolean hasElevationData;
 		public boolean hasSpeedData;
+		public boolean hasSpeedInTrack;
 
 		public boolean isSpeedSpecified() {
 			return avgSpeed > 0;
@@ -394,15 +395,9 @@ public class GPXUtilities {
 					}
 
 					float speed = (float) point.speed;
-					Speed speed1 = new Speed();
-					if (speed > 0) {
-						totalSpeedSum += speed;
-						maxSpeed = Math.max(speed, maxSpeed);
-						speedCount++;
 
-						speed1.speed = speed;
-					} else {
-						speed1.speed = 0;
+					if (speed > 0) {
+						hasSpeedInTrack = true;
 					}
 
 					// Trend channel approach for elevation gain/loss, Hardy 2015-09-22
@@ -478,6 +473,10 @@ public class GPXUtilities {
 						point.distance = segmentDistance;
 						timeDiff = (int)((point.time - prev.time) / 1000);
 
+						if (!hasSpeedInTrack && speed == 0 && timeDiff > 0) {
+							speed = calculations[0] / timeDiff;
+						}
+
 						// Motion detection:
 						//   speed > 0  uses GPS chipset's motion detection
 						//   calculations[0] > minDisplacment * time  is heuristic needed because tracks may be filtered at recording time, so points at rest may not be present in file at all
@@ -499,6 +498,15 @@ public class GPXUtilities {
 					if (!hasElevationData && !Float.isNaN(elevation1.elevation) && totalDistance > 0) {
 						hasElevationData = true;
 					}
+
+					Speed speed1 = new Speed();
+					if (speed > 0) {
+						totalSpeedSum += speed;
+						maxSpeed = Math.max(speed, maxSpeed);
+						speedCount++;
+					}
+
+					speed1.speed = speed;
 					speed1.time = timeDiff;
 					speed1.distance = elevation1.distance;
 					speedData.add(speed1);


### PR DESCRIPTION
Most GPX tracks don't contain speed (GPX has no standard way of including it), but do include time for each point, so speed can be calculated.

Partly fixes #3702--ideally tracks where speed is calculated should be indicated slightly differently in the UI.

Includes a trivial refactor of this code too:

```java
          if (speed > 0) {
            totalSpeedSum += speed;
            maxSpeed = Math.max(speed, maxSpeed);
            speedCount++;

            speed1.speed = speed;
          } else {
            speed1.speed = 0;
          }
```

Since `speed1.speed` is always assigned to, it can be moved out of "if", and the "else" can be removed, because if `speed` is 0 then assigning `speed` to `speed1.speed` will have the desired effect. No need to explicitly assign 0.