### PR TITLE
Fix "Android 6: CopyOnWriteArrayList sort problems"

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/util/Algorithms.java
+++ b/OsmAnd-java/src/main/java/net/osmand/util/Algorithms.java
@@ -1274,4 +1274,29 @@ public class Algorithms {
 		}
 		return copy;
 	}
+
+	public static <T> List<T> addToList(Collection<T> original, T element) {
+		List<T> copy = new ArrayList<>(original);
+		copy.add(element);
+		return copy;
+	}
+
+	public static <T> List<T> addAllToList(Collection<T> original, Collection<T> elements) {
+		List<T> copy = new ArrayList<>(original);
+		copy.addAll(elements);
+		return copy;
+	}
+
+	public static <T> List<T> removeFromList(Collection<T> original, T element) {
+		List<T> copy = new ArrayList<>(original);
+		copy.remove(element);
+		return copy;
+	}
+
+	public static <T> List<T> removeAllFromList(Collection<T> original, Collection<T> elements) {
+		List<T> copy = new ArrayList<>(original);
+		copy.removeAll(elements);
+		return copy;
+	}
+
 }

--- a/OsmAnd/src/net/osmand/plus/auto/FavoritesScreen.java
+++ b/OsmAnd/src/net/osmand/plus/auto/FavoritesScreen.java
@@ -108,7 +108,7 @@ public final class FavoritesScreen extends Screen {
 
 	@NonNull
 	private List<FavouritePoint> getFavorites() {
-		List<FavouritePoint> favouritePoints = new ArrayList<>(getApp().getFavoritesHelper().getFavouritePoints());
+		List<FavouritePoint> favouritePoints = getApp().getFavoritesHelper().getFavouritePoints();
 		Collections.sort(favouritePoints, (left, right) -> Long.compare(right.getTimestamp(), left.getTimestamp()));
 		return favouritePoints;
 	}

--- a/OsmAnd/src/net/osmand/plus/backup/BackupExecutor.java
+++ b/OsmAnd/src/net/osmand/plus/backup/BackupExecutor.java
@@ -6,11 +6,12 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import net.osmand.plus.OsmandApplication;
+import net.osmand.util.Algorithms;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -20,8 +21,8 @@ public class BackupExecutor extends ThreadPoolExecutor {
 
 	private final OsmandApplication app;
 	private final AtomicInteger aState = new AtomicInteger(State.IDLE.ordinal());
-	private final List<BackupCommand> activeCommands = new CopyOnWriteArrayList<>();
-	private final List<BackupExecutorListener> listeners = new CopyOnWriteArrayList<>();
+	private List<BackupCommand> activeCommands = new ArrayList<>();
+	private List<BackupExecutorListener> listeners = new ArrayList<>();
 
 	public enum State {
 		IDLE,
@@ -52,17 +53,17 @@ public class BackupExecutor extends ThreadPoolExecutor {
 	}
 
 	public void addListener(@NonNull BackupExecutorListener listener) {
-		listeners.add(listener);
+		listeners = Algorithms.addToList(listeners, listener);
 	}
 
 	public void removeListener(@NonNull BackupExecutorListener listener) {
-		listeners.remove(listener);
+		listeners = Algorithms.removeFromList(listeners, listener);
 	}
 
 	public void runCommand(@NonNull BackupCommand command) {
 		updateActiveCommands();
 		if (command.getStatus() == AsyncTask.Status.PENDING) {
-			activeCommands.add(command);
+			activeCommands = Algorithms.addToList(activeCommands, command);
 			command.executeOnExecutor(this);
 		}
 	}
@@ -120,6 +121,6 @@ public class BackupExecutor extends ThreadPoolExecutor {
 				commandsToRemove.add(command);
 			}
 		}
-		activeCommands.removeAll(commandsToRemove);
+		activeCommands = Algorithms.removeAllFromList(activeCommands, commandsToRemove);
 	}
 }

