### PR TITLE
Add name element to track and route when saving gpx-files

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/MapActivityActions.java
+++ b/OsmAnd/src/net/osmand/plus/activities/MapActivityActions.java
@@ -74,6 +74,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import static net.osmand.plus.helpers.ImportHelper.GPX_SUFFIX;
+
 public class MapActivityActions implements DialogProvider {
 	private static final Log LOG = PlatformUtil.getLog(MapActivityActions.class);
 	public static final String KEY_LONGITUDE = "longitude";
@@ -226,8 +228,8 @@ public class MapActivityActions implements DialogProvider {
 				fileDir.mkdirs();
 				File toSave = fileDir;
 				if (name.length() > 0) {
-					if (!name.endsWith(".gpx")) {
-						name += ".gpx";
+					if (!name.endsWith(GPX_SUFFIX)) {
+						name += GPX_SUFFIX;
 					}
 					toSave = new File(fileDir, name);
 				}
@@ -263,7 +265,8 @@ public class MapActivityActions implements DialogProvider {
 		protected String doInBackground(File... params) {
 			if (params.length > 0) {
 				File file = params[0];
-				GPXFile gpx = app.getRoutingHelper().generateGPXFileWithRoute();
+				String fileName = file.getName();
+				GPXFile gpx = app.getRoutingHelper().generateGPXFileWithRoute(fileName.substring(0,fileName.length()-GPX_SUFFIX.length()));
 				GPXUtilities.writeGpxFile(file, gpx, app);
 				return app.getString(R.string.route_successfully_saved_at, file.getName());
 			}

--- a/OsmAnd/src/net/osmand/plus/activities/ShowRouteInfoDialogFragment.java
+++ b/OsmAnd/src/net/osmand/plus/activities/ShowRouteInfoDialogFragment.java
@@ -65,8 +65,11 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 import static net.osmand.binary.RouteDataObject.HEIGHT_UNDEFINED;
 
@@ -439,7 +442,8 @@ public class ShowRouteInfoDialogFragment extends DialogFragment {
 		shareRoute.setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				final GPXFile gpx = helper.generateGPXFileWithRoute();
+				final String trackName = new SimpleDateFormat("yyyy-MM-dd_HH-mm_EEE", Locale.US).format(new Date());
+				final GPXFile gpx = helper.generateGPXFileWithRoute(trackName);
 				final Uri fileUri = AndroidUtils.getUriForFile(getMyApplication(), new File(gpx.path));
 				File dir = new File(getActivity().getCacheDir(), "share");
 				if (!dir.exists()) {

--- a/OsmAnd/src/net/osmand/plus/measurementtool/MeasurementToolFragment.java
+++ b/OsmAnd/src/net/osmand/plus/measurementtool/MeasurementToolFragment.java
@@ -1212,6 +1212,7 @@ public class MeasurementToolFragment extends BaseOsmAndFragment {
 				TrkSegment after = editingCtx.getAfterTrkSegmentLine();
 				if (gpx == null) {
 					toSave = new File(dir, fileName);
+					String trackName = fileName.substring(0,fileName.length()-GPX_SUFFIX.length());
 					GPXFile gpx = new GPXFile();
 					if (measurementLayer != null) {
 						if (saveType == SaveType.LINE) {
@@ -1223,6 +1224,7 @@ public class MeasurementToolFragment extends BaseOsmAndFragment {
 								segment.points.addAll(points);
 							}
 							Track track = new Track();
+							track.name = trackName;
 							track.segments.add(segment);
 							gpx.tracks.add(track);
 						} else if (saveType == SaveType.ROUTE_POINT) {
@@ -1231,10 +1233,12 @@ public class MeasurementToolFragment extends BaseOsmAndFragment {
 								segment.points.addAll(before.points);
 								segment.points.addAll(after.points);
 								Track track = new Track();
+								track.name = trackName;
 								track.segments.add(segment);
 								gpx.tracks.add(track);
 							}
 							Route rt = new Route();
+							rt.name = trackName;
 							gpx.routes.add(rt);
 							rt.points.addAll(points);
 						}

--- a/OsmAnd/src/net/osmand/plus/routing/RouteProvider.java
+++ b/OsmAnd/src/net/osmand/plus/routing/RouteProvider.java
@@ -1005,7 +1005,7 @@ public class RouteProvider {
 		return directions;
 	}
 
-	public GPXFile createOsmandRouterGPX(RouteCalculationResult srcRoute, OsmandApplication ctx) {	
+	public GPXFile createOsmandRouterGPX(RouteCalculationResult srcRoute, OsmandApplication ctx, String name) {
 		TargetPointsHelper helper = ctx.getTargetPointsHelper();
 		int currentRoute = srcRoute.currentRoute;
 		List<Location> routeNodes = srcRoute.getImmutableAllLocations();
@@ -1015,6 +1015,7 @@ public class RouteProvider {
 		GPXFile gpx = new GPXFile();
 		gpx.author = OSMAND_ROUTER;
 		Track track = new Track();
+		track.name = name;
 		gpx.tracks.add(track);
 		TrkSegment trkSegment = new TrkSegment();
 		track.segments.add(trkSegment);
@@ -1055,6 +1056,7 @@ public class RouteProvider {
 		}
 
 		Route route = new Route();
+		route.name = name;
 		gpx.routes.add(route);
 		for (int i = cDirInfo; i < directionInfo.size(); i++) {
 			RouteDirectionInfo dirInfo = directionInfo.get(i);

--- a/OsmAnd/src/net/osmand/plus/routing/RoutingHelper.java
+++ b/OsmAnd/src/net/osmand/plus/routing/RoutingHelper.java
@@ -1080,8 +1080,8 @@ public class RoutingHelper {
 		return route;
 	}
 
-	public GPXFile generateGPXFileWithRoute(){
-		return provider.createOsmandRouterGPX(route, app);
+	public GPXFile generateGPXFileWithRoute(String name){
+		return provider.createOsmandRouterGPX(route, app, name);
 	}
 
 


### PR DESCRIPTION
When saving the current route as new gpx-file the containing track and route-elements do not have a name-element. That might cause trouble when opening the gpx-file with other soft- or hardware (e.g. a Garmin eTrex-device will ignore the filename of the gpx-file and list the track as empty string).

This pull request does:
- set the name-element of track and route to the filename entered (without the '.gpx' suffix) when saving the current route as new gpx-file.
- As when sharing the current route no filename is given (it defaults to 'route.gpx') the track within the shared gpx-file gets a name created from the current timestamp.
- When saving a route being newly created with the measurment-tool the entered filename is also being used as track-name.
