### PR TITLE
Rescue Track: Retrieve Logs API

### DIFF
--- a/OsmAnd-api/src/net/osmand/aidlapi/IOsmAndAidlCallback.aidl
+++ b/OsmAnd-api/src/net/osmand/aidlapi/IOsmAndAidlCallback.aidl
@@ -4,6 +4,7 @@ import net.osmand.aidlapi.search.SearchResult;
 import net.osmand.aidlapi.gpx.AGpxBitmap;
 import net.osmand.aidlapi.navigation.ADirectionInfo;
 import net.osmand.aidlapi.navigation.OnVoiceNavigationParams;
+import net.osmand.aidlapi.logcat.OnLogcatMessageParams;
 
 interface IOsmAndAidlCallback {
 
@@ -56,4 +57,9 @@ interface IOsmAndAidlCallback {
      *  Callback for {@link IOsmAndAidlInterface} registerForKeyEvents() method.
      */
     void onKeyEvent(in KeyEvent params);
+
+    /**
+     *  Callback for {@link IOsmAndAidlInterface} registerForLogcatMessages() method.
+     */
+    void onLogcatMessage(in OnLogcatMessageParams params);
 }

--- a/OsmAnd-api/src/net/osmand/aidlapi/IOsmAndAidlInterface.aidl
+++ b/OsmAnd-api/src/net/osmand/aidlapi/IOsmAndAidlInterface.aidl
@@ -926,7 +926,7 @@ interface IOsmAndAidlInterface {
      *
      * @params subscribeToUpdates (boolean) - boolean flag to subscribe or unsubscribe from messages
      * @params callbackId (long) - id of callback, needed to unsubscribe from messages
-     * @params filterLelev (String) determines which type of logs will be returned by callback
+     * @params filterLevel (String) determines which type of logs will be returned by callback
      * Must be one of the values below:
      * - "D" (debug)
      * - "I" (info)

--- a/OsmAnd-api/src/net/osmand/aidlapi/IOsmAndAidlInterface.aidl
+++ b/OsmAnd-api/src/net/osmand/aidlapi/IOsmAndAidlInterface.aidl
@@ -932,7 +932,7 @@ interface IOsmAndAidlInterface {
      * - "I" (info)
      * - "W" (warn)
      * - "E" (error)
-     * @params callback (IOsmAndAidlCallback) - callback to notify user on new application logs
+     * @params callback (IOsmAndAidlCallback) - callback to notify user on new OsmAnd logs
      */
     long registerForLogcatMessages(in ALogcatListenerParams params, IOsmAndAidlCallback callback);
 }

--- a/OsmAnd-api/src/net/osmand/aidlapi/IOsmAndAidlInterface.aidl
+++ b/OsmAnd-api/src/net/osmand/aidlapi/IOsmAndAidlInterface.aidl
@@ -118,6 +118,8 @@ import net.osmand.aidlapi.profile.ExportProfileParams;
 
 import net.osmand.aidlapi.exit.ExitAppParams;
 
+import net.osmand.aidlapi.logcat.ALogcatListenerParams;
+
 // NOTE: Add new methods at the end of file!!!
 
 interface IOsmAndAidlInterface {
@@ -919,4 +921,18 @@ interface IOsmAndAidlInterface {
 
     boolean getPreference(inout PreferenceParams params);
 
+    /**
+     * Method to register for Logcat messages. Notifies user about new logs in application.
+     *
+     * @params subscribeToUpdates (boolean) - boolean flag to subscribe or unsubscribe from messages
+     * @params callbackId (long) - id of callback, needed to unsubscribe from messages
+     * @params filterLelev (String) determines which type of logs will be returned by callback
+     * Must be one of the values below:
+     * - "D" (debug)
+     * - "I" (info)
+     * - "W" (warn)
+     * - "E" (error)
+     * @params callback (IOsmAndAidlCallback) - callback to notify user on new application logs
+     */
+    long registerForLogcatMessages(in ALogcatListenerParams params, IOsmAndAidlCallback callback);
 }

--- a/OsmAnd-api/src/net/osmand/aidlapi/logcat/ALogcatListenerParams.aidl
+++ b/OsmAnd-api/src/net/osmand/aidlapi/logcat/ALogcatListenerParams.aidl
@@ -1,0 +1,3 @@
+package net.osmand.aidlapi.logcat;
+
+parcelable ALogcatListenerParams;

--- a/OsmAnd-api/src/net/osmand/aidlapi/logcat/ALogcatListenerParams.java
+++ b/OsmAnd-api/src/net/osmand/aidlapi/logcat/ALogcatListenerParams.java
@@ -1,0 +1,73 @@
+package net.osmand.aidlapi.logcat;
+
+import android.os.Bundle;
+import android.os.Parcel;
+
+import net.osmand.aidlapi.AidlParams;
+
+public class ALogcatListenerParams extends AidlParams {
+
+	private static final String ARG_CALLBACK_ID = "callback_id";
+	private static final String ARG_SUBSCRIBED = "subscribed";
+	private static final String ARG_FILTER_LEVEL = "filter_level";
+
+	private boolean subscribeToUpdates = true;
+	private long callbackId = -1L;
+	private String filterLevel;
+
+	public static final Creator<ALogcatListenerParams> CREATOR = new Creator<ALogcatListenerParams>() {
+		@Override
+		public ALogcatListenerParams createFromParcel(Parcel in) {
+			return new ALogcatListenerParams(in);
+		}
+
+		@Override
+		public ALogcatListenerParams[] newArray(int size) {
+			return new ALogcatListenerParams[size];
+		}
+	};
+
+	public ALogcatListenerParams() { }
+
+	protected ALogcatListenerParams(Parcel in) {
+		readFromParcel(in);
+	}
+
+	public long getCallbackId() {
+		return callbackId;
+	}
+
+	public void setCallbackId(long callbackId) {
+		this.callbackId = callbackId;
+	}
+
+	public void setSubscribeToUpdates(boolean subscribeToUpdates) {
+		this.subscribeToUpdates = subscribeToUpdates;
+	}
+
+	public boolean isSubscribeToUpdates() {
+		return subscribeToUpdates;
+	}
+
+	public String getFilterLevel() {
+		return filterLevel;
+	}
+
+	public void setFilterLevel(String filterLevel) {
+		this.filterLevel = filterLevel;
+	}
+
+	@Override
+	protected void readFromBundle(Bundle bundle) {
+		callbackId = bundle.getLong(ARG_CALLBACK_ID);
+		subscribeToUpdates = bundle.getBoolean(ARG_SUBSCRIBED);
+		filterLevel = bundle.getString(ARG_FILTER_LEVEL);
+	}
+
+	@Override
+	protected void writeToBundle(Bundle bundle) {
+		bundle.putLong(ARG_CALLBACK_ID, callbackId);
+		bundle.putBoolean(ARG_SUBSCRIBED, subscribeToUpdates);
+		bundle.putString(ARG_FILTER_LEVEL, filterLevel);
+	}
+}

--- a/OsmAnd-api/src/net/osmand/aidlapi/logcat/OnLogcatMessageParams.aidl
+++ b/OsmAnd-api/src/net/osmand/aidlapi/logcat/OnLogcatMessageParams.aidl
@@ -1,0 +1,3 @@
+package net.osmand.aidlapi.logcat;
+
+parcelable OnLogcatMessageParams;

--- a/OsmAnd-api/src/net/osmand/aidlapi/logcat/OnLogcatMessageParams.java
+++ b/OsmAnd-api/src/net/osmand/aidlapi/logcat/OnLogcatMessageParams.java
@@ -1,0 +1,66 @@
+package net.osmand.aidlapi.logcat;
+
+import android.os.Bundle;
+import android.os.Parcel;
+
+import net.osmand.aidlapi.AidlParams;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OnLogcatMessageParams extends AidlParams {
+
+	private final static String ARG_FILTER_LEVEL = "filter_level";
+	private final static String ARG_LOGS = "logs";
+
+	private String filterLevel = "";
+	private ArrayList<String> logs = new ArrayList<>();
+
+	public static final Creator<OnLogcatMessageParams> CREATOR = new Creator<OnLogcatMessageParams>() {
+		@Override
+		public OnLogcatMessageParams createFromParcel(Parcel in) {
+			return new OnLogcatMessageParams(in);
+		}
+
+		@Override
+		public OnLogcatMessageParams[] newArray(int size) {
+			return new OnLogcatMessageParams[size];
+		}
+	};
+
+	public OnLogcatMessageParams() { }
+
+	public OnLogcatMessageParams(String filterLevel, List<String> logs) {
+		this.filterLevel = filterLevel;
+		if (logs != null) {
+			this.logs.addAll(logs);
+		}
+	}
+
+	protected OnLogcatMessageParams(Parcel in) {
+		readFromParcel(in);
+	}
+
+	@Override
+	protected void writeToBundle(Bundle bundle) {
+		bundle.putString(ARG_FILTER_LEVEL, filterLevel);
+		bundle.putStringArrayList(ARG_LOGS, logs);
+	}
+
+	@Override
+	protected void readFromBundle(Bundle bundle) {
+		filterLevel = bundle.getString(ARG_FILTER_LEVEL);
+		logs = bundle.getStringArrayList(ARG_LOGS);
+		if (logs == null) {
+			logs = new ArrayList<>();
+		}
+	}
+
+	public String getFilterLevel() {
+		return filterLevel;
+	}
+
+	public ArrayList<String> getLogs() {
+		return logs;
+	}
+}

--- a/OsmAnd-api/src/net/osmand/aidlapi/logcat/OnLogcatMessageParams.java
+++ b/OsmAnd-api/src/net/osmand/aidlapi/logcat/OnLogcatMessageParams.java
@@ -60,7 +60,7 @@ public class OnLogcatMessageParams extends AidlParams {
 		return filterLevel;
 	}
 
-	public ArrayList<String> getLogs() {
+	public List<String> getLogs() {
 		return logs;
 	}
 }

--- a/OsmAnd-api/src/net/osmand/aidlapi/navigation/OnVoiceNavigationParams.java
+++ b/OsmAnd-api/src/net/osmand/aidlapi/navigation/OnVoiceNavigationParams.java
@@ -13,9 +13,7 @@ public class OnVoiceNavigationParams extends AidlParams {
 	private ArrayList<String> cmds = new ArrayList<>();
 	private ArrayList<String> played = new ArrayList<>();
 
-	public OnVoiceNavigationParams() {
-
-	}
+	public OnVoiceNavigationParams() { }
 
 	public OnVoiceNavigationParams(List<String> cmds, List<String> played) {
 		if (cmds != null) {

--- a/OsmAnd/src/net/osmand/aidl/OsmandAidlApi.java
+++ b/OsmAnd/src/net/osmand/aidl/OsmandAidlApi.java
@@ -241,7 +241,7 @@ public class OsmandAidlApi {
 	private final Map<String, AidlContextMenuButtonsWrapper> contextMenuButtonsParams = new ConcurrentHashMap<>();
 	private final Map<Long, VoiceRouter.VoiceMessageListener> voiceRouterMessageCallbacks = new ConcurrentHashMap<>();
 	private final Map<Long, Set<Integer>> keyEventCallbacks = new ConcurrentHashMap<>();
-	private final Map<Long, LogcatAsyncTask> runningLogcatAsyncTasks = new ConcurrentHashMap<>();
+	private final Map<Long, LogcatAsyncTask> logcatAsyncTasks = new ConcurrentHashMap<>();
 
 	private MapActivity mapActivity;
 
@@ -2159,14 +2159,14 @@ public class OsmandAidlApi {
 				}
 			}
 		};
-		stopRunningLogcatTask(id);
+		stopLogcatTask(id);
 		LogcatAsyncTask task = new LogcatAsyncTask(listener, filterLevel);
 		task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-		runningLogcatAsyncTasks.put(id, task);
+		logcatAsyncTasks.put(id, task);
 	}
 
-	public void stopRunningLogcatTask(long id) {
-		LogcatAsyncTask task = runningLogcatAsyncTasks.remove(id);
+	public void stopLogcatTask(long id) {
+		LogcatAsyncTask task = logcatAsyncTasks.remove(id);
 		if (task != null) {
 			task.stop();
 		}

--- a/OsmAnd/src/net/osmand/aidl/OsmandAidlApi.java
+++ b/OsmAnd/src/net/osmand/aidl/OsmandAidlApi.java
@@ -42,6 +42,7 @@ import net.osmand.aidlapi.customization.PreferenceParams;
 import net.osmand.aidlapi.exit.ExitAppParams;
 import net.osmand.aidlapi.info.AppInfoParams;
 import net.osmand.aidlapi.info.GetTextParams;
+import net.osmand.aidlapi.logcat.OnLogcatMessageParams;
 import net.osmand.aidlapi.map.ALatLon;
 import net.osmand.aidlapi.map.ALocation;
 import net.osmand.aidlapi.navigation.ABlockedRoad;
@@ -72,6 +73,8 @@ import net.osmand.plus.myplaces.TrackBitmapDrawer.TracksDrawParams;
 import net.osmand.plus.plugins.CustomOsmandPlugin;
 import net.osmand.plus.plugins.OsmandPlugin;
 import net.osmand.plus.plugins.audionotes.AudioVideoNotesPlugin;
+import net.osmand.plus.plugins.development.LogcatAsyncTask;
+import net.osmand.plus.plugins.development.LogcatMessageListener;
 import net.osmand.plus.plugins.monitoring.OsmandMonitoringPlugin;
 import net.osmand.plus.plugins.rastermaps.OsmandRasterMapsPlugin;
 import net.osmand.plus.quickaction.QuickAction;
@@ -81,6 +84,7 @@ import net.osmand.plus.routing.IRoutingDataUpdateListener;
 import net.osmand.plus.routing.RouteCalculationResult.NextDirectionInfo;
 import net.osmand.plus.routing.RoutingHelper;
 import net.osmand.plus.routing.VoiceRouter;
+import net.osmand.plus.routing.VoiceRouter.VoiceMessageListener;
 import net.osmand.plus.settings.backend.ApplicationMode;
 import net.osmand.plus.settings.backend.ApplicationMode.ApplicationModeBean;
 import net.osmand.plus.settings.backend.ExportSettingsType;
@@ -163,6 +167,7 @@ public class OsmandAidlApi {
 	public static final int KEY_ON_CONTEXT_MENU_BUTTONS_CLICK = 4;
 	public static final int KEY_ON_VOICE_MESSAGE = 8;
 	public static final int KEY_ON_KEY_EVENT = 16;
+	public static final int KEY_ON_LOGCAT_MESSAGE = 32;
 
 	private static final Log LOG = PlatformUtil.getLog(OsmandAidlApi.class);
 
@@ -232,8 +237,11 @@ public class OsmandAidlApi {
 	private final OsmandApplication app;
 	private Map<String, BroadcastReceiver> receivers = new TreeMap<>();
 	private final Map<String, ConnectedApp> connectedApps = new ConcurrentHashMap<>();
+	private final Map<Long, IRoutingDataUpdateListener> navUpdateCallbacks = new ConcurrentHashMap<>();
 	private final Map<String, AidlContextMenuButtonsWrapper> contextMenuButtonsParams = new ConcurrentHashMap<>();
 	private final Map<Long, VoiceRouter.VoiceMessageListener> voiceRouterMessageCallbacks = new ConcurrentHashMap<>();
+	private final Map<Long, Set<Integer>> keyEventCallbacks = new ConcurrentHashMap<>();
+	private final Map<Long, LogcatAsyncTask> runningLogcatAsyncTasks = new ConcurrentHashMap<>();
 
 	private MapActivity mapActivity;
 
@@ -2040,8 +2048,6 @@ public class OsmandAidlApi {
 		return app.getAppCustomization().changePluginStatus(pluginId, newState);
 	}
 
-	private final Map<Long, IRoutingDataUpdateListener> navUpdateCallbacks = new ConcurrentHashMap<>();
-
 	void registerForNavigationUpdates(long id) {
 		final NextDirectionInfo baseNdi = new NextDirectionInfo();
 		IRoutingDataUpdateListener listener = () -> {
@@ -2133,8 +2139,37 @@ public class OsmandAidlApi {
 	}
 
 	public void unregisterFromVoiceRouterMessages(long id) {
-		app.getRoutingHelper().getVoiceRouter().removeVoiceMessageListener(voiceRouterMessageCallbacks.get(id));
-		voiceRouterMessageCallbacks.remove(id);
+		VoiceMessageListener callback = voiceRouterMessageCallbacks.remove(id);
+		if (callback != null) {
+			app.getRoutingHelper().getVoiceRouter().removeVoiceMessageListener(callback);
+		}
+	}
+
+	public void registerLogcatListener(long id, String filterLevel) {
+		LogcatMessageListener listener = (_filterLevel, logs) -> {
+			if (aidlCallbackListenerV2 != null) {
+				for (OsmandAidlServiceV2.AidlCallbackParams cb : aidlCallbackListenerV2.getAidlCallbacks().values()) {
+					if (!aidlCallbackListenerV2.getAidlCallbacks().isEmpty() && (cb.getKey() & KEY_ON_LOGCAT_MESSAGE) > 0) {
+						try {
+							cb.getCallback().onLogcatMessage(new OnLogcatMessageParams(_filterLevel, logs));
+						} catch (Exception e) {
+							LOG.error(e.getMessage(), e);
+						}
+					}
+				}
+			}
+		};
+		stopRunningLogcatTask(id);
+		LogcatAsyncTask task = new LogcatAsyncTask(listener, filterLevel);
+		task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+		runningLogcatAsyncTasks.put(id, task);
+	}
+
+	public void stopRunningLogcatTask(long id) {
+		LogcatAsyncTask task = runningLogcatAsyncTasks.remove(id);
+		if (task != null) {
+			task.stop();
+		}
 	}
 
 	public Map<String, AidlContextMenuButtonsWrapper> getContextMenuButtonsParams() {
@@ -2663,8 +2698,6 @@ public class OsmandAidlApi {
 				a.avgElevation, a.minElevation, a.maxElevation, a.minSpeed, a.maxSpeed, a.avgSpeed,
 				a.points, a.wptPoints, a.wptCategoryNames);
 	}
-
-	private final Map<Long, Set<Integer>> keyEventCallbacks = new ConcurrentHashMap<>();
 
 	public boolean onKeyEvent(KeyEvent event) {
 		if (aidlCallbackListenerV2 != null) {

--- a/OsmAnd/src/net/osmand/aidl/OsmandAidlServiceV2.java
+++ b/OsmAnd/src/net/osmand/aidl/OsmandAidlServiceV2.java
@@ -1,15 +1,5 @@
 package net.osmand.aidl;
 
-import static net.osmand.aidl.OsmandAidlApi.KEY_ON_CONTEXT_MENU_BUTTONS_CLICK;
-import static net.osmand.aidl.OsmandAidlApi.KEY_ON_KEY_EVENT;
-import static net.osmand.aidl.OsmandAidlApi.KEY_ON_NAV_DATA_UPDATE;
-import static net.osmand.aidl.OsmandAidlApi.KEY_ON_UPDATE;
-import static net.osmand.aidl.OsmandAidlApi.KEY_ON_VOICE_MESSAGE;
-import static net.osmand.aidlapi.OsmandAidlConstants.CANNOT_ACCESS_API_ERROR;
-import static net.osmand.aidlapi.OsmandAidlConstants.MIN_UPDATE_TIME_MS;
-import static net.osmand.aidlapi.OsmandAidlConstants.MIN_UPDATE_TIME_MS_ERROR;
-import static net.osmand.aidlapi.OsmandAidlConstants.UNKNOWN_API_ERROR;
-
 import android.app.Service;
 import android.content.Intent;
 import android.graphics.Bitmap;
@@ -35,10 +25,10 @@ import net.osmand.aidlapi.copyfile.CopyFileParams;
 import net.osmand.aidlapi.customization.AProfile;
 import net.osmand.aidlapi.customization.CustomPluginParams;
 import net.osmand.aidlapi.customization.CustomizationInfoParams;
-import net.osmand.aidlapi.customization.PreferenceParams;
 import net.osmand.aidlapi.customization.MapMarginsParams;
 import net.osmand.aidlapi.customization.OsmandSettingsInfoParams;
 import net.osmand.aidlapi.customization.OsmandSettingsParams;
+import net.osmand.aidlapi.customization.PreferenceParams;
 import net.osmand.aidlapi.customization.ProfileSettingsParams;
 import net.osmand.aidlapi.customization.SelectProfileParams;
 import net.osmand.aidlapi.customization.SetWidgetsParams;
@@ -65,6 +55,7 @@ import net.osmand.aidlapi.gpx.StopGpxRecordingParams;
 import net.osmand.aidlapi.info.AppInfoParams;
 import net.osmand.aidlapi.info.GetTextParams;
 import net.osmand.aidlapi.lock.SetLockStateParams;
+import net.osmand.aidlapi.logcat.ALogcatListenerParams;
 import net.osmand.aidlapi.map.ALatLon;
 import net.osmand.aidlapi.map.SetLocationParams;
 import net.osmand.aidlapi.map.SetMapLocationParams;
@@ -123,6 +114,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+
+import static net.osmand.aidl.OsmandAidlApi.KEY_ON_CONTEXT_MENU_BUTTONS_CLICK;
+import static net.osmand.aidl.OsmandAidlApi.KEY_ON_KEY_EVENT;
+import static net.osmand.aidl.OsmandAidlApi.KEY_ON_LOGCAT_MESSAGE;
+import static net.osmand.aidl.OsmandAidlApi.KEY_ON_NAV_DATA_UPDATE;
+import static net.osmand.aidl.OsmandAidlApi.KEY_ON_UPDATE;
+import static net.osmand.aidl.OsmandAidlApi.KEY_ON_VOICE_MESSAGE;
+import static net.osmand.aidlapi.OsmandAidlConstants.CANNOT_ACCESS_API_ERROR;
+import static net.osmand.aidlapi.OsmandAidlConstants.MIN_UPDATE_TIME_MS;
+import static net.osmand.aidlapi.OsmandAidlConstants.MIN_UPDATE_TIME_MS_ERROR;
+import static net.osmand.aidlapi.OsmandAidlConstants.UNKNOWN_API_ERROR;
 
 public class OsmandAidlServiceV2 extends Service implements AidlCallbackListenerV2 {
 
@@ -1514,6 +1516,30 @@ public class OsmandAidlServiceV2 extends Service implements AidlCallbackListener
 			} catch (Exception e) {
 				handleException(e);
 				return false;
+			}
+		}
+
+		@Override
+		public long registerForLogcatMessages(ALogcatListenerParams params, IOsmAndAidlCallback callback) {
+			try {
+				OsmandAidlApi api = getApi("registerForLogcatMessages");
+				if (api != null) {
+					if (!params.isSubscribeToUpdates() && params.getCallbackId() != -1) {
+						api.stopRunningLogcatTask(params.getCallbackId());
+						removeAidlCallback(params.getCallbackId());
+						return -1;
+					} else {
+						long id = addAidlCallback(callback, KEY_ON_LOGCAT_MESSAGE);
+						String filterLevel = params.getFilterLevel();
+						api.registerLogcatListener(id, filterLevel);
+						return id;
+					}
+				} else {
+					return -1;
+				}
+			} catch (Exception e) {
+				handleException(e);
+				return UNKNOWN_API_ERROR;
 			}
 		}
 	};

--- a/OsmAnd/src/net/osmand/aidl/OsmandAidlServiceV2.java
+++ b/OsmAnd/src/net/osmand/aidl/OsmandAidlServiceV2.java
@@ -1525,7 +1525,7 @@ public class OsmandAidlServiceV2 extends Service implements AidlCallbackListener
 				OsmandAidlApi api = getApi("registerForLogcatMessages");
 				if (api != null) {
 					if (!params.isSubscribeToUpdates() && params.getCallbackId() != -1) {
-						api.stopRunningLogcatTask(params.getCallbackId());
+						api.stopLogcatTask(params.getCallbackId());
 						removeAidlCallback(params.getCallbackId());
 						return -1;
 					} else {

--- a/OsmAnd/src/net/osmand/plus/plugins/development/LogcatAsyncTask.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/development/LogcatAsyncTask.java
@@ -1,0 +1,76 @@
+package net.osmand.plus.plugins.development;
+
+import android.os.AsyncTask;
+
+import androidx.annotation.NonNull;
+
+import net.osmand.PlatformUtil;
+
+import org.apache.commons.logging.Log;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class LogcatAsyncTask extends AsyncTask<Void, String, Void> {
+
+	private static final Log log = PlatformUtil.getLog(LogcatAsyncTask.class);
+
+	public static int MAX_BUFFER_LOG = 10000;
+
+	private LogcatMessageListener mListener;
+	private final String mFilterLevel;
+	private Process mLogcat;
+
+	public LogcatAsyncTask(@NonNull LogcatMessageListener listener, @NonNull String filterLevel) {
+		mListener = listener;
+		mFilterLevel = filterLevel;
+	}
+
+	@Override
+	protected Void doInBackground(Void... voids) {
+		try {
+			String pid = String.valueOf(android.os.Process.myPid());
+			String[] command = {"logcat", mFilterLevel, "--pid=" + pid, "-T", String.valueOf(MAX_BUFFER_LOG)};
+			mLogcat = Runtime.getRuntime().exec(command);
+			BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(mLogcat.getInputStream()));
+
+			String line;
+			while ((line = bufferedReader.readLine()) != null) {
+				if (isCancelled()) {
+					break;
+				}
+				publishProgress(line);
+			}
+			stopLogging();
+		} catch (IOException e) {
+			// ignore
+		} catch (Exception e) {
+			log.error(e);
+		}
+
+		return null;
+	}
+
+	@Override
+	protected void onProgressUpdate(String... values) {
+		if (values.length > 0 && !isCancelled()) {
+			mListener.onLogcatLogs(mFilterLevel, Arrays.asList(values));
+		}
+	}
+
+	public void stop() {
+		if (getStatus() == AsyncTask.Status.RUNNING) {
+			cancel(false);
+			stopLogging();
+			mListener = null;
+		}
+	}
+
+	private void stopLogging() {
+		if (mLogcat != null) {
+			mLogcat.destroy();
+		}
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/plugins/development/LogcatMessageListener.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/development/LogcatMessageListener.java
@@ -1,0 +1,7 @@
+package net.osmand.plus.plugins.development;
+
+import java.util.List;
+
+public interface LogcatMessageListener {
+	void onLogcatLogs(String filterLevel, List<String> logs);
+}


### PR DESCRIPTION
Add ability to receive OsmAnd logs by AIDL.

To receive callback with logs, AIDL user should register callback and put logs type he wants to receive. Logs type must be one of the values below:
- "D" (for _debug_ messages)
- "I" (for _info_ messages)
- "W" (for _warn_ messages)
- "E" (for _error_ messages)

Logcat logs will come through appropriate method of IOsmAndAidlCallback interface.