### PR TITLE
Add "GPS Connected" app to GPS status app list.

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/actions/StartGPSStatus.java
+++ b/OsmAnd/src/net/osmand/plus/activities/actions/StartGPSStatus.java
@@ -31,6 +31,7 @@ import net.osmand.plus.views.OsmandMapTileView;
 public class StartGPSStatus extends OsmAndAction {
 
 	public enum GpsStatusApps {
+		GPC_CONNECTED("GPS Connected", "org.bruxo.gpsconnected", "", ""),
 		GPS_STATUS("GPS Status & Toolbox", "com.eclipsim.gpsstatus2", "", "com.eclipsim.gpsstatus2.GPSStatus"),
 		GPS_TEST("GPS Test", "com.chartcross.gpstest", "com.chartcross.gpstestplus", ""),
 		INVIU_GPS("inViu GPS-details ", "de.enaikoon.android.inviu.gpsdetails", "", ""),


### PR DESCRIPTION
It provides a replacement for the removed "sleep mode".
While the GPS status apps might be the obvious thing
to show here for new users, none of them being a replacement
for the previous functionality is annoying and confusing
to existing users.

Note: I don't have a working compilation setup to actually test this, sorry!