### PR TITLE
Add support for online tile source template URLs with only bounding box

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/map/TileSourceManager.java
+++ b/OsmAnd-java/src/main/java/net/osmand/map/TileSourceManager.java
@@ -3,6 +3,7 @@ package net.osmand.map;
 import net.osmand.PlatformUtil;
 import net.osmand.osm.io.NetworkUtils;
 import net.osmand.util.Algorithms;
+import net.osmand.util.MapUtils;
 
 import org.apache.commons.logging.Log;
 import org.xmlpull.v1.XmlPullParser;
@@ -66,6 +67,7 @@ public class TileSourceManager {
 
 	private static final String PARAM_BING_QUAD_KEY = "{q}";
 	private static final String PARAM_RND = "{rnd}";
+	private static final String PARAM_BOUNDING_BOX = "{bbox}";
 	public static final String PARAMETER_NAME = "{PARAM}";
 
 	public static class TileSourceTemplate implements ITileSource, Cloneable {
@@ -418,6 +420,14 @@ public class TileSourceManager {
 			return new String(tn);
 		}
 
+		private static String calcBoundingBoxForTile(int zoom, int x, int y) {
+			double xmin = MapUtils.getLongitudeFromTile(zoom, x);
+			double xmax = MapUtils.getLongitudeFromTile(zoom, x+1);
+			double ymin = MapUtils.getLatitudeFromTile(zoom, y+1);
+			double ymax = MapUtils.getLatitudeFromTile(zoom, y);
+			return String.format("%.8f,%.8f,%.8f,%.8f", xmin, ymin, xmax, ymax);
+		}
+
 		public static String buildUrlToLoad(String urlTemplate, String[] randomsArray, int x, int y, int zoom, Map<String, String> params) {
 			try {
 				if (randomsArray != null && randomsArray.length > 0) {
@@ -436,6 +446,11 @@ public class TileSourceManager {
 				int bingQuadKeyParamIndex = urlTemplate.indexOf(PARAM_BING_QUAD_KEY);
 				if (bingQuadKeyParamIndex != -1) {
 					return urlTemplate.replace(PARAM_BING_QUAD_KEY, eqtBingQuadKey(zoom, x, y));
+				}
+
+				int bbKeyParamIndex = urlTemplate.indexOf(PARAM_BOUNDING_BOX);
+				if (bbKeyParamIndex != -1) {
+					return urlTemplate.replace(PARAM_BOUNDING_BOX, calcBoundingBoxForTile(zoom, x, y));
 				}
 
 				if (!Algorithms.isEmpty(params)) {


### PR DESCRIPTION
Some online map data sources do not have native support for tiled web map
(slippy map) requests. A common way of operating without the tile zoom/x/y
triplet is to specify a lat/lon bounding box in the tile request.

Previously, as a workaround, osmand suggested pointing at a redirecting
proxy that would rewrite requests for zoom/x/y tiles with an equivalent request
for a bounding box (i.e. http://whoots.mapwarper.net/tms)

Instead of this workaround, implement this functionality natively by adding
a "{bbox}" parameter to templated tile URLs, which will be replaced at request
time with the tile's lat/lon bounding box.

Examples of services that use the templated bounding box method:
1) ArcGIS rest service:
https://gis.charttools.noaa.gov/arcgis/rest/services/MCS/NOAAChartDisplay/MapServer/exts/MaritimeChartService/MapServer/export?dpi=96&transparent=true&format=png24&layers=show:0,1,2,3,4,5,6,7&bbox={bbox}&bboxSR=4326&imageSR=3857&size=256,256&f=image

2) WMS:
https://encdirect.noaa.gov/arcgis/services/encdirect/enc_harbour/MapServer/WmsServer?bbox={bbox}&format=image/png&service=WMS&version=1.1.1&request=GetMap&srs=EPSG:4326&width=256&height=256&layers=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29&map=&styles=