### PR TITLE
Add cs/de/es/fr/it/pl/sk translations of shared_string_resume

### DIFF
--- a/OsmAnd/res/values-cs/strings.xml
+++ b/OsmAnd/res/values-cs/strings.xml
@@ -2027,6 +2027,7 @@ Délka %2$s</string>
     <string name="trip_rec_notification_settings">Povolit rychlé spuštění záznamu</string>
     <string name="trip_rec_notification_settings_desc">Zobrazit systémové oznámení, které umožňuje spustit nahrávání.</string>
     <string name="shared_string_notifications">Oznámení</string>
+    <string name="shared_string_resume">Pokračovat</string>
     <string name="shared_string_continue">Pokračovat</string>
     <string name="shared_string_pause">Pozastavit</string>
     <string name="shared_string_trip">Cesta</string>

--- a/OsmAnd/res/values-de/strings.xml
+++ b/OsmAnd/res/values-de/strings.xml
@@ -2085,6 +2085,7 @@ Lon %2$s</string>
     <string name="trip_rec_notification_settings">Schnellaufzeichnung einschalten</string>
     <string name="trip_rec_notification_settings_desc">Anzeige einer Systembenachrichtigung zum Starten der Streckenaufzeichnung.</string>
     <string name="shared_string_notifications">Benachrichtigungen</string>
+    <string name="shared_string_resume">Fortsetzen</string>
     <string name="shared_string_appearance">Aussehen</string>
     <string name="route_calculation">Routenberechnung</string>
     <string name="gpx_no_tracks_title">Sie haben noch keine GPX-Dateien</string>

--- a/OsmAnd/res/values-es/strings.xml
+++ b/OsmAnd/res/values-es/strings.xml
@@ -2046,6 +2046,7 @@
     <string name="gpx_add_track">Añadir más…</string>
     <string name="shared_string_appearance">Aspecto</string>
     <string name="shared_string_notifications">Notificaciones</string>
+    <string name="shared_string_resume">Continuar</string>
     <string name="shared_string_continue">Continuar</string>
     <string name="shared_string_pause">Pausar</string>
     <string name="gpx_logging_no_data">Sin datos</string>

--- a/OsmAnd/res/values-fr/strings.xml
+++ b/OsmAnd/res/values-fr/strings.xml
@@ -2068,6 +2068,7 @@
     <string name="shared_string_record">Enregistrer</string>
     <string name="gpx_logging_no_data">Aucune donnée</string>
     <string name="shared_string_notifications">Notifications</string>
+    <string name="shared_string_resume">Continuer</string>
     <string name="trip_rec_notification_settings">Activer le démarrage rapide d\'enregistrement d\'itinéraire</string>
     <string name="trip_rec_notification_settings_desc">Afficher une notification système permettant d’enregistrer l\'itinéraire.</string>
     <string name="gpx_no_tracks_title">Vous n\'avez pas encore de fichier GPX</string>

--- a/OsmAnd/res/values-it/strings.xml
+++ b/OsmAnd/res/values-it/strings.xml
@@ -2066,6 +2066,7 @@ Memoria in proporzione %4$s MB (limite di Android %5$s MB, Dalvik %6$s MB).</str
     <string name="trip_rec_notification_settings">Abilita l\'avvio veloce della registrazione</string>
     <string name="trip_rec_notification_settings_desc">Mostra una notifica che permette di iniziare a registrare il viaggio.</string>
     <string name="shared_string_notifications">Notifiche</string>
+    <string name="shared_string_resume">Riprendi</string>
     <string name="route_calculation">Calcolo del percorso</string>
     <string name="gpx_no_tracks_title">Non hai ancora nessun file GPX</string>
     <string name="gpx_no_tracks_title_folder">È anche possibile aggiungere file GPX alla cartella</string>

--- a/OsmAnd/res/values-pl/strings.xml
+++ b/OsmAnd/res/values-pl/strings.xml
@@ -2078,6 +2078,7 @@ Długość %2$s</string>
     <string name="trip_rec_notification_settings">Szybkie rozpoczęcie rejestrowania</string>
     <string name="trip_rec_notification_settings_desc">Wyświetla powiadomienie systemowe umożliwiające rejestrowanie podróży.</string>
     <string name="shared_string_notifications">Powiadomienia</string>
+    <string name="shared_string_resume">Kontynuuj</string>
     <string name="gpx_no_tracks_title">Nie ma na razie żadnych plików GPX</string>
     <string name="gpx_no_tracks_title_folder">Można także dodać pliki GPX do katalogu</string>
     <string name="gpx_add_track">Dodaj więcej…</string>

--- a/OsmAnd/res/values-sk/strings.xml
+++ b/OsmAnd/res/values-sk/strings.xml
@@ -2072,6 +2072,7 @@ Dĺžka %2$s</string>
     <string name="trip_rec_notification_settings">Zapnúť rýchly záznam</string>
     <string name="trip_rec_notification_settings_desc">Zobraziť systémové oznámenie, ktoré umožňuje nahrávanie.</string>
     <string name="shared_string_notifications">Oznámenia</string>
+    <string name="shared_string_resume">Pokračovať</string>
     <string name="gpx_no_tracks_title">Nemáte zatiaľ žiadne súbory GPX</string>
     <string name="gpx_no_tracks_title_folder">Do priečinka môžete pridať aj súbory GPX</string>
     <string name="gpx_add_track">Pridať viac…</string>


### PR DESCRIPTION
Add cs/de/es/fr/it/pl/sk translations of `shared_string_resume` to #8945 