### PR TITLE
fix testTooManyCapitalLetters wrt unicameral scripts

### DIFF
--- a/OsmAnd/src/net/osmand/plus/osmedit/EditPoiDialogFragment.java
+++ b/OsmAnd/src/net/osmand/plus/osmedit/EditPoiDialogFragment.java
@@ -408,10 +408,10 @@ public class EditPoiDialogFragment extends BaseOsmAndDialogFragment {
 		for(int i = 0; i < name.length(); i++) {
 			char c = name.charAt(i);
 			if(Character.isLetter(c) || Character.getType(c) == Character.LETTER_NUMBER) {
-				if(Character.toUpperCase(c) != c && Character.toLowerCase(c) == c) {
-					lower ++;
-				} else {
+				if(Character.isUpperCase(c)) {
 					capital ++;
+				} else {
+					lower ++;
 				}
 			} else {
 				nonalpha ++;


### PR DESCRIPTION
In v2.6.3, Osmand would keep complaining about too many capital letters in a name when using any script that doesn't distinguish between upper- and lowercase such as the CJK family, Arabic, Thai/Lao etc.
This is because the `Character.toUpperCase(c) != c` test could never be true for those scripts so all characters were classified as uppercase. The builtin Character.isUpperCase() handles this correctly and is much clearer, too.