--- a/OsmAnd/src/net/osmand/plus/backup/BackupExporter.java
+++ b/OsmAnd/src/net/osmand/plus/backup/BackupExporter.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class BackupExporter extends Exporter {
@@ -37,7 +36,7 @@ public class BackupExporter extends Exporter {
 	private final List<SettingsItem> oldItemsToDelete = new ArrayList<>();
 	private ThreadPoolTaskExecutor<ItemWriterTask> executor;
 	private final NetworkExportProgressListener listener;
-	private final List<RemoteFile> oldFilesToDelete = new CopyOnWriteArrayList<>();
+	private List<RemoteFile> oldFilesToDelete = new ArrayList<>();
 
 	public interface NetworkExportProgressListener {
 		void itemExportStarted(@NonNull String type, @NonNull String fileName, int work);
@@ -271,7 +270,7 @@ public class BackupExporter extends Exporter {
 		if (exportType != null && !backupHelper.getVersionHistoryTypePref(exportType).get()) {
 			RemoteFile remoteFile = backupHelper.getBackup().getRemoteFile(type, fileName);
 			if (remoteFile != null) {
-				oldFilesToDelete.add(remoteFile);
+				oldFilesToDelete = Algorithms.addToList(oldFilesToDelete, remoteFile);
 			}
 		}
 	}

--- a/OsmAnd/src/net/osmand/plus/dashboard/DashFavoritesFragment.java
+++ b/OsmAnd/src/net/osmand/plus/dashboard/DashFavoritesFragment.java
@@ -97,7 +97,7 @@ public class DashFavoritesFragment extends DashLocationFragment {
 			return;
 		}
 
-		List<FavouritePoint> favouritePoints = new ArrayList<>(app.getFavoritesHelper().getFavouritePoints());
+		List<FavouritePoint> favouritePoints = app.getFavoritesHelper().getFavouritePoints();
 		if (Algorithms.isEmpty(favouritePoints)) {
 			AndroidUiHelper.updateVisibility(mainView.findViewById(R.id.main_fav), false);
 			return;

--- a/OsmAnd/src/net/osmand/plus/download/DownloadIndexesThread.java
+++ b/OsmAnd/src/net/osmand/plus/download/DownloadIndexesThread.java
@@ -52,7 +52,7 @@ public class DownloadIndexesThread {
 
 	private final DatabaseHelper dbHelper;
 	private final DownloadFileHelper downloadFileHelper;
-	private final List<BasicProgressAsyncTask<?, ?, ?, ?>> currentRunningTask = Collections.synchronizedList(new ArrayList<>());;
+	private final List<BasicProgressAsyncTask<?, ?, ?, ?>> currentRunningTask = Collections.synchronizedList(new ArrayList<>());
 	private final ConcurrentLinkedQueue<IndexItem> indexItemDownloading = new ConcurrentLinkedQueue<>();
 
 	private DownloadEvents uiActivity;

--- a/OsmAnd/src/net/osmand/plus/download/DownloadIndexesThread.java
+++ b/OsmAnd/src/net/osmand/plus/download/DownloadIndexesThread.java
@@ -35,13 +35,13 @@ import org.apache.commons.logging.Log;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 @SuppressLint({ "NewApi", "DefaultLocale" })
 public class DownloadIndexesThread {
@@ -52,7 +52,7 @@ public class DownloadIndexesThread {
 
 	private final DatabaseHelper dbHelper;
 	private final DownloadFileHelper downloadFileHelper;
-	private final List<BasicProgressAsyncTask<?, ?, ?, ?>> currentRunningTask = new CopyOnWriteArrayList<>();
+	private final List<BasicProgressAsyncTask<?, ?, ?, ?>> currentRunningTask = Collections.synchronizedList(new ArrayList<>());;
 	private final ConcurrentLinkedQueue<IndexItem> indexItemDownloading = new ConcurrentLinkedQueue<>();
 
 	private DownloadEvents uiActivity;

--- a/OsmAnd/src/net/osmand/plus/mapmarkers/MapMarkersHelper.java
+++ b/OsmAnd/src/net/osmand/plus/mapmarkers/MapMarkersHelper.java
@@ -37,13 +37,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -71,9 +69,9 @@ public class MapMarkersHelper {
 
 	private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
-	private List<MapMarker> mapMarkers = new CopyOnWriteArrayList<>();
-	private final List<MapMarker> mapMarkersHistory = new CopyOnWriteArrayList<>();
-	private List<MapMarkersGroup> mapMarkersGroups = new CopyOnWriteArrayList<>();
+	private List<MapMarker> mapMarkers = new ArrayList<>();
+	private List<MapMarker> mapMarkersHistory = new ArrayList<>();
+	private List<MapMarkersGroup> mapMarkersGroups = new ArrayList<>();
 
 	private final List<MapMarkerChangedListener> listeners = new ArrayList<>();
 	private final Set<OnGroupSyncedListener> syncListeners = new HashSet<>();
@@ -142,8 +140,8 @@ public class MapMarkersHelper {
 
 	public void syncAllGroups() {
 		Pair<Map<String, MapMarkersGroup>, Map<String, MapMarker>> pair = dataHelper.loadGroupsAndOrder();
-		mapMarkers = new CopyOnWriteArrayList<>(pair.second.values());
-		mapMarkersGroups = new CopyOnWriteArrayList<>(pair.first.values());
+		mapMarkers = new ArrayList<>(pair.second.values());
+		mapMarkersGroups = new ArrayList<>(pair.first.values());
 
 		boolean hasFavoriteGroup = false;
 		boolean hasTrackGroup = false;
@@ -270,34 +268,31 @@ public class MapMarkersHelper {
 	                         boolean visited,
 	                         @MapMarkersSortByDef int sortByMode,
 	                         @Nullable LatLon location) {
-		AndroidUtils.sortCopyOnWriteList(markers, new Comparator<MapMarker>() {
-			@Override
-			public int compare(MapMarker mapMarker1, MapMarker mapMarker2) {
-				if (sortByMode == BY_DATE_ADDED_DESC || sortByMode == BY_DATE_ADDED_ASC) {
-					long t1 = visited ? mapMarker1.visitedDate : mapMarker1.creationDate;
-					long t2 = visited ? mapMarker2.visitedDate : mapMarker2.creationDate;
-					if (t1 > t2) {
-						return sortByMode == BY_DATE_ADDED_DESC ? -1 : 1;
-					} else if (t1 == t2) {
-						return 0;
-					} else {
-						return sortByMode == BY_DATE_ADDED_DESC ? 1 : -1;
-					}
-				} else if (location != null && (sortByMode == BY_DISTANCE_DESC || sortByMode == BY_DISTANCE_ASC)) {
-					int d1 = (int) MapUtils.getDistance(location, mapMarker1.getLatitude(), mapMarker1.getLongitude());
-					int d2 = (int) MapUtils.getDistance(location, mapMarker2.getLatitude(), mapMarker2.getLongitude());
-					if (d1 > d2) {
-						return sortByMode == BY_DISTANCE_DESC ? -1 : 1;
-					} else if (d1 == d2) {
-						return 0;
-					} else {
-						return sortByMode == BY_DISTANCE_DESC ? 1 : -1;
-					}
+		Collections.sort(markers, (mapMarker1, mapMarker2) -> {
+			if (sortByMode == BY_DATE_ADDED_DESC || sortByMode == BY_DATE_ADDED_ASC) {
+				long t1 = visited ? mapMarker1.visitedDate : mapMarker1.creationDate;
+				long t2 = visited ? mapMarker2.visitedDate : mapMarker2.creationDate;
+				if (t1 > t2) {
+					return sortByMode == BY_DATE_ADDED_DESC ? -1 : 1;
+				} else if (t1 == t2) {
+					return 0;
 				} else {
-					String n1 = mapMarker1.getName(ctx);
-					String n2 = mapMarker2.getName(ctx);
-					return n1.compareToIgnoreCase(n2);
+					return sortByMode == BY_DATE_ADDED_DESC ? 1 : -1;
 				}
+			} else if (location != null && (sortByMode == BY_DISTANCE_DESC || sortByMode == BY_DISTANCE_ASC)) {
+				int d1 = (int) MapUtils.getDistance(location, mapMarker1.getLatitude(), mapMarker1.getLongitude());
+				int d2 = (int) MapUtils.getDistance(location, mapMarker2.getLatitude(), mapMarker2.getLongitude());
+				if (d1 > d2) {
+					return sortByMode == BY_DISTANCE_DESC ? -1 : 1;
+				} else if (d1 == d2) {
+					return 0;
+				} else {
+					return sortByMode == BY_DISTANCE_DESC ? 1 : -1;
+				}
+			} else {
+				String n1 = mapMarker1.getName(ctx);
+				String n2 = mapMarker2.getName(ctx);
+				return n1.compareToIgnoreCase(n2);
 			}
 		});
 	}
@@ -479,7 +474,7 @@ public class MapMarkersHelper {
 
 	private void sortGroups() {
 		if (mapMarkersGroups.size() > 0) {
-			AndroidUtils.sortCopyOnWriteList(mapMarkersGroups, (group1, group2) -> {
+			Collections.sort(mapMarkersGroups, (group1, group2) -> {
 				long t1 = group1.getCreationDate();
 				long t2 = group2.getCreationDate();
 				return (t1 > t2) ? -1 : ((t1 == t2) ? 0 : 1);
@@ -772,7 +767,7 @@ public class MapMarkersHelper {
 
 	public void reverseActiveMarkersOrder() {
 		cancelAddressRequests();
-		AndroidUtils.reverseCopyOnWriteList(mapMarkers);
+		Collections.reverse(mapMarkers);
 		saveGroups(false);
 	}
 
@@ -785,7 +780,7 @@ public class MapMarkersHelper {
 			marker.history = true;
 		}
 		addToMapMarkersHistoryList(mapMarkers);
-		mapMarkers = new CopyOnWriteArrayList<>();
+		mapMarkers = new ArrayList<>();
 		sortMarkers(mapMarkersHistory, true, BY_DATE_ADDED_DESC);
 		updateGroups();
 		syncPassedPoints();
@@ -973,52 +968,56 @@ public class MapMarkersHelper {
 		addToMapMarkersList(mapMarkers.size(), marker);
 	}
 
-	private void addToMapMarkersList(int position, MapMarker marker) {
-		mapMarkers.add(position, marker);
-	}
-
 	private void addToMapMarkersList(List<MapMarker> markers) {
 		addToMapMarkersList(mapMarkers.size(), markers);
 	}
 
+	private void addToMapMarkersList(int position, MapMarker marker) {
+		List<MapMarker> copy = new ArrayList<>(mapMarkers);
+		copy.add(position, marker);
+		mapMarkers = copy;
+	}
+
 	private void addToMapMarkersList(int position, List<MapMarker> markers) {
-		mapMarkers.addAll(position, markers);
+		List<MapMarker> copy = new ArrayList<>(mapMarkers);
+		copy.addAll(position, markers);
+		mapMarkers = copy;
 	}
 
 	private void removeFromMapMarkersList(MapMarker marker) {
-		mapMarkers.remove(marker);
+		mapMarkers = Algorithms.removeFromList(mapMarkers, marker);
 	}
 
 	private void removeFromMapMarkersList(List<MapMarker> markers) {
-		mapMarkers.removeAll(markers);
+		mapMarkers = Algorithms.removeAllFromList(mapMarkers, markers);
 	}
 
 	// accessors to history markers:
 
 	private void addToMapMarkersHistoryList(MapMarker marker) {
-		mapMarkersHistory.add(marker);
+		mapMarkersHistory = Algorithms.addToList(mapMarkersHistory, marker);
 	}
 
 	private void addToMapMarkersHistoryList(List<MapMarker> markers) {
-		mapMarkersHistory.addAll(markers);
+		mapMarkersHistory = Algorithms.addAllToList(mapMarkersHistory, markers);
 	}
 
 	private void removeFromMapMarkersHistoryList(MapMarker marker) {
-		mapMarkersHistory.remove(marker);
+		mapMarkersHistory = Algorithms.removeFromList(mapMarkersHistory, marker);
 	}
 
 	private void removeFromMapMarkersHistoryList(List<MapMarker> markers) {
-		mapMarkersHistory.removeAll(markers);
+		mapMarkersHistory = Algorithms.removeAllFromList(mapMarkersHistory, markers);
 	}
 
 	// accessors to markers groups:
 
 	private void addToGroupsList(MapMarkersGroup group) {
-		mapMarkersGroups.add(group);
+		mapMarkersGroups = Algorithms.addToList(mapMarkersGroups, group);
 	}
 
 	private void removeFromGroupsList(MapMarkersGroup group) {
-		mapMarkersGroups.remove(group);
+		mapMarkersGroups = Algorithms.removeFromList(mapMarkersGroups, group);
 	}
 
 	// ---------------------------------------------------------------------------------------------

--- a/OsmAnd/src/net/osmand/plus/mapmarkers/MapMarkersHelper.java
+++ b/OsmAnd/src/net/osmand/plus/mapmarkers/MapMarkersHelper.java
@@ -24,6 +24,7 @@ import net.osmand.plus.myplaces.FavoriteGroup;
 import net.osmand.plus.track.helpers.GPXDatabase.GpxDataItem;
 import net.osmand.plus.track.helpers.GpxSelectionHelper;
 import net.osmand.plus.track.helpers.SelectedGpxFile;
+import net.osmand.plus.utils.AndroidUtils;
 import net.osmand.plus.wikivoyage.data.TravelArticle;
 import net.osmand.plus.wikivoyage.data.TravelHelper;
 import net.osmand.util.Algorithms;
@@ -269,7 +270,7 @@ public class MapMarkersHelper {
 	                         boolean visited,
 	                         @MapMarkersSortByDef int sortByMode,
 	                         @Nullable LatLon location) {
-		Collections.sort(markers, new Comparator<MapMarker>() {
+		AndroidUtils.sortCopyOnWriteList(markers, new Comparator<MapMarker>() {
 			@Override
 			public int compare(MapMarker mapMarker1, MapMarker mapMarker2) {
 				if (sortByMode == BY_DATE_ADDED_DESC || sortByMode == BY_DATE_ADDED_ASC) {
@@ -478,7 +479,7 @@ public class MapMarkersHelper {
 
 	private void sortGroups() {
 		if (mapMarkersGroups.size() > 0) {
-			Collections.sort(mapMarkersGroups, (group1, group2) -> {
+			AndroidUtils.sortCopyOnWriteList(mapMarkersGroups, (group1, group2) -> {
 				long t1 = group1.getCreationDate();
 				long t2 = group2.getCreationDate();
 				return (t1 > t2) ? -1 : ((t1 == t2) ? 0 : 1);
@@ -771,7 +772,7 @@ public class MapMarkersHelper {
 
 	public void reverseActiveMarkersOrder() {
 		cancelAddressRequests();
-		Collections.reverse(mapMarkers);
+		AndroidUtils.reverseCopyOnWriteList(mapMarkers);
 		saveGroups(false);
 	}
 

--- a/OsmAnd/src/net/osmand/plus/myplaces/FavouritesHelper.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/FavouritesHelper.java
@@ -19,6 +19,7 @@ import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.R;
 import net.osmand.plus.mapmarkers.MapMarkersGroup;
 import net.osmand.plus.mapmarkers.MapMarkersHelper;
+import net.osmand.plus.utils.AndroidUtils;
 import net.osmand.util.Algorithms;
 
 import org.apache.commons.logging.Log;
@@ -602,7 +603,7 @@ public class FavouritesHelper {
 		for (FavoriteGroup g : favoriteGroups) {
 			Collections.sort(g.getPoints(), favoritesComparator);
 		}
-		Collections.sort(cachedFavoritePoints, favoritesComparator);
+		AndroidUtils.sortCopyOnWriteList(cachedFavoritePoints, favoritesComparator);
 	}
 
 	public static Comparator<FavouritePoint> getComparator() {

--- a/OsmAnd/src/net/osmand/plus/myplaces/FavouritesHelper.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/FavouritesHelper.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 
 public class FavouritesHelper {
@@ -47,7 +46,7 @@ public class FavouritesHelper {
 
 	private final List<FavoriteGroup> favoriteGroups = new ArrayList<>();
 	private final Map<String, FavoriteGroup> flatGroups = new LinkedHashMap<>();
-	private final List<FavouritePoint> cachedFavoritePoints = new CopyOnWriteArrayList<>();
+	private List<FavouritePoint> cachedFavoritePoints = new ArrayList<>();
 
 	private final Set<FavoritesListener> listeners = new HashSet<>();
 	private final Map<FavouritePoint, AddressLookupRequest> addressRequestMap = new ConcurrentHashMap<>();
@@ -80,7 +79,7 @@ public class FavouritesHelper {
 
 	@NonNull
 	public List<FavouritePoint> getFavouritePoints() {
-		return cachedFavoritePoints;
+		return new ArrayList<>(cachedFavoritePoints);
 	}
 
 	@Nullable
@@ -575,15 +574,15 @@ public class FavouritesHelper {
 	}
 
 	private void addFavouritePoint(@NonNull FavouritePoint point) {
-		cachedFavoritePoints.add(point);
+		cachedFavoritePoints = Algorithms.addToList(cachedFavoritePoints, point);
 	}
 
 	private void removeFavouritePoint(@NonNull FavouritePoint point) {
-		cachedFavoritePoints.remove(point);
+		cachedFavoritePoints = Algorithms.removeFromList(cachedFavoritePoints, point);
 	}
 
 	private void removeFavouritePoints(@NonNull List<FavouritePoint> points) {
-		cachedFavoritePoints.removeAll(points);
+		cachedFavoritePoints = Algorithms.removeAllFromList(cachedFavoritePoints, points);
 	}
 
 	public void recalculateCachedFavPoints() {
@@ -591,8 +590,7 @@ public class FavouritesHelper {
 		for (FavoriteGroup f : favoriteGroups) {
 			allPoints.addAll(f.getPoints());
 		}
-		cachedFavoritePoints.clear();
-		cachedFavoritePoints.addAll(allPoints);
+		cachedFavoritePoints = new ArrayList<>(allPoints);
 	}
 
 	public void sortAll() {
@@ -603,7 +601,7 @@ public class FavouritesHelper {
 		for (FavoriteGroup g : favoriteGroups) {
 			Collections.sort(g.getPoints(), favoritesComparator);
 		}
-		AndroidUtils.sortCopyOnWriteList(cachedFavoritePoints, favoritesComparator);
+		Collections.sort(cachedFavoritePoints, favoritesComparator);
 	}
 
 	public static Comparator<FavouritePoint> getComparator() {

--- a/OsmAnd/src/net/osmand/plus/plugins/osmedit/data/EditPoiData.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/osmedit/data/EditPoiData.java
@@ -17,7 +17,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
 
 import static net.osmand.osm.edit.Entity.POI_TYPE_TAG;
 
@@ -34,7 +33,7 @@ public class EditPoiData {
 	private PoiCategory category;
 	private PoiType currentPoiType;
 
-	private final Set<String> changedTags = new CopyOnWriteArraySet<>();
+	private final Set<String> changedTags = Collections.synchronizedSet(new HashSet<>());
 	
 	public EditPoiData(Entity entity, OsmandApplication app) {
 		allTranslatedSubTypes = app.getPoiTypes().getAllTranslatedNames(true);

--- a/OsmAnd/src/net/osmand/plus/plugins/osmedit/data/OpenstreetmapPoint.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/osmedit/data/OpenstreetmapPoint.java
@@ -5,6 +5,7 @@ import net.osmand.osm.edit.Entity;
 import net.osmand.osm.edit.OSMSettings.OSMTagKey;
 import net.osmand.util.Algorithms;
 
+import java.util.HashSet;
 import java.util.Set;
 
 public class OpenstreetmapPoint extends OsmPoint {
@@ -96,7 +97,7 @@ public class OpenstreetmapPoint extends OsmPoint {
 		if (entity == null) {
 			return;
 		}
-		Set<String> changedTags = entity.getChangedTags();
+		Set<String> changedTags = new HashSet<>(entity.getChangedTags());
 		if (!Algorithms.isEmpty(changedTags)) {
 			for (String changedTag : changedTags) {
 				if (changedTag == null || changedTag.trim().equals(changedTag)) {
@@ -110,6 +111,7 @@ public class OpenstreetmapPoint extends OsmPoint {
 				entity.putTag(trimmedTag, Algorithms.trimIfNotNull(tagValue));
 				entity.removeTag(changedTag);
 			}
+			entity.setChangedTags(changedTags);
 		}
 	}
 

--- a/OsmAnd/src/net/osmand/plus/plugins/osmedit/helpers/OpenstreetmapsDbHelper.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/osmedit/helpers/OpenstreetmapsDbHelper.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -221,7 +220,7 @@ public class OpenstreetmapsDbHelper extends SQLiteOpenHelper {
 						}
 						String changedTags = query.getString(6);
 						if (changedTags != null) {
-							entity.setChangedTags(new CopyOnWriteArraySet<>(Arrays.asList(changedTags.split("\\$\\$\\$"))));
+							entity.setChangedTags(new HashSet<>(Arrays.asList(changedTags.split("\\$\\$\\$"))));
 						}
 						p.setEntity(entity);
 						p.setAction(query.getString(3));

--- a/OsmAnd/src/net/osmand/plus/poi/PoiFiltersHelper.java
+++ b/OsmAnd/src/net/osmand/plus/poi/PoiFiltersHelper.java
@@ -18,6 +18,7 @@ import net.osmand.plus.api.SQLiteAPI.SQLiteCursor;
 import net.osmand.plus.api.SQLiteAPI.SQLiteStatement;
 import net.osmand.plus.backup.BackupHelper;
 import net.osmand.plus.settings.backend.ApplicationMode;
+import net.osmand.plus.utils.AndroidUtils;
 
 import org.apache.commons.logging.Log;
 import org.json.JSONArray;
@@ -432,7 +433,7 @@ public class PoiFiltersHelper {
 		boolean res = helper.addFilter(filter, helper.getWritableDatabase(), false, forHistory);
 		if (res) {
 			addTopPoiFilter(filter);
-			Collections.sort(cacheTopStandardFilters);
+			AndroidUtils.sortCopyOnWriteList(cacheTopStandardFilters);
 		}
 		helper.close();
 		return res;

--- a/OsmAnd/src/net/osmand/plus/poi/PoiFiltersHelper.java
+++ b/OsmAnd/src/net/osmand/plus/poi/PoiFiltersHelper.java
@@ -258,10 +258,8 @@ public class PoiFiltersHelper {
 				PoiUIFilter f = new PoiUIFilter(t, application, "");
 				filters.add(f);
 			}
+			OsmandPlugin.registerCustomPoiFilters(filters);
 			cacheTopStandardFilters = Algorithms.addAllToList(cacheTopStandardFilters, filters);
-			List<PoiUIFilter> customPoiFilters = new ArrayList<>();
-			OsmandPlugin.registerCustomPoiFilters(customPoiFilters);
-			cacheTopStandardFilters = Algorithms.addAllToList(cacheTopStandardFilters, customPoiFilters);
 		}
 		List<PoiUIFilter> result = new ArrayList<>();
 		for (PoiUIFilter filter : cacheTopStandardFilters) {

--- a/OsmAnd/src/net/osmand/plus/utils/AndroidUtils.java
+++ b/OsmAnd/src/net/osmand/plus/utils/AndroidUtils.java
@@ -23,8 +23,6 @@ import android.graphics.drawable.ShapeDrawable;
 import android.graphics.drawable.StateListDrawable;
 import android.net.Uri;
 import android.os.Build;
-import android.os.Build.VERSION;
-import android.os.Build.VERSION_CODES;
 import android.os.IBinder;
 import android.os.PowerManager;
 import android.os.StatFs;
@@ -1176,32 +1174,6 @@ public class AndroidUtils {
 			return ctx.getString(in);
 		}
 		return null;
-	}
-
-	public static <T> void reverseCopyOnWriteList(List<T> list) {
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-			Collections.reverse(list);
-		} else {
-			List<T> copy = new ArrayList<>(list);
-			Collections.reverse(copy);
-			list.clear();
-			list.addAll(copy);
-		}
-	}
-
-	public static <T> void sortCopyOnWriteList(List<T> list) {
-		sortCopyOnWriteList(list, null);
-	}
-
-	public static <T> void sortCopyOnWriteList(List<T> list, Comparator<T> comparator) {
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-			Collections.sort(list, comparator);
-		} else {
-			List<T> copy = new ArrayList<>(list);
-			Collections.sort(copy, comparator);
-			list.clear();
-			list.addAll(copy);
-		}
 	}
 
 	public static void openUrl(@NonNull Context context, int urlStringId, boolean nightMode) {

--- a/OsmAnd/src/net/osmand/plus/utils/AndroidUtils.java
+++ b/OsmAnd/src/net/osmand/plus/utils/AndroidUtils.java
@@ -1178,6 +1178,32 @@ public class AndroidUtils {
 		return null;
 	}
 
+	public static <T> void reverseCopyOnWriteList(List<T> list) {
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+			Collections.reverse(list);
+		} else {
+			List<T> copy = new ArrayList<>(list);
+			Collections.reverse(copy);
+			list.clear();
+			list.addAll(copy);
+		}
+	}
+
+	public static <T> void sortCopyOnWriteList(List<T> list) {
+		sortCopyOnWriteList(list, null);
+	}
+
+	public static <T> void sortCopyOnWriteList(List<T> list, Comparator<T> comparator) {
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+			Collections.sort(list, comparator);
+		} else {
+			List<T> copy = new ArrayList<>(list);
+			Collections.sort(copy, comparator);
+			list.clear();
+			list.addAll(copy);
+		}
+	}
+
 	public static void openUrl(@NonNull Context context, int urlStringId, boolean nightMode) {
 		openUrl(context, context.getString(urlStringId), nightMode);
 	}

--- a/OsmAnd/src/net/osmand/plus/views/OsmandMap.java
+++ b/OsmAnd/src/net/osmand/plus/views/OsmandMap.java
@@ -22,10 +22,10 @@ import net.osmand.plus.helpers.TargetPointsHelper;
 import net.osmand.plus.resources.ResourceManager;
 import net.osmand.plus.routing.RoutingHelper;
 import net.osmand.plus.utils.AndroidUtils;
+import net.osmand.util.Algorithms;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 public class OsmandMap implements NavigationSessionListener {
 
@@ -37,7 +37,7 @@ public class OsmandMap implements NavigationSessionListener {
 	private final MapActions mapActions;
 	private final IMapDownloaderCallback downloaderCallback;
 
-	private final List<OsmandMapListener> listeners = new CopyOnWriteArrayList<>();
+	private List<OsmandMapListener> listeners = new ArrayList<>();
 
 	public interface OsmandMapListener {
 		void onChangeZoom(int stp);
@@ -49,12 +49,12 @@ public class OsmandMap implements NavigationSessionListener {
 
 	public void addListener(@NonNull OsmandMapListener listener) {
 		if (!listeners.contains(listener)) {
-			listeners.add(listener);
+			listeners = Algorithms.addToList(listeners, listener);
 		}
 	}
 
 	public void removeListener(@NonNull OsmandMapListener listener) {
-		listeners.remove(listener);
+		listeners = Algorithms.removeFromList(listeners, listener);
 	}
 
 	public OsmandMap(@NonNull OsmandApplication app) {

--- a/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
+++ b/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
@@ -67,6 +67,7 @@ import net.osmand.plus.views.layers.base.OsmandMapLayer.MapGestureType;
 import net.osmand.render.RenderingRuleSearchRequest;
 import net.osmand.render.RenderingRuleStorageProperties;
 import net.osmand.render.RenderingRulesStorage;
+import net.osmand.util.Algorithms;
 import net.osmand.util.MapUtils;
 
 import org.apache.commons.logging.Log;
@@ -75,7 +76,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 public class OsmandMapTileView implements IMapDownloaderCallback {
 
@@ -153,7 +153,7 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 
 	private boolean showMapPosition = true;
 
-	private final List<IMapLocationListener> locationListeners = new CopyOnWriteArrayList<>();
+	private List<IMapLocationListener> locationListeners = new ArrayList<>();
 
 	private OnLongClickListener onLongClickListener;
 
@@ -609,11 +609,11 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 	}
 
 	public void addMapLocationListener(@NonNull IMapLocationListener listener) {
-		locationListeners.add(listener);
+		locationListeners = Algorithms.addToList(locationListeners, listener);
 	}
 
 	public void removeMapLocationListener(@NonNull IMapLocationListener listener) {
-		locationListeners.remove(listener);
+		locationListeners = Algorithms.removeFromList(locationListeners, listener);
 	}
 
 	public void setOnDrawMapListener(OnDrawMapListener onDrawMapListener) {

--- a/OsmAnd/src/net/osmand/plus/views/layers/FavouritesLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/FavouritesLayer.java
@@ -284,8 +284,7 @@ public class FavouritesLayer extends OsmandMapLayer implements IContextMenuProvi
 		int r = getScaledTouchRadius(view.getApplication(), tb.getDefaultRadiusPoi());
 		int ex = (int) point.x;
 		int ey = (int) point.y;
-		List<FavouritePoint> favouritePoints = new ArrayList<>(favouritesHelper.getFavouritePoints());
-		for (FavouritePoint n : favouritePoints) {
+		for (FavouritePoint n : favouritesHelper.getFavouritePoints()) {
 			getFavFromPoint(tb, res, r, ex, ey, n);
 		}
 	}

--- a/OsmAnd/src/net/osmand/plus/views/layers/MapInfoLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/MapInfoLayer.java
@@ -30,9 +30,10 @@ import net.osmand.plus.views.mapwidgets.WidgetsPanel;
 import net.osmand.plus.views.mapwidgets.widgets.AlarmWidget;
 import net.osmand.plus.views.mapwidgets.widgets.RulerWidget;
 import net.osmand.plus.views.mapwidgets.widgets.TextInfoWidget;
+import net.osmand.util.Algorithms;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 public class MapInfoLayer extends OsmandMapLayer {
 
@@ -143,7 +144,7 @@ public class MapInfoLayer extends OsmandMapLayer {
 	}
 
 	private void registerAllControls(@NonNull MapActivity mapActivity) {
-		rulerWidgets = new CopyOnWriteArrayList<>();
+		rulerWidgets = new ArrayList<>();
 
 		topToolbarView = new TopToolbarView(mapActivity);
 		updateTopToolbar(false);
@@ -191,7 +192,7 @@ public class MapInfoLayer extends OsmandMapLayer {
 			boolean nightMode = drawSettings != null && drawSettings.isNightMode();
 			rulerWidget.updateTextSize(nightMode, ts.textColor, ts.textShadowColor, (int) (2 * view.getDensity()));
 
-			rulerWidgets.add(rulerWidget);
+			rulerWidgets = Algorithms.addToList(rulerWidgets, rulerWidget);
 
 			return rulerWidget;
 		} else {
@@ -200,7 +201,7 @@ public class MapInfoLayer extends OsmandMapLayer {
 	}
 
 	public void removeRulerWidgets(@NonNull List<RulerWidget> rulers) {
-		rulerWidgets.removeAll(rulers);
+		rulerWidgets = Algorithms.removeAllFromList(rulerWidgets, rulers);
 	}
 
 	public void setTrackChartPoints(TrackChartPoints trackChartPoints) {

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/MapWidgetRegistry.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/MapWidgetRegistry.java
@@ -59,7 +59,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 public class MapWidgetRegistry {
 
@@ -79,7 +78,7 @@ public class MapWidgetRegistry {
 
 	private Map<WidgetsPanel, Set<MapWidgetInfo>> allWidgets = new HashMap<>();
 
-	private final List<WidgetsRegistryListener> listeners = new CopyOnWriteArrayList<>();
+	private List<WidgetsRegistryListener> listeners = new ArrayList<>();
 
 	public MapWidgetRegistry(OsmandApplication app) {
 		this.app = app;
@@ -176,11 +175,11 @@ public class MapWidgetRegistry {
 	}
 
 	public void addWidgetsRegistryListener(@NonNull WidgetsRegistryListener listener) {
-		listeners.add(listener);
+		listeners = Algorithms.addToList(listeners, listener);
 	}
 
 	public void removeWidgetsRegistryListener(@NonNull WidgetsRegistryListener listener) {
-		listeners.remove(listener);
+		listeners = Algorithms.removeFromList(listeners, listener);
 	}
 
 	private void notifyWidgetRegistered(@NonNull MapWidgetInfo widgetInfo) {

--- a/OsmAnd/src/net/osmand/plus/voice/JsMediaCommandPlayer.java
+++ b/OsmAnd/src/net/osmand/plus/voice/JsMediaCommandPlayer.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * That class represents command player.
@@ -36,7 +35,7 @@ public class JsMediaCommandPlayer extends CommandPlayer implements OnCompletionL
 
 	private MediaPlayer mediaPlayer;
 	// indicates that player is ready to play first file
-	private final List<String> filesToPlay = new CopyOnWriteArrayList<>();
+	private final List<String> filesToPlay = Collections.synchronizedList(new ArrayList<>());
 
 	protected JsMediaCommandPlayer(@NonNull OsmandApplication app,
 	                               @NonNull ApplicationMode applicationMode,
@@ -63,9 +62,7 @@ public class JsMediaCommandPlayer extends CommandPlayer implements OnCompletionL
 
 	@Override
 	public void stop() {
-		if (filesToPlay != null) {
-			filesToPlay.clear();
-		}
+		filesToPlay.clear();
 		if (mediaPlayer != null) {
 			mediaPlayer.stop();
 		}
@@ -75,9 +72,7 @@ public class JsMediaCommandPlayer extends CommandPlayer implements OnCompletionL
 	@Override
 	public void clear() {
 		super.clear();
-		if (filesToPlay != null) {
-			filesToPlay.clear();
-		}
+		filesToPlay.clear();
 		if (mediaPlayer != null) {
 			mediaPlayer.release();
 		}


### PR DESCRIPTION
We had the same problem with sorting CopyOnWriteArrayList that resulted in diferent issues on Android 6: #15128, #15129, #15202, #15203.
**Problem:** Collections.sort uses ListIterator.set, but CopyOnWriteArrayList's ListIterator does not support the "remove", "set" or "add" methods.