### PR TITLE
AIDL updates updateMapMarker, removeMapMarker, removeAllMarkers

### DIFF
--- a/OsmAnd/src/net/osmand/aidl/IOsmAndAidlInterface.aidl
+++ b/OsmAnd/src/net/osmand/aidl/IOsmAndAidlInterface.aidl
@@ -105,16 +105,23 @@ interface IOsmAndAidlInterface {
     boolean addMapMarker(in AddMapMarkerParams params);
 
     /**
-     * Add map marker at given location.
+     * Remove map marker.
+     *
+     * If ignoreCoordinates is false the marker is only removed if lat/lon match the currently set values of the marker.
+     * If ignoreCoordinates is true the marker is removed if the name matches, the values of lat/lon are ignored.
      *
      * @param lat (double) -  latitude.
      * @param lon (double) - longitude.
      * @param name (String)- name of marker.
+     * @param ignoreCoordinates (boolean) - flag to determine whether lat/lon shall be ignored
      */
     boolean removeMapMarker(in RemoveMapMarkerParams params);
 
     /**
-     * Update map marker at given location with name.
+     * Update map marker.
+     *
+     * If ignoreCoordinates is false the marker gets updated only if latPrev/lonPrev match the currently set values of the marker.
+     * If ignoreCoordinates is true the marker gets updated if the name matches, the values of latPrev/lonPrev are ignored.
      *
      * @param latPrev (double) - latitude (current marker).
      * @param lonPrev (double) - longitude (current marker).
@@ -122,6 +129,7 @@ interface IOsmAndAidlInterface {
      * @param latNew (double) - latitude (new marker).
      * @param lonNew (double) - longitude (new marker).
      * @param nameNew (String) - name (new marker).
+     * @param ignoreCoordinates (boolean) - flag to determine whether latPrev/lonPrev shall be ignored
      */
     boolean updateMapMarker(in UpdateMapMarkerParams params);
 
@@ -816,4 +824,9 @@ interface IOsmAndAidlInterface {
      * @params callback (IOsmAndAidlCallback) - callback to notify user on voice message
      */
     long registerForVoiceRouterMessages(in ANavigationVoiceRouterMessageParams params, IOsmAndAidlCallback callback);
+
+    /**
+     * Remove all map markers.
+     */
+    boolean removeAllMapMarkers();
 }

--- a/OsmAnd/src/net/osmand/aidl/OsmandAidlApi.java
+++ b/OsmAnd/src/net/osmand/aidl/OsmandAidlApi.java
@@ -1037,16 +1037,18 @@ public class OsmandAidlApi {
 		}
 	}
 
