### PR TITLE
Fix favorite import issues

### DIFF
--- a/OsmAnd/src/net/osmand/data/FavouritePoint.java
+++ b/OsmAnd/src/net/osmand/data/FavouritePoint.java
@@ -121,4 +121,26 @@ public class FavouritePoint implements Serializable, LocationPoint {
 		return "Favourite " + getName(); //$NON-NLS-1$
 	}
 
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+
+		if (!(o instanceof FavouritePoint)) return false;
+
+		FavouritePoint fp = (FavouritePoint)o;
+
+		return (this.latitude == fp.latitude)
+				   && (this.longitude == fp.longitude)
+				   && (this.name.equals(fp.name));
+	}
+
+	@Override
+	public int hashCode() {
+		int hash = (int)latitude*1000 + (int)longitude*1000;
+		hash += (name != null) ? name.hashCode() : 0;
+		return hash;
+	}
+
 }
+

--- a/OsmAnd/src/net/osmand/plus/helpers/GpxImportHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/GpxImportHelper.java
@@ -565,6 +565,7 @@ public class GpxImportHelper {
 				if (p.desc != null) {
 					fp.setDescription(p.desc);
 				}
+				fp.setColor(p.getColor(0));
 				favourites.add(fp);
 			}
 		}


### PR DESCRIPTION
When importing as favourites the color was not being passed through.
Override equals and hashcode in FavouritePoint to allow deleteFavourite to work correctly. This prevents duplicates if the same gpx file is imported more than once.