### PR TITLE
Add bottom sheet dialogs to clear recoderd data and stop trip recording

### DIFF
--- a/OsmAnd/res/layout/bottom_sheet_item_button_with_icon.xml
+++ b/OsmAnd/res/layout/bottom_sheet_item_button_with_icon.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:tools="http://schemas.android.com/tools"
+	xmlns:osmand="http://schemas.android.com/apk/res-auto"
+	android:layout_width="match_parent"
+	android:layout_height="wrap_content">
+
+	<LinearLayout
+		android:id="@+id/button_container"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:gravity="center_vertical"
+		android:orientation="horizontal"
+		android:duplicateParentState="true"
+		android:paddingStart="@dimen/content_padding_small"
+		android:paddingLeft="@dimen/content_padding_small"
+		android:paddingTop="@dimen/text_margin_small"
+		android:paddingEnd="@dimen/content_padding_small"
+		android:paddingRight="@dimen/content_padding_small"
+		android:paddingBottom="@dimen/text_margin_small"
+		tools:background="@drawable/dlg_btn_secondary_dark"
+		tools:ignore="UselessParent">
+
+		<LinearLayout
+			android:layout_width="0dp"
+			android:layout_height="wrap_content"
+			android:layout_weight="1"
+			android:duplicateParentState="true"
+			android:orientation="vertical">
+
+			<net.osmand.plus.widgets.TextViewEx
+				android:id="@+id/button_text"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:duplicateParentState="true"
+				android:textSize="@dimen/default_desc_text_size"
+				osmand:letterSpacing="@dimen/description_letter_spacing"
+				osmand:typeface="@string/font_roboto_medium"
+				tools:text="Title"
+				tools:textColor="@color/text_color_secondary_light" />
+
+			<net.osmand.plus.widgets.TextViewEx
+				android:id="@+id/desc"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:duplicateParentState="true"
+				android:textColor="@color/text_color_secondary_light"
+				android:textSize="@dimen/default_desc_text_size"
+				android:visibility="gone"
+				osmand:letterSpacing="@dimen/description_letter_spacing"
+				osmand:typeface="@string/font_roboto_medium"
+				tools:text="Description"
+				tools:visibility="visible" />
+
+		</LinearLayout>
+
+		<androidx.appcompat.widget.AppCompatImageView
+			android:id="@+id/icon"
+			android:layout_width="@dimen/map_widget_icon"
+			android:layout_height="@dimen/map_widget_icon"
+			android:duplicateParentState="true"
+			android:layout_marginStart="@dimen/context_menu_padding_margin_large"
+			android:layout_marginLeft="@dimen/context_menu_padding_margin_large"
+			tools:srcCompat="@drawable/ic_action_appearance"
+			tools:tint="@color/icon_color_secondary_light" />
+
+	</LinearLayout>
+
+</FrameLayout>

--- a/OsmAnd/res/values/sizes.xml
+++ b/OsmAnd/res/values/sizes.xml
@@ -413,4 +413,6 @@
 
 	<dimen name="radioButtonSize">32dp</dimen>
 	<dimen name="checkBoxSize">24dp</dimen>
+
+	<dimen name="zero">0dp</dimen>
 </resources>

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -12,6 +12,10 @@
 
 -->
 
+    <string name="track_recording_description">Are you sure you want to stop recording?\nAll unsaved data will be lost.</string>
+    <string name="track_recording_title">Track recording stopped</string>
+    <string name="track_recording_save_and_stop">Save and stop recording</string>
+    <string name="track_recording_stop_without_saving">Stop without saving</string>
     <string name="login_open_place_reviews">Login to OpenPlaceReviews</string>
     <string name="opr_use_dev_url">Use test.openplacereviews.org</string>
     <string name="open_place_reviews">OpenPlaceReviews</string>

