### PR TITLE
less greedy intent-filter for www.openstreetmap.org (fixes #4440)

### DIFF
--- a/OsmAnd/AndroidManifest.xml
+++ b/OsmAnd/AndroidManifest.xml
@@ -229,7 +229,9 @@
 				<data android:scheme="https" />
 				<data android:host="maps.yandex.ru" />
 				<data android:host="maps.yandex.com" />
-				<data android:host="www.openstreetmap.org" />
+				<data android:host="www.openstreetmap.org" android:path="/"/> <!-- catches /#map=... -->
+				<data android:host="www.openstreetmap.org" android:pathPrefix="/query"/>
+				<data android:host="www.openstreetmap.org" android:pathPrefix="/go"/>
 				<data android:host="openstreetmap.org" />
 				<data android:host="osm.org" />
 				<data android:host="map.baidu.cn" />


### PR DESCRIPTION
# Issue
OsmAnd currently offers to open any www.openstreetmap.org URL. This is incorrect, as OsmAnd can only make use of URLs that reference a geo point.

Also, registering an intent filter for all of openstreetmap breaks the OAuth process for other Android apps, trying to access www.openstreetmap.org/oauth. See #4440 for details.

# Solution
In [GeoPointParserUtil.java#L932ff](https://github.com/osmandapp/Osmand/blob/master/OsmAnd-java/src/net/osmand/util/GeoPointParserUtil.java#L932) I identified the following schemes which OsmAnd can parse a geo point from the URL (click for example URL):
[www.openstreetmap.org/#map=...](http://www.openstreetmap.org/#map=17/50.06644/19.93515&layers=C)
[www.openstreetmap.org/query?...](http://www.openstreetmap.org/query?lat=16.7108&lon=44.2676)
[www.openstreetmap.org/go/...](http://openstreetmap.org/go/0LQ127-?m)

All the three paths are now explicitly specified in the intent-filter. I.e., with this change, OsmAnd will not offer to open any of the following URLs
* [Node details](http://www.openstreetmap.org/node/2595324513)
* [User diaries](https://www.openstreetmap.org/diary)
* [Edit the map with iD](https://www.openstreetmap.org/edit?editor=id)
* [Registering as new user](https://www.openstreetmap.org/user/new)
* and any other part of the website, most importantly (for my purposes) login and oauth