### PR TITLE
added initial .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: android
+
+android:
+  components:
+    - tools
+    - platform-tools
+
+    # The BuildTools version used by your project
+    - build-tools-27.0.3
+    - android-27
+
+script: ./gradlew test


### PR DESCRIPTION
Show failure of `./gradlew test`, see https://travis-ci.org/krichter722/Osmand/builds/386720192 for details. If there's another CI already been used it doesn't detect these issues or you're allowing commits which break the build on master.

I'm not familiar with Osmand and with Android on Travis CI, so feel free to suggest better Gradle targets and more test commands. The installation(s) should be tested as well.