### PR TITLE
Fix #12038 manifest TTS declaration when targeting Android 11

### DIFF
--- a/OsmAnd/AndroidManifest.xml
+++ b/OsmAnd/AndroidManifest.xml
@@ -45,6 +45,11 @@
 	<supports-screens android:resizeable="true" android:smallScreens="true" android:normalScreens="true" android:largeScreens="true"
 		android:xlargeScreens="true" android:anyDensity="true" />
 
+	<queries>
+		<intent>
+			<action android:name="android.intent.action.TTS_SERVICE" />
+		</intent>
+	</queries>
 
 	<!-- android:theme="@style/OsmandLightDarkActionBarTheme" -->
 	<application android:allowBackup="true" android:backupAgent="net.osmand.plus.OsmandBackupAgent"


### PR DESCRIPTION
Tested with gradle settings: "compileSdkVersion 30" and "targetSdkVersion 30"
Without \<queries\> tag in manifest TTS doesn't work