### PR TITLE
Fix integration of openrouteservice in OSMAnd

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-routing-report.md
+++ b/.github/ISSUE_TEMPLATE/3-routing-report.md
@@ -29,7 +29,7 @@ Please give us the following information so that we can try to **reproduce** you
 <!-- Which routing provider was used? (please tick the proper box [x]) -->
 
 - [ ] OsmAnd's in-app offline routing
-- [ ] Any online routing provider (YOURS, OpenRouteService, OSRM, etc.)
+- [ ] Any online routing provider (YOURS, openrouteservice, OSRM, etc.)
 
 ### Routing Profile
 

--- a/OsmAnd/res/values-ar/strings.xml
+++ b/OsmAnd/res/values-ar/strings.xml
@@ -4194,7 +4194,7 @@
     <string name="loading_list_of_routing_services">تحميل قائمة خدمات التوجيه المتوفرة</string>
     <string name="shared_string_offline">دون اتصال</string>
     <string name="shared_string_online">عبر الإنترنت</string>
-    <string name="osmand_online_routing_promo">استخدم قوالب محددة مسبقًا ، أو أضف OSRM، GraphHopper، OpenRouteService أو توجيه مدعم بال GPX عبر الانترنت.</string>
+    <string name="osmand_online_routing_promo">استخدم قوالب محددة مسبقًا ، أو أضف OSRM، GraphHopper، openrouteservice أو توجيه مدعم بال GPX عبر الانترنت.</string>
     <string name="shared_string_external">خارجي</string>
     <string name="provided_by">مقدمة من %1$s</string>
     <string name="failed_loading_predefined_engines">فشل تحميل قائمة القوالب المحددة مسبقًا.

--- a/OsmAnd/res/values-b+ast/strings.xml
+++ b/OsmAnd/res/values-b+ast/strings.xml
@@ -4135,7 +4135,7 @@
     <string name="loading_list_of_routing_services">Loading list of available routing services</string>
     <string name="shared_string_offline">Offline</string>
     <string name="shared_string_online">Online</string>
-    <string name="osmand_online_routing_promo">You can use predefined templates, or add custom online routing, supported: OSRM, Graphhopper, OpenRouteService, GPX.</string>
+    <string name="osmand_online_routing_promo">You can use predefined templates, or add custom online routing, supported: OSRM, Graphhopper, openrouteservice, GPX.</string>
     <string name="shared_string_external">External</string>
     <string name="provided_by">Provided by %1$s</string>
     <string name="failed_loading_predefined_engines">Failed to load the list of predefined templates.

--- a/OsmAnd/res/values-cs/strings.xml
+++ b/OsmAnd/res/values-cs/strings.xml
@@ -4129,7 +4129,7 @@
     <string name="loading_list_of_routing_services">Načítání seznamu dostupných navigačních služeb</string>
     <string name="shared_string_offline">Offline</string>
     <string name="shared_string_online">Online</string>
-    <string name="osmand_online_routing_promo">Můžete použít předdefinované šablony, nebo přidat vlastní online navigaci. Podporováno: OSRM, Graphhopper, OpenRouteService, GPX.</string>
+    <string name="osmand_online_routing_promo">Můžete použít předdefinované šablony, nebo přidat vlastní online navigaci. Podporováno: OSRM, Graphhopper, openrouteservice, GPX.</string>
     <string name="shared_string_external">Externí</string>
     <string name="provided_by">Zprostředkuje %1$s</string>
     <string name="failed_loading_predefined_engines">Seznam předdefinovaných šablon se nepodařilo načíst.

--- a/OsmAnd/res/values-da/strings.xml
+++ b/OsmAnd/res/values-da/strings.xml
@@ -4089,7 +4089,7 @@
     <string name="verification_code_missing_description">Det kan tage 10 minutter. Brug knappen nedenfor, hvis den ikke er i din spam-mappe.</string>
     <string name="shared_string_offline">Offline</string>
     <string name="shared_string_online">Online</string>
-    <string name="osmand_online_routing_promo">Brug foruddefinerede skabeloner, eller tilføj OSRM, GraphHopper, OpenRouteService eller GPX online-routing.</string>
+    <string name="osmand_online_routing_promo">Brug foruddefinerede skabeloner, eller tilføj OSRM, GraphHopper, openrouteservice eller GPX online-routing.</string>
     <string name="shared_string_external">Ekstern</string>
     <string name="provided_by">Leveret af %1$s</string>
     <string name="failed_loading_predefined_engines">Kunne ikke indlæse listen over foruddefinerede skabeloner.

--- a/OsmAnd/res/values-de/strings.xml
+++ b/OsmAnd/res/values-de/strings.xml
@@ -4130,7 +4130,7 @@
     <string name="loading_list_of_routing_services">Lade Liste der verfügbaren Routingdienste</string>
     <string name="shared_string_offline">Offline</string>
     <string name="shared_string_online">Online</string>
