### PR TITLE
Use https when downloading index file

### DIFF
--- a/OsmAnd/src/net/osmand/plus/OsmAndAppCustomization.java
+++ b/OsmAnd/src/net/osmand/plus/OsmAndAppCustomization.java
@@ -167,7 +167,7 @@ public class OsmAndAppCustomization {
 	}
 
 	public String getIndexesUrl() {
-		return "http://" + IndexConstants.INDEX_DOWNLOAD_DOMAIN + "/get_indexes?gzip&" + Version.getVersionAsURLParam(app);
+		return "https://" + IndexConstants.INDEX_DOWNLOAD_DOMAIN + "/get_indexes?gzip&" + Version.getVersionAsURLParam(app);
 	}
 
 	public boolean showDownloadExtraActions() {


### PR DESCRIPTION
download.osmand.net is accessible via https. Please consider using https for index file downloading.