### PR TITLE
Add an option for always adding track waypoints to the current track

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -12,6 +12,7 @@
 
 -->
 
+    <string name="always_store_waypoint_in_current_track_title">Always add track waypoints to the currently recording track</string>
     <string name="change_folder">Change folder</string>
     <string name="rename_track">Rename track</string>
     <string name="edit_track">Edit track</string>

--- a/OsmAnd/res/xml/monitoring_settings.xml
+++ b/OsmAnd/res/xml/monitoring_settings.xml
@@ -116,6 +116,17 @@
 		android:layout="@layout/simple_divider_item"
 		android:selectable="false" />
 
+	<net.osmand.plus.settings.preferences.SwitchPreferenceEx
+		android:key="always_store_waypoint_in_current_track"
+		android:layout="@layout/preference_with_descr_dialog_and_switch"
+		android:summaryOff="@string/shared_string_disabled"
+		android:summaryOn="@string/shared_string_enabled"
+		android:title="@string/always_store_waypoint_in_current_track_title" />
+
+	<Preference
+		android:layout="@layout/simple_divider_item"
+		android:selectable="false" />
+
 	<Preference
 		android:key="open_tracks_description"
 		android:layout="@layout/preference_description"

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/MapContextMenu.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/MapContextMenu.java
@@ -1225,7 +1225,8 @@ public class MapContextMenu extends MenuTitleController implements StateChangedL
 					return true;
 				}
 			};
-			GpxUiHelper.selectSingleGPXFile(mapActivity, true, callbackWithObject);
+
+			selectGPXFileOrUseCurrent(mapActivity, callbackWithObject);
 		}
 	}
 
@@ -1252,6 +1253,16 @@ public class MapContextMenu extends MenuTitleController implements StateChangedL
 				}
 			};
 
+			selectGPXFileOrUseCurrent(mapActivity, callbackWithObject);
+		}
+	}
+
+	private void selectGPXFileOrUseCurrent(MapActivity mapActivity, CallbackWithObject<GPXFile[]> callbackWithObject) {
+		if (mapActivity.getMyApplication().getSettings().ALWAYS_STORE_WAYPOINT_IN_CURRENT_TRACK.get()
+				&& OsmandPlugin.getEnabledPlugin(OsmandMonitoringPlugin.class) != null) {
+			callbackWithObject.processResult(null);
+			mapActivity.getMyApplication().getSettings().LAST_SELECTED_GPX_TRACK_FOR_NEW_POINT.set(null);
+		} else {
 			GpxUiHelper.selectSingleGPXFile(mapActivity, true, callbackWithObject);
 		}
 	}

--- a/OsmAnd/src/net/osmand/plus/monitoring/MonitoringSettingsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/monitoring/MonitoringSettingsFragment.java
@@ -99,6 +99,8 @@ public class MonitoringSettingsFragment extends BaseSettingsFragment
 		setupOpenNotesDescrPref();
 		setupOpenNotesPref();
 
+		setupAlwaysStoreWaypointInCurrentTrackPref();
+
 		setupCopyProfileSettingsPref();
 		setupResetToDefaultPref();
 	}
@@ -280,6 +282,11 @@ public class MonitoringSettingsFragment extends BaseSettingsFragment
 	private void setupOpenNotesPref() {
 		Preference openNotes = findPreference(OPEN_TRACKS);
 		openNotes.setIcon(getActiveIcon(R.drawable.ic_action_folder));
+	}
+
+	private void setupAlwaysStoreWaypointInCurrentTrackPref() {
+		SwitchPreferenceEx alwaysStoreWaypointInCurrentTrack = (SwitchPreferenceEx) findPreference(settings.ALWAYS_STORE_WAYPOINT_IN_CURRENT_TRACK.getId());
+		alwaysStoreWaypointInCurrentTrack.setDescription(getString(R.string.always_store_waypoint_in_current_track_title));
 	}
 
 	private void setupCopyProfileSettingsPref() {

--- a/OsmAnd/src/net/osmand/plus/monitoring/OsmandMonitoringPlugin.java
+++ b/OsmAnd/src/net/osmand/plus/monitoring/OsmandMonitoringPlugin.java
@@ -88,6 +88,7 @@ public class OsmandMonitoringPlugin extends OsmandPlugin {
 		pluginPreferences.add(settings.LIVE_MONITORING_URL);
 		pluginPreferences.add(settings.LIVE_MONITORING_INTERVAL);
 		pluginPreferences.add(settings.LIVE_MONITORING_MAX_INTERVAL_TO_SEND);
+		pluginPreferences.add(settings.ALWAYS_STORE_WAYPOINT_IN_CURRENT_TRACK);
 	}
 
 	@Override

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -1426,6 +1426,8 @@ public class OsmandSettings {
 	//}
 	public final CommonPreference<Boolean> AUTO_SPLIT_RECORDING = new BooleanPreference(this, "auto_split_recording", true).makeProfile();
 
+	public final CommonPreference<Boolean> ALWAYS_STORE_WAYPOINT_IN_CURRENT_TRACK = new BooleanPreference(this, "always_store_waypoint_in_current_track", false).makeProfile();
+
 	public final CommonPreference<Boolean> SHOW_TRIP_REC_NOTIFICATION = new BooleanPreference(this, "show_trip_recording_notification", true).makeProfile();
 
 	// this value string is synchronized with settings_pref.xml preference name


### PR DESCRIPTION
When recording a track (and displaying it), and displaying one or more
tracks at the same time, OsmAnd asks which track to add any track waypoints
to.

This can become tedious when adding many track waypoints (like I do when
using OsmAnd to collect addresses). There's a possibility that you might
tap the wrong track by mistake, particularly if your phone screen is wet or
you're wearing gloves.

This change introduces a new setting for the trip recording plugin. When
enabled (it's disabled by default), track waypoints will always be added to
the current track (OsmAnd will not prompt ask which track to use).