### PR TITLE
All 2xx responses as success in Online Tracking

### DIFF
--- a/OsmAnd/src/net/osmand/plus/monitoring/LiveMonitoringHelper.java
+++ b/OsmAnd/src/net/osmand/plus/monitoring/LiveMonitoringHelper.java
@@ -193,7 +193,7 @@ public class LiveMonitoringHelper  {
 
 			log.info("Monitor " + uri);
 
-			if (urlConnection.getResponseCode() != 200) {
+			if (urlConnection.getResponseCode()/100 != 2) {
 
 				String msg = urlConnection.getResponseCode() + " : " + //$NON-NLS-1$//$NON-NLS-2$
 						urlConnection.getResponseMessage();


### PR DESCRIPTION
Any http response code 2xx indicates success.

Actually we should expect that server replies with "201 Created" (check https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html for details) after storing proposed data point.

Alleviates #4472 

-----
I have not tried building OsmAnd with this change but it's pretty trivial and I expect it to work. Though pay attention, I don't know Java.