-    <string name="osmand_online_routing_promo">Verwenden Sie vordefinierte Vorlagen, oder fügen Sie OSRM, GraphHopper, OpenRouteService oder GPX Online-Routing hinzu.</string>
+    <string name="osmand_online_routing_promo">Verwenden Sie vordefinierte Vorlagen, oder fügen Sie OSRM, GraphHopper, openrouteservice oder GPX Online-Routing hinzu.</string>
     <string name="shared_string_external">Extern</string>
     <string name="provided_by">Bereitgestellt von %1$s</string>
     <string name="failed_loading_predefined_engines">Die Liste der vordefinierten Vorlagen konnte nicht geladen werden.

--- a/OsmAnd/res/values-eo/strings.xml
+++ b/OsmAnd/res/values-eo/strings.xml
@@ -4129,7 +4129,7 @@
     <string name="loading_list_of_routing_services">Ŝargado de listo de disponeblaj navigiloj</string>
     <string name="shared_string_offline">Malkonekta</string>
     <string name="shared_string_online">Enreta</string>
-    <string name="osmand_online_routing_promo">Vi povas uzi antaŭdifinitajn ŝablonojn, aŭ aldoni enretajn navigilojn OSRM, GraphHopper, OpenRouteService aŭ GPX.</string>
+    <string name="osmand_online_routing_promo">Vi povas uzi antaŭdifinitajn ŝablonojn, aŭ aldoni enretajn navigilojn OSRM, GraphHopper, openrouteservice aŭ GPX.</string>
     <string name="shared_string_external">Ekstera</string>
     <string name="provided_by">Liverata de %1$s</string>
     <string name="failed_loading_predefined_engines">Fiaskis enlegi liston de antaŭdifinitaj ŝablonoj.

--- a/OsmAnd/res/values-es-rAR/strings.xml
+++ b/OsmAnd/res/values-es-rAR/strings.xml
@@ -4127,7 +4127,7 @@
     <string name="loading_list_of_routing_services">Cargando lista de servicios de navegación disponibles</string>
     <string name="shared_string_offline">Desconectado</string>
     <string name="shared_string_online">En línea</string>
-    <string name="osmand_online_routing_promo">Usa plantillas predefinidas o añade navegadores en línea admitidos como OSRM, Graphhopper, OpenRouteService o GPX.</string>
+    <string name="osmand_online_routing_promo">Usa plantillas predefinidas o añade navegadores en línea admitidos como OSRM, Graphhopper, openrouteservice o GPX.</string>
     <string name="shared_string_external">Externo</string>
     <string name="provided_by">Provisto por %1$s</string>
     <string name="failed_loading_predefined_engines">No se pudo cargar la lista de plantillas predefinidas.

--- a/OsmAnd/res/values-es-rUS/strings.xml
+++ b/OsmAnd/res/values-es-rUS/strings.xml
@@ -4126,7 +4126,7 @@
     <string name="loading_list_of_routing_services">Cargando lista de servicios de navegación disponibles</string>
     <string name="shared_string_offline">Desconectado</string>
     <string name="shared_string_online">En línea</string>
-    <string name="osmand_online_routing_promo">Usa plantillas predefinidas o añade navegadores en línea admitidos como OSRM, Graphhopper, OpenRouteService o GPX.</string>
+    <string name="osmand_online_routing_promo">Usa plantillas predefinidas o añade navegadores en línea admitidos como OSRM, Graphhopper, openrouteservice o GPX.</string>
     <string name="shared_string_external">Externo</string>
     <string name="provided_by">Provisto por %1$s</string>
     <string name="failed_loading_predefined_engines">No se pudo cargar la lista de plantillas predefinidas.

--- a/OsmAnd/res/values-et/strings.xml
+++ b/OsmAnd/res/values-et/strings.xml
@@ -4217,7 +4217,7 @@
     <string name="loading_list_of_routing_services">Saadaval olevate marsruutimisteenuste loendi laadimine</string>
     <string name="shared_string_offline">Võrguühenduseta</string>
     <string name="shared_string_online">Veebis</string>
-    <string name="osmand_online_routing_promo">Võid kasutada etteantud malle või lisada kohandatud online marsruutimise omi, mida toetatakse: OSRM, Graphhopper, OpenRouteService, GPX.</string>
+    <string name="osmand_online_routing_promo">Võid kasutada etteantud malle või lisada kohandatud online marsruutimise omi, mida toetatakse: OSRM, Graphhopper, openrouteservice, GPX.</string>
     <string name="failed_loading_predefined_engines">Eeldefineeritud mallide nimekirja ei õnnestunud laadida.
 \nPalun kontrolli oma internetiühendust.</string>
     <string name="backup_delete_old_data_warning">Oled kustutamas varem laetud andmete muutuste ajalugu.

--- a/OsmAnd/res/values-fa/strings.xml
+++ b/OsmAnd/res/values-fa/strings.xml
@@ -4217,7 +4217,7 @@
 \n
 \n</string>
     <string name="send_logcat_log">ارسال گزارش logcat</string>
