### PR TITLE
Mgrs coordinates

### DIFF
--- a/OsmAnd-java/src/main/java/com/jwetherell/openmap/common/MGRSPoint.java
+++ b/OsmAnd-java/src/main/java/com/jwetherell/openmap/common/MGRSPoint.java
@@ -14,6 +14,10 @@
 
 package com.jwetherell.openmap.common;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class MGRSPoint extends ZonedUTMPoint {
 
     /**
@@ -632,6 +636,97 @@ public class MGRSPoint extends ZonedUTMPoint {
 
         return twoLetter;
     }
+
+    public String toFlavoredString() {
+        try {
+            List<String> all = new ArrayList<>();
+            for (int i = 0; i <= mgrs.length(); i++) {
+                if (Character.isAlphabetic(mgrs.charAt(i))){
+                    all.add(mgrs.substring(0,i+1));
+                    all.add(mgrs.substring(i+1,i+3));
+                    String remains = mgrs.substring(i+3);
+                    all.add(remains.substring(0,remains.length()/2));
+                    all.add(remains.substring(remains.length()/2));
+                    break;
+                }
+            }
+            StringBuilder os = new StringBuilder();
+            for(String part: all){
+                if (os.length() > 0) os.append(" ");
+                os.append(part);
+            }
+            return os.toString();
+        }catch (Exception e){
+            return mgrs;
+        }
+    }
+
+    public String toFlavoredString(int accuracy) {
+        try {
+            List<String> all = new ArrayList<>();
+            for (int i = 0; i <= mgrs.length(); i++) {
+                if (Character.isAlphabetic(mgrs.charAt(i))){
+                    all.add(mgrs.substring(0,i+1));
+                    all.add(mgrs.substring(i+1,i+3));
+                    String remains = mgrs.substring(i+3);
+                    int easting = Integer.parseInt(remains.substring(0,remains.length()/2));
+                    int northing = Integer.parseInt(remains.substring(remains.length()/2));
+                    double resolution = Math.pow(10, getAccuracy() - accuracy);
+                    long roundedEasting = Math.round(easting/resolution);
+                    long roundedNorthing = Math.round(northing/resolution);
+                    int eastShift = 0;
+                    int northShift = 0;
+                    if (roundedEasting == resolution*10){
+                        roundedEasting = 0L;
+                        eastShift = 1;
+                    }
+                    if (roundedNorthing == resolution*10){
+                        roundedNorthing = 0L;
+                        northShift = 1;
+                    }
+                    if (eastShift != 0 || northShift != 0){
+                        all.set(1, shiftChar(all.get(1), eastShift, northShift));
+                        String zero = "";
+                    }
+
+
+                    all.add(String.format("%0" + accuracy + "d", roundedEasting));
+                    all.add(String.format("%0" + accuracy + "d", roundedNorthing));
+                    break;
+                }
+            }
+            StringBuilder os = new StringBuilder();
+            for(String part: all){
+                if (os.length() > 0) os.append(" ");
+                os.append(part);
+            }
+            return os.toString();
+        }catch (Exception e){
+            return toFlavoredString();
+        }
+    }
+
+    private static String shiftChar(String chars, int east, int north){
+        ArrayList<Character> keys = new ArrayList<Character>(
+                Arrays.asList('A','B','C','D','E','F','G','H','J','K','L','M','N','P','Q','R','S','T','U','V','W','X','Y','Z'));
+        StringBuilder s = new StringBuilder();
+        if (east != 0){
+            int idx = keys.indexOf(chars.charAt(0));
+            idx += east;
+            if (idx >= keys.size()) idx -= keys.size();
+            if (idx < 0) idx += keys.size();
+            s.append(keys.get(idx));
+        }else s.append(chars.charAt(0));
+        if (north != 0){
+            int idx = keys.indexOf(chars.charAt(1));
+            idx += north;
+            if (idx >= keys.size()) idx -= keys.size();
+            if (idx < 0) idx += keys.size();
+            s.append(keys.get(idx));
+        }else s.append(chars.charAt(1));
+        return s.toString();
+    }
+
 
     /**
      * {@inheritDoc}

--- a/OsmAnd-java/src/main/java/net/osmand/LocationConvert.java
+++ b/OsmAnd-java/src/main/java/net/osmand/LocationConvert.java
@@ -15,6 +15,7 @@ public class LocationConvert {
 	public static final int FORMAT_SECONDS = 2;
 	public static final int UTM_FORMAT = 3;
 	public static final int OLC_FORMAT = 4;
+	public static final int MGRS_FORMAT = 5;
 	private static final char DELIM = ':';
 	private static final char DELIMITER_DEGREES = '°';
 	private static final char DELIMITER_MINUTES = '′';

--- a/OsmAnd-java/src/main/java/net/osmand/util/LocationParser.java
+++ b/OsmAnd-java/src/main/java/net/osmand/util/LocationParser.java
@@ -3,6 +3,7 @@ package net.osmand.util;
 import com.google.openlocationcode.OpenLocationCode;
 import com.google.openlocationcode.OpenLocationCode.CodeArea;
 import com.jwetherell.openmap.common.LatLonPoint;
+import com.jwetherell.openmap.common.MGRSPoint;
 import com.jwetherell.openmap.common.UTMPoint;
 
 import net.osmand.data.LatLon;
@@ -111,7 +112,7 @@ public class LocationParser {
 			return null;
 		}
 		// detect UTM
-		if (all.size() == 4 && d.size() == 3 && all.get(1) instanceof String) {
+		if (all.size() == 4 && d.size() == 3 && all.get(1) instanceof String && ((String) all.get(1)).length() == 1) {
 			char ch = all.get(1).toString().charAt(0);
 			if (Character.isLetter(ch)) {
 				UTMPoint upoint = new UTMPoint(d.get(2), d.get(1), d.get(0).intValue(), ch);
@@ -120,7 +121,7 @@ public class LocationParser {
 			}
 		}
 
-		if (all.size() == 3 && d.size() == 2 && all.get(1) instanceof String) {
+		if (all.size() == 3 && d.size() == 2 && all.get(1) instanceof String && ((String) all.get(1)).length() == 1) {
 			char ch = all.get(1).toString().charAt(0);
 			String combined = strings.get(2);
 			if (Character.isLetter(ch)) {
@@ -133,6 +134,21 @@ public class LocationParser {
 					return validateAndCreateLatLon(ll.getLatitude(), ll.getLongitude());
 				} catch (NumberFormatException e) {
 				}
+			}
+		}
+
+		//detect MGRS
+		if (all.size() >= 3 && (d.size() == 2 || d.size() == 3) && all.get(1) instanceof String) {
+			try {
+				StringBuilder s = new StringBuilder();
+				for (String i : strings) {
+					s.append(i);
+				}
+				MGRSPoint mgrsPoint = new MGRSPoint(s.toString());
+				LatLonPoint ll = mgrsPoint.toLatLonPoint();
+				return validateAndCreateLatLon(ll.getLatitude(), ll.getLongitude());
+			} catch (NumberFormatException e) {
+				//do nothing
 			}
 		}
 		// try to find split lat/lon position

--- a/OsmAnd/res/layout/search_advanced_coords.xml
+++ b/OsmAnd/res/layout/search_advanced_coords.xml
@@ -325,6 +325,52 @@
                 </LinearLayout>
 
                 <LinearLayout
+                    android:id="@+id/mgrsLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:paddingTop="16dp"
+                    android:visibility="gone">
+
+                    <FrameLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content">
+
+                        <com.google.android.material.textfield.TextInputLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginLeft="54dp"
+                            android:layout_marginRight="16dp"
+                            android:layout_marginStart="54dp"
+                            android:layout_marginEnd="16dp">
+
+                            <EditText
+                                android:id="@+id/mgrsEditText"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:hint="@string/navigate_point_mgrs"
+                                android:imeOptions="actionDone"
+                                android:inputType="textCapCharacters|textNoSuggestions"
+                                tools:text="22.12345"/>
+
+                        </com.google.android.material.textfield.TextInputLayout>
+
+                        <ImageButton
+                            android:id="@+id/mgrsClearButton"
+                            style="@style/Widget.AppCompat.ActionButton"
+                            android:layout_width="48dp"
+                            android:layout_height="48dp"
+                            android:layout_gravity="end"
+                            android:layout_marginRight="4dp"
+                            android:contentDescription="@string/shared_string_clear"
+                            app:srcCompat="@drawable/ic_action_remove_dark"
+                            android:layout_marginEnd="4dp" />
+
+                    </FrameLayout>
+
+                </LinearLayout>
+
+                <LinearLayout
                     android:id="@+id/olcLayout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/OsmAnd/res/layout/search_point.xml
+++ b/OsmAnd/res/layout/search_point.xml
@@ -139,6 +139,26 @@
 	                    android:layout_marginEnd="5dp"></EditText>
                 </TableRow>
 
+                <TableRow android:layout_width="fill_parent" android:id="@+id/mgrs_row">
+
+                    <TextView
+                        android:textSize="@dimen/default_list_text_size"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="5dp"
+                        android:text="@string/navigate_point_mgrs"
+                        android:layout_marginStart="5dp"></TextView>
+
+                    <EditText
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:id="@+id/MGRSEdit"
+                        android:layout_marginLeft="5dp"
+                        android:layout_marginRight="5dp"
+                        android:layout_marginStart="5dp"
+                        android:layout_marginEnd="5dp"></EditText>
+                </TableRow>
+
                 <TableRow android:layout_width="fill_parent" >
 
                     <TextView

--- a/OsmAnd/res/values-de/strings.xml
+++ b/OsmAnd/res/values-de/strings.xml
@@ -3224,8 +3224,10 @@
     <string name="get_discount_first_few_part">%1$s für die ersten %2$s</string>
     <string name="configure_profile_info">Einstellungen für Profil:</string>
     <string name="utm_format_descr">OsmAnd verwendet den UTM-Standard, der ähnlich, aber nicht identisch zum UTM-NATO-Format ist.</string>
+    <string name="mgrs_format_descr">OsmAnd verwendet MGRS, das identisch zum UTM-NATO-Format ist.</string>
     <string name="shared_string_example">Beispiel</string>
     <string name="navigate_point_format_utm">UTM-Standard</string>
+    <string name="navigate_point_format_mgrs">MGRS</string>
     <string name="coordinates_format_info">Das gewählte Format wird in der gesamten App angewandt.</string>
     <string name="pref_selected_by_default_for_profiles">Für Profile wird als Vorgabe diese Einstellung gewählt: %s</string>
     <string name="change_default_settings">Einstellung ändern</string>

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -628,8 +628,10 @@
     <string name="configure_profile">Configure profile</string>
     <string name="configure_profile_info">Settings for profile:</string>
     <string name="utm_format_descr">OsmAnd uses the UTM Standard, which is similar but not identical to the UTM NATO format.</string>
+    <string name="mgrs_format_descr">OsmAnd uses MGRS, which is similar to the UTM NATO format.</string>
     <string name="shared_string_example">Example</string>
     <string name="navigate_point_format_utm">UTM Standard</string>
+    <string name="navigate_point_format_mgrs">MGRS</string>
     <string name="navigate_point_format_olc">Open Location Code</string>
     <string name="coordinates_format_info">The selected format will be applied throughout the app.</string>
     <string name="pref_selected_by_default_for_profiles">This setting is selected by default for profiles: %s</string>
@@ -2209,6 +2211,7 @@
     <string name="map_locale">Map language</string>
     <string name="rendering_attr_transportStops_name">Transport stops</string>
     <string name="navigate_point_zone">Zone</string>
+    <string name="navigate_point_mgrs">MGRS</string>
     <!-- (OLC) is a geocode system -->
     <string name="navigate_point_olc">Open Location Code</string>
     <string name="navigate_point_olc_info_invalid">Invalid OLC\n</string>

--- a/OsmAnd/res/xml/coordinates_format.xml
+++ b/OsmAnd/res/xml/coordinates_format.xml
@@ -28,6 +28,12 @@
 		android:title="@string/navigate_point_format_utm" />
 
 	<CheckBoxPreference
+		android:key="mgrs_format"
+		android:layout="@layout/preference_radio_button"
+		android:persistent="false"
+		android:title="@string/navigate_point_format_mgrs" />
+
+	<CheckBoxPreference
 		android:key="olc_format"
 		android:layout="@layout/preference_radio_button"
 		android:persistent="false"

--- a/OsmAnd/src/net/osmand/data/PointDescription.java
+++ b/OsmAnd/src/net/osmand/data/PointDescription.java
@@ -171,7 +171,8 @@ public class PointDescription {
 		
 		String utm = OsmAndFormatter.getFormattedCoordinates(lat, lon, OsmAndFormatter.UTM_FORMAT);
 		String olc = OsmAndFormatter.getFormattedCoordinates(lat, lon, OsmAndFormatter.OLC_FORMAT);
-		
+		String mgrs = OsmAndFormatter.getFormattedCoordinates(lat, lon, OsmAndFormatter.MGRS_FORMAT);
+
 		try {
 			latLonString = OsmAndFormatter.getFormattedCoordinates(lat, lon, OsmAndFormatter.FORMAT_DEGREES_SHORT);
 			latLonDeg = OsmAndFormatter.getFormattedCoordinates(lat, lon, OsmAndFormatter.FORMAT_DEGREES);
@@ -190,7 +191,8 @@ public class PointDescription {
 		results.put(OsmAndFormatter.FORMAT_SECONDS, latLonSec);
 		results.put(OsmAndFormatter.UTM_FORMAT, utm);
 		results.put(OsmAndFormatter.OLC_FORMAT, olc);
-		
+		results.put(OsmAndFormatter.MGRS_FORMAT, mgrs);
+
 		int zoom = 17;
 		if (ctx.getMapView() != null) {
 			zoom = ctx.getMapView().getZoom();
@@ -204,6 +206,8 @@ public class PointDescription {
 			results.put(LOCATION_LIST_HEADER, utm);
 		} else if (f == PointDescription.OLC_FORMAT) {
 			results.put(LOCATION_LIST_HEADER, olc);
+		} else if (f == PointDescription.MGRS_FORMAT) {
+			results.put(LOCATION_LIST_HEADER, mgrs);
 		} else if (f == PointDescription.FORMAT_DEGREES) {
 			results.put(LOCATION_LIST_HEADER, latLonDeg);
 		} else if (f == PointDescription.FORMAT_MINUTES) {
@@ -396,7 +400,8 @@ public class PointDescription {
 	public static final int FORMAT_SECONDS = LocationConvert.FORMAT_SECONDS;
 	public static final int UTM_FORMAT = LocationConvert.UTM_FORMAT;
 	public static final int OLC_FORMAT = LocationConvert.OLC_FORMAT;
-	
+	public static final int MGRS_FORMAT = LocationConvert.MGRS_FORMAT;
+
 	public static String formatToHumanString(Context ctx, int format) {
 		switch (format) {
 			case LocationConvert.FORMAT_DEGREES:
@@ -409,6 +414,8 @@ public class PointDescription {
 				return "UTM";
 			case LocationConvert.OLC_FORMAT:
 				return "OLC";
+			case LocationConvert.MGRS_FORMAT:
+				return "MGRS";
 			default:
 				return "Unknown format";
 		}

--- a/OsmAnd/src/net/osmand/plus/OsmAndFormatter.java
+++ b/OsmAnd/src/net/osmand/plus/OsmAndFormatter.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.text.format.DateUtils;
 
 import com.jwetherell.openmap.common.LatLonPoint;
+import com.jwetherell.openmap.common.MGRSPoint;
 import com.jwetherell.openmap.common.UTMPoint;
 
 import net.osmand.LocationConvert;
@@ -53,6 +54,7 @@ public class OsmAndFormatter {
 	public static final int FORMAT_SECONDS = LocationConvert.FORMAT_SECONDS;
 	public static final int UTM_FORMAT = LocationConvert.UTM_FORMAT;
 	public static final int OLC_FORMAT = LocationConvert.OLC_FORMAT;
+	public static final int MGRS_FORMAT = LocationConvert.MGRS_FORMAT;
 	private static final char DELIMITER_DEGREES = '°';
 	private static final char DELIMITER_MINUTES = '′';
 	private static final char DELIMITER_SECONDS = '″';
@@ -518,6 +520,9 @@ public class OsmAndFormatter {
 				r = "0, 0";
 			}
 			result.append(r);
+		} else if (outputFormat == MGRS_FORMAT) {
+			MGRSPoint pnt = new MGRSPoint(new LatLonPoint(lat, lon));
+			result.append(pnt.toString());
 		}
 		return result.toString();
 	}

--- a/OsmAnd/src/net/osmand/plus/OsmAndFormatter.java
+++ b/OsmAnd/src/net/osmand/plus/OsmAndFormatter.java
@@ -522,7 +522,7 @@ public class OsmAndFormatter {
 			result.append(r);
 		} else if (outputFormat == MGRS_FORMAT) {
 			MGRSPoint pnt = new MGRSPoint(new LatLonPoint(lat, lon));
-			result.append(pnt.toString());
+			result.append(pnt.toFlavoredString(5));
 		}
 		return result.toString();
 	}

--- a/OsmAnd/src/net/osmand/plus/activities/NavigatePointFragment.java
+++ b/OsmAnd/src/net/osmand/plus/activities/NavigatePointFragment.java
@@ -182,7 +182,7 @@ public class NavigatePointFragment extends Fragment implements SearchActivityChi
 
 				final EditText mgrsEdit = ((EditText) view.findViewById(R.id.MGRSEdit));
 				MGRSPoint pnt = new MGRSPoint(new LatLonPoint(l.getLatitude(), l.getLongitude()));
-				mgrsEdit.setText(pnt.toString());
+				mgrsEdit.setText(pnt.toFlavoredString(5));
 				break;
 			}
 

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/MenuBuilder.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/MenuBuilder.java
@@ -676,9 +676,15 @@ public class MenuBuilder {
 		LinearLayout llv = buildCollapsableContentView(mapActivity, true, true);
 		for (final Map.Entry<Integer, String> line : locationData.entrySet()) {
 			final TextViewEx button = buildButtonInCollapsableView(mapActivity, false, false);
-			if (line.getKey() == OsmAndFormatter.UTM_FORMAT || line.getKey() == OsmAndFormatter.OLC_FORMAT) {
+			if (line.getKey() == OsmAndFormatter.UTM_FORMAT || line.getKey() == OsmAndFormatter.OLC_FORMAT || line.getKey() == OsmAndFormatter.MGRS_FORMAT) {
 				SpannableStringBuilder ssb = new SpannableStringBuilder();
-				ssb.append(line.getKey() == OsmAndFormatter.UTM_FORMAT ? "UTM: " : "OLC: ");
+				if (line.getKey() == OsmAndFormatter.UTM_FORMAT) {
+					ssb.append("UTM: ");
+				} else if (line.getKey() == OsmAndFormatter.MGRS_FORMAT) {
+					ssb.append("MGRS: ");
+				} else if (line.getKey() == OsmAndFormatter.OLC_FORMAT){
+					ssb.append("OLC: ");
+				}
 				ssb.setSpan(new ForegroundColorSpan(app.getResources().getColor(R.color.text_color_secondary_light)), 0, 4, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
 				ssb.append(line.getValue());
 				button.setText(ssb);

--- a/OsmAnd/src/net/osmand/plus/search/QuickSearchCoordinatesFragment.java
+++ b/OsmAnd/src/net/osmand/plus/search/QuickSearchCoordinatesFragment.java
@@ -29,6 +29,7 @@ import androidx.fragment.app.DialogFragment;
 
 import com.google.openlocationcode.OpenLocationCode;
 import com.jwetherell.openmap.common.LatLonPoint;
+import com.jwetherell.openmap.common.MGRSPoint;
 import com.jwetherell.openmap.common.UTMPoint;
 
 import net.osmand.AndroidUtils;
@@ -73,6 +74,7 @@ public class QuickSearchCoordinatesFragment extends DialogFragment implements Os
 	private static final String QUICK_SEARCH_COORDS_NORTH_KEY = "quick_search_coords_north_key";
 	private static final String QUICK_SEARCH_COORDS_EAST_KEY = "quick_search_coords_east_key";
 	private static final String QUICK_SEARCH_COORDS_ZONE_KEY = "quick_search_coords_zone_key";
+	private static final String QUICK_SEARCH_COORDS_MGRS_KEY = "quick_search_coords_mgrs_key";
 	private static final String QUICK_SEARCH_COORDS_OLC_KEY = "quick_search_coords_olc_key";
 	private static final String QUICK_SEARCH_COORDS_OLC_INFO_KEY = "quick_search_coords_olc_info_key";
 	private static final String QUICK_SEARCH_COORDS_FORMAT_KEY = "quick_search_coords_format_key";
@@ -89,6 +91,7 @@ public class QuickSearchCoordinatesFragment extends DialogFragment implements Os
 	private EditText northingEdit;
 	private EditText eastingEdit;
 	private EditText zoneEdit;
+	private EditText mgrsEdit;
 	private EditText olcEdit;
 	private TextView olcInfo;
 	private EditText formatEdit;
@@ -153,6 +156,7 @@ public class QuickSearchCoordinatesFragment extends DialogFragment implements Os
 		northingEdit = ((EditText) view.findViewById(R.id.northingEditText));
 		eastingEdit = ((EditText) view.findViewById(R.id.eastingEditText));
 		zoneEdit = ((EditText) view.findViewById(R.id.zoneEditText));
+		mgrsEdit = ((EditText) view.findViewById(R.id.mgrsEditText));
 		olcEdit = ((EditText) view.findViewById(R.id.olcEditText));
 		olcInfo = ((TextView) view.findViewById(R.id.olcInfoTextView));
 		formatEdit = ((EditText) view.findViewById(R.id.formatEditText));
@@ -160,6 +164,7 @@ public class QuickSearchCoordinatesFragment extends DialogFragment implements Os
 
 		String defaultLat = "";
 		String defaultZone = "";
+		String defaultMgrs = "";
 		String defaultOlc = "";
 		boolean coordinatesApplied = false;
 		if (getArguments() != null) {
@@ -167,6 +172,8 @@ public class QuickSearchCoordinatesFragment extends DialogFragment implements Os
 			if (!Algorithms.isEmpty(text)) {
 				if (currentFormat == PointDescription.UTM_FORMAT) {
 					defaultZone = text.trim();
+				} else if (currentFormat == PointDescription.MGRS_FORMAT) {
+					defaultMgrs = text.trim();
 				} else if (currentFormat == PointDescription.OLC_FORMAT) {
 					defaultOlc = text.trim();
 				} else {
@@ -188,6 +195,7 @@ public class QuickSearchCoordinatesFragment extends DialogFragment implements Os
 		String northingStr = getStringValue(savedInstanceState, QUICK_SEARCH_COORDS_NORTH_KEY, "");
 		String eastingStr = getStringValue(savedInstanceState, QUICK_SEARCH_COORDS_EAST_KEY, "");
 		String zoneStr = getStringValue(savedInstanceState, QUICK_SEARCH_COORDS_ZONE_KEY, defaultZone);
+		String mgrsStr = getStringValue(savedInstanceState, QUICK_SEARCH_COORDS_MGRS_KEY, defaultMgrs);
 		String olcStr = getStringValue(savedInstanceState, QUICK_SEARCH_COORDS_OLC_KEY, defaultOlc);
 		String olcInfoStr = getStringValue(savedInstanceState, QUICK_SEARCH_COORDS_OLC_INFO_KEY, defaultOlc);
 
@@ -209,6 +217,8 @@ public class QuickSearchCoordinatesFragment extends DialogFragment implements Os
 			eastingEdit.setSelection(eastingStr.length());
 			zoneEdit.setText(zoneStr);
 			zoneEdit.setSelection(zoneStr.length());
+			mgrsEdit.setText(mgrsStr);
+			mgrsEdit.setSelection(mgrsStr.length());
 			olcEdit.setText(olcStr);
 			olcEdit.setSelection(olcStr.length());
 			olcInfo.setText(olcInfoStr);
@@ -242,6 +252,7 @@ public class QuickSearchCoordinatesFragment extends DialogFragment implements Os
 		northingEdit.addTextChangedListener(textWatcher);
 		eastingEdit.addTextChangedListener(textWatcher);
 		zoneEdit.addTextChangedListener(textWatcher);
+		mgrsEdit.addTextChangedListener(textWatcher);
 		olcEdit.addTextChangedListener(textWatcher);
 
 		OnEditorActionListener doneListener = new OnEditorActionListener() {
@@ -258,6 +269,7 @@ public class QuickSearchCoordinatesFragment extends DialogFragment implements Os
 
 		lonEdit.setOnEditorActionListener(doneListener);
 		zoneEdit.setOnEditorActionListener(doneListener);
+		mgrsEdit.setOnEditorActionListener(doneListener);
 		olcEdit.setOnEditorActionListener(doneListener);
 
 		UiUtilities ic = app.getUIUtilities();
@@ -318,6 +330,15 @@ public class QuickSearchCoordinatesFragment extends DialogFragment implements Os
 				olcEdit.setText("");
 			}
 		});
+		ImageButton mgrsClearButton = (ImageButton) view.findViewById(R.id.mgrsClearButton);
+		mgrsClearButton.setImageDrawable(ic.getThemedIcon(R.drawable.ic_action_remove_dark));
+		mgrsClearButton.setOnClickListener(new View.OnClickListener() {
+			@Override
+			public void onClick(View v) {
+				mgrsEdit.setText("");
+			}
+		});
+
 		ImageButton formatSelectButton = (ImageButton) view.findViewById(R.id.formatSelectButton);
 		formatSelectButton.setImageDrawable(ic.getThemedIcon(R.drawable.ic_action_arrow_drop_down));
 		formatSelectButton.setOnClickListener(new View.OnClickListener() {
@@ -364,6 +385,7 @@ public class QuickSearchCoordinatesFragment extends DialogFragment implements Os
 			final TextView northEdit = ((TextView) view.findViewById(R.id.northingEditText));
 			final TextView eastEdit = ((TextView) view.findViewById(R.id.eastingEditText));
 			final TextView zoneEdit = ((TextView) view.findViewById(R.id.zoneEditText));
+			final TextView mgrsEdit = ((TextView) view.findViewById(R.id.mgrsEditText));
 			final TextView olcEdit = ((TextView) view.findViewById(R.id.olcEditText));
 			final TextView olcInfo = ((TextView) view.findViewById(R.id.olcInfoTextView));
 			outState.putString(QUICK_SEARCH_COORDS_LAT_KEY, latEdit.getText().toString());
@@ -371,6 +393,7 @@ public class QuickSearchCoordinatesFragment extends DialogFragment implements Os
 			outState.putString(QUICK_SEARCH_COORDS_NORTH_KEY, northEdit.getText().toString());
 			outState.putString(QUICK_SEARCH_COORDS_EAST_KEY, eastEdit.getText().toString());
 			outState.putString(QUICK_SEARCH_COORDS_ZONE_KEY, zoneEdit.getText().toString());
+			outState.putString(QUICK_SEARCH_COORDS_MGRS_KEY, mgrsEdit.getText().toString());
 			outState.putString(QUICK_SEARCH_COORDS_OLC_KEY, olcEdit.getText().toString());
 			outState.putString(QUICK_SEARCH_COORDS_OLC_INFO_KEY, olcInfo.getText().toString());
 		}
@@ -470,23 +493,52 @@ public class QuickSearchCoordinatesFragment extends DialogFragment implements Os
 	}
 
 	private void updateControlsVisibility() {
-		if (currentFormat == PointDescription.OLC_FORMAT) {
-			view.findViewById(R.id.eastingLayout).setVisibility(View.GONE);
-			view.findViewById(R.id.northingLayout).setVisibility(View.GONE);
-			view.findViewById(R.id.zoneLayout).setVisibility(View.GONE);
-			view.findViewById(R.id.olcLayout).setVisibility(View.VISIBLE);
-			view.findViewById(R.id.olcInfoLayout).setVisibility(View.VISIBLE);
-			view.findViewById(R.id.latitudeLayout).setVisibility(View.GONE);
-			view.findViewById(R.id.longitudeLayout).setVisibility(View.GONE);
-		} else {
-			boolean utm = currentFormat == PointDescription.UTM_FORMAT;
-			view.findViewById(R.id.eastingLayout).setVisibility(utm ? View.VISIBLE : View.GONE);
-			view.findViewById(R.id.northingLayout).setVisibility(utm ? View.VISIBLE : View.GONE);
-			view.findViewById(R.id.zoneLayout).setVisibility(utm ? View.VISIBLE : View.GONE);
-			view.findViewById(R.id.olcLayout).setVisibility(View.GONE);
-			view.findViewById(R.id.olcInfoLayout).setVisibility(View.GONE);
-			view.findViewById(R.id.latitudeLayout).setVisibility(!utm ? View.VISIBLE : View.GONE);
-			view.findViewById(R.id.longitudeLayout).setVisibility(!utm ? View.VISIBLE : View.GONE);
+		switch (currentFormat){
+
+			case PointDescription.OLC_FORMAT: {
+				view.findViewById(R.id.eastingLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.northingLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.zoneLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.olcLayout).setVisibility(View.VISIBLE);
+				view.findViewById(R.id.olcInfoLayout).setVisibility(View.VISIBLE);
+				view.findViewById(R.id.latitudeLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.longitudeLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.mgrsLayout).setVisibility(View.GONE);
+				break;
+			}
+			case PointDescription.UTM_FORMAT: {
+				view.findViewById(R.id.eastingLayout).setVisibility(View.VISIBLE);
+				view.findViewById(R.id.northingLayout).setVisibility(View.VISIBLE);
+				view.findViewById(R.id.zoneLayout).setVisibility(View.VISIBLE);
+				view.findViewById(R.id.olcLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.olcInfoLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.latitudeLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.longitudeLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.mgrsLayout).setVisibility(View.GONE);
+				break;
+			}
+			case PointDescription.MGRS_FORMAT: {
+				view.findViewById(R.id.eastingLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.northingLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.zoneLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.olcLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.olcInfoLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.latitudeLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.longitudeLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.mgrsLayout).setVisibility(View.VISIBLE);
+				break;
+			}
+			default: {
+				view.findViewById(R.id.eastingLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.northingLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.zoneLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.olcLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.olcInfoLayout).setVisibility(View.GONE);
+				view.findViewById(R.id.latitudeLayout).setVisibility(View.VISIBLE);
+				view.findViewById(R.id.longitudeLayout).setVisibility(View.VISIBLE);
+				view.findViewById(R.id.mgrsLayout).setVisibility(View.GONE);
+				break;
+			}
 		}
 	}
 
@@ -544,10 +596,23 @@ public class QuickSearchCoordinatesFragment extends DialogFragment implements Os
 					zoneEdit.setText(olcEdit.getText());
 					northingEdit.setText("");
 					eastingEdit.setText("");
+				} else if (prevFormat == PointDescription.MGRS_FORMAT) {
+					zoneEdit.setText(mgrsEdit.getText());
+					northingEdit.setText("");
+					eastingEdit.setText("");
 				} else {
 					zoneEdit.setText(latEdit.getText());
 					northingEdit.setText("");
 					eastingEdit.setText("");
+				}
+			} else if (currentFormat == PointDescription.MGRS_FORMAT) {
+				final EditText mgrsEdit = ((EditText) view.findViewById(R.id.mgrsEditText));
+				if (latLon != null) {
+					MGRSPoint pnt = new MGRSPoint(new LatLonPoint(latLon.getLatitude(), latLon.getLongitude()));
+					mgrsEdit.setText(pnt.toString());
+				} else {
+					mgrsEdit.setText(latEdit.getText());
+
 				}
 			} else if (currentFormat == PointDescription.OLC_FORMAT) {
 				if (latLon != null) {
@@ -556,6 +621,9 @@ public class QuickSearchCoordinatesFragment extends DialogFragment implements Os
 					olcInfo.setText(provideOlcInfo(olc));
 				} else if (prevFormat == PointDescription.UTM_FORMAT) {
 					olcEdit.setText(zoneEdit.getText());
+					olcInfo.setText(provideOlcInfo(olcEdit.getText().toString()));
+				} else if (prevFormat == PointDescription.MGRS_FORMAT) {
+					olcEdit.setText(mgrsEdit.getText());
 					olcInfo.setText(provideOlcInfo(olcEdit.getText().toString()));
 				} else {
 					olcEdit.setText(latEdit.getText());
@@ -567,6 +635,9 @@ public class QuickSearchCoordinatesFragment extends DialogFragment implements Os
 					lonEdit.setText(LocationConvert.convert(MapUtils.checkLongitude(latLon.getLongitude()), currentFormat));
 				} else if (prevFormat == PointDescription.UTM_FORMAT) {
 					latEdit.setText(zoneEdit.getText());
+					lonEdit.setText("");
+				} else if (prevFormat == PointDescription.MGRS_FORMAT) {
+					latEdit.setText(mgrsEdit.getText());
 					lonEdit.setText("");
 				} else if (prevFormat == PointDescription.OLC_FORMAT) {
 					latEdit.setText(olcEdit.getText());
@@ -589,6 +660,11 @@ public class QuickSearchCoordinatesFragment extends DialogFragment implements Os
 				char c = zone.charAt(zone.length() - 1);
 				int z = Integer.parseInt(zone.substring(0, zone.length() - 1));
 				UTMPoint upoint = new UTMPoint(northing, easting, z, c);
+				LatLonPoint ll = upoint.toLatLonPoint();
+				loc = new LatLon(ll.getLatitude(), ll.getLongitude());
+			} else if (currentFormat == LocationConvert.MGRS_FORMAT) {
+				String mgrs = (mgrsEdit.getText().toString());
+				MGRSPoint upoint = new MGRSPoint(mgrs);
 				LatLonPoint ll = upoint.toLatLonPoint();
 				loc = new LatLon(ll.getLatitude(), ll.getLongitude());
 			} else if (currentFormat == LocationConvert.OLC_FORMAT) {
@@ -851,12 +927,13 @@ public class QuickSearchCoordinatesFragment extends DialogFragment implements Os
 		@Override
 		public Dialog onCreateDialog(Bundle savedInstanceState) {
 			final QuickSearchCoordinatesFragment parent = (QuickSearchCoordinatesFragment) getParentFragment();
-			String[] entries = new String[5];
+			String[] entries = new String[6];
 			entries[0] = PointDescription.formatToHumanString(getContext(), PointDescription.FORMAT_DEGREES);
 			entries[1] = PointDescription.formatToHumanString(getContext(), PointDescription.FORMAT_MINUTES);
 			entries[2] = PointDescription.formatToHumanString(getContext(), PointDescription.FORMAT_SECONDS);
 			entries[3] = PointDescription.formatToHumanString(getContext(), PointDescription.UTM_FORMAT);
 			entries[4] = PointDescription.formatToHumanString(getContext(), PointDescription.OLC_FORMAT);
+			entries[5] = PointDescription.formatToHumanString(getContext(), PointDescription.MGRS_FORMAT);
 
 			AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
 			builder.setTitle(R.string.coords_format)

--- a/OsmAnd/src/net/osmand/plus/search/QuickSearchCoordinatesFragment.java
+++ b/OsmAnd/src/net/osmand/plus/search/QuickSearchCoordinatesFragment.java
@@ -609,7 +609,7 @@ public class QuickSearchCoordinatesFragment extends DialogFragment implements Os
 				final EditText mgrsEdit = ((EditText) view.findViewById(R.id.mgrsEditText));
 				if (latLon != null) {
 					MGRSPoint pnt = new MGRSPoint(new LatLonPoint(latLon.getLatitude(), latLon.getLongitude()));
-					mgrsEdit.setText(pnt.toString());
+					mgrsEdit.setText(pnt.toFlavoredString(5));
 				} else {
 					mgrsEdit.setText(latEdit.getText());
 

--- a/OsmAnd/src/net/osmand/plus/settings/fragments/CoordinatesFormatFragment.java
+++ b/OsmAnd/src/net/osmand/plus/settings/fragments/CoordinatesFormatFragment.java
@@ -31,11 +31,13 @@ public class CoordinatesFormatFragment extends BaseSettingsFragment {
 	public static final String TAG = CoordinatesFormatFragment.class.getSimpleName();
 
 	private static final String UTM_FORMAT_WIKI_LINK = "https://en.wikipedia.org/wiki/Universal_Transverse_Mercator_coordinate_system";
+	private static final String MGRS_FORMAT_WIKI_LINK = "https://en.wikipedia.org/wiki/Military_Grid_Reference_System";
 
 	private static final String FORMAT_DEGREES = "format_degrees";
 	private static final String FORMAT_MINUTES = "format_minutes";
 	private static final String FORMAT_SECONDS = "format_seconds";
 	private static final String UTM_FORMAT = "utm_format";
+	private static final String MGRS_FORMAT = "mgrs_format";
 	private static final String OLC_FORMAT = "olc_format";
 
 	@Override
@@ -44,6 +46,7 @@ public class CoordinatesFormatFragment extends BaseSettingsFragment {
 		CheckBoxPreference minutesPref = (CheckBoxPreference) findPreference(FORMAT_MINUTES);
 		CheckBoxPreference secondsPref = (CheckBoxPreference) findPreference(FORMAT_SECONDS);
 		CheckBoxPreference utmPref = (CheckBoxPreference) findPreference(UTM_FORMAT);
+		CheckBoxPreference mgrsPref = (CheckBoxPreference) findPreference(MGRS_FORMAT);
 		CheckBoxPreference olcPref = (CheckBoxPreference) findPreference(OLC_FORMAT);
 
 		Location loc = app.getLocationProvider().getLastKnownLocation();
@@ -52,6 +55,7 @@ public class CoordinatesFormatFragment extends BaseSettingsFragment {
 		minutesPref.setSummary(getCoordinatesFormatSummary(loc, PointDescription.FORMAT_MINUTES));
 		secondsPref.setSummary(getCoordinatesFormatSummary(loc, PointDescription.FORMAT_SECONDS));
 		utmPref.setSummary(getCoordinatesFormatSummary(loc, PointDescription.UTM_FORMAT));
+		mgrsPref.setSummary(getCoordinatesFormatSummary(loc, PointDescription.MGRS_FORMAT));
 		olcPref.setSummary(getCoordinatesFormatSummary(loc, PointDescription.OLC_FORMAT));
 
 		int currentFormat = settings.COORDINATES_FORMAT.getModeValue(getSelectedAppMode());
@@ -64,6 +68,12 @@ public class CoordinatesFormatFragment extends BaseSettingsFragment {
 		super.onBindPreferenceViewHolder(preference, holder);
 
 		if (UTM_FORMAT.equals(preference.getKey())) {
+			TextView summaryView = (TextView) holder.findViewById(android.R.id.summary);
+			if (summaryView != null) {
+				summaryView.setOnTouchListener(new ClickableSpanTouchListener());
+			}
+		}
+		if (MGRS_FORMAT.equals(preference.getKey())) {
 			TextView summaryView = (TextView) holder.findViewById(android.R.id.summary);
 			if (summaryView != null) {
 				summaryView.setOnTouchListener(new ClickableSpanTouchListener());
@@ -93,6 +103,36 @@ public class CoordinatesFormatFragment extends BaseSettingsFragment {
 					Context ctx = getContext();
 					if (ctx != null) {
 						WikipediaDialogFragment.showFullArticle(ctx, Uri.parse(UTM_FORMAT_WIKI_LINK), isNightMode());
+					}
+				}
+
+				@Override
+				public void updateDrawState(@NonNull TextPaint ds) {
+					super.updateDrawState(ds);
+					ds.setUnderlineText(false);
+				}
+			};
+			spannableBuilder.setSpan(clickableSpan, start, spannableBuilder.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+
+			return spannableBuilder;
+		}
+		if (format == PointDescription.MGRS_FORMAT) {
+			SpannableStringBuilder spannableBuilder = new SpannableStringBuilder();
+			String combined = getString(R.string.ltr_or_rtl_combine_via_colon, getString(R.string.shared_string_example), formattedCoordinates);
+			spannableBuilder.append(combined);
+			spannableBuilder.append("\n");
+			spannableBuilder.append(getString(R.string.mgrs_format_descr));
+
+			int start = spannableBuilder.length();
+			spannableBuilder.append(" ");
+			spannableBuilder.append(getString(R.string.shared_string_read_more));
+
+			ClickableSpan clickableSpan = new ClickableSpan() {
+				@Override
+				public void onClick(@NonNull View widget) {
+					Context ctx = getContext();
+					if (ctx != null) {
+						WikipediaDialogFragment.showFullArticle(ctx, Uri.parse(MGRS_FORMAT_WIKI_LINK), isNightMode());
 					}
 				}
 
@@ -159,6 +199,8 @@ public class CoordinatesFormatFragment extends BaseSettingsFragment {
 				return PointDescription.FORMAT_SECONDS;
 			case UTM_FORMAT:
 				return PointDescription.UTM_FORMAT;
+			case MGRS_FORMAT:
+				return PointDescription.MGRS_FORMAT;
 			case OLC_FORMAT:
 				return PointDescription.OLC_FORMAT;
 			default:
@@ -176,6 +218,8 @@ public class CoordinatesFormatFragment extends BaseSettingsFragment {
 				return FORMAT_SECONDS;
 			case PointDescription.UTM_FORMAT:
 				return UTM_FORMAT;
+			case PointDescription.MGRS_FORMAT:
+				return MGRS_FORMAT;
 			case PointDescription.OLC_FORMAT:
 				return OLC_FORMAT;
 			default:

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/MapInfoWidgetsFactory.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/MapInfoWidgetsFactory.java
@@ -1258,7 +1258,7 @@ public class MapInfoWidgetsFactory {
 						AndroidUiHelper.updateVisibility(latitudeIcon, true);
 						latitudeIcon.setImageDrawable(iconsCache.getIcon(nightMode ? R.drawable.widget_coordinates_utm_night : R.drawable.widget_coordinates_utm_day));
 						MGRSPoint pnt = new MGRSPoint(new LatLonPoint(lat, lon));
-						latitudeText.setText(pnt.toString());
+						latitudeText.setText(pnt.toFlavoredString(5));
 					} else if (f == PointDescription.OLC_FORMAT) {
 						AndroidUiHelper.updateVisibility(lonCoordinatesContainer, false);
 						AndroidUiHelper.updateVisibility(coordinatesDivider, false);

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/MapInfoWidgetsFactory.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/MapInfoWidgetsFactory.java
@@ -33,6 +33,7 @@ import androidx.core.graphics.drawable.DrawableCompat;
 
 import com.google.android.material.snackbar.Snackbar;
 import com.jwetherell.openmap.common.LatLonPoint;
+import com.jwetherell.openmap.common.MGRSPoint;
 import com.jwetherell.openmap.common.UTMPoint;
 
 import net.osmand.AndroidUtils;
@@ -1251,6 +1252,13 @@ public class MapInfoWidgetsFactory {
 						UTMPoint pnt = new UTMPoint(new LatLonPoint(lat, lon));
 						String utmLocation = pnt.zone_number + "" + pnt.zone_letter + " " + ((long) pnt.easting) + " " + ((long) pnt.northing);
 						latitudeText.setText(utmLocation);
+					} else if (f == PointDescription.MGRS_FORMAT) {
+						AndroidUiHelper.updateVisibility(lonCoordinatesContainer, false);
+						AndroidUiHelper.updateVisibility(coordinatesDivider, false);
+						AndroidUiHelper.updateVisibility(latitudeIcon, true);
+						latitudeIcon.setImageDrawable(iconsCache.getIcon(nightMode ? R.drawable.widget_coordinates_utm_night : R.drawable.widget_coordinates_utm_day));
+						MGRSPoint pnt = new MGRSPoint(new LatLonPoint(lat, lon));
+						latitudeText.setText(pnt.toString());
 					} else if (f == PointDescription.OLC_FORMAT) {
 						AndroidUiHelper.updateVisibility(lonCoordinatesContainer, false);
 						AndroidUiHelper.updateVisibility(coordinatesDivider, false);


### PR DESCRIPTION
Hey everyone!
I added support for the [MGRS coordinate standard](https://en.wikipedia.org/wiki/Military_Grid_Reference_System). It is sometimes called "NATO UTM Standard".

This standard was already included in jwetherell's openmap.common-package that OsmAnd includes. But it was not used by now.

This coordinate standard is used intensively by all the public emergency services – like ambulances, firefighters, etc. – at least in Germany. That's why I added it.

The second commit extends jwetherell's package itself by an option of flavoring the coordinate string. This adds spaces between the coordinates parts what makes the coordinates easier to read and –much more important – allows to search for them even with spaces included (which is quite common). 

I also included an option for modifying the accuracy of the coordinate (length of the numbers) at this point, which still keeps the highest accuracy (1m) for calculation. This is different than jwetherell's implementation, which would decrease the overall accuracy at a point's creation. Currently, this is hardcoded in OsmAnd to keep the highest resolution but one might allow the user to modify the accuracy in the profile settings later.

Currently, there are only English and German translations of the settings descriptions. One might add different languages later, but the name 'MGRS' itself is internationally common and needs no translation.