### PR TITLE
Fix cs/de/es/fr/it/pl/sk translations of pause/resume

### DIFF
--- a/OsmAnd/res/values-cs/strings.xml
+++ b/OsmAnd/res/values-cs/strings.xml
@@ -1247,8 +1247,8 @@ Proporcionální paměť %4$s MB (limit Androidu %5$s MB, Dalvik %6$s MB).</stri
     <string name="live_monitoring_m">On-line sledování (vyžaduje GPX)</string>
     <string name="live_monitoring_start">Spustit on-line sledování</string>
     <string name="live_monitoring_stop">Zastavit on-line sledování</string>
-    <string name="gpx_monitoring_start">Zapnout GPX logování</string>
-    <string name="gpx_monitoring_stop">Zastavit GPX logování</string>
+    <string name="gpx_monitoring_start">Pokračovat v GPX logování</string>
+    <string name="gpx_monitoring_stop">Pozastavit GPX logování</string>
     <string name="gpx_start_new_segment">Začít nový segment</string>
     <string name="rendering_attr_hideNonVehicleHighways_name">Cesty, které nejsou pro vozidla</string>
     <string name="rendering_attr_buildings15zoom_name">Budovy při přiblížení 15</string>

--- a/OsmAnd/res/values-de/strings.xml
+++ b/OsmAnd/res/values-de/strings.xml
@@ -1327,8 +1327,8 @@
 \nTrack %2$s</string>
     <string name="gpx_split_interval">Trennungsintervall</string>
     <string name="gpx_info_subtracks">Track-Segmente: %1$s</string>
-    <string name="gpx_monitoring_start">GPX-Aufzeichnung starten</string>
-    <string name="gpx_monitoring_stop">GPX-Aufzeichnung beenden</string>
+    <string name="gpx_monitoring_start">GPX-Aufzeichnung fortsetzen</string>
+    <string name="gpx_monitoring_stop">GPX-Aufzeichnung anhalten</string>
     <string name="gpx_start_new_segment">Neues Segment starten</string>
     <string name="shared_string_waypoint">Wegpunkt</string>
     <string name="gpx_visibility_txt">Sichtbarkeit</string>

--- a/OsmAnd/res/values-es/strings.xml
+++ b/OsmAnd/res/values-es/strings.xml
@@ -1276,8 +1276,8 @@
     <string name="live_monitoring_m">Seguimiento en línea (requiere GPX)</string>
     <string name="live_monitoring_start">Iniciar seguimiento en línea</string>
     <string name="live_monitoring_stop">Parar seguimiento en línea</string>
-    <string name="gpx_monitoring_start">Iniciar grabación GPX</string>
-    <string name="gpx_monitoring_stop">Parar grabación GPX</string>
+    <string name="gpx_monitoring_start">Continuar grabación GPX</string>
+    <string name="gpx_monitoring_stop">Detener grabación GPX</string>
     <string name="gpx_start_new_segment">Iniciar nuevo segmento</string>
     <string name="lang_fa">Persa</string>
     <string name="lang_al">Albanés</string>

--- a/OsmAnd/res/values-fr/strings.xml
+++ b/OsmAnd/res/values-fr/strings.xml
@@ -1258,8 +1258,8 @@
     <string name="live_monitoring_m">Suivi en ligne (GPX requis)</string>
     <string name="live_monitoring_start">Démarrer le suivi en ligne</string>
     <string name="live_monitoring_stop">Arrêter le suivi en ligne</string>
-    <string name="gpx_monitoring_start">Démarrer l\'enregistrement GPX</string>
-    <string name="gpx_monitoring_stop">Arrêter l\'enregistrement GPX</string>
+    <string name="gpx_monitoring_start">Continuer l\'enregistrement GPX</string>
+    <string name="gpx_monitoring_stop">Interrompre l\'enregistrement GPX</string>
     <string name="gpx_start_new_segment">Débuter un nouveau segment</string>
     <string name="rendering_attr_hideBuildings_name">Bâtiments</string>
     <string name="rendering_attr_hideNonVehicleHighways_name">Voies non adaptées aux véhicules</string>

--- a/OsmAnd/res/values-it/strings.xml
+++ b/OsmAnd/res/values-it/strings.xml
@@ -1213,8 +1213,8 @@ Memoria in proporzione %4$s MB (limite di Android %5$s MB, Dalvik %6$s MB).</str
     <string name="live_monitoring_m">Tracciamento online (GPX richiesto)</string>
     <string name="live_monitoring_start">Avvia il tracciamento online</string>
     <string name="live_monitoring_stop">Ferma il tracciamento online</string>
-    <string name="gpx_monitoring_start">Avvia la registrazione GPX</string>
-    <string name="gpx_monitoring_stop">Ferma la registrazione GPX</string>
+    <string name="gpx_monitoring_start">Riprendi la registrazione GPX</string>
+    <string name="gpx_monitoring_stop">Metti in pausa la registrazione GPX</string>
     <string name="gpx_start_new_segment">Inizia un nuovo segmento</string>
     <string name="lang_fa">Persiano</string>
     <string name="lang_he">Ebraico</string>

--- a/OsmAnd/res/values-pl/strings.xml
+++ b/OsmAnd/res/values-pl/strings.xml
@@ -1262,8 +1262,8 @@
     <string name="live_monitoring_m">Śledzenie online (wymagane GPX)</string>
     <string name="live_monitoring_start">Rozpocznij śledzenie online</string>
     <string name="live_monitoring_stop">Zakończ śledzenie online</string>
-    <string name="gpx_monitoring_start">Rozpocznij rejestrowanie śladu</string>
-    <string name="gpx_monitoring_stop">Zakończ rejestrowanie śladu</string>
+    <string name="gpx_monitoring_start">Kontynuuj rejestrowanie śladu</string>
+    <string name="gpx_monitoring_stop">Wstrzymaj rejestrowanie śladu</string>
     <string name="gpx_start_new_segment">Rozpocznij nowy segment</string>
     <string name="rendering_attr_hideBuildings_name">Budynki</string>
     <string name="rendering_attr_hideNonVehicleHighways_name">Trasy niedostępne dla aut</string>

--- a/OsmAnd/res/values-sk/strings.xml
+++ b/OsmAnd/res/values-sk/strings.xml
@@ -1208,8 +1208,8 @@
     <string name="live_monitoring_m">Online stopovanie (potrebné GPX)</string>
     <string name="live_monitoring_start">Zapnúť online stopovanie</string>
     <string name="live_monitoring_stop">Zastaviť online stopovanie</string>
-    <string name="gpx_monitoring_start">Zapnúť zaznamenávanie GPX</string>
-    <string name="gpx_monitoring_stop">Zastaviť zaznamenávanie GPX</string>
+    <string name="gpx_monitoring_start">Pokračovať v zaznamenávaní GPX</string>
+    <string name="gpx_monitoring_stop">Pozastaviť zaznamenávanie GPX</string>
     <string name="gpx_start_new_segment">Začať nový segment</string>
     <string name="rendering_attr_hideBuildings_name">Budovy</string>
     <string name="rendering_attr_hideNonVehicleHighways_name">Cesty, ktoré nie sú pre vozidlá</string>


### PR DESCRIPTION
Fix a few translations of modified strings `gpx_monitoring_start` and `gpx_monitoring_stop` changed in 
https://github.com/osmandapp/Osmand/commit/75b8b0de3a69e429f850aa0e60be17192c909eba