### PR TITLE
Avoid integer overflow in disk space calculation.

### DIFF
--- a/OsmAnd/src/net/osmand/AndroidUtils.java
+++ b/OsmAnd/src/net/osmand/AndroidUtils.java
@@ -895,7 +895,7 @@ public class AndroidUtils {
 				if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR2) {
 					return fs.getAvailableBlocksLong() * fs.getBlockSizeLong();
 				} else {
-					return fs.getAvailableBlocks() * fs.getBlockSize();
+					return (long)(fs.getAvailableBlocks()) * fs.getBlockSize();
 				}
 			} catch (IllegalArgumentException e) {
 				LOG.error(e);
@@ -911,7 +911,7 @@ public class AndroidUtils {
 				if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR2) {
 					return fs.getBlockCountLong() * fs.getBlockSizeLong();
 				} else {
-					return fs.getBlockCount() * fs.getBlockSize();
+					return (long)(fs.getBlockCount()) * fs.getBlockSize();
 				}
 			} catch (IllegalArgumentException e) {
 				LOG.error(e);


### PR DESCRIPTION
The compatibility code would do the block count * block size
multiplication using int, which meant it would overflow if the
total size is above 2GB, leading to errors claiming negative
space available and refusing to download.
Add explicit cast to long to avoid the overflow.