### PR TITLE
Typo in phrases.xml

### DIFF
--- a/OsmAnd/res/values/phrases.xml
+++ b/OsmAnd/res/values/phrases.xml
@@ -4672,7 +4672,7 @@
 	<string name="poi_generator_type_redox_flow">Generator type: redox flow</string>
 	<string name="poi_generator_type_molten_salt">Generator type: molten-salt</string>
 	<string name="poi_service_fleurop_yes">Yes;Fleurop</string>
-	<string name="poi_mattress_yes">Yes;Matress</string>
+	<string name="poi_mattress_yes">Yes;Mattress</string>
 	<string name="poi_mattress_no">No</string>
 	<string name="poi_furniture_used">Used;Used furniture</string>
 	<string name="poi_furniture_office">Office;Office furniture</string>


### PR DESCRIPTION
lgbtq=no means 'not allowed' according to the wiki.