--- a/OsmAnd/src/net/osmand/plus/monitoring/ClearRecordedDataBottomSheetFragment.java
+++ b/OsmAnd/src/net/osmand/plus/monitoring/ClearRecordedDataBottomSheetFragment.java
@@ -1,0 +1,160 @@
+package net.osmand.plus.monitoring;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.LinearLayout;
+
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.R;
+import net.osmand.plus.UiUtilities;
+import net.osmand.plus.base.MenuBottomSheetDialogFragment;
+import net.osmand.plus.base.bottomsheetmenu.BaseBottomSheetItem;
+import net.osmand.plus.base.bottomsheetmenu.BottomSheetItemWithDescription;
+import net.osmand.plus.widgets.TextViewEx;
+
+import androidx.annotation.DimenRes;
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+import androidx.appcompat.widget.AppCompatImageView;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+
+public class ClearRecordedDataBottomSheetFragment extends MenuBottomSheetDialogFragment implements View.OnClickListener {
+
+	public static final String TAG = ClearRecordedDataBottomSheetFragment.class.getSimpleName();
+
+	private OsmandApplication app;
+
+	@Override
+	public void createMenuItems(Bundle savedInstanceState) {
+		app = requiredMyApplication();
+
+		items.add(new BottomSheetItemWithDescription.Builder()
+				.setDescription(app.getString(R.string.clear_recorded_data_warning))
+				.setDescriptionColorId(!nightMode ? R.color.text_color_primary_light : R.color.text_color_primary_dark)
+				.setDescriptionMaxLines(2)
+				.setTitle(app.getString(R.string.clear_recorded_data))
+				.setLayoutId(R.layout.bottom_sheet_item_title_with_description)
+				.create());
+
+		LayoutInflater inflater = UiUtilities.getInflater(getContext(), nightMode);
+
+		items.add(new BaseBottomSheetItem.Builder()
+				.setCustomView(setupBtn(inflater, ButtonType.CLEAR))
+				.setOnClickListener(this)
+				.create());
+
+		items.add(new BaseBottomSheetItem.Builder()
+				.setCustomView(setupBtn(inflater, ButtonType.CANCEL))
+				.setOnClickListener(this)
+				.create());
+
+	}
+
+	private View setupBtn(LayoutInflater inflater, ButtonType type) {
+		View button = inflater.inflate(R.layout.bottom_sheet_item_button_with_icon, null);
+		button.setTag(type);
+		Context context = button.getContext();
+
+		LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+		int horizontal = context.getResources().getDimensionPixelSize(R.dimen.content_padding);
+		int top = context.getResources().getDimensionPixelSize(type.topMarginRes);
+		int bottom = context.getResources().getDimensionPixelSize(R.dimen.content_padding_small);
+		params.setMargins(horizontal, top, horizontal, bottom);
+		button.setLayoutParams(params);
+
+		UiUtilities.setupDialogButton(nightMode, button, type.effect, type.titleId);
+
+		TextViewEx title = button.findViewById(R.id.button_text);
+		int margin = context.getResources().getDimensionPixelSize(R.dimen.context_menu_padding_margin_medium);
+		UiUtilities.setMargins(title, 0, margin, 0, margin);
+
+		int colorRes;
+		if (type.effect == UiUtilities.DialogButtonType.SECONDARY_HARMFUL) {
+			colorRes = R.color.color_osm_edit_delete;
+		} else {
+			colorRes = nightMode ? R.color.dlg_btn_secondary_text_dark : R.color.dlg_btn_secondary_text_light;
+		}
+		AppCompatImageView icon = button.findViewById(R.id.icon);
+		icon.setImageDrawable(getIcon(type.iconRes, colorRes));
+
+		return button;
+	}
+
+	@Override
+	public void onClick(View v) {
+		Object o = v.getTag();
+		if (!(o instanceof ButtonType)) {
+			return;
+		}
+
+		ButtonType tag = (ButtonType) o;
+		if (tag == ButtonType.CLEAR) {
+			app.getSavingTrackHelper().clearRecordedData(true);
+		}
+		dismiss();
+	}
+
+	@Override
+	public void onResume() {
+		super.onResume();
+		// Replace later with tTripRecordingActiveBottomSheet.hide()
+		Fragment target = getTargetFragment();
+		if (target instanceof TripRecordingActiveBottomSheet) {
+			Dialog dialog = ((TripRecordingActiveBottomSheet) target).getDialog();
+			if (dialog != null) {
+				dialog.hide();
+			}
+		}
+	}
+
+	@Override
+	public void onPause() {
+		super.onPause();
+		// Replace later with tTripRecordingActiveBottomSheet.show()
+		Fragment target = getTargetFragment();
+		if (target instanceof TripRecordingActiveBottomSheet) {
+			Dialog dialog = ((TripRecordingActiveBottomSheet) target).getDialog();
+			if (dialog != null) {
+				dialog.show();
+			}
+		}
+	}
+
+	enum ButtonType {
+		CLEAR(R.string.clear_recorded_data, R.drawable.ic_action_delete_dark, R.dimen.dialog_content_margin, UiUtilities.DialogButtonType.SECONDARY_HARMFUL),
+		CANCEL(R.string.shared_string_cancel, R.drawable.ic_action_close, R.dimen.content_padding_small, UiUtilities.DialogButtonType.SECONDARY);
+
+		@StringRes
+		private final int titleId;
+		@DrawableRes
+		private final int iconRes;
+		@DimenRes
+		private final int topMarginRes;
+		private final UiUtilities.DialogButtonType effect;
+
+		ButtonType(int titleId, int iconRes, int topMarginRes, UiUtilities.DialogButtonType effect) {
+			this.titleId = titleId;
+			this.iconRes = iconRes;
+			this.topMarginRes = topMarginRes;
+			this.effect = effect;
+		}
+	}
+
+	@Override
+	protected boolean hideButtonsContainer() {
+		return true;
+	}
+
+	public static void showInstance(@NonNull FragmentManager fragmentManager, @NonNull Fragment target) {
+		if (!fragmentManager.isStateSaved()) {
+			ClearRecordedDataBottomSheetFragment fragment = new ClearRecordedDataBottomSheetFragment();
+			fragment.setTargetFragment(target, 0);
+			fragment.show(fragmentManager, TAG);
+		}
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/monitoring/StopTrackRecordingBottomFragment.java
+++ b/OsmAnd/src/net/osmand/plus/monitoring/StopTrackRecordingBottomFragment.java
@@ -1,0 +1,187 @@
+package net.osmand.plus.monitoring;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.LinearLayout;
+
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.OsmandPlugin;
+import net.osmand.plus.R;
+import net.osmand.plus.UiUtilities;
+import net.osmand.plus.UiUtilities.DialogButtonType;
+import net.osmand.plus.base.MenuBottomSheetDialogFragment;
+import net.osmand.plus.base.bottomsheetmenu.BaseBottomSheetItem;
+import net.osmand.plus.base.bottomsheetmenu.BottomSheetItemWithDescription;
+import net.osmand.plus.settings.backend.OsmandSettings;
+import net.osmand.plus.widgets.TextViewEx;
+
+import androidx.annotation.DimenRes;
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+import androidx.appcompat.widget.AppCompatImageView;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+
+public class StopTrackRecordingBottomFragment extends MenuBottomSheetDialogFragment implements View.OnClickListener {
+
+	public static final String TAG = StopTrackRecordingBottomFragment.class.getSimpleName();
+
+	private OsmandApplication app;
+	private OsmandSettings settings;
+	private OsmandMonitoringPlugin plugin;
+
+	@Override
+	public void createMenuItems(Bundle savedInstanceState) {
+		app = requiredMyApplication();
+		settings = app.getSettings();
+		plugin = OsmandPlugin.getPlugin(OsmandMonitoringPlugin.class);
+
+		items.add(new BottomSheetItemWithDescription.Builder()
+				.setDescription(app.getString(R.string.track_recording_description))
+				.setDescriptionColorId(!nightMode ? R.color.text_color_primary_light : R.color.text_color_primary_dark)
+				.setDescriptionMaxLines(4)
+				.setTitle(app.getString(R.string.track_recording_title))
+				.setLayoutId(R.layout.bottom_sheet_item_title_with_description)
+				.create());
+
+		LayoutInflater inflater = UiUtilities.getInflater(getContext(), nightMode);
+
+		items.add(new BaseBottomSheetItem.Builder()
+				.setCustomView(setupButton(inflater, ButtonType.STOP_AND_DISCARD))
+				.setOnClickListener(this)
+				.create());
+
+		items.add(new BaseBottomSheetItem.Builder()
+				.setCustomView(setupButton(inflater, ButtonType.SAVE_AND_STOP))
+				.setOnClickListener(this)
+				.create());
+
+		items.add(new BaseBottomSheetItem.Builder()
+				.setCustomView(setupButton(inflater, ButtonType.CANCEL))
+				.setOnClickListener(this)
+				.create());
+	}
+
+	private View setupButton(LayoutInflater inflater, ButtonType type) {
+		View button = inflater.inflate(R.layout.bottom_sheet_item_button_with_icon, null);
+		button.setTag(type);
+		Context context = button.getContext();
+
+		LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+		int horizontal = context.getResources().getDimensionPixelSize(R.dimen.content_padding);
+		int top = context.getResources().getDimensionPixelSize(type.topMarginRes);
+		int bottom = context.getResources().getDimensionPixelSize(R.dimen.content_padding_small);
+		params.setMargins(horizontal, top, horizontal, bottom);
+		button.setLayoutParams(params);
+
+		UiUtilities.setupDialogButton(nightMode, button, type.effect, type.titleId);
+
+		TextViewEx title = button.findViewById(R.id.button_text);
+		int margin = context.getResources().getDimensionPixelSize(R.dimen.context_menu_padding_margin_medium);
+		UiUtilities.setMargins(title, 0, margin, 0, margin);
+
+		int colorRes;
+		if (type.effect == DialogButtonType.SECONDARY_HARMFUL) {
+			colorRes = R.color.color_osm_edit_delete;
+		} else {
+			colorRes = nightMode ? R.color.dlg_btn_secondary_text_dark : R.color.dlg_btn_secondary_text_light;
+		}
+		AppCompatImageView icon = button.findViewById(R.id.icon);
+		icon.setImageDrawable(getIcon(type.iconRes, colorRes));
+
+		if (type == ButtonType.STOP_AND_DISCARD) {
+			int size = context.getResources().getDimensionPixelSize(R.dimen.map_widget_height);
+			LinearLayout.LayoutParams iconParams = new LinearLayout.LayoutParams(size, size);
+			icon.setLayoutParams(iconParams);
+		}
+
+		return button;
+	}
+
+	@Override
+	public void onClick(View v) {
+		Object o = v.getTag();
+		if (!(o instanceof ButtonType)) {
+			return;
+		}
+
+		ButtonType tag = (ButtonType) o;
+		if (tag == ButtonType.STOP_AND_DISCARD) {
+			if (plugin != null && settings.SAVE_GLOBAL_TRACK_TO_GPX.get()) {
+				plugin.stopRecording();
+				app.getNotificationHelper().refreshNotifications();
+			}
+			app.getSavingTrackHelper().clearRecordedData(true);
+		} else if (tag == ButtonType.SAVE_AND_STOP) {
+			if (plugin != null && settings.SAVE_GLOBAL_TRACK_TO_GPX.get()) {
+				plugin.saveCurrentTrack();
+				app.getNotificationHelper().refreshNotifications();
+			}
+		}
+		dismiss();
+	}
+
+	@Override
+	public void onResume() {
+		super.onResume();
+		// Replace later with tTripRecordingActiveBottomSheet.hide()
+		Fragment target = getTargetFragment();
+		if (target instanceof TripRecordingActiveBottomSheet) {
+			Dialog dialog = ((TripRecordingActiveBottomSheet) target).getDialog();
+			if (dialog != null) {
+				dialog.hide();
+			}
+		}
+	}
+
+	@Override
+	public void onPause() {
+		super.onPause();
+		// Replace later with tTripRecordingActiveBottomSheet.show()
+		Fragment target = getTargetFragment();
+		if (target instanceof TripRecordingActiveBottomSheet) {
+			Dialog dialog = ((TripRecordingActiveBottomSheet) target).getDialog();
+			if (dialog != null) {
+				dialog.show();
+			}
+		}
+	}
+
+	enum ButtonType {
+		STOP_AND_DISCARD(R.string.track_recording_stop_without_saving, R.drawable.ic_action_rec_stop, R.dimen.dialog_content_margin, DialogButtonType.SECONDARY_HARMFUL),
+		SAVE_AND_STOP(R.string.track_recording_save_and_stop, R.drawable.ic_action_save_to_file, R.dimen.content_padding_small, DialogButtonType.SECONDARY),
+		CANCEL(R.string.shared_string_cancel, R.drawable.ic_action_close, R.dimen.zero, DialogButtonType.SECONDARY);
+
+		@StringRes
+		private final int titleId;
+		@DrawableRes
+		private final int iconRes;
+		@DimenRes
+		private final int topMarginRes;
+		private final DialogButtonType effect;
+
+		ButtonType(int titleId, int iconRes, int topMarginRes, DialogButtonType type) {
+			this.titleId = titleId;
+			this.iconRes = iconRes;
+			this.topMarginRes = topMarginRes;
+			this.effect = type;
+		}
+	}
+
+	@Override
+	protected boolean hideButtonsContainer() {
+		return true;
+	}
+
+	public static void showInstance(@NonNull FragmentManager fragmentManager, @NonNull Fragment target) {
+		if (!fragmentManager.isStateSaved()) {
+			StopTrackRecordingBottomFragment fragment = new StopTrackRecordingBottomFragment();
+			fragment.setTargetFragment(target, 0);
+			fragment.show(fragmentManager, TAG);
+		}
+	}
+}


### PR DESCRIPTION
Bottom sheets [(1)](https://github.com/osmandapp/OsmAnd/blob/5605e33c3238941e798da548fad99886d61648bd/OsmAnd/src/net/osmand/plus/monitoring/ClearRecordedDataBottomSheetFragment.java) and ([2)](https://github.com/osmandapp/OsmAnd/blob/5605e33c3238941e798da548fad99886d61648bd/OsmAnd/src/net/osmand/plus/monitoring/StopTrackRecordingBottomFragment.java) of this pull request need to be started from another [botton sheet](https://github.com/osmandapp/OsmAnd/blob/1c8fcefcc0d5966be27365c7e1ced4e523f027fc/OsmAnd/src/net/osmand/plus/monitoring/TripRecordingActiveBottomSheet.java) of [another pull request](https://github.com/osmandapp/OsmAnd/pull/10764).