### PR TITLE
Fix for #6002, number of tracks from disk on dashboard limited to 3

### DIFF
--- a/OsmAnd/src/net/osmand/plus/monitoring/DashTrackFragment.java
+++ b/OsmAnd/src/net/osmand/plus/monitoring/DashTrackFragment.java
@@ -111,7 +111,9 @@ public class DashTrackFragment extends DashBaseFragment {
 				}
 			}
 		}
-		int totalCount = 3 + list.size() / 2;
+		// 10 is the maximum length of the list. The actual length is determined later by
+		// DashboardOnMap.handleNumberOfRows()
+		int totalCount = 10;
 		if(app.getSettings().SAVE_GLOBAL_TRACK_TO_GPX.get()) {
 			totalCount --;
 		}


### PR DESCRIPTION
Set the totalCount to 10 as this is the max number of rows available in settings.
The actual list is limited to the value defined in settings by DashboardOnMap.handleNumberOfRows.