### PR TITLE
Ignore empty gx:coord elements in kml files

### DIFF
--- a/OsmAnd/src/net/osmand/plus/helpers/kml2gpx.xslt
+++ b/OsmAnd/src/net/osmand/plus/helpers/kml2gpx.xslt
@@ -178,17 +178,19 @@
 									</xsl:otherwise>
 								</xsl:choose>
 							</xsl:variable>
-							<trkpt lon="{$lon}" lat="{$lat}">
-								<xsl:choose>
-									<xsl:when test="contains($latele,' ')">
-										<ele><xsl:value-of select="substring-after($latele,' ')"/></ele>
-									</xsl:when>
-								</xsl:choose>
-								<xsl:variable name="ts" select="../kml:when[$i]"/>
-								<xsl:if test="$ts">
-									<time><xsl:value-of select="$ts"/></time>
-								</xsl:if>
-							</trkpt>
+							<xsl:if test="$lon">
+								<trkpt lon="{$lon}" lat="{$lat}">
+									<xsl:choose>
+										<xsl:when test="contains($latele,' ')">
+											<ele><xsl:value-of select="substring-after($latele,' ')"/></ele>
+										</xsl:when>
+									</xsl:choose>
+									<xsl:variable name="ts" select="../kml:when[$i]"/>
+									<xsl:if test="$ts">
+										<time><xsl:value-of select="$ts"/></time>
+									</xsl:if>
+								</trkpt>
+							</xsl:if>
 						</xsl:for-each>
 					</trkseg>
 				</trk>


### PR DESCRIPTION
[KML](https://developers.google.com/kml/documentation/kmlreference#gxtrack) allows empty gx:coord elements and [OpenTracks](https://github.com/OpenTracksApp/OpenTracks) has started to use them. Currently, kml2gpx.xslt creates trkpt elements with empty lon and lat attributes, which are later interpreted as 0. This pull request adds an xsl:if conditional to kml2gpx.xslt so that empty gx:coord elements are omitted from the GPX output.

```xml
<trkpt lon="" lat="">
  <time>2021-03-02T09:30:40.993Z</time>
</trkpt>
```