### PR TITLE
Fix rendering_exception leading to "Could not draw chosen area"

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/binary/BinaryMapDataObject.java
+++ b/OsmAnd-java/src/main/java/net/osmand/binary/BinaryMapDataObject.java
@@ -109,7 +109,7 @@ public class BinaryMapDataObject {
 	}
 	
 	public boolean containsAdditionalType(int cachedType) {
-		if (cachedType != -1) {
+		if (cachedType != -1 && additionalTypes != null) {
 			for (int i = 0; i < additionalTypes.length; i++) {
 				if (additionalTypes[i] == cachedType) {
 					return true;


### PR DESCRIPTION
Exception was caused by additionalTypes being null.
Occurred consistently after zooming out some steps.

**Solution**
Check that additionalTypes is not null before accessing it.

**Details**
A `rendering_exception` was caught in
```
net/osmand/plus/render/MapRenderRepositories.java:830
java.lang.NullPointerException: Attempt to get length of null array
```
Putting a breakpoint there revealed:
```
e = {NullPointerException@6117} "java.lang.NullPointerException: Attempt to get length of null array"
 backtrace = {Object[15]@6193} 
 cause = {NullPointerException@6117} "java.lang.NullPointerException: Attempt to get length of null array"
 detailMessage = "Attempt to get length of null array"
 stackTrace = {StackTraceElement[14]@6197} 
  0 = {StackTraceElement@6204} "net.osmand.binary.BinaryMapDataObject.containsAdditionalType(BinaryMapDataObject.java:113)"
  1 = {StackTraceElement@6205} "net.osmand.render.RenderingRuleProperty$3.accept(RenderingRuleProperty.java:303)"
  2 = {StackTraceElement@6206} "net.osmand.render.RenderingRuleSearchRequest.checkInputProperties(RenderingRuleSearchRequest.java:238)"
```

Sony G3112; Android 8.0.0