### PR TITLE
Fix "Not selected" is not selected by default after clean installation

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/GeneralRouter.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/GeneralRouter.java
@@ -758,6 +758,9 @@ public class GeneralRouter implements VehicleRouter {
 		public boolean getDefaultBoolean() {
 			return defaultBoolean;
 		}
+		public String getDefaultString() {
+			return type == RoutingParameterType.NUMERIC ? "0.0" : "-";
+		}
 		public String[] getProfiles() {
 			return profiles;
 		}

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/EmissionHelper.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/EmissionHelper.java
@@ -96,8 +96,7 @@ public class EmissionHelper {
 		if (router != null && mode.getRouteService() == RouteService.OSMAND) {
 			RoutingParameter parameter = getParameterForDerivedProfile(MOTOR_TYPE, mode, router);
 			if (parameter != null) {
-				OsmandPreference<String> pref = settings.getCustomRoutingProperty(parameter.getId(),
-						parameter.getType() == RoutingParameterType.NUMERIC ? "0.0" : "-");
+				OsmandPreference<String> pref = settings.getCustomRoutingProperty(parameter.getId(), parameter.getDefaultString());
 				ListParameters parameters = populateListParameters(app, parameter);
 				int index = parameters.findIndexOfValue(pref.getModeValue(mode));
 				if (index != -1) {

--- a/OsmAnd/src/net/osmand/plus/routing/RouteProvider.java
+++ b/OsmAnd/src/net/osmand/plus/routing/RouteProvider.java
@@ -776,7 +776,7 @@ public class RouteProvider {
 				Boolean bool = pref.getModeValue(params.mode);
 				vl = bool ? "true" : null;
 			} else {
-				vl = settings.getCustomRoutingProperty(key, "").getModeValue(params.mode);
+				vl = settings.getCustomRoutingProperty(key, pr.getDefaultString()).getModeValue(params.mode);
 			}
 			if (vl != null && vl.length() > 0) {
 				paramsR.put(key, vl);

--- a/OsmAnd/src/net/osmand/plus/routing/TransportRoutingHelper.java
+++ b/OsmAnd/src/net/osmand/plus/routing/TransportRoutingHelper.java
@@ -504,7 +504,7 @@ public class TransportRoutingHelper {
 					Boolean bool = pref.getModeValue(params.mode);
 					vl = bool ? "true" : null;
 				} else {
-					vl = settings.getCustomRoutingProperty(key, "").getModeValue(params.mode);
+					vl = settings.getCustomRoutingProperty(key, pr.getDefaultString()).getModeValue(params.mode);
 				}
 				if (vl != null && vl.length() > 0) {
 					params.params.put(key, vl);

--- a/OsmAnd/src/net/osmand/plus/settings/fragments/RouteParametersFragment.java
+++ b/OsmAnd/src/net/osmand/plus/settings/fragments/RouteParametersFragment.java
@@ -324,7 +324,7 @@ public class RouteParametersFragment extends BaseSettingsFragment implements OnP
 			return preference;
 		} else {
 			ListParameters listParameters = populateListParameters(ctx, p);
-			OsmandPreference<String> pref = settings.getCustomRoutingProperty(p.getId(), p.getType() == RoutingParameterType.NUMERIC ? "0.0" : "-");
+			OsmandPreference<String> pref = settings.getCustomRoutingProperty(p.getId(), p.getDefaultString());
 			ListPreferenceEx preference = createListPreferenceEx(ctx, pref.getId(), listParameters.names, listParameters.values, title, R.layout.preference_with_descr);
 			preference.setDescription(description);
 			return preference;
@@ -613,7 +613,7 @@ public class RouteParametersFragment extends BaseSettingsFragment implements OnP
 				CommonPreference<Boolean> pref = settings.getCustomRoutingBooleanProperty(parameter.getId(), parameter.getDefaultBoolean());
 				pref.addListener(booleanRoutingPrefListener);
 			} else {
-				CommonPreference<String> pref = settings.getCustomRoutingProperty(parameter.getId(), parameter.getType() == RoutingParameterType.NUMERIC ? "0.0" : "-");
+				CommonPreference<String> pref = settings.getCustomRoutingProperty(parameter.getId(), parameter.getDefaultString());
 				pref.addListener(customRoutingPrefListener);
 			}
 		}
@@ -628,7 +628,7 @@ public class RouteParametersFragment extends BaseSettingsFragment implements OnP
 				CommonPreference<Boolean> pref = settings.getCustomRoutingBooleanProperty(parameter.getId(), parameter.getDefaultBoolean());
 				pref.removeListener(booleanRoutingPrefListener);
 			} else {
-				CommonPreference<String> pref = settings.getCustomRoutingProperty(parameter.getId(), parameter.getType() == RoutingParameterType.NUMERIC ? "0.0" : "-");
+				CommonPreference<String> pref = settings.getCustomRoutingProperty(parameter.getId(), parameter.getDefaultString());
 				pref.removeListener(customRoutingPrefListener);
 			}
 		}

--- a/OsmAnd/src/net/osmand/plus/settings/fragments/VehicleParametersFragment.java
+++ b/OsmAnd/src/net/osmand/plus/settings/fragments/VehicleParametersFragment.java
@@ -94,12 +94,9 @@ public class VehicleParametersFragment extends BaseSettingsFragment implements O
 		}
 		String parameterId = parameter.getId();
 		String title = AndroidUtils.getRoutingStringPropertyName(app, parameterId, parameter.getName());
-		String description = AndroidUtils.getRoutingStringPropertyDescription(app, parameterId,
-				parameter.getDescription());
-		String defValue = parameter.getType() == RoutingParameterType.NUMERIC
-				? ROUTING_PARAMETER_NUMERIC_DEFAULT : ROUTING_PARAMETER_SYMBOLIC_DEFAULT;
-		StringPreference pref = (StringPreference) app.getSettings()
-				.getCustomRoutingProperty(parameterId, defValue);
+		String description = AndroidUtils.getRoutingStringPropertyDescription(app, parameterId, parameter.getDescription());
+		String defValue = parameter.getDefaultString();
+		StringPreference pref = (StringPreference) app.getSettings().getCustomRoutingProperty(parameterId, defValue);
 		VehicleSizeAssets assets = VehicleSizeAssets.getAssets(parameterId, profile);
 		Object[] values = parameter.getPossibleValues();
 		String[] valuesStr = new String[values.length];


### PR DESCRIPTION
To reproduce the bug that was fixed in this pull request, you should remove profile preferences or only "prouting_motor_type" preference for needed profile.
Then start navigation with this profile and after that move to "Navigation Settings" -> "Vehicle Parameters" -> "Fuel used by motor". "Fuel used by motor" preference has missed its default value, that should be displayed as "Not selected".
It happened because of wrong default value (an empty string) that initialize preference when navigation started.
The correct default value must be "0.0" for routing preferences which have **_numeric_** type.