### PR TITLE
Add basic text styles

### DIFF
--- a/OsmAnd/res/values/sizes.xml
+++ b/OsmAnd/res/values/sizes.xml
@@ -221,6 +221,7 @@
 	<dimen name="travel_card_primary_text_size">15sp</dimen>
 	<dimen name="default_title_line_height">24sp</dimen>
 	<dimen name="default_desc_line_height">20sp</dimen>
+	<dimen name="small_desc_line_height">14sp</dimen>
 
 	<dimen name="default_split_segments_overview">13sp</dimen>
 	<dimen name="default_split_segments_data">13sp</dimen>

--- a/OsmAnd/res/values/styles.xml
+++ b/OsmAnd/res/values/styles.xml
@@ -843,4 +843,46 @@
         <item name="hintTextColor">?android:textColorSecondary</item>
     </style>
 
+
+    <!--******************************** Basic text styles ********************************-->
+
+    <!--To apply style for a specific TextView, use TextViewEx and tag "style"-->
+    <!--Don't use tag "textAppearance". It loses font family and line height parameters-->
+
+    <!-- Title -->
+    <style name="TitleStyle">
+        <item name="android:textSize">@dimen/default_list_text_size</item>
+        <item name="lineHeight">@dimen/default_title_line_height</item>
+        <item name="android:letterSpacing">@dimen/text_button_letter_spacing</item>
+        <item name="typeface">@string/font_roboto_regular</item>
+    </style>
+
+    <style name="TitleStyle.Medium">
+        <item name="typeface">@string/font_roboto_medium</item>
+    </style>
+
+    <!-- Description -->
+    <style name="DescStyle">
+        <item name="android:textSize">@dimen/default_desc_text_size</item>
+        <item name="lineHeight">@dimen/default_desc_line_height</item>
+        <item name="android:letterSpacing">@dimen/description_letter_spacing</item>
+        <item name="typeface">@string/font_roboto_regular</item>
+    </style>
+
+    <style name="DescStyle.Medium">
+        <item name="typeface">@string/font_roboto_medium</item>
+    </style>
+
+    <!-- Small Description -->
+    <style name="SmallDescStyle">
+        <item name="android:textSize">@dimen/default_sub_text_size</item>
+        <item name="lineHeight">@dimen/small_desc_line_height</item>
+        <item name="android:letterSpacing">@dimen/text_button_letter_spacing</item>
+        <item name="typeface">@string/font_roboto_regular</item>
+    </style>
+
+    <style name="SmallDescStyle.Medium">
+        <item name="typeface">@string/font_roboto_medium</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Created styles for basic text appearances: title, description, small description.

* TitleStyle
* DescStyle
* SmallDescStyle

By default each style uses "regular" font family. To use "medium" add ".Medium" extension to text style name:

* TitleStyle.Medium
* DescStyle.Medium
* SmallDescStyle.Medium

To apply style for a specific TextView, use TextViewEx and tag "style".
Don't use tag "textAppearance". It loses font family and line height parameters.