### PR TITLE
Allow custom "user-agent" for tile download

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/map/ITileSource.java
+++ b/OsmAnd-java/src/main/java/net/osmand/map/ITileSource.java
@@ -32,6 +32,8 @@ public interface ITileSource {
 
 	public String getReferer();
 
+	public String getUserAgent();
+
 	public void deleteTiles(String path);
 
 	public int getAvgSize();

--- a/OsmAnd-java/src/main/java/net/osmand/map/MapTileDownloader.java
+++ b/OsmAnd-java/src/main/java/net/osmand/map/MapTileDownloader.java
@@ -90,6 +90,7 @@ public class MapTileDownloader {
 		public final int yTile;
 		public String url;
 		public String referer = null;
+		public String userAgent = null;
 		public boolean error;
 
 		public DownloadRequest(String url, File fileToSave, int xTile, int yTile, int zoom) {
@@ -266,7 +267,7 @@ public class MapTileDownloader {
 				request.setError(false);
 				try {
 					URLConnection connection = NetworkUtils.getHttpURLConnection(request.url);
-					connection.setRequestProperty("User-Agent", USER_AGENT); //$NON-NLS-1$
+					connection.setRequestProperty("User-Agent", Algorithms.isEmpty(request.userAgent) ? USER_AGENT : request.userAgent); //$NON-NLS-1$
 					if (request.referer != null)
 						connection.setRequestProperty("Referer", request.referer); //$NON-NLS-1$
 					connection.setConnectTimeout(CONNECTION_TIMEOUT);

--- a/OsmAnd-java/src/main/java/net/osmand/map/TileSourceManager.java
+++ b/OsmAnd-java/src/main/java/net/osmand/map/TileSourceManager.java
@@ -68,6 +68,7 @@ public class TileSourceManager {
 		private String[] randomsArray;
 		private String rule;
 		private String referer;
+		private String userAgent;
 		private boolean hidden; // if hidden in configure map settings, for example mapillary sources
 
 		private boolean isRuleAcceptable = true;
@@ -259,6 +260,14 @@ public class TileSourceManager {
 
 		public void setReferer(String referer) {
 			this.referer = referer;
+		}
+
+		public String getUserAgent() {
+			return userAgent;
+		}
+
+		public void setUserAgent(String userAgent) {
+			this.userAgent = userAgent;
 		}
 
 		@Override
@@ -484,6 +493,9 @@ public class TileSourceManager {
 		if (!Algorithms.isEmpty(tm.getReferer())) {
 			properties.put("referer", tm.getReferer());
 		}
+		if (!Algorithms.isEmpty(tm.getUserAgent())) {
+			properties.put("user_agent", tm.getUserAgent());
+		}
 
 		properties.put("ext", tm.getTileFormat());
 		properties.put("min_zoom", tm.getMinimumZoomSupported() + "");
@@ -708,6 +720,12 @@ public class TileSourceManager {
 		}
 		String randoms = attributes.get("randoms");
 		TileSourceTemplate templ = new TileSourceTemplate(name, urlTemplate, ext, maxZoom, minZoom, tileSize, bitDensity, avgTileSize);
+		if (attributes.get("referer") != null) {
+			templ.setReferer(attributes.get("referer"));
+		}
+		if (attributes.get("user_agent") != null) {
+			templ.setUserAgent(attributes.get("user_agent"));
+		}
 		if(expirationTime >= 0) {
 			templ.setExpirationTimeMinutes(expirationTime);
 		}

--- a/OsmAnd/src/net/osmand/plus/SQLiteTileSource.java
+++ b/OsmAnd/src/net/osmand/plus/SQLiteTileSource.java
@@ -39,6 +39,7 @@ public class SQLiteTileSource implements ITileSource {
 	private static final String ELLIPSOID = "ellipsoid";
 	private static final String INVERTED_Y = "inverted_y";
 	private static final String REFERER = "referer";
+	private static final String USER_AGENT = "useragent";
 	private static final String TIME_COLUMN = "timecolumn";
 	private static final String EXPIRE_MINUTES = "expireminutes";
 	private static final String RULE = "rule";
@@ -62,6 +63,7 @@ public class SQLiteTileSource implements ITileSource {
 	private String[] randomsArray;
 	private String rule = null;
 	private String referer = null;
+	private String userAgent = null;
 	
 	int tileSize = 256;
 	boolean tileSizeSpecified = false;
@@ -93,7 +95,7 @@ public class SQLiteTileSource implements ITileSource {
 	}
 
 	public SQLiteTileSource(OsmandApplication ctx, String name, int minZoom, int maxZoom, String urlTemplate,
-							String randoms, boolean isEllipsoid, boolean invertedY, String referer,
+							String randoms, boolean isEllipsoid, boolean invertedY, String referer, String userAgent,
 							boolean timeSupported, long expirationTimeMillis, boolean inversiveZoom, String rule) {
 		this.ctx = ctx;
 		this.name = name;
@@ -104,6 +106,7 @@ public class SQLiteTileSource implements ITileSource {
 		this.expirationTimeMillis = expirationTimeMillis;
 		this.randoms = randoms;
 		this.referer = referer;
+		this.userAgent = userAgent;
 		this.rule = rule;
 		this.invertedY = invertedY;
 		this.timeSupported = timeSupported;
@@ -120,6 +123,7 @@ public class SQLiteTileSource implements ITileSource {
 		this.expirationTimeMillis = tileSource.getExpirationTimeMillis();
 		this.randoms = tileSource.getRandoms();
 		this.referer = tileSource.getReferer();
+		this.userAgent = tileSource.getUserAgent();
 		this.invertedY = tileSource.isInvertedYTile();
 		this.timeSupported = tileSource.isTimeSupported();
 		this.inversiveZoom = tileSource.getInversiveZoom();
@@ -139,6 +143,7 @@ public class SQLiteTileSource implements ITileSource {
 		addInfoColumn(db, ELLIPSOID, isEllipsoid ? "1" : "0");
 		addInfoColumn(db, INVERTED_Y, invertedY ? "1" : "0");
 		addInfoColumn(db, REFERER, referer);
+		addInfoColumn(db, USER_AGENT, userAgent);
 		addInfoColumn(db, TIME_COLUMN, timeSupported ? "yes" : "no");
 		addInfoColumn(db, EXPIRE_MINUTES, String.valueOf(getExpirationTimeMinutes()));
 
@@ -263,6 +268,10 @@ public class SQLiteTileSource implements ITileSource {
 					int refererId = list.indexOf(REFERER);
 					if(refererId != -1) {
 						referer = cursor.getString(refererId);
+					}
+					int userAgentId = list.indexOf(USER_AGENT);
+					if(userAgentId != -1) {
+						userAgent = cursor.getString(userAgentId);
 					}
 					int tnumbering = list.indexOf(TILENUMBERING);
 					if(tnumbering != -1) {
@@ -671,6 +680,10 @@ public class SQLiteTileSource implements ITileSource {
 	
 	public String getReferer() {
 		return referer;
+	}
+
+	public String getUserAgent() {
+		return userAgent;
 	}
 
 }

--- a/OsmAnd/src/net/osmand/plus/resources/AsyncLoadingThread.java
+++ b/OsmAnd/src/net/osmand/plus/resources/AsyncLoadingThread.java
@@ -105,12 +105,13 @@ public class AsyncLoadingThread extends Thread {
 		}
 		
 		public TileLoadDownloadRequest(File dirWithTiles, String url, File fileToSave, String tileId, ITileSource source, int tileX,
-				int tileY, int zoom, String referer) {
+				int tileY, int zoom, String referer, String userAgent) {
 			super(url, fileToSave, tileX, tileY, zoom);
 			this.dirWithTiles = dirWithTiles;
 			this.tileSource = source;
 			this.tileId = tileId;
 			this.referer = referer;
+			this.userAgent = userAgent;
 		}
 		
 		public void saveTile(InputStream inputStream) throws IOException {

--- a/OsmAnd/src/net/osmand/plus/resources/TilesCache.java
+++ b/OsmAnd/src/net/osmand/plus/resources/TilesCache.java
@@ -144,7 +144,7 @@ public abstract class TilesCache<T> {
 				}
 			}
 			TileLoadDownloadRequest req = new TileLoadDownloadRequest(dirWithTiles, url, toSave,
-					tileId, map, x, y, zoom, map.getReferer());
+					tileId, map, x, y, zoom, map.getReferer(), map.getUserAgent());
 			if (sync) {
 				return getRequestedTile(req);
 			} else {

--- a/OsmAnd/src/net/osmand/plus/settings/backend/SettingsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/SettingsHelper.java
@@ -2035,6 +2035,7 @@ public class SettingsHelper {
 					boolean ellipsoid = object.optBoolean("ellipsoid", false);
 					boolean invertedY = object.optBoolean("inverted_y", false);
 					String referer = object.optString("referer");
+					String userAgent = object.optString("userAgent");
 					boolean timeSupported = object.optBoolean("timesupported", false);
 					long expire = object.optLong("expire", -1);
 					boolean inversiveZoom = object.optBoolean("inversiveZoom", false);
@@ -2054,13 +2055,14 @@ public class SettingsHelper {
 						tileSourceTemplate.setRule(rule);
 						tileSourceTemplate.setRandoms(randoms);
 						tileSourceTemplate.setReferer(referer);
+						tileSourceTemplate.setUserAgent(userAgent);
 						tileSourceTemplate.setEllipticYTile(ellipsoid);
 						tileSourceTemplate.setInvertedYTile(invertedY);
 						tileSourceTemplate.setExpirationTimeMillis(timeSupported ? expire : -1);
 
 						template = tileSourceTemplate;
 					} else {
-						template = new SQLiteTileSource(app, name, minZoom, maxZoom, url, randoms, ellipsoid, invertedY, referer, timeSupported, expire, inversiveZoom, rule);
+						template = new SQLiteTileSource(app, name, minZoom, maxZoom, url, randoms, ellipsoid, invertedY, referer, userAgent, timeSupported, expire, inversiveZoom, rule);
 					}
 					items.add(template);
 				}
@@ -2087,6 +2089,7 @@ public class SettingsHelper {
 						jsonObject.put("ellipsoid", template.isEllipticYTile());
 						jsonObject.put("inverted_y", template.isInvertedYTile());
 						jsonObject.put("referer", template.getReferer());
+						jsonObject.put("userAgent", template.getUserAgent());
 						jsonObject.put("timesupported", template.isTimeSupported());
 						jsonObject.put("expire", template.getExpirationTimeMinutes());
 						jsonObject.put("inversiveZoom", template.getInversiveZoom());


### PR DESCRIPTION
This PR allows you to use a custom "User-Agent" for tile request, instead of the default one. Like "Referer", this parameter is optional in both SQLite and MetaInfo formats. Btw, this PR also loads `referer` parameter from MetaInfo.