### PR TITLE
Fix the resulting position when using a quick action.

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/MapQuickActionLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/MapQuickActionLayer.java
@@ -420,8 +420,8 @@ public class MapQuickActionLayer extends OsmandMapLayer implements QuickActionRe
 
     @Override
     public void onActionSelected(QuickAction action) {
-        setLayerState(false);
         QuickActionFactory.produceAction(action).execute(mapActivity);
+        setLayerState(false);
     }
 
     public PointF getMovableCenterPoint(RotatedTileBox tb) {


### PR DESCRIPTION
This should fix #6508 and the duplicated issue #6624. The regression happened in 713a3b9.

The `setLayer` method with the false parameter call the method `quitMovingMarker` https://github.com/osmandapp/Osmand/blob/e1392212dbd36ecc3ed8b37b861e51b7cbcd0fe7/OsmAnd/src/net/osmand/plus/views/MapQuickActionLayer.java#L219 which seems to do magic things with the center of the map.

I don't know the reason behind the initial change. Any hints @MadWasp79?