-    <string name="osmand_online_routing_promo">از الگوهای از پیش تعریف شده استفاده کنید یا از خدمات مسیریابی آنلاین OSRM،‏ GrapgHopper،‏ OpenRouteService یا GPX اضافه نمایید.</string>
+    <string name="osmand_online_routing_promo">از الگوهای از پیش تعریف شده استفاده کنید یا از خدمات مسیریابی آنلاین OSRM،‏ GrapgHopper،‏ openrouteservice یا GPX اضافه نمایید.</string>
     <string name="backup_view_conflicts">دیدن تداخل‌ها</string>
     <string name="backup_delete_old_data_warning">در حال حذف سابقهٔ تغییر مربوط به داده‌های پیش‌تر بارشده هستید.
 \n

--- a/OsmAnd/res/values-fi/strings.xml
+++ b/OsmAnd/res/values-fi/strings.xml
@@ -3063,7 +3063,7 @@
     <string name="loading_list_of_routing_services">Ladataan luettelo käytettävissä olevista reitityspalveluista</string>
     <string name="shared_string_offline">Offline</string>
     <string name="shared_string_online">Online</string>
-    <string name="osmand_online_routing_promo">Voit käyttää valmiita malleja tai lisätä tuettuja mukautettuja online-reitityksiä: OSRM, Graphhopper, OpenRouteService, GPX.</string>
+    <string name="osmand_online_routing_promo">Voit käyttää valmiita malleja tai lisätä tuettuja mukautettuja online-reitityksiä: OSRM, Graphhopper, openrouteservice, GPX.</string>
     <string name="shared_string_external">Ulkoinen</string>
     <string name="provided_by">Toimittanut %1$s</string>
     <string name="wikivoyage_travel_guide_descr">Oppaita planeetan mielenkiintoisimpiin paikkoihin OsmAndin sisällä, ilman Internet-yhteyttä.</string>

--- a/OsmAnd/res/values-fr/strings.xml
+++ b/OsmAnd/res/values-fr/strings.xml
@@ -4139,7 +4139,7 @@
     <string name="backup_delete_old_data">Supprimer les anciennes versions</string>
     <string name="backup_data">Sauvegarder les données</string>
     <string name="select_backup_data_descr">Sélectionnez les données et dossiers à sauvegarder.</string>
-    <string name="osmand_online_routing_promo">Utiliser des modèles prédéfinis ou ajouter OSRM, GraphHopper, OpenRouteService, ou un moteur de routage GPX en ligne.</string>
+    <string name="osmand_online_routing_promo">Utiliser des modèles prédéfinis ou ajouter OSRM, GraphHopper, openrouteservice, ou un moteur de routage GPX en ligne.</string>
     <string name="failed_loading_predefined_engines">Impossible d\'actualiser la liste des modèles prédéfinis.
 \nVeuillez vérifier votre connexion Internet.</string>
     <string name="backup_delete_all_data_warning">Vous êtes sur le point de supprimer toutes les données envoyées précédemment sur OsmAnd Cloud, y compris l\'historique des versions.

--- a/OsmAnd/res/values-hu/strings.xml
+++ b/OsmAnd/res/values-hu/strings.xml
@@ -4126,7 +4126,7 @@
     <string name="loading_list_of_routing_services">Elérhető útvonaltervező szolgáltatások listájának betöltése</string>
     <string name="shared_string_offline">Offline</string>
     <string name="shared_string_online">Online</string>
-    <string name="osmand_online_routing_promo">Használhat előre meghatározott sablonokat, vagy a következő online útvonaltervezőket: OSRM, Graphhopper, OpenRouteService és GPX.</string>
+    <string name="osmand_online_routing_promo">Használhat előre meghatározott sablonokat, vagy a következő online útvonaltervezőket: OSRM, Graphhopper, openrouteservice és GPX.</string>
     <string name="shared_string_external">Külső</string>
     <string name="failed_loading_predefined_engines">Nem sikerült betölteni az előre meghatározott sablonok listáját.
 \nKérjük, ellenőrizze internetkapcsolatát.</string>

--- a/OsmAnd/res/values-it/strings.xml
+++ b/OsmAnd/res/values-it/strings.xml
@@ -4116,7 +4116,7 @@
     <string name="loading_list_of_routing_services">Caricamento della lista dei servizi di navigazione disponibili</string>
     <string name="shared_string_offline">Offline</string>
     <string name="shared_string_online">Online</string>
-    <string name="osmand_online_routing_promo">Puoi utilizzare i modelli predefiniti o aggiungere OSRM, Graphhopper, OpenRouteService, o navigatori online di GPX.</string>
+    <string name="osmand_online_routing_promo">Puoi utilizzare i modelli predefiniti o aggiungere OSRM, Graphhopper, openrouteservice, o navigatori online di GPX.</string>
     <string name="shared_string_external">Esterno</string>
     <string name="provided_by">Fornito da %1$s</string>
     <string name="failed_loading_predefined_engines">Impossibile caricare la lista dei modelli predefiniti.

--- a/OsmAnd/res/values-iw/strings.xml
+++ b/OsmAnd/res/values-iw/strings.xml
@@ -4129,7 +4129,7 @@
     <string name="loading_list_of_routing_services">רשימת שירותי הניווט הזמינים נטענת</string>
     <string name="shared_string_offline">בלתי מקוון</string>
     <string name="shared_string_online">מקוון</string>
