### PR TITLE
Replace deprecated setAudioStreamType

### DIFF
--- a/OsmAnd/src/net/osmand/plus/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/OsmandSettings.java
@@ -1446,6 +1446,9 @@ public class OsmandSettings {
 	// this value string is synchronized with settings_pref.xml preference name
 	public final OsmandPreference<Integer> AUDIO_STREAM_GUIDANCE = new IntPreference("audio_stream",
 			3/*AudioManager.STREAM_MUSIC*/).makeProfile();
+	// Corresponding USAGE value for AudioAttributes
+	public final OsmandPreference<Integer> AUDIO_USAGE = new IntPreference("audio_usage",
+			12/*AudioAttributes.USAGE_ASSISTANCE_NAVIGATION_GUIDANCE*/).makeProfile();
 
 	// For now this can be changed only in TestVoiceActivity
 	public final OsmandPreference<Integer> BT_SCO_DELAY = new IntPreference("bt_sco_delay",	1500).makeGlobal().cache();

--- a/OsmAnd/src/net/osmand/plus/activities/SettingsNavigationActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/SettingsNavigationActivity.java
@@ -6,6 +6,7 @@ import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
 import android.content.DialogInterface.OnMultiChoiceClickListener;
 import android.content.Intent;
+import android.media.AudioAttributes;
 import android.media.AudioManager;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
@@ -270,8 +271,20 @@ public class SettingsNavigationActivity extends SettingsBaseActivity {
 					if (player != null) {
 						player.updateAudioStream(settings.AUDIO_STREAM_GUIDANCE.get());
 					}
+					// Sync corresponding AUDIO_USAGE value
+					ApplicationMode mode = getMyApplication().getSettings().getApplicationMode();
+					int stream = settings.AUDIO_STREAM_GUIDANCE.getModeValue(mode);
+					if (stream == AudioManager.STREAM_MUSIC) {
+						settings.AUDIO_USAGE.setModeValue(mode, AudioAttributes.USAGE_ASSISTANCE_NAVIGATION_GUIDANCE);
+					} else if (stream == AudioManager.STREAM_NOTIFICATION) {
+						settings.AUDIO_USAGE.setModeValue(mode, AudioAttributes.USAGE_NOTIFICATION);
+					} else if (stream == AudioManager.STREAM_VOICE_CALL) {
+						settings.AUDIO_USAGE.setModeValue(mode, AudioAttributes.USAGE_VOICE_COMMUNICATION);
+					}
+
 					// Sync DEFAULT value with CAR value, as we have other way to set it for now
 					settings.AUDIO_STREAM_GUIDANCE.setModeValue(ApplicationMode.DEFAULT, settings.AUDIO_STREAM_GUIDANCE.getModeValue(ApplicationMode.CAR));
+					settings.AUDIO_USAGE.setModeValue(ApplicationMode.DEFAULT, settings.AUDIO_USAGE.getModeValue(ApplicationMode.CAR));
 					return true;
 				}
 			});

--- a/OsmAnd/src/net/osmand/plus/voice/MediaCommandPlayerImpl.java
+++ b/OsmAnd/src/net/osmand/plus/voice/MediaCommandPlayerImpl.java
@@ -174,15 +174,14 @@ public class MediaCommandPlayerImpl extends AbstractPrologCommandPlayer implemen
 			mediaPlayer.reset();
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
 				mediaPlayer.setAudioAttributes(new AudioAttributes.Builder()
-						.setUsage(AudioAttributes.USAGE_ASSISTANCE_NAVIGATION_GUIDANCE)
+						.setUsage(ctx.getSettings().AUDIO_USAGE.get())
 						.setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
 						.build());
-			}
-			//if (Build.VERSION.SDK_INT < 26) {
+
+			} else {
 				// Deprecated in API Level 26, use above AudioAtrributes instead
-				// TODO: convert code to replace deprecated setAudioStreamType and requestAudioFocus(AudioManager.OnAudioFocusChangeListener l, int streamType, int durationHint)
 				mediaPlayer.setAudioStreamType(streamType);
-			//}
+			}
 			mediaPlayer.setDataSource(file.getAbsolutePath());
 			mediaPlayer.prepare();
 			mediaPlayer.setOnCompletionListener(this);

--- a/OsmAnd/src/net/osmand/plus/voice/TTSCommandPlayerImpl.java
+++ b/OsmAnd/src/net/osmand/plus/voice/TTSCommandPlayerImpl.java
@@ -118,7 +118,7 @@ public class TTSCommandPlayerImpl extends AbstractPrologCommandPlayer {
 				requestAudioFocus();
 				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
 					mTts.setAudioAttributes(new AudioAttributes.Builder()
-							.setUsage(AudioAttributes.USAGE_ASSISTANCE_NAVIGATION_GUIDANCE)
+							.setUsage(ctx.getSettings().AUDIO_USAGE.get())
 							.setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
 							.build());
 				}


### PR DESCRIPTION
Tested to work on Android 6, not yet 8 or 9.

This should replace the `setAudioStreamType`, while replacing the also deprecated `requestAudioFocus (AudioManager.OnAudioFocusChangeListener l, int streamType, int durationHint)` and `abandonAudioFocus` is still open.