### PR TITLE
Added explicit Java source encoding

### DIFF
--- a/OsmAnd-java/build.gradle
+++ b/OsmAnd-java/build.gradle
@@ -8,6 +8,7 @@ configurations {
 tasks.withType(JavaCompile) {
 	sourceCompatibility = "1.7"
 	targetCompatibility = "1.7"
+	options.encoding = 'UTF-8'
 }
 
 task collectRoutingResources(type: Sync) {


### PR DESCRIPTION
At my PC java compiler use codepage CP1251 by default and fails to compile file OsmAnd-java/src/main/java/net/osmand/data/MapObject.java because in line 26 because there are some unicode symbols.
To fix compilation errors I've added UTF8 encoding configuration to Osmand-java/build.gradle file