### PR TITLE
support incoming content:// URIs pointing to OBF files

### DIFF
--- a/OsmAnd/AndroidManifest.xml
+++ b/OsmAnd/AndroidManifest.xml
@@ -247,6 +247,7 @@
 				<action android:name="android.intent.action.VIEW" />
 				<category android:name="android.intent.category.DEFAULT" />
 				<category android:name="android.intent.category.BROWSABLE" />
+				<data android:scheme="content"/>
 				<data android:scheme="file"/>
 				<data android:host="*"/>
 				<data android:pathPattern=".*\\.obf" />
@@ -262,6 +263,7 @@
 				<action android:name="android.intent.action.VIEW" />
 				<category android:name="android.intent.category.DEFAULT" />
 				<category android:name="android.intent.category.BROWSABLE" />
+				<data android:scheme="content"/>
 				<data android:scheme="file"/>
 				<data android:host="*"/>
 				<data android:mimeType="*/*"/>


### PR DESCRIPTION
The whole "handle import" plumbing is already in place to handle both file:// and content:// URIs for OBF files.  The `ObfImportTask` gets an `InputStream` from the `ContentResolver` already.  `handleContentImport` defers to the `handleFileImport` for which helper to instantiate.  Supporting content:// URIs here means this import can happen via `FileProvider` and other `ContentProvider` instances.

My use case is offline sharing of OBF files as handled by F-Droid Nearby Swap.  Users can select which installed OBF files to share, then nearby users can connect to the device via Bluetooth or local WiFi to get the files.