-    <string name="osmand_online_routing_promo">ניתן להשתמש בתבניות שהוגדרו מראש או להוסיף ניווט מקוון מותאם אישית, נתמכים: OSRM,‏ Graphhopper,‏ OpenRouteService,‏ GPX.</string>
+    <string name="osmand_online_routing_promo">ניתן להשתמש בתבניות שהוגדרו מראש או להוסיף ניווט מקוון מותאם אישית, נתמכים: OSRM,‏ Graphhopper,‏ openrouteservice,‏ GPX.</string>
     <string name="shared_string_external">חיצוני</string>
     <string name="provided_by">סופק על ידי %1$s</string>
     <string name="failed_loading_predefined_engines">לא ניתן לטעון את התבניות שהוגדרו מראש.

--- a/OsmAnd/res/values-ja/strings.xml
+++ b/OsmAnd/res/values-ja/strings.xml
@@ -4107,8 +4107,8 @@ POIの更新は利用できません</string>
     <string name="renew_subscription">サブスクリプションの更新</string>
     <string name="shared_string_offline">オフライン</string>
     <string name="shared_string_online">オンライン</string>
-    <string name="osmand_online_routing_promo">定義済みのテンプレートの使用、カスタムオンラインルートが追加できます。サポート形式は以下の通り:OSRM, Graphhopper, OpenRouteService, GPX
-\n定義済みのテンプレートの使用、OSRM・GraphHopper・OpenRouteServiceや、GPXオンラインルーティング機能が利用可能になります。</string>
+    <string name="osmand_online_routing_promo">定義済みのテンプレートの使用、カスタムオンラインルートが追加できます。サポート形式は以下の通り:OSRM, Graphhopper, openrouteservice, GPX
+\n定義済みのテンプレートの使用、OSRM・GraphHopper・openrouteserviceや、GPXオンラインルーティング機能が利用可能になります。</string>
     <string name="shared_string_external">外部</string>
     <string name="provided_by">%1$sから提供</string>
     <string name="failed_loading_predefined_engines">定義済みのテンプレートリストを読み込めませんでした。

--- a/OsmAnd/res/values-nb/strings.xml
+++ b/OsmAnd/res/values-nb/strings.xml
@@ -4049,7 +4049,7 @@
     <string name="verify_email_address_descr">Bekreftelseskode sendt til %1$s. Skriv den inn i feltet nedenfor.</string>
     <string name="delete_version_history">Slett versjonshistorikk</string>
     <string name="nautical_depth">Havdybde</string>
-    <string name="osmand_online_routing_promo">Du kan bruke forhåndsdefinerte maler, eller legge til egendefinert nettbasert ruteberegning. OSRM, GrapHopper, OpenRouteService og GPX støttes.</string>
+    <string name="osmand_online_routing_promo">Du kan bruke forhåndsdefinerte maler, eller legge til egendefinert nettbasert ruteberegning. OSRM, GrapHopper, openrouteservice og GPX støttes.</string>
     <string name="loading_list_of_routing_services">Laster inn liste over tilgjengelige ruteberegningstjenester</string>
     <string name="send_logcat_log">Send Logcat-logg</string>
     <string name="open_place_reviews">OpenPlaceReviews</string>

--- a/OsmAnd/res/values-pl/strings.xml
+++ b/OsmAnd/res/values-pl/strings.xml
@@ -4121,7 +4121,7 @@
     <string name="open_place_reviews">OpenPlaceReviews</string>
     <string name="select_nav_profile_dialog_message">„Rodzaj nawigacji” wybiera sposób obliczania tras z dostępnymi silnikami wyznaczania tras offline i online.</string>
     <string name="loading_list_of_routing_services">Wczytywanie listy dostępnych usług routingu</string>
-    <string name="osmand_online_routing_promo">Użyj wstępnie zdefiniowanych szablonów, lub dodaj OSRM, Graphhopper, OpenRouteService lub GPX wyznaczania tras online.</string>
+    <string name="osmand_online_routing_promo">Użyj wstępnie zdefiniowanych szablonów, lub dodaj OSRM, Graphhopper, openrouteservice lub GPX wyznaczania tras online.</string>
     <string name="shared_string_external">Zewnętrzny</string>
     <string name="provided_by">Dostarczone przez %1$s</string>
     <string name="failed_loading_predefined_engines">Nie udało się załadować listy wstępnie zdefiniowanych szablonów.

--- a/OsmAnd/res/values-pt-rBR/strings.xml
+++ b/OsmAnd/res/values-pt-rBR/strings.xml
@@ -4120,7 +4120,7 @@
     <string name="loading_list_of_routing_services">Lista de carregamento de serviços de roteamento disponíveis</string>
     <string name="shared_string_offline">Offline</string>
     <string name="shared_string_online">Online</string>
-    <string name="osmand_online_routing_promo">Use modelos predefinidos ou adicione roteamento online OSRM, GraphHopper, OpenRouteService ou GPX.</string>
+    <string name="osmand_online_routing_promo">Use modelos predefinidos ou adicione roteamento online OSRM, GraphHopper, openrouteservice ou GPX.</string>
     <string name="shared_string_external">Externo</string>
     <string name="provided_by">Fornecido por %1$s</string>
     <string name="failed_loading_predefined_engines">Não foi possível carregar a lista de modelos predefinidos.

