### PR TITLE
Fix Wikimedia Commons TIFF image visualization

### DIFF
--- a/OsmAnd/src/net/osmand/plus/wikimedia/WikiImageHelper.java
+++ b/OsmAnd/src/net/osmand/plus/wikimedia/WikiImageHelper.java
@@ -29,7 +29,7 @@ public class WikiImageHelper {
 	private static final String WIKIMEDIA_ACTION = "?action=query&list=categorymembers&cmtitle=";
 	private static final String CM_LIMIT = "&cmlimit=500";
 	private static final String FORMAT_JSON = "&format=json";
-	private static final String IMAGE_BASE_URL = "https://upload.wikimedia.org/wikipedia/commons/";
+	private static final String IMAGE_BASE_URL = "https://commons.wikimedia.org/wiki/Special:FilePath/";
 
 	private static final String WIKIDATA_PREFIX = "Q";
 	private static final String WIKIMEDIA_FILE = "File:";
@@ -116,14 +116,9 @@ public class WikiImageHelper {
 			imageName = imageName.substring(0, imageName.lastIndexOf("."));
 			String[] urlHashParts = getHash(imageFileName);
 
-			String imageHiResUrl = IMAGE_BASE_URL +
-					urlHashParts[0] + "/" + urlHashParts[1] + "/" +
-					imageFileName;
+			String imageHiResUrl = IMAGE_BASE_URL + imageFileName;
 
-			String imageStubUrl = IMAGE_BASE_URL + "thumb/" +
-					urlHashParts[0] + "/" + urlHashParts[1] + "/" +
-					imageFileName + "/" + THUMB_SIZE + "px-" +
-					imageFileName;
+			String imageStubUrl = IMAGE_BASE_URL + imageFileName + "?width=" + THUMB_SIZE;
 
 			return new WikiImage(imageFileName, imageName, imageStubUrl, imageHiResUrl);
 


### PR DESCRIPTION
These changes aim to resolve the problem reported in https://github.com/osmandapp/OsmAnd/issues/12765 by using [Wikimedia Commons hotlinking](https://commons.wikimedia.org/wiki/Commons:Reusing_content_outside_Wikimedia/technical#Hotlinking)

Take for exampled [File:Il Monumento a Francesco Baracca - Lugo - 3.tif](https://commons.wikimedia.org/wiki/File:Il_Monumento_a_Francesco_Baracca_-_Lugo_-_3.tif) which as shown in the issue is not represented correctly in the current version of OsmAnd.

This is how this image and it's thumbnail would be fetched before and after these changes:
| Description | URL | Actual URL (redirects to) | Visualization |
| --- | --- | --- | --- |
| **Image** link **before** changes | https://upload.wikimedia.org/wikipedia/commons/4/47/Il_Monumento_a_Francesco_Baracca_-_Lugo_-_3.tif | https://upload.wikimedia.org/wikipedia/commons/4/47/Il_Monumento_a_Francesco_Baracca_-_Lugo_-_3.tif | ![image](https://upload.wikimedia.org/wikipedia/commons/4/47/Il_Monumento_a_Francesco_Baracca_-_Lugo_-_3.tif) |
| **Image** link **after** changes | https://commons.wikimedia.org/wiki/Special:FilePath/Il_Monumento_a_Francesco_Baracca_-_Lugo_-_3.tif | https://upload.wikimedia.org/wikipedia/commons/4/47/Il_Monumento_a_Francesco_Baracca_-_Lugo_-_3.tif | ![image](https://commons.wikimedia.org/wiki/Special:FilePath/Il_Monumento_a_Francesco_Baracca_-_Lugo_-_3.tif) |
| **Thumbnail** link **before** changes | https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/Il_Monumento_a_Francesco_Baracca_-_Lugo_-_3.tif/500px-Il_Monumento_a_Francesco_Baracca_-_Lugo_-_3.tif | https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/Il_Monumento_a_Francesco_Baracca_-_Lugo_-_3.tif/500px-Il_Monumento_a_Francesco_Baracca_-_Lugo_-_3.tif | ![image](https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/Il_Monumento_a_Francesco_Baracca_-_Lugo_-_3.tif/500px-Il_Monumento_a_Francesco_Baracca_-_Lugo_-_3.tif) |
| **Thumbnail** link **after** changes | https://commons.wikimedia.org/wiki/Special:FilePath/Il_Monumento_a_Francesco_Baracca_-_Lugo_-_3.tif?width=500px | https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/Il_Monumento_a_Francesco_Baracca_-_Lugo_-_3.tif/lossy-page1-500px-Il_Monumento_a_Francesco_Baracca_-_Lugo_-_3.tif.jpg | ![image](https://commons.wikimedia.org/wiki/Special:FilePath/Il_Monumento_a_Francesco_Baracca_-_Lugo_-_3.tif?width=500px) |

The thumbnail after changes, being actually jpg instead of tif, should be shown correctly.

I  tried to test these changes on my phone to check how they worked but when building the app on Android Studio I receive some errors that are not linked with Wikimedia commons images (like a test error on Routing) so I wasn't able to test them