### PR TITLE
fix export parking with time in osf

### DIFF
--- a/OsmAnd/src/net/osmand/plus/parkingpoint/ParkingPositionPlugin.java
+++ b/OsmAnd/src/net/osmand/plus/parkingpoint/ParkingPositionPlugin.java
@@ -370,6 +370,8 @@ public class ParkingPositionPlugin extends OsmandPlugin {
 				cal.add(Calendar.HOUR_OF_DAY, timePicker.getCurrentHour());
 				cal.add(Calendar.MINUTE, timePicker.getCurrentMinute());
 				setParkingTime(cal.getTimeInMillis());
+				mapActivity.getMyApplication().getFavorites().getSpecialPoint(SpecialPointType.PARKING).setTimestamp(cal.getTimeInMillis());
+				mapActivity.getMyApplication().getFavorites().saveCurrentPointsIntoFile();
 				CheckBox addCalendarEvent = (CheckBox) setTimeParking.findViewById(R.id.check_event_in_calendar);
 				if (addCalendarEvent.isChecked()) {
 					addCalendarEvent(setTimeParking.getContext());

--- a/OsmAnd/src/net/osmand/plus/parkingpoint/ParkingPositionPlugin.java
+++ b/OsmAnd/src/net/osmand/plus/parkingpoint/ParkingPositionPlugin.java
@@ -370,8 +370,7 @@ public class ParkingPositionPlugin extends OsmandPlugin {
 				cal.add(Calendar.HOUR_OF_DAY, timePicker.getCurrentHour());
 				cal.add(Calendar.MINUTE, timePicker.getCurrentMinute());
 				setParkingTime(cal.getTimeInMillis());
-				mapActivity.getMyApplication().getFavorites().getSpecialPoint(SpecialPointType.PARKING).setTimestamp(cal.getTimeInMillis());
-				mapActivity.getMyApplication().getFavorites().saveCurrentPointsIntoFile();
+				app.getFavorites().setParkingPoint(getParkingPosition(), null, getParkingTime(), isParkingEventAdded());
 				CheckBox addCalendarEvent = (CheckBox) setTimeParking.findViewById(R.id.check_event_in_calendar);
 				if (addCalendarEvent.isChecked()) {
 					addCalendarEvent(setTimeParking.getContext());

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 #
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
- org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 #
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
https://github.com/osmandapp/OsmAnd-iOS/issues/1309

Without this line parking point is always exported with default time:
<time>1969-12-31T23:59:59Z</time>

