### PR TITLE
Add BaseCamp compatibility for planned Tracks and claculated routes exported to gpx

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/GPXUtilities.java
+++ b/OsmAnd-java/src/main/java/net/osmand/GPXUtilities.java
@@ -1822,6 +1822,25 @@ public class GPXUtilities {
 			}
 			serializer.endTag(null, "metadata");
 
+			for (WptPt l : file.points) {
+				serializer.startTag(null, "wpt"); //$NON-NLS-1$
+				writeWpt(format, serializer, l);
+				serializer.endTag(null, "wpt"); //$NON-NLS-1$
+			}
+
+			for (Route track : file.routes) {
+				serializer.startTag(null, "rte"); //$NON-NLS-1$
+				writeNotNullText(serializer, "name", track.name);
+				writeNotNullText(serializer, "desc", track.desc);
+
+				for (WptPt p : track.points) {
+					serializer.startTag(null, "rtept"); //$NON-NLS-1$
+					writeWpt(format, serializer, p);
+					serializer.endTag(null, "rtept"); //$NON-NLS-1$
+				}
+				writeExtensions(serializer, track);
+				serializer.endTag(null, "rte"); //$NON-NLS-1$
+			}
 
 			for (Track track : file.tracks) {
 				if (!track.generalTrack) {
@@ -1842,26 +1861,6 @@ public class GPXUtilities {
 					writeExtensions(serializer, track);
 					serializer.endTag(null, "trk"); //$NON-NLS-1$
 				}
-			}
-
-			for (Route track : file.routes) {
-				serializer.startTag(null, "rte"); //$NON-NLS-1$
-				writeNotNullText(serializer, "name", track.name);
-				writeNotNullText(serializer, "desc", track.desc);
-
-				for (WptPt p : track.points) {
-					serializer.startTag(null, "rtept"); //$NON-NLS-1$
-					writeWpt(format, serializer, p);
-					serializer.endTag(null, "rtept"); //$NON-NLS-1$
-				}
-				writeExtensions(serializer, track);
-				serializer.endTag(null, "rte"); //$NON-NLS-1$
-			}
-
-			for (WptPt l : file.points) {
-				serializer.startTag(null, "wpt"); //$NON-NLS-1$
-				writeWpt(format, serializer, l);
-				serializer.endTag(null, "wpt"); //$NON-NLS-1$
 			}
 
 			writeExtensions(serializer, file);

--- a/OsmAnd-java/src/main/java/net/osmand/binary/StringBundleWriter.java
+++ b/OsmAnd-java/src/main/java/net/osmand/binary/StringBundleWriter.java
@@ -20,7 +20,7 @@ public abstract class StringBundleWriter {
 
 	public void writeBundle() {
 		for (Entry<String, Item<?>> entry : bundle.getMap().entrySet()) {
-			writeItem(entry.getKey(), entry.getValue());
+			writeItem("osmand:" + entry.getKey(), entry.getValue());
 		}
 	}
 }


### PR DESCRIPTION
I had to change the order in which wpt, rte and trk was written into the gpx files to comply to the gpx 1.1 standard.

I did test examples of both type of gpx files with BaseCamp and could successfully import them.