### PR TITLE
Remove references to Manage map files from strings.xml

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -3898,7 +3898,7 @@
     <!-- A file is downloaded -->
     <string name="confirm_interrupt_download">Cancel download?</string>
     <!-- Use ← for RTL languages -->
-    <string name="first_time_msg">Thank you for using OsmAnd. Download regional data for offline use via \'Settings\' → \'Manage map files\' to view maps, locate addresses, look up POIs, find public transport and more.</string>
+    <string name="first_time_msg">Thank you for using OsmAnd. Download regional data for offline use via \'Menu\' → \'Download maps\' to view maps, locate addresses, look up POIs, find public transport and more.</string>
     <string name="basemap_was_selected_to_download">The basemap needed to provide basic functionality is in the download queue.</string>
     <string name="local_indexes_cat_tile">Online and cached tile maps</string>
     <string name="local_indexes_cat_map">Standard maps (vector)</string>
@@ -3914,7 +3914,7 @@
     <string name="play_commands_of_currently_selected_voice">Select a voice and test by playing announcements:</string>
     <string name="native_rendering">Native rendering</string>
     <string name="test_voice_prompts">Test voice prompts</string>
-    <string name="switch_to_raster_map_to_see">Download an offline vector map for this location in \'Settings\' (\'Manage map files\'), or switch to the \'Online maps\' plugin.</string>
+    <string name="switch_to_raster_map_to_see">Download an offline vector map for this location in \'Menu\' (\'Download maps\'), or switch to the \'Online maps\' plugin.</string>
     <string name="send_files_to_osm">Send GPX files to OSM?</string>
     <string name="gpx_visibility_txt">Visibility</string>
     <string name="gpx_tags_txt">Tags</string>
@@ -4027,7 +4027,6 @@
     <string name="routing_settings">Navigation</string>
     <string name="routing_settings_descr">Specify options for navigation.</string>
     <string name="global_settings">Global Settings</string>
-    <string name="index_settings">Manage map files</string>
     <string name="general_settings">General</string>
     <string name="general_settings_descr">Set up display and common settings for the app.</string>
     <string name="global_app_settings">Global app settings</string>


### PR DESCRIPTION
There does not seem to be any "Manage map files" item in the settings.