### PR TITLE
added recycling:small_electrical_appliances

### DIFF
--- a/OsmAnd/res/values/phrases.xml
+++ b/OsmAnd/res/values/phrases.xml
@@ -498,6 +498,7 @@
 	<string name="poi_recycling_magazines">Magazines</string>
 	<string name="poi_recycling_paper_packaging">Paper packaging</string>
 	<string name="poi_recycling_small_appliances">Small appliances</string>
+	<string name="poi_recycling_small_electrical_appliances">Small electrical appliances</string>
 	<string name="poi_recycling_wood">Wood</string>
 	<string name="poi_recycling_books">Books</string>
 	<string name="poi_recycling_shoes">Shoes</string>


### PR DESCRIPTION
recycling:small_electrical_applicances is documented in https://wiki.openstreetmap.org/wiki/Tag:amenity%3Drecycling and it's a bit more precise than just recycling:small_appliances.

recycling:small_electrical_applicances gets more and more used when people want to add the information that there is the possibility to recycle these things.