--- a/OsmAnd/res/values-pt/strings.xml
+++ b/OsmAnd/res/values-pt/strings.xml
@@ -4129,7 +4129,7 @@
     <string name="loading_list_of_routing_services">A carregar a lista de serviços de roteamento disponíveis</string>
     <string name="shared_string_offline">Offline</string>
     <string name="shared_string_online">Online</string>
-    <string name="osmand_online_routing_promo">Use modelos predefinidos ou adicione um roteamento online OSRM, GraphHopper, OpenRouteService ou GPX.</string>
+    <string name="osmand_online_routing_promo">Use modelos predefinidos ou adicione um roteamento online OSRM, GraphHopper, openrouteservice ou GPX.</string>
     <string name="shared_string_external">Externo</string>
     <string name="provided_by">Fornecido por %1$s</string>
     <string name="failed_loading_predefined_engines">Não foi possível carregar a lista de modelos predefinidos.

--- a/OsmAnd/res/values-ro/strings.xml
+++ b/OsmAnd/res/values-ro/strings.xml
@@ -2935,7 +2935,7 @@
     <string name="loading_list_of_routing_services">Încărcarea listei de servicii de rutare disponibile</string>
     <string name="shared_string_offline">Offline</string>
     <string name="shared_string_online">Online</string>
-    <string name="osmand_online_routing_promo">Utilizați șabloane predefinite sau adăugați rutare online OSRM, GraphHopper, OpenRouteService sau GPX.</string>
+    <string name="osmand_online_routing_promo">Utilizați șabloane predefinite sau adăugați rutare online OSRM, GraphHopper, openrouteservice sau GPX.</string>
     <string name="shared_string_external">Extern</string>
     <string name="provided_by">Furnizat de %1$s</string>
     <string name="failed_loading_predefined_engines">Nu s-a putut încărca lista de șabloane predefinite.

--- a/OsmAnd/res/values-ru/strings.xml
+++ b/OsmAnd/res/values-ru/strings.xml
@@ -4148,7 +4148,7 @@
     <string name="loading_list_of_routing_services">Загрузка списка доступных сервисов маршрутизации</string>
     <string name="shared_string_offline">Офлайн</string>
     <string name="shared_string_online">Онлайн</string>
-    <string name="osmand_online_routing_promo">Используйте предопределённые шаблоны или добавьте онлайн-маршрутизацию OSRM, GraphHopper, OpenRouteService или GPX.</string>
+    <string name="osmand_online_routing_promo">Используйте предопределённые шаблоны или добавьте онлайн-маршрутизацию OSRM, GraphHopper, openrouteservice или GPX.</string>
     <string name="shared_string_external">Внешний</string>
     <string name="provided_by">Предоставлен %1$s</string>
     <string name="failed_loading_predefined_engines">Не удалось загрузить список предустановленных шаблонов.

--- a/OsmAnd/res/values-sc/strings.xml
+++ b/OsmAnd/res/values-sc/strings.xml
@@ -4130,7 +4130,7 @@
     <string name="loading_list_of_routing_services">Carrighende sa lista de sos servìtzios de càrculu de sas àndalas a disponimentu</string>
     <string name="shared_string_offline">Non in lìnia</string>
     <string name="shared_string_online">In lìnia</string>
-    <string name="osmand_online_routing_promo">Imprea modellos predefinidos o annanghe OSRM, Graphhopper, OpenRouteService o su càrculu de s\'àndala GPX in lìnia.</string>
+    <string name="osmand_online_routing_promo">Imprea modellos predefinidos o annanghe OSRM, Graphhopper, openrouteservice o su càrculu de s\'àndala GPX in lìnia.</string>
     <string name="shared_string_external">Esternu</string>
     <string name="provided_by">Frunidu dae %1$s</string>
     <string name="failed_loading_predefined_engines">Carrigamentu de sa lista de sos modellos predefinidos fallidu.

--- a/OsmAnd/res/values-sk/strings.xml
+++ b/OsmAnd/res/values-sk/strings.xml
@@ -4120,7 +4120,7 @@
     <string name="loading_list_of_routing_services">Načítava sa zoznam dostupných navigačných služieb</string>
     <string name="shared_string_offline">Offline</string>
     <string name="shared_string_online">Online</string>
-    <string name="osmand_online_routing_promo">Použite prednastavené šablóny alebo prijte online navigácie OSRM, Graphhopper, OpenRouteService, GPX.</string>
+    <string name="osmand_online_routing_promo">Použite prednastavené šablóny alebo prijte online navigácie OSRM, Graphhopper, openrouteservice, GPX.</string>
     <string name="shared_string_external">Externé</string>
     <string name="provided_by">Poskytované %1$s</string>
     <string name="failed_loading_predefined_engines">Nepodarilo sa načítať zoznam prednastavených šablón.

