### PR TITLE
Save recorded tracks to correct month directories

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/SavingTrackHelper.java
+++ b/OsmAnd/src/net/osmand/plus/activities/SavingTrackHelper.java
@@ -203,7 +203,6 @@ public class SavingTrackHelper extends SQLiteOpenHelper {
 						File targetDir = dir;
 						if (ctx.getSettings().STORE_TRACKS_IN_MONTHLY_DIRECTORIES.get()) {
 							SimpleDateFormat dateDirFormat = new SimpleDateFormat("yyyy-MM");
-							dateDirFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 							String dateDirName = dateDirFormat.format(new Date(pt.time));
 							File dateDir = new File(dir, dateDirName);
 							dateDir.mkdirs();


### PR DESCRIPTION
(Fixes the other part of #4895 not fixed in de4d697)

When a setting is enabled, OsmAnd saves recorded tracks to monthly directories. For example, all tracks recorded in January 2018 are saved to a directory named 2018-01, tracks recorded in February 2018 are saved to 2018-02, and so on.

Previously, the UTC time of the first track point was to determine the monthly directory to use, but the local time of the first track point was used to determine the track filename.

This meant that if OsmAnd was running on a device with a time zone ahead of UTC, at the start of a month, a track could be saved in the previous month's directory, but with the new month in the filename, causing confusion.

For example, suppose OsmAnd is running on a phone whose time zone is set to UTC+0300. A user starts recording a track at 0100 local time on 1st January 2018. When the user saves the track, OsmAnd uses the UTC time of the track's first point, which is 0100 local but 2200 UTC on the previous day, so the track is incorrectly placed in the 2017-12 directory. The track filename is based on local time, so it is correct, but it's confusing to have a 2018-01... track in the 2017-12 directory.