### PR TITLE
Fix #14993 Custom POI disappears when screen turns off

### DIFF
--- a/OsmAnd/src/net/osmand/plus/AppVersionUpgradeOnInit.java
+++ b/OsmAnd/src/net/osmand/plus/AppVersionUpgradeOnInit.java
@@ -69,11 +69,11 @@ import java.util.Set;
 
 class AppVersionUpgradeOnInit {
 
-	public static final String FIRST_TIME_APP_RUN = "FIRST_TIME_APP_RUN"; //$NON-NLS-1$
-	public static final String VERSION_INSTALLED_NUMBER = "VERSION_INSTALLED_NUMBER"; //$NON-NLS-1$
-	public static final String NUMBER_OF_STARTS = "NUMBER_OF_STARTS"; //$NON-NLS-1$
-	public static final String FIRST_INSTALLED = "FIRST_INSTALLED"; //$NON-NLS-1$
-	public static final String UPDATE_TIME_MS = "UPDATE_TIME_MS"; //$NON-NLS-1$
+	private static final String FIRST_TIME_APP_RUN = "FIRST_TIME_APP_RUN";
+	private static final String VERSION_INSTALLED_NUMBER = "VERSION_INSTALLED_NUMBER";
+	private static final String NUMBER_OF_STARTS = "NUMBER_OF_STARTS";
+	private static final String FIRST_INSTALLED = "FIRST_INSTALLED";
+	private static final String UPDATE_TIME_MS = "UPDATE_TIME_MS";
 
 	// 22 - 2.2
 	public static final int VERSION_2_2 = 22;
@@ -108,13 +108,14 @@ class AppVersionUpgradeOnInit {
 	// 4006 - 4.0-06 (Merge widgets: Intermediate time to go and Intermediate arrival time, Time to go and Arrival time)
 	public static final int VERSION_4_0_06 = 4006;
 	// 4007 - 4.0-07 (Update type of "Selected POI" preference)
-	public static final int VERSION_4_0_07 = 4007;
+	public static final int VERSION_4_3_01 = 4301;
 
-	public static final int LAST_APP_VERSION = VERSION_4_0_07;
+	public static final int LAST_APP_VERSION = VERSION_4_3_01;
 
-	static final String VERSION_INSTALLED = "VERSION_INSTALLED";
+	private static final String VERSION_INSTALLED = "VERSION_INSTALLED";
 
 	private final OsmandApplication app;
+
 	private int prevAppVersion;
 	private boolean appVersionChanged;
 	private boolean firstTime;
@@ -228,7 +229,7 @@ class AppVersionUpgradeOnInit {
 				if (prevAppVersion < VERSION_4_0_06) {
 					mergeTimeToNavigationPointWidgets();
 				}
-				if (prevAppVersion < VERSION_4_0_07) {
+				if (prevAppVersion < VERSION_4_3_01) {
 					updateSelectedPoiPreference();
 				}
 				startPrefs.edit().putInt(VERSION_INSTALLED_NUMBER, lastVersion).commit();
@@ -622,11 +623,11 @@ class AppVersionUpgradeOnInit {
 
 	private void updateSelectedPoiPreference() {
 		OsmandSettings settings = app.getSettings();
-		OsmandPreference<String> oldPreference = new StringPreference(
-				settings, "selected_poi_filter_for_map", null).makeProfile().cache();
+		OsmandPreference<String> oldPreference = new StringPreference(settings,
+				"selected_poi_filter_for_map", null).makeProfile();
 		for (ApplicationMode appMode : ApplicationMode.allPossibleValues()) {
 			String filterId = oldPreference.getModeValue(appMode);
-			if (filterId != null && !filterId.trim().isEmpty()) {
+			if (!Algorithms.isBlank(filterId)) {
 				Set<String> selectedIds = new LinkedHashSet<>();
 				Collections.addAll(selectedIds, filterId.split(","));
 				settings.setSelectedPoiFilters(appMode, selectedIds);

--- a/OsmAnd/src/net/osmand/plus/poi/PoiFiltersHelper.java
+++ b/OsmAnd/src/net/osmand/plus/poi/PoiFiltersHelper.java
@@ -575,8 +575,8 @@ public class PoiFiltersHelper {
 		}
 		Set<PoiUIFilter> selectedPoiFilters = new TreeSet<>();
 		Set<String> selectedFiltersIds = application.getSettings().getSelectedPoiFilters();
-		for (String f : selectedFiltersIds) {
-			PoiUIFilter filter = getFilterById(f);
+		for (String filterId : selectedFiltersIds) {
+			PoiUIFilter filter = getFilterById(filterId);
 			if (filter != null) {
 				selectedPoiFilters.add(filter);
 			}

--- a/OsmAnd/src/net/osmand/plus/poi/PoiFiltersHelper.java
+++ b/OsmAnd/src/net/osmand/plus/poi/PoiFiltersHelper.java
@@ -574,7 +574,8 @@ public class PoiFiltersHelper {
 			return;
 		}
 		Set<PoiUIFilter> selectedPoiFilters = new TreeSet<>();
-		for (String f : application.getSettings().getSelectedPoiFilters()) {
+		Set<String> selectedFiltersIds = application.getSettings().getSelectedPoiFilters();
+		for (String f : selectedFiltersIds) {
 			PoiUIFilter filter = getFilterById(f);
 			if (filter != null) {
 				selectedPoiFilters.add(filter);

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -2698,20 +2698,21 @@ public class OsmandSettings {
 
 	// Avoid using this property, probably you need to use PoiFiltersHelper.getSelectedPoiFilters()
 	private final ListStringPreference SELECTED_POI_FILTER_FOR_MAP = (ListStringPreference)
-			new ListStringPreference(this, "selected_poi_filter_for_map_list", null, ",,").makeProfile().cache();
+			new ListStringPreference(this, "selected_poi_filters_for_map", null, ",,").makeProfile().cache();
 
+	@NonNull
 	public Set<String> getSelectedPoiFilters() {
 		List<String> result = SELECTED_POI_FILTER_FOR_MAP.getStringsList();
-		return result != null ? new HashSet<>(result) : Collections.emptySet();
+		return result != null ? new LinkedHashSet<>(result) : Collections.emptySet();
 	}
 
-	public void setSelectedPoiFilters(Set<String> poiFilters) {
+	public void setSelectedPoiFilters(@Nullable Set<String> poiFilters) {
 		setSelectedPoiFilters(APPLICATION_MODE.get(), poiFilters);
 	}
 
-	public void setSelectedPoiFilters(@NonNull ApplicationMode appMode, Set<String> poiFilters) {
-		List<String> asList = poiFilters != null ? new ArrayList<>(poiFilters) : null;
-		SELECTED_POI_FILTER_FOR_MAP.setStringsListForProfile(appMode, asList);
+	public void setSelectedPoiFilters(@NonNull ApplicationMode appMode, @Nullable Set<String> poiFilters) {
+		List<String> filters = poiFilters != null ? new ArrayList<>(poiFilters) : null;
+		SELECTED_POI_FILTER_FOR_MAP.setStringsListForProfile(appMode, filters);
 	}
 
 	public final ListStringPreference POI_FILTERS_ORDER = (ListStringPreference)

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -2696,25 +2696,13 @@ public class OsmandSettings {
 
 	public final OsmandPreference<String> LAST_SELECTED_GPX_TRACK_FOR_NEW_POINT = new StringPreference(this, "last_selected_gpx_track_for_new_point", null).makeGlobal().cache();
 
-	private final OsmandPreference<String> SELECTED_POI_FILTER_FOR_MAP__OUTDATED = new StringPreference(this, "selected_poi_filter_for_map", null).makeProfile().cache();
-
 	// Avoid using this property, probably you need to use PoiFiltersHelper.getSelectedPoiFilters()
 	private final ListStringPreference SELECTED_POI_FILTER_FOR_MAP = (ListStringPreference)
 			new ListStringPreference(this, "selected_poi_filter_for_map_list", null, ",,").makeProfile().cache();
 
 	public Set<String> getSelectedPoiFilters() {
 		List<String> result = SELECTED_POI_FILTER_FOR_MAP.getStringsList();
-		return result != null ? new HashSet<>(result) : getSelectedPoiFiltersOld();
-	}
-
-	// Get value from the old version of the preference
-	private Set<String> getSelectedPoiFiltersOld() {
-		Set<String> result = new LinkedHashSet<>();
-		String filtersId = SELECTED_POI_FILTER_FOR_MAP__OUTDATED.get();
-		if (filtersId != null && !filtersId.trim().isEmpty()) {
-			Collections.addAll(result, filtersId.split(","));
-		}
-		return result;
+		return result != null ? new HashSet<>(result) : Collections.emptySet();
 	}
 
 	public void setSelectedPoiFilters(Set<String> poiFilters) {
@@ -2724,7 +2712,6 @@ public class OsmandSettings {
 	public void setSelectedPoiFilters(@NonNull ApplicationMode appMode, Set<String> poiFilters) {
 		List<String> asList = poiFilters != null ? new ArrayList<>(poiFilters) : null;
 		SELECTED_POI_FILTER_FOR_MAP.setStringsListForProfile(appMode, asList);
-		SELECTED_POI_FILTER_FOR_MAP__OUTDATED.resetToDefault();
 	}
 
 	public final ListStringPreference POI_FILTERS_ORDER = (ListStringPreference)

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -2696,12 +2696,21 @@ public class OsmandSettings {
 
 	public final OsmandPreference<String> LAST_SELECTED_GPX_TRACK_FOR_NEW_POINT = new StringPreference(this, "last_selected_gpx_track_for_new_point", null).makeGlobal().cache();
 
+	private final OsmandPreference<String> SELECTED_POI_FILTER_FOR_MAP__OUTDATED = new StringPreference(this, "selected_poi_filter_for_map", null).makeProfile().cache();
+
 	// Avoid using this property, probably you need to use PoiFiltersHelper.getSelectedPoiFilters()
-	public final OsmandPreference<String> SELECTED_POI_FILTER_FOR_MAP = new StringPreference(this, "selected_poi_filter_for_map", null).makeProfile().cache();
+	private final ListStringPreference SELECTED_POI_FILTER_FOR_MAP = (ListStringPreference)
+			new ListStringPreference(this, "selected_poi_filter_for_map_list", null, ",,").makeProfile().cache();
 
 	public Set<String> getSelectedPoiFilters() {
+		List<String> result = SELECTED_POI_FILTER_FOR_MAP.getStringsList();
+		return result != null ? new HashSet<>(result) : getSelectedPoiFiltersOld();
+	}
+
+	// Get value from the old version of the preference
+	private Set<String> getSelectedPoiFiltersOld() {
 		Set<String> result = new LinkedHashSet<>();
-		String filtersId = SELECTED_POI_FILTER_FOR_MAP.get();
+		String filtersId = SELECTED_POI_FILTER_FOR_MAP__OUTDATED.get();
 		if (filtersId != null && !filtersId.trim().isEmpty()) {
 			Collections.addAll(result, filtersId.split(","));
 		}
@@ -2713,7 +2722,9 @@ public class OsmandSettings {
 	}
 
 	public void setSelectedPoiFilters(@NonNull ApplicationMode appMode, Set<String> poiFilters) {
-		SELECTED_POI_FILTER_FOR_MAP.setModeValue(appMode, android.text.TextUtils.join(",", poiFilters));
+		List<String> asList = poiFilters != null ? new ArrayList<>(poiFilters) : null;
+		SELECTED_POI_FILTER_FOR_MAP.setStringsListForProfile(appMode, asList);
+		SELECTED_POI_FILTER_FOR_MAP__OUTDATED.resetToDefault();
 	}
 
 	public final ListStringPreference POI_FILTERS_ORDER = (ListStringPreference)


### PR DESCRIPTION
We should not use a single comma sign as a delimiter when storing a list of POI selected to display.