### PR TITLE
Optionally store recorded GPX tracks in monthly directories

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -9,6 +9,8 @@
          3. All your modified/created strings are in the top of the file (to make easier find what\'s translated).
     PLEASE: Have a look at http://code.google.com/p/osmand/wiki/UIConsistency, it may really improve your and our work  :-)  Thx - Hardy
     -->
+    <string name="store_tracks_in_monthly_directories">Store recorded tracks in monthly directories</string>
+    <string name="store_tracks_in_monthly_directories_descrp">Store recorded tracks in directories based on the month that the track was recorded in, for example 2017-01 for January 2017.</string>
     <string name="shared_string_reset">Reset</string>
     <string name="shared_string_reload">Reload</string>
     <string name="mapillary_menu_descr_tile_cache">Reload tiles to see up to date data.</string>

--- a/OsmAnd/src/net/osmand/plus/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/OsmandSettings.java
@@ -1028,6 +1028,8 @@ public class OsmandSettings {
 
 	public final CommonPreference<Boolean> DISABLE_RECORDING_ONCE_APP_KILLED = new BooleanPreference("disable_recording_once_app_killed", false).makeGlobal();
 
+	public final CommonPreference<Boolean> STORE_TRACKS_IN_MONTHLY_DIRECTORIES = new BooleanPreference("store_tracks_in_monthly_directories", false).makeGlobal();
+
 	// this value string is synchronized with settings_pref.xml preference name
 	public final OsmandPreference<Boolean> FAST_ROUTE_MODE = new BooleanPreference("fast_route_mode", true).makeProfile();
 	// temporarily for new version

--- a/OsmAnd/src/net/osmand/plus/activities/SavingTrackHelper.java
+++ b/OsmAnd/src/net/osmand/plus/activities/SavingTrackHelper.java
@@ -32,6 +32,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 
 public class SavingTrackHelper extends SQLiteOpenHelper {
 	
@@ -198,6 +199,20 @@ public class SavingTrackHelper extends SQLiteOpenHelper {
 					File fout = new File(dir, f + ".gpx"); //$NON-NLS-1$
 					if (!data.get(f).isEmpty()) {
 						WptPt pt = data.get(f).findPointToShow();
+
+						if (ctx.getSettings().STORE_TRACKS_IN_MONTHLY_DIRECTORIES.get()) {
+							SimpleDateFormat dateDirFormat = new SimpleDateFormat("yyyy-MM");
+							dateDirFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+							String dateDirName = dateDirFormat.format(new Date(pt.time));
+
+							File dateDir = new File(dir, dateDirName);
+							dateDir.mkdirs();
+
+							if (dateDir.exists()) {
+								dir = dateDir;
+							}
+						}
+
 						String fileName = f + "_" + new SimpleDateFormat("HH-mm_EEE", Locale.US).format(new Date(pt.time)); //$NON-NLS-1$
 						fout = new File(dir, fileName + ".gpx"); //$NON-NLS-1$
 						int ind = 1;

--- a/OsmAnd/src/net/osmand/plus/monitoring/SettingsMonitoringActivity.java
+++ b/OsmAnd/src/net/osmand/plus/monitoring/SettingsMonitoringActivity.java
@@ -118,6 +118,8 @@ public class SettingsMonitoringActivity extends SettingsBaseActivity {
 				R.string.auto_split_recording_descr));
 		cat.addPreference(createCheckBoxPreference(settings.DISABLE_RECORDING_ONCE_APP_KILLED, R.string.disable_recording_once_app_killed,
 				R.string.disable_recording_once_app_killed_descrp));
+		cat.addPreference(createCheckBoxPreference(settings.STORE_TRACKS_IN_MONTHLY_DIRECTORIES, R.string.store_tracks_in_monthly_directories,
+				R.string.store_tracks_in_monthly_directories_descrp));
 	}
 
 


### PR DESCRIPTION
I use OsmAnd's track recording extensively and have over 200 recorded tracks saved. Managing them is inconvenient as they are all displayed in a single, flat list.

With this feature, recorded GPX tracks can optionally be automatically stored in monthly directories. For example, GPX tracks recorded in July 2017 will be stored in rec/2017-07. This makes tracks much easier to
manage.