### PR TITLE
Fix: ask to unlock device if it requires keyboard interaction while locked

### DIFF
--- a/OsmAnd/src/net/osmand/AndroidUtils.java
+++ b/OsmAnd/src/net/osmand/AndroidUtils.java
@@ -96,20 +96,24 @@ public class AndroidUtils {
 		return context.getResources().getConfiguration().keyboard != Configuration.KEYBOARD_NOKEYS;
 	}
 
-	public static void softKeyboardDelayed(final View view) {
+	public static void softKeyboardDelayed(final Activity activity, final View view) {
 		view.post(new Runnable() {
 			@Override
 			public void run() {
 				if (!isHardwareKeyboardAvailable(view.getContext())) {
-					showSoftKeyboard(view);
+					showSoftKeyboard(activity,view);
 				}
 			}
 		});
 	}
 
-	public static void showSoftKeyboard(final View view) {
+	public static void showSoftKeyboard(final Activity activity, final View view) {
 		InputMethodManager imm = (InputMethodManager) view.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
 		if (imm != null) {
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+				KeyguardManager keyguardManager = (KeyguardManager) view.getContext().getSystemService(Context.KEYGUARD_SERVICE);
+				keyguardManager.requestDismissKeyguard(activity,null);
+			}
 			imm.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT);
 		}
 	}

