### PR TITLE
Fix #5358: Do not intercept media button

### DIFF
--- a/OsmAnd/AndroidManifest.xml
+++ b/OsmAnd/AndroidManifest.xml
@@ -172,7 +172,7 @@
 		<receiver android:name="net.osmand.plus.audionotes.MediaRemoteControlReceiver">
 			<intent-filter>
 				<action android:name="android.intent.action.CAMERA_BUTTON" />
-				<action android:name="android.intent.action.MEDIA_BUTTON" />
+				<!-- <action android:name="android.intent.action.MEDIA_BUTTON" /> -->
 			</intent-filter>
 		</receiver>
 


### PR DESCRIPTION
Currently Osmand intercepts media button and then ignores it. This change allows a music player to keep the media button focus.

I'm commenting out the MEDIA_BUTTON as there is bunch of commented out code in the listener class. We may want to simply delete the code, but that is for another pull request.