### PR TITLE
Add support for showing GPX tracks in pink

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -627,6 +627,7 @@
     <string name="rendering_value_translucent_blue_name">Translucent blue</string>
     <string name="rendering_value_purple_name">Purple</string>
     <string name="rendering_value_pink_name">Pink</string>
+    <string name="rendering_value_translucent_pink_name">Translucent pink</string>
     <string name="rendering_value_brown_name">Brown</string>
     <string name="rendering_value_translucent_purple_name">Translucent purple</string>
     <string name="restart_is_required">In order to fully apply the changes, a manual application restart is required.</string>


### PR DESCRIPTION
Pink is one of the least used colours on the map, making it a good choice for clearly showing GPX tracks. Pink was previously available in OsmAnd 2.5 but removed in 2.6.

**This requires the corresponding [OsmAnd-resources pull request](https://github.com/osmandapp/OsmAnd-resources/pull/443).**