--- a/OsmAnd/src/net/osmand/plus/activities/FavoritesSearchFragment.java
+++ b/OsmAnd/src/net/osmand/plus/activities/FavoritesSearchFragment.java
@@ -249,7 +249,7 @@ public class FavoritesSearchFragment extends DialogFragment {
 
 	private void openKeyboard() {
 		searchEditText.requestFocus();
-		AndroidUtils.softKeyboardDelayed(searchEditText);
+		AndroidUtils.softKeyboardDelayed(getActivity(), searchEditText);
 	}
 
 	public void hideKeyboard() {

--- a/OsmAnd/src/net/osmand/plus/dialogs/FavoriteDialogs.java
+++ b/OsmAnd/src/net/osmand/plus/dialogs/FavoriteDialogs.java
@@ -113,7 +113,7 @@ public class FavoriteDialogs {
 		editText.requestFocus();
 		final AutoCompleteTextView cat =  (AutoCompleteTextView) dialog.findViewById(R.id.Category);
 		cat.setText(point.getCategory());
-		AndroidUtils.softKeyboardDelayed(editText);
+		AndroidUtils.softKeyboardDelayed(activity, editText);
 	}
 	
 	public  static Dialog createAddFavouriteDialog(final Activity activity, final Bundle args) {

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/editors/EditCategoryDialogFragment.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/editors/EditCategoryDialogFragment.java
@@ -78,7 +78,7 @@ public class EditCategoryDialogFragment extends DialogFragment {
 		nameEdit = (EditText)v.findViewById(R.id.edit_name);
 		nameEdit.setText(name);
 		nameEdit.requestFocus();
-		AndroidUtils.softKeyboardDelayed(nameEdit);
+		AndroidUtils.softKeyboardDelayed(getActivity(), nameEdit);
 		colorSpinner = (Spinner)v.findViewById(R.id.edit_color);
 		final TIntArrayList colors = new TIntArrayList();
 		final int intColor = color;

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/editors/PointEditorFragment.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/editors/PointEditorFragment.java
@@ -207,7 +207,7 @@ public abstract class PointEditorFragment extends BaseOsmAndFragment {
 		if (editor != null && editor.isNew()) {
 			nameEdit.selectAll();
 			nameEdit.requestFocus();
-			AndroidUtils.softKeyboardDelayed(nameEdit);
+			AndroidUtils.softKeyboardDelayed(getActivity(), nameEdit);
 		}
 	}
 

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/editors/PointEditorFragmentNew.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/editors/PointEditorFragmentNew.java
@@ -235,7 +235,7 @@ public abstract class PointEditorFragmentNew extends BaseOsmAndFragment {
 					addDelDescription.setText(view.getResources().getString(R.string.delete_description));
 					View descriptionEdit = view.findViewById(R.id.description_edit);
 					descriptionEdit.requestFocus();
-					AndroidUtils.softKeyboardDelayed(descriptionEdit);
+					AndroidUtils.softKeyboardDelayed(getActivity(), descriptionEdit);
 				} else {
 					descriptionCaption.setVisibility(View.GONE);
 					addDelDescription.setText(view.getResources().getString(R.string.add_description));
@@ -267,7 +267,7 @@ public abstract class PointEditorFragmentNew extends BaseOsmAndFragment {
 			deleteIcon.setVisibility(View.GONE);
 			nameEdit.selectAll();
 			nameEdit.requestFocus();
-			AndroidUtils.softKeyboardDelayed(nameEdit);
+			AndroidUtils.softKeyboardDelayed(getActivity(), nameEdit);
 		} else {
 			toolbarAction.setImageDrawable(app.getUIUtilities().getIcon(R.drawable.ic_action_delete_dark, activeColorResId));
 			deleteButton.setVisibility(View.VISIBLE);

--- a/OsmAnd/src/net/osmand/plus/mapmarkers/CoordinateInputDialogFragment.java
+++ b/OsmAnd/src/net/osmand/plus/mapmarkers/CoordinateInputDialogFragment.java
@@ -391,7 +391,7 @@ public class CoordinateInputDialogFragment extends DialogFragment implements Osm
 				}
 				final View focusedView = getDialog().getCurrentFocus();
 				if (focusedView != null) {
-					AndroidUtils.softKeyboardDelayed(focusedView);
+					AndroidUtils.softKeyboardDelayed(getActivity(), focusedView);
 				}
 			}
 		});
@@ -707,7 +707,7 @@ public class CoordinateInputDialogFragment extends DialogFragment implements Osm
 		final View focusedView = getDialog().getCurrentFocus();
 		if (focusedView != null) {
 			if (!isOsmandKeyboardOn()) {
-				AndroidUtils.softKeyboardDelayed(focusedView);
+				AndroidUtils.softKeyboardDelayed(getActivity(), focusedView);
 			}
 		}
 	}
@@ -1039,7 +1039,7 @@ public class CoordinateInputDialogFragment extends DialogFragment implements Osm
 				new Handler().postDelayed(new Runnable() {
 					@Override
 					public void run() {
-						AndroidUtils.showSoftKeyboard(focusedView);
+						AndroidUtils.showSoftKeyboard(getActivity(), focusedView);
 					}
 				}, 200);
 			}
@@ -1271,7 +1271,7 @@ public class CoordinateInputDialogFragment extends DialogFragment implements Osm
 				changeOsmandKeyboardVisibility(true);
 			}
 		} else if (!softKeyboardShown && focusedView != null) {
-			AndroidUtils.softKeyboardDelayed(focusedView);
+			AndroidUtils.softKeyboardDelayed(getActivity(), focusedView);
 		}
 	}
 

--- a/OsmAnd/src/net/osmand/plus/osmedit/EditPoiDialogFragment.java
+++ b/OsmAnd/src/net/osmand/plus/osmedit/EditPoiDialogFragment.java
@@ -281,7 +281,7 @@ public class EditPoiDialogFragment extends BaseOsmAndDialogFragment {
 		});
 		poiNameEditText.setText(editPoiData.getTag(OSMSettings.OSMTagKey.NAME.getValue()));
 		poiNameEditText.requestFocus();
-		AndroidUtils.showSoftKeyboard(poiNameEditText);
+		AndroidUtils.showSoftKeyboard(getActivity(), poiNameEditText);
 		poiTypeTextInputLayout = (TextInputLayout) view.findViewById(R.id.poiTypeTextInputLayout);
 		poiTypeEditText = (AutoCompleteTextView) view.findViewById(R.id.poiTypeEditText);
 		AndroidUtils.setTextHorizontalGravity(poiTypeEditText, Gravity.START);

