### PR TITLE
Fix import nonexistent application modes

### DIFF
--- a/OsmAnd/src/net/osmand/plus/settings/backend/ApplicationMode.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/ApplicationMode.java
@@ -169,6 +169,15 @@ public class ApplicationMode {
 		return customModes;
 	}
 
+	public static boolean exist(String key) {
+		for (ApplicationMode p : values) {
+			if (p.getStringKey().equals(key)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	public static ApplicationMode valueOfStringKey(String key, ApplicationMode def) {
 		for (ApplicationMode p : values) {
 			if (p.getStringKey().equals(key)) {

--- a/OsmAnd/src/net/osmand/plus/settings/backend/ApplicationMode.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/ApplicationMode.java
@@ -169,15 +169,6 @@ public class ApplicationMode {
 		return customModes;
 	}
 
-	public static boolean exist(String key) {
-		for (ApplicationMode p : values) {
-			if (p.getStringKey().equals(key)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
 	public static ApplicationMode valueOfStringKey(String key, ApplicationMode def) {
 		for (ApplicationMode p : values) {
 			if (p.getStringKey().equals(key)) {

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -768,17 +768,17 @@ public class OsmandSettings {
 
 		@Override
 		public void readFromJson(JSONObject json, ApplicationMode appMode) throws JSONException {
-			Set<String> importAppModesKeys = Algorithms.decodeStringSet(json.getString(getId()),",");
-			Set<String> nonexistentCustomAppModesKeys = new HashSet<>();
-			for (String importAppModeKey : importAppModesKeys) {
-				if (ApplicationMode.valueOfStringKey(importAppModeKey, null) == null) {
-					nonexistentCustomAppModesKeys.add(importAppModeKey);
+			Set<String> appModesKeys = Algorithms.decodeStringSet(json.getString(getId()),",");
+			Set<String> nonexistentAppModesKeys = new HashSet<>();
+			for (String appModeKey : appModesKeys) {
+				if (ApplicationMode.valueOfStringKey(appModeKey, null) == null) {
+					nonexistentAppModesKeys.add(appModeKey);
 				}
 			}
-			if (!nonexistentCustomAppModesKeys.isEmpty()) {
-				importAppModesKeys.removeAll(nonexistentCustomAppModesKeys);
-				set(parseString(Algorithms.encodeStringSet(importAppModesKeys, ",")));
+			if (!nonexistentAppModesKeys.isEmpty()) {
+				appModesKeys.removeAll(nonexistentAppModesKeys);
 			}
+			set(parseString(Algorithms.encodeStringSet(appModesKeys, ",")));
 		}
 
 	}.makeGlobal().makeShared().cache();

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -768,36 +768,17 @@ public class OsmandSettings {
 
 		@Override
 		public void readFromJson(JSONObject json, ApplicationMode appMode) throws JSONException {
-			Set<String> customAppModesKeys = new HashSet<>();
-			if ((json.has(CUSTOM_APP_MODES_KEYS.getId()))) {
-				customAppModesKeys = Algorithms.decodeStringSet(json.getString(CUSTOM_APP_MODES_KEYS.getId()), ",");
-			}
-
+			Set<String> importAppModesKeys = Algorithms.decodeStringSet(json.getString(getId()),",");
 			Set<String> nonexistentCustomAppModesKeys = new HashSet<>();
-			for (String customAppModeKey : customAppModesKeys) {
-				if (!ApplicationMode.exist(customAppModeKey)) {
-					nonexistentCustomAppModesKeys.add(customAppModeKey);
-				}
-			}
-			customAppModesKeys.removeAll(nonexistentCustomAppModesKeys);
-			nonexistentCustomAppModesKeys.clear();
-			json.put(CUSTOM_APP_MODES_KEYS.getId(), Algorithms.encodeStringSet(customAppModesKeys, ","));
-
-			Set<String> availableAppModesKeys = new HashSet<>();
-			if (json.has(AVAILABLE_APP_MODES.getId())) {
-				availableAppModesKeys = Algorithms.decodeStringSet(json.getString(AVAILABLE_APP_MODES.getId()),",");
-			}
-			for (String availableAppModeKey : availableAppModesKeys) {
-				if (availableAppModeKey.matches("^.*_\\d{10,13}$") && !customAppModesKeys.contains(availableAppModeKey)) {
-					nonexistentCustomAppModesKeys.add(availableAppModeKey);
+			for (String importAppModeKey : importAppModesKeys) {
+				if (ApplicationMode.valueOfStringKey(importAppModeKey, null) == null) {
+					nonexistentCustomAppModesKeys.add(importAppModeKey);
 				}
 			}
 			if (!nonexistentCustomAppModesKeys.isEmpty()) {
-				availableAppModesKeys.removeAll(nonexistentCustomAppModesKeys);
+				importAppModesKeys.removeAll(nonexistentCustomAppModesKeys);
+				set(parseString(Algorithms.encodeStringSet(importAppModesKeys, ",")));
 			}
-			json.put(AVAILABLE_APP_MODES.getId(), Algorithms.encodeStringSet(availableAppModesKeys, ","));
-
-			super.readFromJson(json, appMode);
 		}
 
 	}.makeGlobal().makeShared().cache();
@@ -2954,7 +2935,7 @@ public class OsmandSettings {
 			new EnumStringPreference<>(this, "rate_us_state", RateUsState.INITIAL_STATE, RateUsState.values()).makeGlobal();
 
 	public final CommonPreference<String> CUSTOM_APP_MODES_KEYS =
-			new StringPreference(this, "custom_app_modes_keys", "").makeGlobal().makeShared().cache();
+			new StringPreference(this, "custom_app_modes_keys", "").makeGlobal().cache();
 
 	public Set<String> getCustomAppModesKeys() {
 		String appModesKeys = CUSTOM_APP_MODES_KEYS.get();

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -780,6 +780,7 @@ public class OsmandSettings {
 				}
 			}
 			customAppModesKeys.removeAll(nonexistentCustomAppModesKeys);
+			nonexistentCustomAppModesKeys.clear();
 			json.put(CUSTOM_APP_MODES_KEYS.getId(), Algorithms.encodeStringSet(customAppModesKeys, ","));
 
 			Set<String> availableAppModesKeys = new HashSet<>();


### PR DESCRIPTION
After import a file that contains only global settings (no profiles), empty profiles with a name (string key + "_" + milliseconds) are created, as in this screenshot:
<img src="https://user-images.githubusercontent.com/32697608/121729788-87434e00-caf7-11eb-8697-cd52e08777b0.jpg" width="300">