### PR TITLE
Fix "GPX route" theme of popup is switching immediately

### DIFF
--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/RouteOptionsBottomSheet.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/RouteOptionsBottomSheet.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.content.ContextCompat;
+import android.support.v7.view.ContextThemeWrapper;
 import android.support.v7.widget.PopupMenu;
 import android.view.MenuItem;
 import android.view.View;
@@ -426,9 +427,9 @@ public class RouteOptionsBottomSheet extends MenuBottomSheetDialogFragment {
 		}, nightMode);
 	}
 
-	private void showOptionsMenu(final TextView gpxSpinner) {
+	private void showOptionsMenu(View view) {
 		RouteProvider.GPXRouteParamsBuilder rp = mapActivity.getRoutingHelper().getCurrentGPXRoute();
-		final PopupMenu optionsMenu = new PopupMenu(gpxSpinner.getContext(), gpxSpinner);
+		final PopupMenu optionsMenu = new PopupMenu(new ContextThemeWrapper(view.getContext(), themeRes), view);
 		MenuItem item = optionsMenu.getMenu().add(
 				mapActivity.getString(R.string.shared_string_none));
 		item.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {


### PR DESCRIPTION
Fix "Directions->Options->GPX route" theme of this popup was switching only after restart app.