--- a/OsmAnd/res/values-tr/strings.xml
+++ b/OsmAnd/res/values-tr/strings.xml
@@ -4126,7 +4126,7 @@
     <string name="loading_list_of_routing_services">Kullanılabilir yönlendirme hizmetlerinin listesi yükleniyor</string>
     <string name="shared_string_offline">Çevrim dışı</string>
     <string name="shared_string_online">Çevrim içi</string>
-    <string name="osmand_online_routing_promo">Önceden tanımlanan şablonlar kullanın veya OSRM, Graphhopper, OpenRouteService veya GPX çevrim içi yönlendirme ekleyin.</string>
+    <string name="osmand_online_routing_promo">Önceden tanımlanan şablonlar kullanın veya OSRM, Graphhopper, openrouteservice veya GPX çevrim içi yönlendirme ekleyin.</string>
     <string name="shared_string_external">Harici</string>
     <string name="provided_by">%1$s tarafından sağlanan</string>
     <string name="failed_loading_predefined_engines">Önceden tanımlanan şablonların listesi yüklenemedi.

--- a/OsmAnd/res/values-uk/strings.xml
+++ b/OsmAnd/res/values-uk/strings.xml
@@ -4124,7 +4124,7 @@
     <string name="loading_list_of_routing_services">Список завантаження доступних служб маршрутизації</string>
     <string name="shared_string_offline">Автономно</string>
     <string name="shared_string_online">З мережі</string>
-    <string name="osmand_online_routing_promo">Користуйтеся попередньо визначеними шаблонами або додавайте онлайн-маршрутизацію OSRM, GraphHopper, OpenRouteService або GPX.</string>
+    <string name="osmand_online_routing_promo">Користуйтеся попередньо визначеними шаблонами або додавайте онлайн-маршрутизацію OSRM, GraphHopper, openrouteservice або GPX.</string>
     <string name="shared_string_external">Зовнішні</string>
     <string name="provided_by">Надано %1$s</string>
     <string name="failed_loading_predefined_engines">Не вдалося завантажити список попередньо визначених шаблонів.

--- a/OsmAnd/res/values-zh-rTW/strings.xml
+++ b/OsmAnd/res/values-zh-rTW/strings.xml
@@ -4118,7 +4118,7 @@
     <string name="loading_list_of_routing_services">載入可用路線規劃服務清單</string>
     <string name="shared_string_offline">離線</string>
     <string name="shared_string_online">線上</string>
-    <string name="osmand_online_routing_promo">使用預先定義的範本，或是新增 OSRM、Graphhopper、OpenRouteService 或是 GPX 線上路線規劃。</string>
+    <string name="osmand_online_routing_promo">使用預先定義的範本，或是新增 OSRM、Graphhopper、openrouteservice 或是 GPX 線上路線規劃。</string>
     <string name="shared_string_external">外部</string>
     <string name="provided_by">由 %1$s 提供</string>
     <string name="failed_loading_predefined_engines">無法載入預先定義範本。

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -175,7 +175,7 @@
     <string name="failed_loading_predefined_engines">Could not load the list of predefined templates.\nPlease check your Internet connection.</string>
     <string name="provided_by">Provided by %1$s</string>
     <string name="shared_string_external">External</string>
-    <string name="osmand_online_routing_promo">Use predefined templates, or add OSRM, GraphHopper, OpenRouteService, or GPX online routing.</string>
+    <string name="osmand_online_routing_promo">Use predefined templates, or add OSRM, GraphHopper, openrouteservice, or GPX online routing.</string>
     <string name="shared_string_online">Online</string>
     <string name="shared_string_offline">Offline</string>
     <string name="loading_list_of_routing_services">Loading list of available routing services</string>

