### PR TITLE
Fix "Problem with copying widgets from other profiles"

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/WidgetsPanel.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/WidgetsPanel.java
@@ -155,24 +155,6 @@ public enum WidgetsPanel {
 		return orderPreference.setModeValue(appMode, stringBuilder.toString());
 	}
 
-	@NonNull
-	public List<List<String>> getWidgetsOrder(@NonNull ApplicationMode appMode, @NonNull OsmandSettings settings) {
-		List<List<String>> widgetsOrder = new ArrayList<>();
-		ListStringPreference preference = getOrderPreference(settings);
-		List<String> pages = preference.getStringsListForProfile(appMode);
-
-		if (!Algorithms.isEmpty(pages)) {
-			for (int pageIndex = 0; pageIndex < pages.size(); pageIndex++) {
-				String page = pages.get(pageIndex);
-				List<String> orders = Arrays.asList(page.split(WIDGET_SEPARATOR));
-				if (!Algorithms.isEmpty(orders)) {
-					widgetsOrder.add(orders);
-				}
-			}
-		}
-		return widgetsOrder;
-	}
-
 	public boolean contains(@NonNull String widgetId, @NonNull OsmandSettings settings) {
 		return contains(widgetId, settings, settings.getApplicationMode());
 	}

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/WidgetsSettingsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/WidgetsSettingsHelper.java
@@ -121,6 +121,24 @@ public class WidgetsSettingsHelper {
 		panel.setWidgetsOrder(appMode, newPagedOrder, settings);
 	}
 
+	public List<List<String>> getWidgetsPagedOrder(@NonNull ApplicationMode fromAppMode, @NonNull WidgetsPanel panel, int filter) {
+		int previousPage = -1;
+		List<WidgetsPanel> panels = Collections.singletonList(panel);
+		Set<MapWidgetInfo> widgetInfos = widgetRegistry.getWidgetsForPanel(mapActivity, fromAppMode, filter, panels);
+		List<List<String>> pagedOrder = new ArrayList<>();
+		for (MapWidgetInfo widgetInfo : widgetInfos) {
+			String widgetId = widgetInfo.key;
+			if (!Algorithms.isEmpty(widgetId) && WidgetsAvailabilityHelper.isWidgetAvailable(app, widgetId, appMode)) {
+				if (previousPage != widgetInfo.pageIndex || pagedOrder.size() == 0) {
+					previousPage = widgetInfo.pageIndex;
+					pagedOrder.add(new ArrayList<>());
+				}
+				pagedOrder.get(pagedOrder.size() - 1).add(widgetId);
+			}
+		}
+		return pagedOrder;
+	}
+
 	@NonNull
 	private List<MapWidgetInfo> getDefaultWidgetInfos(@NonNull WidgetsPanel panel) {
 		Set<MapWidgetInfo> widgetInfos = widgetRegistry.getWidgetsForPanel(mapActivity, appMode, 0, panel.getMergedPanels());

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/reorder/ReorderWidgetsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/reorder/ReorderWidgetsFragment.java
@@ -471,7 +471,8 @@ public class ReorderWidgetsFragment extends BaseOsmAndFragment implements
 
 	@Override
 	public void copyAppModePrefs(@NonNull ApplicationMode appMode) {
-		dataHolder.copyAppModePrefs(app, selectedAppMode, appMode);
+		MapActivity mapActivity = requireMapActivity();
+		dataHolder.copyAppModePrefs(mapActivity, selectedAppMode, appMode);
 		List<ListItem> enabledItems = createEnabledWidgetsList(appMode);
 		List<ListItem> availableItems = createAvailableWidgetsList(appMode);
 		updateItems(availableItems, enabledItems);

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/reorder/WidgetsDataHolder.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/reorder/WidgetsDataHolder.java
@@ -10,11 +10,11 @@ import androidx.annotation.NonNull;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.activities.MapActivity;
 import net.osmand.plus.settings.backend.ApplicationMode;
-import net.osmand.plus.settings.backend.OsmandSettings;
 import net.osmand.plus.settings.backend.WidgetsAvailabilityHelper;
 import net.osmand.plus.views.mapwidgets.MapWidgetInfo;
 import net.osmand.plus.views.mapwidgets.MapWidgetRegistry;
 import net.osmand.plus.views.mapwidgets.WidgetsPanel;
+import net.osmand.plus.views.mapwidgets.configure.WidgetsSettingsHelper;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -67,12 +67,14 @@ public class WidgetsDataHolder {
 		}
 	}
 
-	public void copyAppModePrefs(@NonNull OsmandApplication app, @NonNull ApplicationMode modeTo, @NonNull ApplicationMode modeFrom) {
+	public void copyAppModePrefs(@NonNull MapActivity activity, @NonNull ApplicationMode modeTo, @NonNull ApplicationMode modeFrom) {
 		pages.clear();
 		orders.clear();
 
-		OsmandSettings settings = app.getSettings();
-		List<List<String>> widgetsOrder = selectedPanel.getWidgetsOrder(modeFrom, settings);
+		int filter = ENABLED_MODE | AVAILABLE_MODE;
+		OsmandApplication app = activity.getMyApplication();
+		WidgetsSettingsHelper helper = new WidgetsSettingsHelper(activity, modeFrom);
+		List<List<String>> widgetsOrder = helper.getWidgetsPagedOrder(modeFrom, selectedPanel, filter);
 		for (int page = 0; page < widgetsOrder.size(); page++) {
 			List<String> pageOrder = widgetsOrder.get(page);
 			for (int order = 0; order < pageOrder.size(); order++) {


### PR DESCRIPTION
Use the same widgets order like when copying after click on "Copy from another profile" action button in the bottom of the selected panel widgets screen.