### PR TITLE
Add rotation to setMapLocation API

### DIFF
--- a/OsmAnd-api/src/net/osmand/aidlapi/map/SetMapLocationParams.java
+++ b/OsmAnd-api/src/net/osmand/aidlapi/map/SetMapLocationParams.java
@@ -10,12 +10,18 @@ public class SetMapLocationParams extends AidlParams {
 	private double latitude;
 	private double longitude;
 	private int zoom;
+	private float rotation;
 	private boolean animated;
 
 	public SetMapLocationParams(double latitude, double longitude, int zoom, boolean animated) {
+		this(latitude, longitude, zoom, Float.NaN, animated);
+	}
+	
+	public SetMapLocationParams(double latitude, double longitude, int zoom, float rotation, boolean animated) {
 		this.latitude = latitude;
 		this.longitude = longitude;
 		this.zoom = zoom;
+		this.rotation = rotation;
 		this.animated = animated;
 	}
 
@@ -47,6 +53,10 @@ public class SetMapLocationParams extends AidlParams {
 		return zoom;
 	}
 
+	public float getRotation() {
+		return rotation;
+	}
+	
 	public boolean isAnimated() {
 		return animated;
 	}
@@ -56,6 +66,7 @@ public class SetMapLocationParams extends AidlParams {
 		bundle.putDouble("latitude", latitude);
 		bundle.putDouble("longitude", longitude);
 		bundle.putInt("zoom", zoom);
+		bundle.putFloat("rotation",rotation);
 		bundle.putBoolean("animated", animated);
 	}
 
@@ -64,6 +75,7 @@ public class SetMapLocationParams extends AidlParams {
 		latitude = bundle.getDouble("latitude");
 		longitude = bundle.getDouble("longitude");
 		zoom = bundle.getInt("zoom");
+		rotation = bundle.getFloat("rotation");
 		animated = bundle.getBoolean("animated");
 	}
 }

