### PR TITLE
Bump dependencies and update README badges

### DIFF
--- a/OsmAnd-java/build.gradle
+++ b/OsmAnd-java/build.gradle
@@ -6,8 +6,8 @@ configurations {
 }
 
 tasks.withType(JavaCompile) {
-	sourceCompatibility = "1.7"
-	targetCompatibility = "1.7"
+	sourceCompatibility = "1.8"
+	targetCompatibility = "1.8"
 	options.encoding = 'UTF-8'
 }
 
@@ -79,19 +79,19 @@ artifacts {
 
 
 dependencies {
-	testImplementation 'junit:junit:4.12'
-	testImplementation 'com.google.code.gson:gson:2.8.2'
+	testImplementation 'junit:junit:4.13-beta-1'
+	testImplementation 'com.google.code.gson:gson:2.8.5'
 	testImplementation 'org.hamcrest:hamcrest-core:1.3'
 
 	implementation group: 'commons-logging', name: 'commons-logging', version: '1.2'
-	implementation group: 'org.json', name: 'json', version: '20171018' 
-	implementation 'it.unibo.alice.tuprolog:tuprolog:3.2.1'
+	implementation group: 'org.json', name: 'json', version: '20180813' 
+	implementation 'it.unibo.alice.tuprolog:tuprolog:3.3.0'
 	implementation 'org.beanshell:bsh-core:2.0b4'
-	implementation 'org.apache.commons:commons-compress:1.17'
+	implementation 'org.apache.commons:commons-compress:1.18'
 	implementation 'com.moparisthebest:junidecode:0.1.1'
 	implementation 'com.vividsolutions:jts-core:1.14.0'
 
-	implementation 'net.sf.kxml:kxml2:2.1.8'
+	implementation 'net.sf.kxml:kxml2:2.3.0'
 	
 
 	implementation fileTree(dir: "libs", include: ["*.jar"])

--- a/OsmAnd-telegram/build.gradle
+++ b/OsmAnd-telegram/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
 	compileSdkVersion 28
-	buildToolsVersion "27.0.3"
+	buildToolsVersion "28.0.3"
 
 	sourceSets {
 		main {
@@ -23,7 +23,7 @@ android {
 	defaultConfig {
 		applicationId "net.osmand.telegram"
 		minSdkVersion 15
-		targetSdkVersion 27
+		targetSdkVersion 28
 		versionCode 1
 		versionCode System.getenv("APK_NUMBER_VERSION") ? System.getenv("APK_NUMBER_VERSION").toInteger() : versionCode
 		versionName "1.0"
@@ -135,15 +135,16 @@ dependencies {
 	implementation project(path: ':OsmAnd-java', configuration: 'android')
 	implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-	implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-	implementation 'com.android.support:appcompat-v7:28.0.0-rc01'
-	implementation 'com.android.support:design:28.0.0-rc01'
-	implementation 'com.android.support:customtabs:28.0.0-rc01'
-	implementation 'com.android.support:support-annotations:28.0.0-rc01'
+	implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+	implementation 'com.android.support:appcompat-v7:28.0.0'
+	implementation 'com.android.support:recyclerview-v7:28.0.0'
+	implementation 'com.android.support:design:28.0.0'
+	implementation 'com.android.support:customtabs:28.0.0'
+	implementation 'com.android.support:support-annotations:28.0.0'
+
 	implementation 'commons-logging:commons-logging-api:1.1'
-	implementation 'com.android.support:recyclerview-v7:28.0.0-rc01'
 	implementation 'com.vividsolutions:jts-core:1.14.0'
-	implementation("com.github.HITGIF:TextFieldBoxes:1.4.4") {
+	implementation('com.github.HITGIF:TextFieldBoxes:1.4.4', {
 		exclude group: 'com.android.support'
-	}
+	})
 }

--- a/OsmAnd/build.gradle
+++ b/OsmAnd/build.gradle
@@ -29,8 +29,8 @@ task printc {
 }
 
 android {
-	compileSdkVersion 27
-	buildToolsVersion "27.0.3"
+	compileSdkVersion 28
+	buildToolsVersion "28.0.3"
 
 	signingConfigs {
 		development {
@@ -49,15 +49,15 @@ android {
 	}
 
 	defaultConfig {
-		minSdkVersion System.getenv("MIN_SDK_VERSION") ? System.getenv("MIN_SDK_VERSION").toInteger() :
-				 (analytics ? 15 : 14)
-		targetSdkVersion 26
+		applicationId "net.osmand"
+		minSdkVersion System.getenv("MIN_SDK_VERSION") ? System.getenv("MIN_SDK_VERSION").toInteger() : (analytics ? 15 : 14)
+		targetSdkVersion 28
 		versionCode 330
 		versionCode System.getenv("APK_NUMBER_VERSION") ? System.getenv("APK_NUMBER_VERSION").toInteger() : versionCode
-		multiDexEnabled true
 		versionName "3.3.0"
 		versionName System.getenv("APK_VERSION")? System.getenv("APK_VERSION").toString(): versionName
 		versionName System.getenv("APK_VERSION_SUFFIX")? versionName + System.getenv("APK_VERSION_SUFFIX").toString(): versionName
+		multiDexEnabled true
 	}
 
 	lintOptions {
@@ -138,29 +138,27 @@ android {
 		// Version
 		freedev {
 			dimension "version"
-			applicationId "net.osmand.dev"
+			applicationIdSuffix ".dev"
 			// resConfig "en"
 		}
 		free {
 			dimension "version"
-			applicationId "net.osmand"
 		}
 		freeres {
 			dimension "version"
-			applicationId "net.osmand"
 			resConfig "en"
 		}
 		freecustom {
 			dimension "version"
-			applicationId "net.osmand.freecustom"
+			applicationIdSuffix ".freecustom"
 		}
 		full {
 			dimension "version"
-			applicationId "net.osmand.plus"
+			applicationIdSuffix ".plus"
 		}
         fulldev {
             dimension "version"
-            applicationId "net.osmand.plus"
+            applicationIdSuffix ".plus"
             resConfig "en"
             //resConfigs "xxhdpi", "nodpi"
         }
@@ -366,32 +364,35 @@ dependencies {
 		implementation 'com.google.firebase:firebase-messaging:12.0.1'
 		implementation 'com.google.firebase:firebase-iid:12.0.1'
 		implementation 'com.google.firebase:firebase-config:12.0.1'
-		implementation 'com.facebook.android:facebook-android-sdk:4.31.0'	
+		implementation 'com.facebook.android:facebook-android-sdk:4.39.0'	
 	}
-	implementation 'com.android.support:multidex:1.0.1'
-	implementation 'com.android.support:gridlayout-v7:27.1.1'
-	implementation 'com.android.support:cardview-v7:27.1.1'
-	implementation 'com.android.support:appcompat-v7:27.1.1'
-	implementation 'com.android.support:design:27.1.1'
-	implementation 'com.android.support:customtabs:27.1.1'
+	implementation 'com.android.support:multidex:1.0.3'
+	implementation 'com.android.support:gridlayout-v7:28.0.0'
+	implementation 'com.android.support:cardview-v7:28.0.0'
+	implementation 'com.android.support:appcompat-v7:28.0.0'
+	implementation 'com.android.support:design:28.0.0'
+	implementation 'com.android.support:customtabs:28.0.0'
 	implementation fileTree(include:  ['gnu-trove-osmand.jar', 'icu4j-49_1_patched.jar'], dir: 'libs')
 
 	implementation group: 'commons-logging', name: 'commons-logging', version: '1.2'
 	implementation 'commons-codec:commons-codec:1.11'
-	implementation 'it.unibo.alice.tuprolog:tuprolog:3.2.1'
+	implementation 'it.unibo.alice.tuprolog:tuprolog:3.3.0'
 	implementation 'org.beanshell:bsh-core:2.0b4'
-	implementation 'org.apache.commons:commons-compress:1.17'
+	implementation 'org.apache.commons:commons-compress:1.18'
 	implementation 'com.moparisthebest:junidecode:0.1.1'
-	implementation 'org.immutables:gson:2.5.0'
+	implementation 'org.immutables:gson:2.7.4'
 	implementation 'com.vividsolutions:jts-core:1.14.0'
 
 	implementation 'com.squareup.picasso:picasso:2.71828'
+	//implementation 'com.squareup.picasso3:picasso:3.0.0-SNAPSHOT'
+
 	// JS core
-	implementation group: 'org.mozilla', name: 'rhino', version: '1.7.9'
+	implementation group: 'org.mozilla', name: 'rhino', version: '1.7.10'
 
 // size restrictions
-// implementation 'com.ibm.icu:icu4j:50.1' 
-// implementation 'net.sf.trove4j:trove4j:3.0.3'
+// implementation 'com.ibm.icu:icu4j:63.1'
+// implementation 'net.sf.trove4j:core:3.1.0'
+
 
 	qtcoreImplementation fileTree(include:  ['QtAndroid.jar', 'QtAndroidBearer.jar'], dir: 'libs')
 	qtcoredebugImplementation fileTree(include:  ['QtAndroid.jar', 'QtAndroidBearer.jar'], dir: 'libs')
@@ -401,13 +402,14 @@ dependencies {
 	qtcoredebugImplementation "net.osmand:OsmAndCore_android:0.1-SNAPSHOT@aar"
 	qtcoreImplementation "net.osmand:OsmAndCore_androidNativeRelease:0.1-SNAPSHOT@aar"
 	qtcoreImplementation "net.osmand:OsmAndCore_android:0.1-SNAPSHOT@aar"
-	implementation ("com.getkeepsafe.taptargetview:taptargetview:1.12.0"){
+
+	implementation ('com.getkeepsafe.taptargetview:taptargetview:1.12.0', {
 		exclude group: 'com.android.support'
-	}
-	implementation 'com.github.PhilJay:MPAndroidChart:v3.0.1'
-	implementation ("com.github.HITGIF:TextFieldBoxes:1.3.5"){
+	})
+	implementation 'com.github.PhilJay:MPAndroidChart:v3.0.3'
+	implementation ('com.github.HITGIF:TextFieldBoxes:1.4.4', {
 		exclude group: 'com.android.support'
-	}
+	})
 }
 if(analytics) {
 	println "Apply GMS plugin"

--- a/OsmAndCore-sample/build.gradle
+++ b/OsmAndCore-sample/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     dexOptions {
         jumboMode true
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         multiDexEnabled true
@@ -122,8 +122,8 @@ repositories {
 dependencies {
     implementation project(path: ':OsmAnd-java', configuration: 'android')
     implementation 'com.android.support:multidex:1.0.3'
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support:design:27.1.1'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
     implementation 'commons-logging:commons-logging-api:1.1'
     implementation 'com.moparisthebest:junidecode:0.1.1'
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,25 @@
 OsmAnd (OSM Automated Navigation Directions)
 ------------
-This project aims at providing comfortable map viewing and navigation (routing) application for mobile devices. Particular stress lies with complete offline features (via pre-loaded offline map data) or economic internet usage.
-To get started, continue with the basic description below, then find more detail on our Welcome Wiki Pages, the Project Homepage, or the OpenStreetMap OsmAnd Wiki Page.
-You are welcome to discuss any question regarding the project at the Google group OsmAnd. Please do not use comments on wiki pages because it is rather difficult to find them.
+This project aims at providing a comfortable map viewing and navigation (routing) application for mobile devices. Particular stress lies with completely offline features (via pre-loaded offline map data) or economic internet usage.
+To get started, continue with the basic description below, then find more details on our Welcome Wiki Pages, the Project Homepage, or the OpenStreetMap OsmAnd Wiki Page.
+You are welcome to discuss any question regarding the project at the OsmAnd Google group. Please do not use comments on wiki pages, because it is rather difficult to find them.
 
-<a href="https://play.google.com/store/apps/details?id=net.osmand" target="_blank">
-<img src="https://raw.githubusercontent.com/osmandapp/osmandapp.github.io/9fc59e5136b6a07045eb96d052b3ce6ddde805c3/website/images/help/badge_store_google_play.png" alt="Get it on Google Play" height="60"/></a>
-<a href="https://www.amazon.com/OsmAnd-Maps-Navigation/dp/B00D0SA8I8" target="_blank">
-<img src="https://raw.githubusercontent.com/osmandapp/osmandapp.github.io/9fc59e5136b6a07045eb96d052b3ce6ddde805c3/website/images/help/badge_store_amazon.png" alt="Get it on Amazon" height="60"/></a>
-<a href="https://itunes.apple.com/app/apple-store/id934850257?mt=8" target="_blank">
-<img src="https://raw.githubusercontent.com/osmandapp/osmandapp.github.io/9fc59e5136b6a07045eb96d052b3ce6ddde805c3/website/images/help/badge_store_appstore.png" alt="Get it on AppStore" height="60"/></a>
-
+<a href="https://play.google.com/store/apps/details?id=net.osmand">
+    <img src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png"
+         alt="Get it on Google Play" height="60">
+</a>
+<a href="https://www.amazon.com/OsmAnd-Maps-Navigation/dp/B00D0SA8I8">
+    <img src="https://images-na.ssl-images-amazon.com/images/G/01/mobile-apps/devportal2/res/images/amazon-appstore-badge-english-black.png"
+         alt="Get it on Amazon" height="60">
+</a>
+<a href="https://itunes.apple.com/app/apple-store/id934850257">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/3c/Download_on_the_App_Store_Badge.svg/1280px-Download_on_the_App_Store_Badge.svg.png"
+         alt="Get it on the App Store" height="60">
+</a>
 
 Functionality
 -------------
-**OsmAnd (OSM Automated Navigation Directions)** is a map and navigation application with access to the free, worldwide, and high-quality OpenStreetMap (OSM) data. All map data can be stored on your device's memory card for offline use. Via your device's GPS, OsmAnd offers routing, with optical and voice guidance, for car, bike, and pedestrian. All the main functionalities work both online and offline (no internet needed).
+**OsmAnd (OSM Automated Navigation Directions)** is a map and navigation application with access to the free, worldwide, and high-quality OpenStreetMap (OSM) data. All map data can be stored on your device's memory card for offline use. Via your device's GPS, OsmAnd offers routing (with optical and voice guidance) for car, bike, and pedestrian. All the main functionalities work both online and offline (no internet needed).
 
 ## Some of the main features:
 
@@ -83,5 +88,27 @@ OsmAnd is open source and actively being developed. Everyone can contribute to t
 | Africa         | ++   |
 
 ##### List of countries supported
-Basically world wide: Afghanistan, Albania, Algeria, Andorra, Angola, Anguilla, Antigua and Barbuda, Argentina, Armenia, Aruba, Australia, Austria, Azerbaijan, Bahamas, Bahrain, Bangladesh, Barbados, Belarus, Belgium, Belize, Benin, Bermuda, Bhutan, Bolivia, Bonaire, Bosnia and Herzegovina, Botswana, Brazil, British Virgin Islands, Brunei, Bulgaria, Burkina Faso, Burundi, Cambodia, Cameroon, Canada, Cape Verde, Central African Republic, Chad, Chile, China, Colombia, Comoros, Congo, Costa Rica, Croatia, Cuba, Curaçao, Cyprus, Czechia, Denmark, Djibouti, Dominica, Dominican Republic, Ecuador, Egypt, El Salvador, Equatorial Guinea, Eritrea, Estonia, Ethiopia, Fiji, Finland, France, French Guiana, French Polynesia, Gabon, Gambia, Georgia, Germany, Ghana, Gibraltar, Greece, Greenland, Grenada, Guadeloupe, Guam, Guatemala, Guernsey, Guinea, Guinea-Bissau, Guyana, Haiti, Vatican, Honduras, Hong Kong, Hungary, Iceland, India, Indonesia, Iran, Iraq, Ireland, Isle of Man, Israel, Italy, Ivory Coast, Jamaica, Japan, Jersey, Jordan, Kazakhstan, Kenya, Kiribati, North Korea and South Korea, Kuwait, Kyrgyzstan, Laos, Latvia, Lebanon, Lesotho, Liberia, Libya, Liechtenstein, Lithuania, Luxembourg, Macao, Macedonia, Madagascar, Malawi, Malaysia, Maldives, Mali, Malta, Martinique, Mauritania, Mauritius, Mayotte, Mexico, Micronesia, Moldova, Monaco, Mongolia, Montenegro, Montserrat, Morocco, Mozambique, Myanmar, Namibia, Nauru, Nepal, Netherlands, Netherlands Antilles, New Caledonia, New Zealand, Nicaragua, Niger, Nigeria, Norway, Oman, Pakistan, Palau, Palestinian Territory, Panama, Papua New Guinea, Paraguay, Peru, Philippines, Poland, Portugal, Puerto Rico, Qatar, Romania, Russia, Rwanda, Saint Barthelemy, Saint Helena, Saint Kitts and Nevis, Saint Lucia, Saint Martin, Saint Pierre and Miquelon, Saint Vincent and the Grenadines, Samoa, San Marino, Saudi Arabia, Senegal, Serbia, Seychelles, Sierra Leone, Singapore, Slovakia, Slovenia, Somalia, South Africa, South Georgia, South Sudan, Spain, Sri Lanka, Sudan, Suriname, Swaziland, Sweden, Switzerland, Syria, Taiwan, Tajikistan, Tanzania, Thailand, Timor-Leste, Togo, Tokelau, Tonga, Trinidad and Tobago, Tunisia, Turkey, Turkmenistan, Tuvalu, Uganda, Ukraine, United Arab Emirates, United Kingdom (UK), United States of America (USA), Uruguay, Uzbekistan, Vanuatu, Venezuela, Vietnam, Wallis and Futuna, Western Sahara, Yemen, Zambia, Zimbabwe.
+Basically world wide: Afghanistan, Albania, Algeria, Andorra, Angola, Anguilla, Antigua and Barbuda, Argentina,
+Armenia, Aruba, Australia, Austria, Azerbaijan, Bahamas, Bahrain, Bangladesh, Barbados, Belarus, Belgium, Belize,
+Benin, Bermuda, Bhutan, Bolivia, Bonaire, Bosnia and Herzegovina, Botswana, Brazil, British Virgin Islands,
+Brunei, Bulgaria, Burkina Faso, Burundi, Cambodia, Cameroon, Canada, Cape Verde, Central African Republic,
+Chad, Chile, China, Colombia, Comoros, Congo, Costa Rica, Croatia, Cuba, Curaçao, Cyprus, Czechia, Denmark,
+Djibouti, Dominica, Dominican Republic, Ecuador, Egypt, El Salvador, Equatorial Guinea, Eritrea, Estonia,
+Ethiopia, Fiji, Finland, France, French Guiana, French Polynesia, Gabon, Gambia, Georgia, Germany, Ghana,
+Gibraltar, Greece, Greenland, Grenada, Guadeloupe, Guam, Guatemala, Guernsey, Guinea, Guinea-Bissau, Guyana,
+Haiti, Vatican, Honduras, Hong Kong, Hungary, Iceland, India, Indonesia, Iran, Iraq, Ireland, Isle of Man,
+Israel, Italy, Ivory Coast, Jamaica, Japan, Jersey, Jordan, Kazakhstan, Kenya, Kiribati, North Korea and South Korea,
+Kuwait, Kyrgyzstan, Laos, Latvia, Lebanon, Lesotho, Liberia, Libya, Liechtenstein, Lithuania, Luxembourg,
+Macao, Macedonia, Madagascar, Malawi, Malaysia, Maldives, Mali, Malta, Martinique, Mauritania, Mauritius,
+Mayotte, Mexico, Micronesia, Moldova, Monaco, Mongolia, Montenegro, Montserrat, Morocco, Mozambique, Myanmar,
+Namibia, Nauru, Nepal, Netherlands, Netherlands Antilles, New Caledonia, New Zealand, Nicaragua, Niger,
+Nigeria, Norway, Oman, Pakistan, Palau, Palestinian Territory, Panama, Papua New Guinea, Paraguay, Peru,
+Philippines, Poland, Portugal, Puerto Rico, Qatar, Romania, Russia, Rwanda, Saint Barthelemy, Saint Helena,
+Saint Kitts and Nevis, Saint Lucia, Saint Martin, Saint Pierre and Miquelon, Saint Vincent and the Grenadines,
+Samoa, San Marino, Saudi Arabia, Senegal, Serbia, Seychelles, Sierra Leone, Singapore, Slovakia, Slovenia,
+Somalia, South Africa, South Georgia, South Sudan, Spain, Sri Lanka, Sudan, Suriname, Swaziland, Sweden,
+Switzerland, Syria, Taiwan, Tajikistan, Tanzania, Thailand, Timor-Leste, Togo, Tokelau, Tonga, Trinidad and Tobago,
+Tunisia, Turkey, Turkmenistan, Tuvalu, Uganda, Ukraine, United Arab Emirates, United Kingdom (UK),
+United States of America (USA), Uruguay, Uzbekistan, Vanuatu, Venezuela, Vietnam, Wallis and Futuna,
+Western Sahara, Yemen, Zambia, Zimbabwe.
 </p>

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        //classpath 'com.android.tools.build:gradle:2.+'
         classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.google.gms:google-services:3.0.0'
+        classpath 'com.google.gms:google-services:3.0.0' //4.2.0
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -26,8 +25,10 @@ allprojects {
         google()
         mavenCentral()
         jcenter()
-        maven {
-            url "https://jitpack.io"
-        }
+        maven { url "https://jitpack.io" }
     }
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Thu Sep 15 09:42:47 MSK 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip

--- a/plugins/Osmand-Nautical/AndroidManifest.xml
+++ b/plugins/Osmand-Nautical/AndroidManifest.xml
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="net.osmand.nauticalPlugin"
-    android:installLocation="auto"
-    android:versionCode="9"
-    android:versionName="1.0" >
+    android:installLocation="auto">
 
-    <uses-sdk android:targetSdkVersion="16" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
 	<supports-screens  android:resizeable="true" android:smallScreens="true" android:normalScreens="true" android:largeScreens="true" 
 	    android:xlargeScreens="true" android:anyDensity="true" />

--- a/plugins/Osmand-Nautical/build.gradle
+++ b/plugins/Osmand-Nautical/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-	compileSdkVersion 27
-	buildToolsVersion "27.0.3"
+	compileSdkVersion 28
+	buildToolsVersion "28.0.3"
 
 	signingConfigs {
 		development {
@@ -20,8 +20,11 @@ android {
 	}
 
 	defaultConfig {
+		applicationId "net.osmand.nauticalPlugin"
 		minSdkVersion 15
-		targetSdkVersion 27
+		targetSdkVersion 28
+		versionCode 9
+		versionName "1.0"
 	}
 
 	lintOptions {
@@ -69,8 +72,8 @@ dependencies {
 		implementation 'com.google.firebase:firebase-core:12.0.1'
 		implementation 'com.google.firebase:firebase-config:12.0.1'
 	}
-	implementation 'com.android.support:appcompat-v7:27.1.1'
-	implementation 'com.android.support:design:27.1.1'
+	implementation 'com.android.support:appcompat-v7:28.0.0'
+	implementation 'com.android.support:design:28.0.0'
 }
 
 if (analytics) {

--- a/plugins/Osmand-ParkingPlugin/AndroidManifest.xml
+++ b/plugins/Osmand-ParkingPlugin/AndroidManifest.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="net.osmand.parkingPlugin"
-    android:versionCode="9"
-    android:versionName="1.0" >
+    package="net.osmand.parkingPlugin">
 
-    <uses-sdk android:targetSdkVersion="16" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
 	<supports-screens  android:resizeable="true" android:smallScreens="true" android:normalScreens="true" android:largeScreens="true" 
 	    android:xlargeScreens="true" android:anyDensity="true" />

--- a/plugins/Osmand-ParkingPlugin/build.gradle
+++ b/plugins/Osmand-ParkingPlugin/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-	compileSdkVersion 27
-	buildToolsVersion "27.0.3"
+	compileSdkVersion 28
+	buildToolsVersion "28.0.3"
 
 	signingConfigs {
 		development {
@@ -21,8 +21,11 @@ android {
 	}
 
 	defaultConfig {
+		applicationId "net.osmand.parkingPlugin"
 		minSdkVersion 15
-		targetSdkVersion 27
+		targetSdkVersion 28
+		versionCode 9
+		versionName "1.0"
 	}
 
 	lintOptions {
@@ -69,8 +72,8 @@ dependencies {
 		implementation 'com.google.firebase:firebase-core:12.0.1'
 		implementation 'com.google.firebase:firebase-config:12.0.1'
 	}
-	implementation 'com.android.support:appcompat-v7:27.1.1'
-	implementation 'com.android.support:design:27.1.1'
+	implementation 'com.android.support:appcompat-v7:28.0.0'
+	implementation 'com.android.support:design:28.0.0'
 }
 
 if (analytics) {

--- a/plugins/Osmand-SRTMPlugin/AndroidManifest.xml
+++ b/plugins/Osmand-SRTMPlugin/AndroidManifest.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="net.osmand.srtmPlugin.paid"
-    android:versionCode="9"
-    android:versionName="1.0" >
+    package="net.osmand.srtmPlugin.paid">
 
-    <uses-sdk android:targetSdkVersion="16" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/> 
 	<supports-screens  android:resizeable="true" android:smallScreens="true" android:normalScreens="true" android:largeScreens="true" 
 	    android:xlargeScreens="true" android:anyDensity="true" />

--- a/plugins/Osmand-SRTMPlugin/build.gradle
+++ b/plugins/Osmand-SRTMPlugin/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
 	signingConfigs {
 		development {
@@ -21,8 +21,11 @@ android {
 	}
 
 	defaultConfig {
+		applicationId "net.osmand.srtmPlugin.paid"
 		minSdkVersion 15
-		targetSdkVersion 27
+		targetSdkVersion 28
+		versionCode 9
+		versionName "1.0"
 	}
 
 	lintOptions {
@@ -69,8 +72,8 @@ dependencies {
 		implementation 'com.google.firebase:firebase-core:12.0.1'
 		implementation 'com.google.firebase:firebase-config:12.0.1'
 	}
-	implementation 'com.android.support:appcompat-v7:27.1.1'
-	implementation 'com.android.support:design:27.1.1'
+	implementation 'com.android.support:appcompat-v7:28.0.0'
+	implementation 'com.android.support:design:28.0.0'
 }
 
 if (analytics) {

--- a/plugins/Osmand-Skimaps/AndroidManifest.xml
+++ b/plugins/Osmand-Skimaps/AndroidManifest.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="net.osmand.skimapsPlugin"
-    android:versionCode="9"
-    android:versionName="1.0" >
+    package="net.osmand.skimapsPlugin">
 
-    <uses-sdk android:targetSdkVersion="16" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
 	<supports-screens  android:resizeable="true" android:smallScreens="true" android:normalScreens="true" android:largeScreens="true" 
 	    android:xlargeScreens="true" android:anyDensity="true" />

--- a/plugins/Osmand-Skimaps/build.gradle
+++ b/plugins/Osmand-Skimaps/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-	compileSdkVersion 27
-	buildToolsVersion "27.0.3"
+	compileSdkVersion 28
+	buildToolsVersion "28.0.3"
 
 	signingConfigs {
 		development {
@@ -21,8 +21,11 @@ android {
 	}
 
 	defaultConfig {
+		applicationId "net.osmand.skimapsPlugin"
 		minSdkVersion 15
-		targetSdkVersion 27
+		targetSdkVersion 28
+		versionCode 9
+		versionName "1.0"
 	}
 
 	lintOptions {
@@ -70,8 +73,8 @@ dependencies {
 		implementation 'com.google.firebase:firebase-core:12.0.1'
 		implementation 'com.google.firebase:firebase-config:12.0.1'
 	}
-	implementation 'com.android.support:appcompat-v7:27.1.1'
-	implementation 'com.android.support:design:27.1.1'
+	implementation 'com.android.support:appcompat-v7:28.0.0'
+	implementation 'com.android.support:design:28.0.0'
 }
 
 if (analytics) {


### PR DESCRIPTION
## General
- updated README.md badges
- gradle 4.6 -> 4.10.3

## Specific
### OsmAnd-java/build.gradle
- compile java 1.8
- junit 4.12 -> 4.13-beta-1
- gson 2.8.2 -> 2.8.5
- json 20171018 -> 20180813
- tuprolog 3.2.1 -> 3.3.0
- commons-compress 1.17 -> 1.18
- kxml2 2.1.8 -> 2.3.0

### OsmAnd-telegram/build.gradle
- buildToolsVersion 27.0.3 -> 28.0.3
- targetSdkVersion 27 -> 28
- kotlin jdk7 -> jdk8
- support libraries 28.0.0-rc01 -> 28.0.0

### OsmAnd/build.gradle
- compileSdkVersion 27 -> 28
- buildToolsVersion 27.0.3 -> 28.0.3
- targetSdkVersion 26 -> 28
- use applicationIdSuffix in place of applicationId
- facebook 4.31.0 -> 4.39.0
- multidex 1.0.1 -> 1.0.3
- support libraries 27.1.1 -> 28.0.0
- tuprolog 3.2.1 -> 3.3.0
- commons-compress 1.17 -> 1.18
- org.immutables:gson 2.5.0 -> 2.7.4
- rhino 1.7.9 -> 1.7.10
- (commented out) icu4j 50.1 -> 63.1
- (commented out) trove4j 3.0.3 -> 3.1.0
- MPAndroidChart v3.0.1 -> v3.0.3
- TextFieldBoxes 1.3.5 -> 1.4.4

### OsmAndCore-sample/build.gradle
- compileSdkVersion 27 -> 28
- buildToolsVersion 27.0.3 -> 28.0.3
- targetSdkVersion 27 -> 28
- support libraries 27.1.1 -> 28.0.0

### plugins
- compileSdkVersion 27 -> 28
- buildToolsVersion 27.0.3 -> 28.0.3
- move version declarations into build.gradles
- add applicationId to build.gradles