### PR TITLE
Folder per day as subfolder

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/SavingTrackHelper.java
+++ b/OsmAnd/src/net/osmand/plus/activities/SavingTrackHelper.java
@@ -200,7 +200,6 @@ public class SavingTrackHelper extends SQLiteOpenHelper {
 
 				// save file
 				for (final String f : data.keySet()) {
-					log.debug("Filename: " + f);
 					File fout = new File(dir, f + ".gpx"); //$NON-NLS-1$
 					if (!data.get(f).isEmpty()) {
 						WptPt pt = data.get(f).findPointToShow();

--- a/OsmAnd/src/net/osmand/plus/activities/SavingTrackHelper.java
+++ b/OsmAnd/src/net/osmand/plus/activities/SavingTrackHelper.java
@@ -207,11 +207,12 @@ public class SavingTrackHelper extends SQLiteOpenHelper {
 						String fileName = f + "_" + new SimpleDateFormat("HH-mm_EEE", Locale.US).format(new Date(pt.time)); //$NON-NLS-1$
 						Integer track_storage_directory = ctx.getSettings().TRACK_STORAGE_DIRECTORY.get();
 						if (track_storage_directory != OsmandSettings.REC_DIRECTORY) {
-							SimpleDateFormat dateDirFormat = new SimpleDateFormat("yyyy-MM");
+							SimpleDateFormat monthDirFormat = new SimpleDateFormat("yyyy-MM");
+							String dateDirName = monthDirFormat.format(new Date(pt.time));
 							if (track_storage_directory == OsmandSettings.DAILY_DIRECTORY) {
-								dateDirFormat = new SimpleDateFormat("yyyy-MM-dd");
+								SimpleDateFormat dayDirFormat = new SimpleDateFormat("yyyy-MM-dd");
+								dateDirName = dateDirName + File.separator + dayDirFormat.format(new Date(pt.time));
 							}
-							String dateDirName = dateDirFormat.format(new Date(pt.time));
 							File dateDir = new File(dir, dateDirName);
 							dateDir.mkdirs();
 							if (dateDir.exists()) {

--- a/OsmAnd/src/net/osmand/plus/helpers/ImportHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/ImportHelper.java
@@ -36,6 +36,7 @@ import net.osmand.plus.FavouritesDbHelper;
 import net.osmand.plus.GPXDatabase;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.OsmandPlugin;
+import net.osmand.plus.OsmandSettings;
 import net.osmand.plus.R;
 import net.osmand.plus.SettingsHelper.SettingsImportListener;
 import net.osmand.plus.activities.MapActivity;
@@ -669,7 +670,7 @@ public class ImportHelper {
 		}
 	}
 
-	private String saveImport(final GPXFile gpxFile, final String fileName, final boolean useImportDir) {
+	private String saveImport(final GPXFile gpxFile, String fileName, final boolean useImportDir) {
 		final String warning;
 
 		if (gpxFile.isEmpty() || fileName == null) {
@@ -685,6 +686,20 @@ public class ImportHelper {
 			importDir.mkdirs();
 			if (importDir.exists() && importDir.isDirectory() && importDir.canWrite()) {
 				final WptPt pt = gpxFile.findPointToShow();
+				Integer track_storage_directory = app.getSettings().TRACK_STORAGE_DIRECTORY.get();
+				if (track_storage_directory != OsmandSettings.REC_DIRECTORY) {
+					SimpleDateFormat monthDirFormat = new SimpleDateFormat("yyyy-MM");
+					String dateDirName = monthDirFormat.format(new Date(pt.time));
+					if (track_storage_directory == OsmandSettings.DAILY_DIRECTORY) {
+						SimpleDateFormat dayDirFormat = new SimpleDateFormat("yyyy-MM-dd");
+						dateDirName = dateDirName + File.separator + dayDirFormat.format(new Date(pt.time));
+					}
+					File dateDir = new File(importDir, dateDirName);
+					dateDir.mkdirs();
+					if (dateDir.exists()) {
+						fileName = dateDirName + File.separator + fileName;
+					}
+				}
 				final File toWrite = getFileToSave(fileName, importDir, pt);
 				boolean destinationExists = toWrite.exists();
 				Exception e = GPXUtilities.writeGpxFile(toWrite, gpxFile);


### PR DESCRIPTION
The daily folders are now subdirectories of the monthly folders and the setting is now also used when importing a gpx-track