### PR TITLE
fix empty profile name on main settings screen

### DIFF
--- a/OsmAnd/src/net/osmand/plus/settings/backend/ApplicationMode.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/ApplicationMode.java
@@ -15,6 +15,8 @@ import net.osmand.plus.profiles.ProfileIconColors;
 import net.osmand.plus.routing.RouteProvider.RouteService;
 import net.osmand.util.Algorithms;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -330,8 +332,12 @@ public class ApplicationMode {
 
 	public String toHumanString() {
 		String userProfileName = getUserProfileName();
-		if (Algorithms.isEmpty(userProfileName) && keyName != -1) {
-			return app.getString(keyName);
+		if (Algorithms.isEmpty(userProfileName)) {
+			if (keyName != -1) {
+				return app.getString(keyName);
+			} else {
+				return StringUtils.capitalize(getStringKey());
+			}
 		} else {
 			return userProfileName;
 		}

--- a/OsmAnd/src/net/osmand/plus/settings/fragments/ConfigureProfileFragment.java
+++ b/OsmAnd/src/net/osmand/plus/settings/fragments/ConfigureProfileFragment.java
@@ -465,7 +465,7 @@ public class ConfigureProfileFragment extends BaseSettingsFragment implements Co
 				bld.setTitle(R.string.profile_alert_delete_title);
 				bld.setMessage(String
 						.format(getString(R.string.profile_alert_delete_msg),
-								profile.getUserProfileName()));
+								profile.toHumanString()));
 				bld.setPositiveButton(R.string.shared_string_delete,
 						new DialogInterface.OnClickListener() {
 							@Override


### PR DESCRIPTION
https://github.com/osmandapp/OsmAnd-Issues/issues/399

<img src="https://www.dropbox.com/s/sr6b82ouczh3nxw/Screenshot%202021-02-19%20.png?raw=1"  height="400"/>

video:
https://www.dropbox.com/s/s4butfyozb566n7/Screen%20Recording%202021-02-19%20at%2011.00.43.mov?dl=0

test osf file:
https://www.dropbox.com/s/vl0kvd5c18mhrqf/trucktest.osf?dl=0

ios pr:
https://github.com/osmandapp/OsmAnd-iOS/pull/1092