### PR TITLE
fix formatting of durations < 1 minute

### DIFF
--- a/OsmAnd/src/net/osmand/plus/OsmAndFormatter.java
+++ b/OsmAnd/src/net/osmand/plus/OsmAndFormatter.java
@@ -86,8 +86,9 @@ public class OsmAndFormatter {
 					+ app.getString(R.string.osmand_parking_minute) : "");
 		} else if (minutes > 0) {
 			return minutes + " " + app.getString(R.string.osmand_parking_minute);
+		} else {
+			return "<1 " + app.getString(R.string.osmand_parking_minute);
 		}
-		return "";
 	}
 
 	public static String getFormattedPassedTime(@NonNull OsmandApplication app, long lastUploadedTimems, String def) {


### PR DESCRIPTION
While fixing #12573 I found the bug, that no total duration is rendered, if the route duration is < 1 minute. This PR fixes this issue by formatting times < 60 seconds as `<1 min`. The alternative would be to render this as `… sec`.

Compare the two screenshots:
<img src="https://user-images.githubusercontent.com/2878899/130597119-45522177-f6e6-4d95-81cb-2ea2b9a34264.png" width="400"> <img src="https://user-images.githubusercontent.com/2878899/130597128-eeafb9a2-df15-4897-862a-8ee730bfba7b.png" width="400">
