### PR TITLE
Show Saint-Lys in searc. Top proirity for full matched search results.

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/search/core/SearchCoreFactory.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/core/SearchCoreFactory.java
@@ -516,6 +516,9 @@ public class SearchCoreFactory {
 				Iterator<BinaryMapIndexReader> offlineIterator = phrase.getRadiusOfflineIndexes(DEFAULT_ADDRESS_BBOX_RADIUS * 5,
 						SearchPhraseDataType.ADDRESS);
 				String wordToSearch = phrase.getUnknownWordToSearch();
+				if (wordToSearch.length() <= 3) {
+					wordToSearch = phrase.getFullSearchPhrase();
+				}
 				while (offlineIterator.hasNext() && wordToSearch.length() > 0) {
 					BinaryMapIndexReader r = offlineIterator.next();
 					currentFile[0] = r;


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd/issues/14570) 
 

Show Saint-Lys in address search
<img width="200" alt="Screenshot 2022-10-18 at 12 43 07" src="https://user-images.githubusercontent.com/35684515/196367815-d3209032-6e2c-466e-8920-b6341f4ac26d.png">

Tune sorting. Show Saint-Lys (with full matching name)  in the top of list
<img width="200" alt="Screenshot 2022-10-18 at 12 41 56" src="https://user-images.githubusercontent.com/35684515/196367599-84311504-f732-4174-8eb6-01dcbc596cc5.png">

---

Delphi - in the top

<img width="150" alt="Screenshot 2022-10-18 at 14 01 05" src="https://user-images.githubusercontent.com/35684515/196386611-e6778484-b2b9-47bc-a31f-50b92e707c2d.png"> <img width="150" alt="Screenshot 2022-10-18 at 14 01 16" src="https://user-images.githubusercontent.com/35684515/196386627-f04284ff-e293-42de-8a76-448c3cc4165a.png"> <img width="150" alt="Screenshot 2022-10-18 at 14 01 31" src="https://user-images.githubusercontent.com/35684515/196386677-d5b3b06c-63d9-4aa6-8e69-01275a5ad278.png"> <img width="150" alt="Screenshot 2022-10-18 at 14 01 53" src="https://user-images.githubusercontent.com/35684515/196386696-77cb2c4f-c51a-4d32-8b73-7add5d907617.png">

---

Hawkinsville - in the top

<img width="150" alt="Screenshot 2022-10-18 at 15 06 12" src="https://user-images.githubusercontent.com/35684515/196401325-188e5521-76ae-476e-b00a-528c4fe9bbea.png"> <img width="150" alt="Screenshot 2022-10-18 at 15 06 28" src="https://user-images.githubusercontent.com/35684515/196401353-c58303b2-8894-473b-81a3-f7c3714674c6.png">

---

Stresa - in the top

<img width="150" alt="Screenshot 2022-10-18 at 15 17 07" src="https://user-images.githubusercontent.com/35684515/196403774-f5476d2a-3306-4060-92e6-5a097dfb1e51.png">  <img width="150" alt="Screenshot 2022-10-18 at 15 17 24" src="https://user-images.githubusercontent.com/35684515/196403795-fdd59bc7-d949-40a9-bbfc-b09abd17ff96.png">

