### PR TITLE
Fix description of traffic_signals:sound=locate

### DIFF
--- a/OsmAnd/res/values/phrases.xml
+++ b/OsmAnd/res/values/phrases.xml
@@ -4241,7 +4241,7 @@
 	<string name="poi_video_no">No</string>
 
 	<string name="poi_internet_access_fee_customers">Internet access: customers</string>
-	<string name="poi_traffic_signals_sound_locate">Only when walking is allowed</string>
+	<string name="poi_traffic_signals_sound_locate">Only to find the pole</string>
 	<string name="poi_tactile_paving_contrasted">Contrasted</string>
 	<string name="poi_tactile_paving_primitive">Primitive</string>
 	<string name="poi_tactile_paving_incorrect">Incorrect</string>


### PR DESCRIPTION
Based on the [OSM wiki](https://wiki.openstreetmap.org/wiki/Key:traffic_signals:sound):

> **traffic_signals:sound=locate** when there is only the signal to _find the pole_ (tock - tock in most countries) , but no signal when walking is allowed.