### PR TITLE
Changed nmi/h to kn

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -852,7 +852,7 @@
     <string name="si_min_km">Minutes per kilometer</string>
     <string name="si_min_m">Minutes per mile</string>
     <string name="si_nm_h">Nautical miles per hour (knots)</string>
-    <string name="nm_h">nmi/h</string>
+    <string name="nm_h">kn</string>
     <string name="min_mile">min/m</string>
     <string name="min_km">min/km</string>
     <string name="m_s">m/s</string>


### PR DESCRIPTION
"Knots" sounds more naturally to those who use nautical miles. "Kn" is the ISO standard for the short form (ISO 80000-3).