### PR TITLE
Update MeasurementToolFragment.java

### DIFF
--- a/OsmAnd/src/net/osmand/plus/measurementtool/MeasurementToolFragment.java
+++ b/OsmAnd/src/net/osmand/plus/measurementtool/MeasurementToolFragment.java
@@ -1132,10 +1132,14 @@ public class MeasurementToolFragment extends BaseOsmAndFragment implements Route
 		final ApplicationMode appMode = editingCtx.getAppMode();
 		if (mapActivity != null) {
 			Drawable icon;
-			if (appMode == MeasurementEditingContext.DEFAULT_APP_MODE) {
-				icon = getActiveIcon(R.drawable.ic_action_split_interval);
+			if (editingCtx.isTrackSnappedToRoad() || editingCtx.isNewData()) {
+				if (appMode == MeasurementEditingContext.DEFAULT_APP_MODE) {
+					icon = getActiveIcon(R.drawable.ic_action_split_interval);
+				} else {
+					icon = getIcon(appMode.getIconRes(), appMode.getIconColorInfo().getColor(nightMode));
+				}
 			} else {
-				icon = getIcon(appMode.getIconRes(), appMode.getIconColorInfo().getColor(nightMode));
+				icon = getContentIcon(R.drawable.ic_action_help);
 			}
 			ImageButton snapToRoadBtn = (ImageButton) mapActivity.findViewById(R.id.snap_to_road_image_button);
 			snapToRoadBtn.setImageDrawable(icon);


### PR DESCRIPTION
If user open existing track that was created outside OsmAnd and Route between points is undefined, show the same icon for route type button on the map