### PR TITLE
Attempt to implement #3721 and #8108 (android part)

### DIFF
--- a/OsmAnd/res/drawable/warnings_speed_camera_w_limit.xml
+++ b/OsmAnd/res/drawable/warnings_speed_camera_w_limit.xml
@@ -1,0 +1,32 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="92dp"
+    android:height="92dp"
+    android:viewportWidth="92"
+    android:viewportHeight="92">
+  <path
+      android:pathData="M86,46C86,68.0914 68.0914,86 46,86C23.9086,86 6,68.0914 6,46C6,23.9086 23.9086,6 46,6C68.0914,6 86,23.9086 86,46Z"
+      android:fillColor="#FFFFFF"/>
+  <path
+      android:pathData="M46,80C64.7777,80 80,64.7777 80,46C80,27.2223 64.7777,12 46,12C27.2223,12 12,27.2223 12,46C12,64.7777 27.2223,80 46,80ZM46,86C68.0914,86 86,68.0914 86,46C86,23.9086 68.0914,6 46,6C23.9086,6 6,23.9086 6,46C6,68.0914 23.9086,86 46,86Z"
+      android:fillColor="#F03434"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M2,60C0.895,60 0,60.895 0,62V90C0,91.105 0.895,92 2,92H43C44.105,92 45,91.105 45,90V62C45,60.895 44.105,60 43,60H2Z"
+      android:fillColor="#000000"/>
+  <path
+      android:pathData="M2,62V90H43V62H2Z"
+      android:fillColor="#FFFFFF"/>
+  <path
+      android:pathData="M6,64C4.895,64 4,64.895 4,66V86C4,87.105 4.895,88 6,88H24.5C25.605,88 26.5,87.105 26.5,86V66C26.5,64.895 25.605,64 24.5,64H6ZM12.5,74C15.538,74 18,76.462 18,79.5C18,82.538 15.538,85 12.5,85C9.462,85 7,82.538 7,79.5C7,76.462 9.462,74 12.5,74ZM20,66.5C21.933,66.5 23.5,68.067 23.5,70C23.5,71.933 21.933,73.5 20,73.5C18.067,73.5 16.5,71.933 16.5,70C16.5,68.067 18.067,66.5 20,66.5Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M12.5,76C14.433,76 16,77.567 16,79.5C16,81.433 14.433,83 12.5,83C10.567,83 9,81.433, 9,79.5C9,77.567 10.567,76 12.5,76ZM20,68C21.105,68 22,68.895 22,70C22,71.105 21.105,72 20,72C18.895,72 18,71.105 18,70C18,68.895 18.895,68 20,68Z"
+      android:fillColor="#000000" />
+  <path
+      android:pathData="M28,67H33V80H28V67Z"
+      android:fillColor="#000000"/>
+  <path
+      android:pathData="M36,70H34.5V81.5H28V83H36V80H41V72.5H36V70Z"
+      android:fillColor="#000000" />
+</vector>