--- a/OsmAnd-api/src/net/osmand/aidlapi/map/SetMapLocationParams.java
+++ b/OsmAnd-api/src/net/osmand/aidlapi/map/SetMapLocationParams.java
@@ -13,10 +13,6 @@ public class SetMapLocationParams extends AidlParams {
 	private float rotation;
 	private boolean animated;
 
-	public SetMapLocationParams(double latitude, double longitude, int zoom, boolean animated) {
-		this(latitude, longitude, zoom, Float.NaN, animated);
-	}
-	
 	public SetMapLocationParams(double latitude, double longitude, int zoom, float rotation, boolean animated) {
 		this.latitude = latitude;
 		this.longitude = longitude;

--- a/OsmAnd-api/src/net/osmand/aidlapi/map/SetMapLocationParams.java
+++ b/OsmAnd-api/src/net/osmand/aidlapi/map/SetMapLocationParams.java
@@ -66,7 +66,7 @@ public class SetMapLocationParams extends AidlParams {
 		bundle.putDouble("latitude", latitude);
 		bundle.putDouble("longitude", longitude);
 		bundle.putInt("zoom", zoom);
-		bundle.putFloat("rotation",rotation);
+		bundle.putFloat("rotation", rotation);
 		bundle.putBoolean("animated", animated);
 	}
 

--- a/OsmAnd-telegram/src/net/osmand/aidl/map/SetMapLocationParams.java
+++ b/OsmAnd-telegram/src/net/osmand/aidl/map/SetMapLocationParams.java
@@ -8,12 +8,19 @@ public class SetMapLocationParams implements Parcelable {
 	private double latitude;
 	private double longitude;
 	private int zoom;
-	private boolean animated;
+	private float rotation;
 
+	private boolean animated;
+	
 	public SetMapLocationParams(double latitude, double longitude, int zoom, boolean animated) {
+		this(latitude, longitude, zoom, Float.NaN, animated);
+	}
+	
+	public SetMapLocationParams(double latitude, double longitude, int zoom, float rotation, boolean animated) {
 		this.latitude = latitude;
 		this.longitude = longitude;
 		this.zoom = zoom;
+		this.rotation = rotation;
 		this.animated = animated;
 	}
 
@@ -44,6 +51,10 @@ public class SetMapLocationParams implements Parcelable {
 		return zoom;
 	}
 
+	public float getRotation() {
+		return rotation;
+	}
+	
 	public boolean isAnimated() {
 		return animated;
 	}
@@ -52,6 +63,7 @@ public class SetMapLocationParams implements Parcelable {
 		out.writeDouble(latitude);
 		out.writeDouble(longitude);
 		out.writeInt(zoom);
+		out.writeFloat(rotation);
 		out.writeByte((byte) (animated ? 1 : 0));
 	}
 
@@ -59,6 +71,7 @@ public class SetMapLocationParams implements Parcelable {
 		latitude = in.readDouble();
 		longitude = in.readDouble();
 		zoom = in.readInt();
+		rotation = in.readFloat();
 		animated = in.readByte() != 0;
 	}
 

--- a/OsmAnd-telegram/src/net/osmand/aidl/map/SetMapLocationParams.java
+++ b/OsmAnd-telegram/src/net/osmand/aidl/map/SetMapLocationParams.java
@@ -12,10 +12,6 @@ public class SetMapLocationParams implements Parcelable {
 
 	private boolean animated;
 	
-	public SetMapLocationParams(double latitude, double longitude, int zoom, boolean animated) {
-		this(latitude, longitude, zoom, Float.NaN, animated);
-	}
-	
 	public SetMapLocationParams(double latitude, double longitude, int zoom, float rotation, boolean animated) {
 		this.latitude = latitude;
 		this.longitude = longitude;
@@ -63,16 +59,16 @@ public class SetMapLocationParams implements Parcelable {
 		out.writeDouble(latitude);
 		out.writeDouble(longitude);
 		out.writeInt(zoom);
-		out.writeFloat(rotation);
 		out.writeByte((byte) (animated ? 1 : 0));
+		out.writeFloat(rotation);
 	}
 
 	private void readFromParcel(Parcel in) {
 		latitude = in.readDouble();
 		longitude = in.readDouble();
 		zoom = in.readInt();
-		rotation = in.readFloat();
 		animated = in.readByte() != 0;
+		rotation = in.readFloat();
 	}
 
 	public int describeContents() {

--- a/OsmAnd/src/net/osmand/aidl/OsmandAidlApi.java
+++ b/OsmAnd/src/net/osmand/aidl/OsmandAidlApi.java
@@ -138,6 +138,8 @@ public class OsmandAidlApi {
 	private static final String AIDL_LATITUDE = "aidl_latitude";
 	private static final String AIDL_LONGITUDE = "aidl_longitude";
 	private static final String AIDL_ZOOM = "aidl_zoom";
+	private static final String AIDL_ROTATION = "aidl_rotation";
+
 	private static final String AIDL_ANIMATED = "aidl_animated";
 
 	private static final String AIDL_START_NAME = "aidl_start_name";
@@ -292,6 +294,8 @@ public class OsmandAidlApi {
 					double lon = intent.getDoubleExtra(AIDL_LONGITUDE, Double.NaN);
 					int zoom = intent.getIntExtra(AIDL_ZOOM, 0);
 					boolean animated = intent.getBooleanExtra(AIDL_ANIMATED, false);
+					float rotation = intent.getFloatExtra(AIDL_ROTATION, Float.NaN);
+
 					if (!Double.isNaN(lat) && !Double.isNaN(lon)) {
 						OsmandMapTileView mapView = mapActivity.getMapView();
 						if (zoom == 0) {
@@ -299,6 +303,9 @@ public class OsmandAidlApi {
 						} else {
 							zoom = zoom > mapView.getMaxZoom() ? mapView.getMaxZoom() : zoom;
 							zoom = zoom < mapView.getMinZoom() ? mapView.getMinZoom() : zoom;
+						}
+						if(rotation != Float.NaN) {
+							mapView.setRotate(rotation,false);
 						}
 						if (animated) {
 							mapView.getAnimatedDraggingThread().startMoving(lat, lon, zoom, true);
@@ -1548,12 +1555,13 @@ public class OsmandAidlApi {
 		return false;
 	}
 
-	boolean setMapLocation(double latitude, double longitude, int zoom, boolean animated) {
+	boolean setMapLocation(double latitude, double longitude, int zoom, float rotation, boolean animated) {
 		Intent intent = new Intent();
 		intent.setAction(AIDL_SET_MAP_LOCATION);
 		intent.putExtra(AIDL_LATITUDE, latitude);
 		intent.putExtra(AIDL_LONGITUDE, longitude);
 		intent.putExtra(AIDL_ZOOM, zoom);
+		intent.putExtra(AIDL_ROTATION, rotation);
 		intent.putExtra(AIDL_ANIMATED, animated);
 		app.sendBroadcast(intent);
 		return true;

--- a/OsmAnd/src/net/osmand/aidl/OsmandAidlApi.java
+++ b/OsmAnd/src/net/osmand/aidl/OsmandAidlApi.java
@@ -302,7 +302,7 @@ public class OsmandAidlApi {
 							zoom = zoom > mapView.getMaxZoom() ? mapView.getMaxZoom() : zoom;
 							zoom = zoom < mapView.getMinZoom() ? mapView.getMinZoom() : zoom;
 						}
-						if(rotation != Float.NaN) {
+						if(!Float.isNaN(rotation)) {
 							mapView.setRotate(rotation, false);
 						}
 						if (animated) {

--- a/OsmAnd/src/net/osmand/aidl/OsmandAidlApi.java
+++ b/OsmAnd/src/net/osmand/aidl/OsmandAidlApi.java
@@ -139,7 +139,6 @@ public class OsmandAidlApi {
 	private static final String AIDL_LONGITUDE = "aidl_longitude";
 	private static final String AIDL_ZOOM = "aidl_zoom";
 	private static final String AIDL_ROTATION = "aidl_rotation";
-
 	private static final String AIDL_ANIMATED = "aidl_animated";
 
 	private static final String AIDL_START_NAME = "aidl_start_name";

--- a/OsmAnd/src/net/osmand/aidl/OsmandAidlApi.java
+++ b/OsmAnd/src/net/osmand/aidl/OsmandAidlApi.java
@@ -294,7 +294,6 @@ public class OsmandAidlApi {
 					int zoom = intent.getIntExtra(AIDL_ZOOM, 0);
 					boolean animated = intent.getBooleanExtra(AIDL_ANIMATED, false);
 					float rotation = intent.getFloatExtra(AIDL_ROTATION, Float.NaN);
-
 					if (!Double.isNaN(lat) && !Double.isNaN(lon)) {
 						OsmandMapTileView mapView = mapActivity.getMapView();
 						if (zoom == 0) {
@@ -304,7 +303,7 @@ public class OsmandAidlApi {
 							zoom = zoom < mapView.getMinZoom() ? mapView.getMinZoom() : zoom;
 						}
 						if(rotation != Float.NaN) {
-							mapView.setRotate(rotation,false);
+							mapView.setRotate(rotation, false);
 						}
 						if (animated) {
 							mapView.getAnimatedDraggingThread().startMoving(lat, lon, zoom, true);

--- a/OsmAnd/src/net/osmand/aidl/OsmandAidlService.java
+++ b/OsmAnd/src/net/osmand/aidl/OsmandAidlService.java
@@ -597,7 +597,7 @@ public class OsmandAidlService extends Service implements AidlCallbackListener {
 				if (params != null) {
 					OsmandAidlApi api = getApi("setMapLocation");
 					return api != null && api.setMapLocation(params.getLatitude(), params.getLongitude(),
-							params.getZoom(), params.isAnimated());
+							params.getZoom(), params.getRotation(), params.isAnimated());
 				}
 				return false;
 			} catch (Exception e) {

--- a/OsmAnd/src/net/osmand/aidl/OsmandAidlServiceV2.java
+++ b/OsmAnd/src/net/osmand/aidl/OsmandAidlServiceV2.java
@@ -597,7 +597,7 @@ public class OsmandAidlServiceV2 extends Service implements AidlCallbackListener
 				if (params != null) {
 					OsmandAidlApi api = getApi("setMapLocation");
 					return api != null && api.setMapLocation(params.getLatitude(), params.getLongitude(),
-							params.getZoom(), params.isAnimated());
+							params.getZoom(), params.getRotation(), params.isAnimated());
 				}
 				return false;
 			} catch (Exception e) {

--- a/OsmAnd/src/net/osmand/aidl/map/SetMapLocationParams.java
+++ b/OsmAnd/src/net/osmand/aidl/map/SetMapLocationParams.java
@@ -11,10 +11,7 @@ public class SetMapLocationParams implements Parcelable {
 	private float rotation;
 	private boolean animated;
 
-	public SetMapLocationParams(double latitude, double longitude, int zoom, boolean animated) {
-		this(latitude, longitude, zoom, Float.NaN, animated);
-	}
-	
+
 	public SetMapLocationParams(double latitude, double longitude, int zoom, float rotation, boolean animated) {
 		this.latitude = latitude;
 		this.longitude = longitude;
@@ -62,16 +59,16 @@ public class SetMapLocationParams implements Parcelable {
 		out.writeDouble(latitude);
 		out.writeDouble(longitude);
 		out.writeInt(zoom);
-		out.writeFloat(rotation);
 		out.writeByte((byte) (animated ? 1 : 0));
+		out.writeFloat(rotation);
 	}
 
 	private void readFromParcel(Parcel in) {
 		latitude = in.readDouble();
 		longitude = in.readDouble();
 		zoom = in.readInt();
-		rotation = in.readFloat();
 		animated = in.readByte() != 0;
+		rotation = in.readFloat();
 	}
 
 	public int describeContents() {

--- a/OsmAnd/src/net/osmand/aidl/map/SetMapLocationParams.java
+++ b/OsmAnd/src/net/osmand/aidl/map/SetMapLocationParams.java
@@ -8,12 +8,18 @@ public class SetMapLocationParams implements Parcelable {
 	private double latitude;
 	private double longitude;
 	private int zoom;
+	private float rotation;
 	private boolean animated;
 
 	public SetMapLocationParams(double latitude, double longitude, int zoom, boolean animated) {
+		this(latitude, longitude, zoom, Float.NaN, animated);
+	}
+	
+	public SetMapLocationParams(double latitude, double longitude, int zoom, float rotation, boolean animated) {
 		this.latitude = latitude;
 		this.longitude = longitude;
 		this.zoom = zoom;
+		this.rotation = rotation;
 		this.animated = animated;
 	}
 
@@ -44,6 +50,10 @@ public class SetMapLocationParams implements Parcelable {
 		return zoom;
 	}
 
+	public float getRotation() {
+		return rotation;
+	}
+
 	public boolean isAnimated() {
 		return animated;
 	}
@@ -52,6 +62,7 @@ public class SetMapLocationParams implements Parcelable {
 		out.writeDouble(latitude);
 		out.writeDouble(longitude);
 		out.writeInt(zoom);
+		out.writeFloat(rotation);
 		out.writeByte((byte) (animated ? 1 : 0));
 	}
 
@@ -59,6 +70,7 @@ public class SetMapLocationParams implements Parcelable {
 		latitude = in.readDouble();
 		longitude = in.readDouble();
 		zoom = in.readInt();
+		rotation = in.readFloat();
 		animated = in.readByte() != 0;
 	}
 


### PR DESCRIPTION
Added a rotation parameter to setMapLocation.
I think it's better to have it before animated parameter, but if you prefer to put it at the end I can do it.
I also added a  SetMapLocationParams constructor without rotation for backward compatibility