-	boolean removeMapMarker(AMapMarker marker) {
+	boolean removeMapMarker(AMapMarker marker, boolean ignoreCoordinates) {
 		if (marker != null) {
 			LatLon latLon = new LatLon(marker.getLatLon().getLatitude(), marker.getLatLon().getLongitude());
 			MapMarkersHelper markersHelper = app.getMapMarkersHelper();
 			List<MapMarker> mapMarkers = markersHelper.getMapMarkers();
 			for (MapMarker m : mapMarkers) {
-				if (m.getOnlyName().equals(marker.getName()) && latLon.equals(new LatLon(m.getLatitude(), m.getLongitude()))) {
-					markersHelper.moveMapMarkerToHistory(m);
-					refreshMap();
-					return true;
+				if (m.getOnlyName().equals(marker.getName())) {
+					if (ignoreCoordinates || latLon.equals(new LatLon(m.getLatitude(), m.getLongitude()))) {
+						markersHelper.moveMapMarkerToHistory(m);
+						refreshMap();
+						return true;
+					}
 				}
 			}
 			return false;
@@ -1055,23 +1057,40 @@ public class OsmandAidlApi {
 		}
 	}
 
-	boolean updateMapMarker(AMapMarker markerPrev, AMapMarker markerNew) {
+	boolean removeAllMapMarkers() {
+		boolean refreshNeeded = false;
+		MapMarkersHelper markersHelper = app.getMapMarkersHelper();
+		List<MapMarker> mapMarkers = markersHelper.getMapMarkers();
+		for (MapMarker m : mapMarkers) {
+			markersHelper.moveMapMarkerToHistory(m);
+			refreshNeeded = true;
+		}
+		if (refreshNeeded) {
+			refreshMap();
+		}
+		return true;
+	}
+
+
+	boolean updateMapMarker(AMapMarker markerPrev, AMapMarker markerNew, boolean ignoreCoordinates) {
 		if (markerPrev != null && markerNew != null) {
 			LatLon latLon = new LatLon(markerPrev.getLatLon().getLatitude(), markerPrev.getLatLon().getLongitude());
 			LatLon latLonNew = new LatLon(markerNew.getLatLon().getLatitude(), markerNew.getLatLon().getLongitude());
 			MapMarkersHelper markersHelper = app.getMapMarkersHelper();
 			List<MapMarker> mapMarkers = markersHelper.getMapMarkers();
 			for (MapMarker m : mapMarkers) {
-				if (m.getOnlyName().equals(markerPrev.getName()) && latLon.equals(new LatLon(m.getLatitude(), m.getLongitude()))) {
-					PointDescription pd = new PointDescription(
-							PointDescription.POINT_TYPE_MAP_MARKER, markerNew.getName() != null ? markerNew.getName() : "");
-					MapMarker marker = new MapMarker(m.point, pd, m.colorIndex, m.selected, m.index);
-					marker.id = m.id;
-					marker.creationDate = m.creationDate;
-					marker.visitedDate = m.visitedDate;
-					markersHelper.moveMapMarker(marker, latLonNew);
-					refreshMap();
-					return true;
+				if (m.getOnlyName().equals(markerPrev.getName())) {
+					if (ignoreCoordinates || latLon.equals(new LatLon(m.getLatitude(), m.getLongitude()))) {
+						PointDescription pd = new PointDescription(
+								PointDescription.POINT_TYPE_MAP_MARKER, markerNew.getName() != null ? markerNew.getName() : "");
+						MapMarker marker = new MapMarker(m.point, pd, m.colorIndex, m.selected, m.index);
+						marker.id = m.id;
+						marker.creationDate = m.creationDate;
+						marker.visitedDate = m.visitedDate;
+						markersHelper.moveMapMarker(marker, latLonNew);
+						refreshMap();
+						return true;
+					}
 				}
 			}
 			return false;

--- a/OsmAnd/src/net/osmand/aidl/OsmandAidlService.java
+++ b/OsmAnd/src/net/osmand/aidl/OsmandAidlService.java
@@ -282,7 +282,7 @@ public class OsmandAidlService extends Service implements AidlCallbackListener {
 		public boolean removeMapMarker(RemoveMapMarkerParams params) {
 			try {
 				OsmandAidlApi api = getApi("removeMapMarker");
-				return params != null && api != null && api.removeMapMarker(params.getMarker());
+				return params != null && api != null && api.removeMapMarker(params.getMarker(), params.getIgnoreCoordinates());
 			} catch (Exception e) {
 				handleException(e);
 				return false;
@@ -293,7 +293,7 @@ public class OsmandAidlService extends Service implements AidlCallbackListener {
 		public boolean updateMapMarker(UpdateMapMarkerParams params) {
 			try {
 				OsmandAidlApi api = getApi("updateMapMarker");
-				return params != null && api != null && api.updateMapMarker(params.getMarkerPrev(), params.getMarkerNew());
+				return params != null && api != null && api.updateMapMarker(params.getMarkerPrev(), params.getMarkerNew(), params.getIgnoreCoordinates());
 			} catch (Exception e) {
 				handleException(e);
 				return false;
@@ -1161,6 +1161,17 @@ public class OsmandAidlService extends Service implements AidlCallbackListener {
 			} catch (Exception e) {
 				handleException(e);
 				return UNKNOWN_API_ERROR;
+			}
+		}
+
+		@Override
+		public boolean removeAllMapMarkers() {
+			try {
+				OsmandAidlApi api = getApi("removeAllMapMarkers");
+				return api != null && api.removeAllMapMarkers();
+			} catch (Exception e) {
+				handleException(e);
+				return false;
 			}
 		}
 	};

--- a/OsmAnd/src/net/osmand/aidl/mapmarker/RemoveMapMarkerParams.java
+++ b/OsmAnd/src/net/osmand/aidl/mapmarker/RemoveMapMarkerParams.java
@@ -6,9 +6,16 @@ import android.os.Parcelable;
 public class RemoveMapMarkerParams implements Parcelable {
 
 	private AMapMarker marker;
+	private boolean ignoreCoordinates;
 
 	public RemoveMapMarkerParams(AMapMarker marker) {
 		this.marker = marker;
+		this.ignoreCoordinates = false;
+	}
+
+	public RemoveMapMarkerParams(AMapMarker marker, boolean ignoreCoordinates) {
+		this.marker = marker;
+		this.ignoreCoordinates = ignoreCoordinates;
 	}
 
 	public RemoveMapMarkerParams(Parcel in) {
@@ -30,12 +37,18 @@ public class RemoveMapMarkerParams implements Parcelable {
 		return marker;
 	}
 
+	public boolean getIgnoreCoordinates() {
+		return ignoreCoordinates;
+	}
+
 	public void writeToParcel(Parcel out, int flags) {
 		out.writeParcelable(marker, flags);
+		out.writeInt(ignoreCoordinates ? 1 : 0);
 	}
 
 	private void readFromParcel(Parcel in) {
 		marker = in.readParcelable(AMapMarker.class.getClassLoader());
+		ignoreCoordinates = in.readInt() != 0;
 	}
 
 	public int describeContents() {

--- a/OsmAnd/src/net/osmand/aidl/mapmarker/UpdateMapMarkerParams.java
+++ b/OsmAnd/src/net/osmand/aidl/mapmarker/UpdateMapMarkerParams.java
@@ -7,10 +7,18 @@ public class UpdateMapMarkerParams implements Parcelable {
 
 	private AMapMarker markerPrev;
 	private AMapMarker markerNew;
+	private boolean ignoreCoordinates;
 
 	public UpdateMapMarkerParams(AMapMarker markerPrev, AMapMarker markerNew) {
 		this.markerPrev = markerPrev;
 		this.markerNew = markerNew;
+		this.ignoreCoordinates = false;
+	}
+
+	public UpdateMapMarkerParams(AMapMarker markerPrev, AMapMarker markerNew, boolean ignoreCoordinates) {
+		this.markerPrev = markerPrev;
+		this.markerNew = markerNew;
+		this.ignoreCoordinates = ignoreCoordinates;
 	}
 
 	public UpdateMapMarkerParams(Parcel in) {
@@ -36,14 +44,20 @@ public class UpdateMapMarkerParams implements Parcelable {
 		return markerNew;
 	}
 
+	public boolean getIgnoreCoordinates() {
+		return ignoreCoordinates;
+	}
+
 	public void writeToParcel(Parcel out, int flags) {
 		out.writeParcelable(markerPrev, flags);
 		out.writeParcelable(markerNew, flags);
+		out.writeInt(ignoreCoordinates ? 1 : 0);
 	}
 
 	private void readFromParcel(Parcel in) {
 		markerPrev = in.readParcelable(AMapMarker.class.getClassLoader());
 		markerNew = in.readParcelable(AMapMarker.class.getClassLoader());
+		ignoreCoordinates = in.readInt() != 0;
 	}
 
 	public int describeContents() {


### PR DESCRIPTION
- introduction of an option to ignore coordinates in updateMapMarker and removeMapMarker AIDL functions; default behaviour is that marker name and coordinates have to match for update/remove functions. The new option allows to ignore the coordinate values, so only the name has to match.

- added new AIDL function removeAllMarkers which removes all map markers