--- a/OsmAnd/src/net/osmand/plus/development/TestVoiceActivity.java
+++ b/OsmAnd/src/net/osmand/plus/development/TestVoiceActivity.java
@@ -214,14 +214,15 @@ public class TestVoiceActivity extends OsmandActionBarActivity {
 
 		addButton(ll, "Attention prompts:", builder(p));
 		addButton(ll, "\u25BA (9.1)  You are exceeding the speed limit '50' (18 m/s)", builder(p).speedAlarm(50, 18f));
-		addButton(ll, "\u25BA (9.2)  Attention, speed camera", builder(p).attention("SPEED_CAMERA"));
-		addButton(ll, "\u25BA (9.3)  Attention, border control", builder(p).attention("BORDER_CONTROL"));
-		addButton(ll, "\u25BA (9.4)  Attention, railroad crossing", builder(p).attention("RAILWAY"));
-		addButton(ll, "\u25BA (9.5)  Attention, traffic calming", builder(p).attention("TRAFFIC_CALMING"));
-		addButton(ll, "\u25BA (9.6)  Attention, toll booth", builder(p).attention("TOLL_BOOTH"));
-		addButton(ll, "\u25BA (9.7)  Attention, stop sign", builder(p).attention("STOP"));
-		addButton(ll, "\u25BA (9.8)  Attention, pedestrian crosswalk", builder(p).attention("PEDESTRIAN"));
-		addButton(ll, "\u25BA (9.9)  Attention, tunnel", builder(p).attention("TUNNEL"));
+		addButton(ll, "\u25BA (9.2)  Attention, speed camera, distance 650m, speed limit '50' (18 m/s)", builder(p).speedCameraAlarm(650f, 50));
+		addButton(ll, "\u25BA (9.3)  Attention, speed camera", builder(p).attention("SPEED_CAMERA"));
+		addButton(ll, "\u25BA (9.4)  Attention, border control", builder(p).attention("BORDER_CONTROL"));
+		addButton(ll, "\u25BA (9.5)  Attention, railroad crossing", builder(p).attention("RAILWAY"));
+		addButton(ll, "\u25BA (9.6)  Attention, traffic calming", builder(p).attention("TRAFFIC_CALMING"));
+		addButton(ll, "\u25BA (9.7)  Attention, toll booth", builder(p).attention("TOLL_BOOTH"));
+		addButton(ll, "\u25BA (9.8)  Attention, stop sign", builder(p).attention("STOP"));
+		addButton(ll, "\u25BA (9.9)  Attention, pedestrian crosswalk", builder(p).attention("PEDESTRIAN"));
+		addButton(ll, "\u25BA (9.10)  Attention, tunnel", builder(p).attention("TUNNEL"));
 
 		addButton(ll, "Other prompts:", builder(p));
 		addButton(ll, "\u25BA (10.1) GPS signal lost", builder(p).gpsLocationLost());

--- a/OsmAnd/src/net/osmand/plus/helpers/WaypointHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/WaypointHelper.java
@@ -230,6 +230,12 @@ public class WaypointHelper {
 					if (!atd.isTurnStateActive(0, d, STATE_LONG_PNT_APPROACH)) {
 						break;
 					}
+
+					// Set actual distance to speed camera
+					if (inf.getType() == AlarmInfoType.SPEED_CAMERA) {
+						inf.setFloatValue(d);
+					}
+
 					float time = speed > 0 ? d / speed : Integer.MAX_VALUE;
 					int vl = inf.updateDistanceAndGetPriority(time, d);
 					if (vl < value && (showCameras || inf.getType() != AlarmInfoType.SPEED_CAMERA)) {
@@ -460,7 +466,15 @@ public class WaypointHelper {
 						} else if (type == ALARMS) {
 							for (LocationPointWrapper pw : approachPoints) {
 								AlarmInfo alarm = (AlarmInfo) pw.point;
-								voiceRouter.announceAlarm(new AlarmInfo(alarm.getType(), -1), lastKnownLocation.getSpeed());
+								AlarmInfo alarmCopy = new AlarmInfo(alarm.getType(), -1);
+
+								// Set actual distance and copy max speed to speed camera
+								if (alarmCopy.getType() == AlarmInfoType.SPEED_CAMERA){
+									alarmCopy.setFloatValue(route.getDistanceToPoint(alarm.getLocationIndex()));
+									alarmCopy.setIntValue(alarm.getIntValue());
+								}
+
+								voiceRouter.announceAlarm(alarmCopy, lastKnownLocation.getSpeed());
 								lastAnnouncedAlarms.put(alarm.getType(), alarm);
 							}
 						} else if (type == FAVORITES) {

--- a/OsmAnd/src/net/osmand/plus/routing/VoiceRouter.java
+++ b/OsmAnd/src/net/osmand/plus/routing/VoiceRouter.java
@@ -321,15 +321,19 @@ public class VoiceRouter {
 		AlarmInfoType type = info.getType();
 		if (type == AlarmInfoType.SPEED_LIMIT) {
 			announceSpeedAlarm(info.getIntValue(), speed);
+		} else if (type == AlarmInfoType.SPEED_CAMERA) {
+			OsmandSettings settings = router.getSettings();
+			if (settings.SPEAK_SPEED_CAMERA.get()) {
+				announceSpeedCameraAlarm(info.getFloatValue(), info.getIntValue());
+			}
 		} else {
 			OsmandSettings settings = router.getSettings();
 			boolean speakTrafficWarnings = settings.SPEAK_TRAFFIC_WARNINGS.get();
 			boolean speakTunnels = type == AlarmInfoType.TUNNEL && settings.SPEAK_TUNNELS.get();
 			boolean speakPedestrian = type == AlarmInfoType.PEDESTRIAN && settings.SPEAK_PEDESTRIAN.get();
-			boolean speakSpeedCamera = type == AlarmInfoType.SPEED_CAMERA && settings.SPEAK_SPEED_CAMERA.get();
-			boolean speakPrefType = type == AlarmInfoType.TUNNEL || type == AlarmInfoType.PEDESTRIAN || type == AlarmInfoType.SPEED_CAMERA;
+			boolean speakPrefType = type == AlarmInfoType.TUNNEL || type == AlarmInfoType.PEDESTRIAN;
 
-			if (speakSpeedCamera || speakPedestrian || speakTunnels || speakTrafficWarnings && !speakPrefType) {
+			if (speakPedestrian || speakTunnels || speakTrafficWarnings && !speakPrefType) {
 				CommandBuilder p = getNewCommandPlayerToPlay();
 				if (p != null) {
 					p.attention(String.valueOf(type));
@@ -365,7 +369,19 @@ public class VoiceRouter {
 			}
 		}
 	}
-	
+
+	private void announceSpeedCameraAlarm(double dist, int maxSpeed) {
+		CommandBuilder p = getNewCommandPlayerToPlay();
+		if (p != null) {
+			if (dist > 0 && maxSpeed > 0) {
+				p.speedCameraAlarm(dist, maxSpeed);
+			} else {
+				p.attention(String.valueOf(AlarmInfoType.SPEED_CAMERA));
+			}
+		}
+		play(p);
+	}
+
 	private boolean isTargetPoint(NextDirectionInfo info) {
 		boolean in = info != null && info.intermediatePoint;
 		boolean target = info == null || info.directionInfo == null

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/widgets/AlarmWidget.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/widgets/AlarmWidget.java
@@ -265,7 +265,14 @@ public class AlarmWidget {
 			}
 			text = alarm.getIntValue() + "";
 		} else if (alarm.getType() == AlarmInfo.AlarmInfoType.SPEED_CAMERA) {
-			locImgId = R.drawable.warnings_speed_camera;
+			int maxSpeed = alarm.getIntValue();
+			if (maxSpeed > 0) {
+				locImgId = R.drawable.warnings_speed_camera_w_limit;
+				text = maxSpeed + "";
+			}
+			else {
+				locImgId = R.drawable.warnings_speed_camera;
+			}
 		} else if (alarm.getType() == AlarmInfo.AlarmInfoType.BORDER_CONTROL) {
 			locImgId = R.drawable.warnings_border_control;
 		} else if (alarm.getType() == AlarmInfo.AlarmInfoType.HAZARD) {

--- a/OsmAnd/src/net/osmand/plus/voice/CommandBuilder.java
+++ b/OsmAnd/src/net/osmand/plus/voice/CommandBuilder.java
@@ -30,6 +30,7 @@ public abstract class CommandBuilder {
 	protected static final String C_REACHED_POI = "reached_poi";
 	protected static final String C_THEN = "then";
 	protected static final String C_SPEAD_ALARM = "speed_alarm";
+	protected static final String C_SPEED_CAMERA_ALARM = "speed_camera_alarm";
 	protected static final String C_ATTENTION = "attention";
 	protected static final String C_OFF_ROUTE = "off_route";
 	protected static final String C_BACK_ON_ROUTE = "back_on_route";
@@ -68,6 +69,8 @@ public abstract class CommandBuilder {
 	public abstract CommandBuilder makeUT(StreetName streetName);
 
 	public abstract CommandBuilder speedAlarm(int maxSpeed, float speed);
+
+	public abstract CommandBuilder speedCameraAlarm(double dist, int maxSpeed);
 
 	public abstract CommandBuilder attention(String type);
 

--- a/OsmAnd/src/net/osmand/plus/voice/JsCommandBuilder.java
+++ b/OsmAnd/src/net/osmand/plus/voice/JsCommandBuilder.java
@@ -80,6 +80,11 @@ public class JsCommandBuilder extends CommandBuilder{
 	}
 
 	@Override
+	public CommandBuilder speedCameraAlarm(double dist, int maxSpeed) {
+		return addCommand(C_SPEED_CAMERA_ALARM, dist, maxSpeed);
+	}
+
+	@Override
 	public CommandBuilder attention(String type) {
 		return addCommand(C_ATTENTION, type);
 	}


### PR DESCRIPTION
There is attempt to implement issues #3721 (except traffic light camera) and #8108.

_Tested in simulation mode for:_
- Speed camera with assigned max speed same as route segment max speed
- Speed camera with assigned max speed different from the route segment max speed  (speed camera max speed expected to be displayed / announced)
- Speed camera without assigned max speed (route max speed expected to be displayed / announced)

_Changes description:_

- RouteCalculationResult attachAlarmInfo method extended to add max speed to speed camera AlarmInfo taken either from speed camera point (preferred) or from RouteSegmentResult.
- WaypointHelper getMostImportantAlarm and announceVisibleLocations updated to attach actual distance to speed camera AlarmInfo.
- AlarmWidget extended with ability to show max speed for speed camera when available.
- VoiceRouter.announceAlarm extended with special handling for speed camera announcement to announce distance and max speed when available.
- CommandBuilder / JsCommandBuilder extended with new speedCameraAlarm method, which allows announce speed camera with distance and max speed.
- TestVoiceActivity extended to test speed camera with distance and max speed announcement.