### PR TITLE
Fix external device keypresses

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/MapActivityKeyListener.java
+++ b/OsmAnd/src/net/osmand/plus/activities/MapActivityKeyListener.java
@@ -13,6 +13,7 @@ import net.osmand.plus.helpers.ScrollHelper;
 import net.osmand.plus.settings.backend.OsmandSettings;
 import net.osmand.plus.views.OsmandMapTileView;
 
+import static net.osmand.plus.settings.backend.OsmandSettings.NO_EXTERNAL_DEVICE;
 import static net.osmand.plus.settings.backend.OsmandSettings.GENERIC_EXTERNAL_DEVICE;
 import static net.osmand.plus.settings.backend.OsmandSettings.PARROT_EXTERNAL_DEVICE;
 import static net.osmand.plus.settings.backend.OsmandSettings.WUNDERLINQ_EXTERNAL_DEVICE;
@@ -60,6 +61,8 @@ public class MapActivityKeyListener implements KeyEvent.Callback {
 				mapActivity.changeZoom(1);
 				return true;
 			}
+		} else if (settings.EXTERNAL_INPUT_DEVICE.get() != NO_EXTERNAL_DEVICE) {
+			return true;
 		} else if (mapScrollHelper.isScrollingDirectionKeyCode(keyCode)) {
 			return mapScrollHelper.onKeyDown(keyCode, event);
 		}


### PR DESCRIPTION
Looks like a recent change to handle onKeyUp and onKeyDown produces duplicate input with External Input Device.  This is a quick fix.