### PR TITLE
CHANGE: enable translation on filter names from a custom package

### DIFF
--- a/OsmAnd/src/net/osmand/plus/poi/PoiFiltersHelper.java
+++ b/OsmAnd/src/net/osmand/plus/poi/PoiFiltersHelper.java
@@ -814,8 +814,7 @@ public class PoiFiltersHelper {
 						if (map.containsKey(filterId) && (includeDeleted || !deleted)) {
 							String filterName = query.getString(1);
 							String translation = application.getPoiTypes().getPoiTranslation(filterName);
-							if(translation != null)
-							{
+							if(translation != null){
 								filterName = translation;
 							}
 							PoiUIFilter filter = new PoiUIFilter(filterName, filterId,

--- a/OsmAnd/src/net/osmand/plus/poi/PoiFiltersHelper.java
+++ b/OsmAnd/src/net/osmand/plus/poi/PoiFiltersHelper.java
@@ -812,7 +812,13 @@ public class PoiFiltersHelper {
 						String filterId = query.getString(0);
 						boolean deleted = query.getInt(3) == TRUE_INT;
 						if (map.containsKey(filterId) && (includeDeleted || !deleted)) {
-							PoiUIFilter filter = new PoiUIFilter(query.getString(1), filterId,
+							String filterName = query.getString(1);
+							String translation = application.getPoiTypes().getPoiTranslation(filterName);
+							if(translation != null)
+							{
+								filterName = translation;
+							}
+							PoiUIFilter filter = new PoiUIFilter(filterName, filterId,
 									map.get(filterId), application);
 							filter.setSavedFilterByName(query.getString(2));
 							filter.setDeleted(deleted);


### PR DESCRIPTION
Test if there is a translation for the filter name and use it. 
It allows to use standard names in custom packages so that translation can be done automatically.
