### PR TITLE
Add GitHub funding link to official OsmAnd FAQ

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://osmand.net/help-online#buy_app


### PR DESCRIPTION
Since I was looking for the funding links myself, this is my humble effort to make it easier for other to support this wonderful project ❤️ 

This will require an admin to enable the repos funding feature, see [GitHub's funding docs](https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/displaying-a-sponsor-button-in-your-repository#displaying-a-sponsor-button-in-your-repository).

_Sidenote: It would be possible to also add the App Store links here, to allow users to quickly find them._