### PR TITLE
Improved performance of the backup method

### DIFF
--- a/OsmAnd/src/net/osmand/plus/myplaces/FavouritesDbHelper.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/FavouritesDbHelper.java
@@ -30,6 +30,7 @@ import net.osmand.util.Algorithms;
 
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -637,7 +638,7 @@ public class FavouritesDbHelper {
 	public static void backup(File backupFile, File externalFile) {
 		try {
 			File f = new File(backupFile.getParentFile(), backupFile.getName());
-			BZip2CompressorOutputStream out = new BZip2CompressorOutputStream(new FileOutputStream(f));
+			BZip2CompressorOutputStream out = new BZip2CompressorOutputStream(new BufferedOutputStream(new FileOutputStream(f)));
 			FileInputStream fis = new FileInputStream(externalFile);
 			Algorithms.streamCopy(fis, out);
 			fis.close();


### PR DESCRIPTION
The app had problems when e.g. importing large amount of favourites data or when deleting a favourite point. The app froze for several seconds when saving the changes.
I observed almost all the time being spent in the backup method.
After this change, with my test data, I observed decrease of method run time from 8300 ms to 700 ms.