### PR TITLE
Use the response text from live monitoring to send commands to the API

### DIFF
--- a/OsmAnd/src/net/osmand/plus/monitoring/OsmandMonitoringPlugin.java
+++ b/OsmAnd/src/net/osmand/plus/monitoring/OsmandMonitoringPlugin.java
@@ -34,6 +34,7 @@ import net.osmand.plus.activities.MapActivity;
 import net.osmand.plus.activities.SavingTrackHelper;
 import net.osmand.plus.activities.SavingTrackHelper.SaveGpxResult;
 import net.osmand.plus.dashboard.tools.DashFragmentData;
+import net.osmand.plus.helpers.ExternalApiHelper;
 import net.osmand.plus.views.MapInfoLayer;
 import net.osmand.plus.views.OsmandMapLayer.DrawSettings;
 import net.osmand.plus.views.OsmandMapTileView;
@@ -106,6 +107,8 @@ public class OsmandMonitoringPlugin extends OsmandPlugin {
 
 	@Override
 	public void registerLayers(MapActivity activity) {
+		liveMonitoringHelper.activity = activity;
+		liveMonitoringHelper.apiHelper = new ExternalApiHelper(activity);
 		registerWidget(activity);
 	}
 


### PR DESCRIPTION
This purpose of this change is to enable live-tracking (and other sophisticated features) without a dependence on Telegram.

I opened this pull-request following a [comment](https://github.com/osmandapp/Osmand/issues/8127#issuecomment-569610900) that it would make it easier for the other developers to understand what I'm trying to do.  

Instead of Telegram, we can use Node-RED as the location broker, which can easily be programmed to implement live-tracking.  (The same system will also be able to push non-player targets to the participants as well.)

I have made an example node-RED editor at https://osmtest1.eu-gb.mybluemix.net/red/ following [these instructions](https://nodered.org/docs/getting-started/ibmcloud).  

The first node is listening for any "http in" signals on the path "/osmand1", the second function node decodes the lat,lon,bearing parameters and adds a random position from them, and the final "http response" node returns the json-encoded osmapicommand response of the form `{"osmandcommands":["osmand.api://add_map_marker?name=nodred-3&lat=52.19&lon=0.10"]}`.

Once you have this pull-request compiled, you need to enable the location tracking to the correct URL with the following steps:

* On Osmand go to plugins -> Trip recording -> Settings -> Cycling -> Online tracking web address and set to:

* http://osmtest1.eu-gb.mybluemix.net/osmand1?lat={0}&lon={1}&timestamp={2}&hop={3}&altitude={4}&speed={5}&bearing={6}

* Click "Apply to all profiles"

* Then click "Online tracking (GPX required)"  and Apply to all profiles

Now on the main map click on "Start GPX logging"

If you have the node-RED editor up, then you click on the bug symbol near the top right corner to see the messages that are coming in and going out.


There are three issues to consider concerning this pull-request:

1. The response is in json form "{ osmandapicmds: [ apistring1, apistring2, ...]}" because there is a json decoder in java, and it's future-proof -- eg extra parameters can be added and ignored.

2. The function [ExternalApiHelper.processApiRequest()](https://github.com/osmandapp/Osmand/blob/21ac829a3da5d2b8ebeee6dd67c08a90a604c824/OsmAnd/src/net/osmand/plus/helpers/ExternalApiHelper.java#L174) is incomplete, because it implements "add_favourite" but not "update_favourite".  (Also, the update_favourite() functions implemented in other places are problematic because it requires the previous lat/lon to be accurately known before it changes it in the database.  This won't work if there are a update message gets missed.)

3. MQTT might be more a appropriate protocol for the purpose of sending and receiving live locations, instead of http polling.  This was noted in [this issue thread](https://github.com/traccar/traccar/issues/1582#issuecomment-343252080) for traccar.

