### PR TITLE
Fix drawing splits for tracks with multiple segments

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/GPXLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/GPXLayer.java
@@ -278,22 +278,22 @@ public class GPXLayer extends OsmandMapLayer implements ContextMenuLayer.IContex
 			// request to load
 			for (SelectedGpxFile g : selectedGPXFiles) {
 				List<GpxDisplayGroup> groups = g.getDisplayGroups();
-				if (groups != null) {
-					for (GpxDisplayGroup group : groups) {
-						GpxDataItem gpxDataItem = view.getApplication().getGpxDatabase().getItem(new File(g.getGpxFile().path));
-						int color = gpxDataItem.getColor();
-						if (color == 0) {
-							color = g.getModifiableGpxFile().getColor(0);
-						}
-						if (color == 0) {
-							color = cachedColor;
-						}
-
-						paintInnerRect.setColor(color);
-						paintInnerRect.setAlpha(179);
-						List<GpxDisplayItem> items = group.getModifiableList();
-						drawSplitItems(canvas, tileBox, items, settings);
+				if (groups != null && !groups.isEmpty()) {
+					GpxDataItem gpxDataItem = view.getApplication().getGpxDatabase().getItem(new File(g.getGpxFile().path));
+					int color = gpxDataItem.getColor();
+					if (color == 0) {
+						color = g.getModifiableGpxFile().getColor(0);
 					}
+					if (color == 0) {
+						color = cachedColor;
+					}
+
+					paintInnerRect.setColor(color);
+					paintInnerRect.setAlpha(179);
+
+					List<GpxDisplayItem> items = groups.get(0).getModifiableList();
+
+					drawSplitItems(canvas, tileBox, items, settings);
 				}
 			}
 		}


### PR DESCRIPTION
Previously, if a track contained multiple segments, split distance/time markers were drawn for *each* segment, including the overview segment produced by OsmAnd.

This meant that many duplicate labels were shown, cluttering the display and making the split markers useless. For example, given a track with two segments of 6 km each, and a 1 km split interval, two 1 km markers are shown: one for the first segment and one for the second segment.

Now splits are only shown for the overview segment, making the display clear and usable.

Please merge this into r2.7 as well :)