--- a/OsmAnd/src/net/osmand/plus/onlinerouting/engine/OrsEngine.java
+++ b/OsmAnd/src/net/osmand/plus/onlinerouting/engine/OrsEngine.java
@@ -123,6 +123,7 @@ public class OrsEngine extends JsonOnlineRoutingEngine {
 		for (int i = 0; i < segments.length(); i++) {
 			JSONArray steps = segments.getJSONObject(i).getJSONArray("steps");
 			for (int j = 0; j < steps.length(); j++) {
+				// parse JSON values
 				JSONObject step = steps.getJSONObject(j);
 				double distance = step.getDouble("distance");
 				double duration = step.getDouble("duration");
@@ -131,6 +132,7 @@ public class OrsEngine extends JsonOnlineRoutingEngine {
 				String streetName = step.getString("name");
 				float averageSpeed = (float) (distance / duration);
 
+				// create direction step
 				RouteDirectionInfo direction = new RouteDirectionInfo(averageSpeed, turnType);
 				direction.setDescriptionRoute(instruction);
 				direction.setStreetName(streetName);
@@ -146,84 +148,49 @@ public class OrsEngine extends JsonOnlineRoutingEngine {
 		return null;
 	}
 
+	/**
+	 * This method takes an ORS instruction type integer and maps it to an OsmAnd TurnType object.
+	 * source: https://github.com/GIScience/openrouteservice/blob/master/openrouteservice/src/main/java/org/heigit/ors/routing/instructions/InstructionType.java
+	 * documentation: https://giscience.github.io/openrouteservice/documentation/Instruction-Types.html
+	 */
 	@NonNull
-	private TurnType getTurnType(int orsTurnIdx) {
-		boolean leftSide = false; // TODO: change
-		// go straight per default
-		String turnTypeStr = "C";
-		OrsInstructionType orsInstructionType = OrsInstructionType.values()[orsTurnIdx];
-	    switch (orsInstructionType) {
-			case TURN_LEFT:
-				turnTypeStr = "TL";
-				break;
-			case TURN_RIGHT:
-				turnTypeStr = "TR";
-			    break;
-			case TURN_SHARP_LEFT:
-				turnTypeStr = "TSHL";
-				break;
-			case TURN_SHARP_RIGHT:
-				turnTypeStr = "TSHR";
-				break;
-			case TURN_SLIGHT_LEFT:
-				turnTypeStr = "TSLL";
-				break;
-			case TURN_SLIGHT_RIGHT:
-				turnTypeStr = "TSLR";
-				break;
-			case CONTINUE:
-				turnTypeStr = "C";
-				break;
-			case ENTER_ROUNDABOUT:
-				turnTypeStr = "RNDB";
-				break;
-			case EXIT_ROUNDABOUT:
-			    turnTypeStr = leftSide ? "TL" : "TR";
-				break;
-			case UTURN:
-			    turnTypeStr = "TU";
-				break;
-			case FINISH:
-			    // not supported -> default
-				break;
-			case DEPART:
-			    turnTypeStr = leftSide ? "KL" : "KR";
-				break;
-			case KEEP_LEFT:
-				turnTypeStr = "KL";
-				break;
-			case KEEP_RIGHT:
-				turnTypeStr = "KR";
-				break;
-			case UNKNOWN:
+	private TurnType getTurnType(int orsTurnType) {
+		// driving on the left or right side is currently not supported by the ORS
+		boolean leftSide = false;
+	    switch (orsTurnType) {
+			case 0: // TURN_LEFT
+				return TurnType.fromString("TL", leftSide);
+			case 1: // TURN_RIGHT
+				return TurnType.fromString("TR", leftSide);
+			case 2: // TURN_SHARP_LEFT
+				return TurnType.fromString("TSHL", leftSide);
+			case 3: // TURN_SHARP_RIGHT
+				return TurnType.fromString("TSHR", leftSide);
+			case 4: // TURN_SLIGHT_LEFT
+				return TurnType.fromString("TSLL", leftSide);
+			case 5: // TURN_SLIGHT_RIGHT
+				return TurnType.fromString("TSLR", leftSide);
+			case 6: // CONTINUE
+				return TurnType.fromString("C", leftSide);
+			case 7: // ENTER_ROUNDABOUT
+				return TurnType.fromString("RNDB", leftSide);
+			case 8: // EXIT_ROUNDABOUT
+				return TurnType.fromString(leftSide ? "TL" : "TR", leftSide);
+			case 9: // UTURN
+			    return TurnType.fromString("TU", leftSide);
+			case 10: // FINISH
+				// not supported -> default
+				return getTurnType(-1);
+			case 11: // DEPART
+			    return TurnType.fromString(leftSide ? "KL" : "KR", leftSide);
+			case 12: // KEEP_LEFT
+				return TurnType.fromString("KL", leftSide);
+			case 13: // KEEP_RIGHT
+				return TurnType.fromString("KR", leftSide);
+			case 14: // UNKNOWN:
 			default:
-				// go straight per default
-				break;
-		}
-		return TurnType.fromString(turnTypeStr, leftSide);
-	}
-
-	// taken from https://github.com/giscience/openrouteservice
-	private enum OrsInstructionType
-	{
-		TURN_LEFT,              /*0*/
-		TURN_RIGHT,             /*1*/
-		TURN_SHARP_LEFT,        /*2*/
-		TURN_SHARP_RIGHT,       /*3*/
-		TURN_SLIGHT_LEFT,       /*4*/
-		TURN_SLIGHT_RIGHT,      /*5*/
-		CONTINUE,               /*6*/
-		ENTER_ROUNDABOUT,       /*7*/
-		EXIT_ROUNDABOUT,        /*8*/
-		UTURN,                  /*9*/
-		FINISH,                 /*10*/
-		DEPART,                 /*11*/
-		KEEP_LEFT,              /*12*/
-		KEEP_RIGHT,             /*13*/
-		UNKNOWN                 /*14*/;
-
-		public boolean isSlightLeftOrRight() {
-			return this == TURN_SLIGHT_RIGHT || this == TURN_SLIGHT_LEFT;
+				// CONTINUE per default
+				return getTurnType(6);
 		}
 	}
 

--- a/OsmAnd/src/net/osmand/plus/onlinerouting/engine/OrsEngine.java
+++ b/OsmAnd/src/net/osmand/plus/onlinerouting/engine/OrsEngine.java
@@ -178,19 +178,17 @@ public class OrsEngine extends JsonOnlineRoutingEngine {
 				return TurnType.fromString(leftSide ? "TL" : "TR", leftSide);
 			case 9: // UTURN
 			    return TurnType.fromString("TU", leftSide);
-			case 10: // FINISH
-				// not supported -> default
-				return getTurnType(-1);
 			case 11: // DEPART
 			    return TurnType.fromString(leftSide ? "KL" : "KR", leftSide);
 			case 12: // KEEP_LEFT
 				return TurnType.fromString("KL", leftSide);
 			case 13: // KEEP_RIGHT
 				return TurnType.fromString("KR", leftSide);
-			case 14: // UNKNOWN:
+			case 10: // FINISH
+			case 14: // UNKNOWN
 			default:
 				// CONTINUE per default
-				return getTurnType(6);
+				return TurnType.fromString("C", leftSide);
 		}
 	}
 

--- a/OsmAnd/src/net/osmand/plus/onlinerouting/engine/OrsEngine.java
+++ b/OsmAnd/src/net/osmand/plus/onlinerouting/engine/OrsEngine.java
@@ -128,15 +128,20 @@ public class OrsEngine extends JsonOnlineRoutingEngine {
 				double distance = step.getDouble("distance");
 				double duration = step.getDouble("duration");
 				String instruction = step.getString("instruction");
-				TurnType turnType = getTurnType(step.getInt("type"));
+				TurnType turnType = getTurnType(step.getInt("type"), leftSideNavigation);
 				String streetName = step.getString("name");
+				JSONArray wayPoints = step.getJSONArray("way_points");
+				int routePointOffset = wayPoints.getInt(0);
+				int routeEndPointOffset = wayPoints.getInt(1);
 				float averageSpeed = (float) (distance / duration);
 
 				// create direction step
 				RouteDirectionInfo direction = new RouteDirectionInfo(averageSpeed, turnType);
+				direction.routePointOffset = routePointOffset;
+				direction.routeEndPointOffset = routeEndPointOffset;
 				direction.setDescriptionRoute(instruction);
 				direction.setStreetName(streetName);
-				direction.setDistance((int) distance);
+				direction.setDistance((int) Math.round(distance));
 				directions.add(direction);
 			}
 		}
@@ -154,9 +159,7 @@ public class OrsEngine extends JsonOnlineRoutingEngine {
 	 * documentation: https://giscience.github.io/openrouteservice/documentation/Instruction-Types.html
 	 */
 	@NonNull
-	private TurnType getTurnType(int orsInstructionType) {
-		// driving on the left or right side is currently not supported by the ORS
-		boolean leftSide = false;
+	private TurnType getTurnType(int orsInstructionType, boolean leftSide) {
 		switch (orsInstructionType) {
 			case 0: // TURN_LEFT
 				return TurnType.fromString("TL", leftSide);

--- a/OsmAnd/src/net/osmand/plus/onlinerouting/engine/OrsEngine.java
+++ b/OsmAnd/src/net/osmand/plus/onlinerouting/engine/OrsEngine.java
@@ -39,7 +39,7 @@ public class OrsEngine extends JsonOnlineRoutingEngine {
 	@Override
 	@NonNull
 	public String getTitle() {
-		return "Openroute Service";
+		return "openrouteservice";
 	}
 
 	@NonNull
@@ -154,10 +154,10 @@ public class OrsEngine extends JsonOnlineRoutingEngine {
 	 * documentation: https://giscience.github.io/openrouteservice/documentation/Instruction-Types.html
 	 */
 	@NonNull
-	private TurnType getTurnType(int orsTurnType) {
+	private TurnType getTurnType(int orsInstructionType) {
 		// driving on the left or right side is currently not supported by the ORS
 		boolean leftSide = false;
-	    switch (orsTurnType) {
+		switch (orsInstructionType) {
 			case 0: // TURN_LEFT
 				return TurnType.fromString("TL", leftSide);
 			case 1: // TURN_RIGHT
@@ -177,9 +177,9 @@ public class OrsEngine extends JsonOnlineRoutingEngine {
 			case 8: // EXIT_ROUNDABOUT
 				return TurnType.fromString(leftSide ? "TL" : "TR", leftSide);
 			case 9: // UTURN
-			    return TurnType.fromString("TU", leftSide);
+				return TurnType.fromString("TU", leftSide);
 			case 11: // DEPART
-			    return TurnType.fromString(leftSide ? "KL" : "KR", leftSide);
+				return TurnType.fromString(leftSide ? "KL" : "KR", leftSide);
 			case 12: // KEEP_LEFT
 				return TurnType.fromString("KL", leftSide);
 			case 13: // KEEP_RIGHT


### PR DESCRIPTION
## Description
This PR fixes the implementation of [openrouteservice](https://openrouteservice.org) into OSMAnd. The issue was brough up initially in the openrouteservice ask forum: https://ask.openrouteservice.org/t/osmand-route-is-empty/3088

## Major changes
 * **OrsEngine.java**: `parseServerResponse` returns the `OnlineRoutingResponse` object and not `null`
 * **OrsEngine.java**: `parseServerResponse` adds basic directions to the `OnlineRoutingResponse` object
 * **OsmAnd/res/values\*/strings.xml**: change the spelling of `OpenRouteService` to `openrouteservice`
 * **.github/ISSUE_TEMPLATE/3-routing-report.md**: change the spelling of `OpenRouteService` to `openrouteservice`

## Issue
closes #12568 