### PR TITLE
Plan a route executor multiple calculations bug fix

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/RoutePlannerFrontEnd.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RoutePlannerFrontEnd.java
@@ -243,6 +243,9 @@ public class RoutePlannerFrontEnd {
 			start = gpxPoints.get(0); 
 		}
 		while (start != null && !gctx.ctx.calculationProgress.isCancelled) {
+			if (Thread.currentThread().isInterrupted()) {
+				return null;
+			}
 			double routeDist = gctx.MAXIMUM_STEP_APPROXIMATION;
 			GpxPoint next = findNextGpxPointWithin(gctx, gpxPoints, start, routeDist);
 			boolean routeFound = false;
@@ -256,7 +259,7 @@ public class RoutePlannerFrontEnd {
 						if (routeFound) {
 							// route is found - cut the end of the route and move to next iteration
 //							start.stepBackRoute = new ArrayList<RouteSegmentResult>();
-//							boolean stepBack = true; 
+//							boolean stepBack = true;
 							boolean stepBack = stepBackAndFindPrevPointInRoute(gctx, gpxPoints, start, next);
 							if (!stepBack) {
 								// not supported case (workaround increase MAXIMUM_STEP_APPROXIMATION)

--- a/OsmAnd/src/net/osmand/plus/routing/GpxApproximator.java
+++ b/OsmAnd/src/net/osmand/plus/routing/GpxApproximator.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -44,6 +45,7 @@ public class GpxApproximator {
 
 	private ThreadPoolExecutor singleThreadedExecutor;
 	private GpxApproximationProgressCallback approximationProgress;
+	private Future<?> currentApproximationTask;
 
 	public interface GpxApproximationProgressCallback {
 
@@ -152,7 +154,10 @@ public class GpxApproximator {
 		this.gctx = gctx;
 		startProgress();
 		updateProgress(gctx);
-		singleThreadedExecutor.submit(new Runnable() {
+		if (currentApproximationTask != null) {
+			currentApproximationTask.cancel(true);
+		}
+		currentApproximationTask = singleThreadedExecutor.submit(new Runnable() {
 			@Override
 			public void run() {
 				try {


### PR DESCRIPTION
When a user starts "route between points"  and switches profiles in "plan a route" the calculations might not stop. 