--- a/OsmAnd/src/net/osmand/plus/osmedit/OsmBugsLayer.java
+++ b/OsmAnd/src/net/osmand/plus/osmedit/OsmBugsLayer.java
@@ -450,7 +450,7 @@ public class OsmBugsLayer extends OsmandMapLayer implements IContextMenuProvider
 			((EditText) view.findViewById(R.id.message_field)).setText(text);
 		}
 		view.findViewById(R.id.message_field).requestFocus();
-		AndroidUtils.softKeyboardDelayed(view.findViewById(R.id.message_field));
+		AndroidUtils.softKeyboardDelayed(activity, view.findViewById(R.id.message_field));
 
 		final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
 		builder.setTitle(R.string.shared_string_commit);

--- a/OsmAnd/src/net/osmand/plus/search/QuickSearchCustomPoiFragment.java
+++ b/OsmAnd/src/net/osmand/plus/search/QuickSearchCustomPoiFragment.java
@@ -223,7 +223,7 @@ public class QuickSearchCustomPoiFragment extends DialogFragment implements OnFi
 			@Override
 			public void onClick(View view) {
 				searchEditText.requestFocus();
-				AndroidUtils.showSoftKeyboard(searchEditText);
+				AndroidUtils.showSoftKeyboard(getActivity(), searchEditText);
 			}
 		});
 		searchCloseIcon = view.findViewById(R.id.search_close);

--- a/OsmAnd/src/net/osmand/plus/search/QuickSearchDialogFragment.java
+++ b/OsmAnd/src/net/osmand/plus/search/QuickSearchDialogFragment.java
@@ -1928,7 +1928,7 @@ public class QuickSearchDialogFragment extends DialogFragment implements OsmAndC
 
 	private void openKeyboard() {
 		searchEditText.requestFocus();
-		AndroidUtils.softKeyboardDelayed(searchEditText);
+		AndroidUtils.softKeyboardDelayed(getActivity(), searchEditText);
 	}
 
 	public void replaceQueryWithText(String txt) {

--- a/OsmAnd/src/net/osmand/plus/search/QuickSearchSubCategoriesFragment.java
+++ b/OsmAnd/src/net/osmand/plus/search/QuickSearchSubCategoriesFragment.java
@@ -210,7 +210,7 @@ public class QuickSearchSubCategoriesFragment extends BaseOsmAndDialogFragment {
 			@Override
 			public void onClick(View view) {
 				searchEditText.requestFocus();
-				AndroidUtils.showSoftKeyboard(searchEditText);
+				AndroidUtils.showSoftKeyboard(getActivity(), searchEditText);
 			}
 		});
 		ImageView searchCloseIcon = root.findViewById(R.id.search_close);

--- a/OsmAnd/src/net/osmand/plus/settings/fragments/ProfileAppearanceFragment.java
+++ b/OsmAnd/src/net/osmand/plus/settings/fragments/ProfileAppearanceFragment.java
@@ -368,7 +368,7 @@ public class ProfileAppearanceFragment extends BaseSettingsFragment {
 				public void onFocusChange(View v, boolean hasFocus) {
 					if(hasFocus){
 						profileName.setSelection(profileName.getText().length());
-						AndroidUtils.showSoftKeyboard(profileName);
+						AndroidUtils.showSoftKeyboard(getMyActivity(), profileName);
 					}
 				}
 			});


### PR DESCRIPTION
Ask to unlock device if it requires keyboard interaction while in FLAG_SHOW_WHEN_LOCKED mode.
It's usefull while hicking with "Turn screen on: Power button" enabled and one wants to add a Poi or search something.
Without  it the keyboard won't show, and the user need to put osmand in backgrund, unlock the screen and put osmand in foreground again in order to interact
