### PR TITLE
Navigation: use cancel/stop instead of dismiss to stop navigation

### DIFF
--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/MapRouteInfoMenu.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/MapRouteInfoMenu.java
@@ -1189,7 +1189,7 @@ public class MapRouteInfoMenu implements IRouteInformationListener, CardListener
 		View cancelButton = mainView.findViewById(R.id.cancel_button);
 		TextView cancelButtonText = mainView.findViewById(R.id.cancel_button_descr);
 		if (helper.isRouteCalculated() || helper.isRouteBeingCalculated() || isTransportRouteCalculated()) {
-			cancelButtonText.setText(R.string.shared_string_dismiss);
+			cancelButtonText.setText(R.string.stop_navigation_service);
 		} else {
 			cancelButtonText.setText(R.string.shared_string_cancel);
 		}


### PR DESCRIPTION
This PR is meant to fix the following issue:
![Screenshot_20221211-224053_Trebuchet](https://user-images.githubusercontent.com/12595971/206930567-733d9802-a67b-4601-847b-ccded68f54dd.png)

As you can see the button to stop navigation is translated to french as "Ignorer" which means "ignore", translated from "dissmiss" I think. In my opinion the button should be more assertive: "stop" or something like that.

Unfortunately I failed to build the app locally to check that I fixed the right file.
```
> Task :OsmAnd:processAndroidFullOpengldebugArm64ReleaseResources FAILED

FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':OsmAnd-java:test'.
> There were failing tests. See the report at: file:///home/symphorien/src/OsmAnd/OsmAnd-java/build/reports/tests/test/index.html

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
==============================================================================

2: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':OsmAnd:processAndroidFullOpengldebugArm64ReleaseResources'.
> A failure occurred while executing com.android.build.gradle.internal.res.LinkApplicationAndroidResourcesTask$TaskAction
   > Android resource linking failed
     warn: removing resource net.osmand.plus:string/advanced_widgets without required default value.
     warn: removing resource net.osmand.plus:string/antplus_plugin_description without required default value.
     warn: removing resource net.osmand.plus:string/antplus_plugin_name without required default value.
     warn: removing resource net.osmand.plus:string/attach_to_roads_banner_desc without required default value.
     warn: removing resource net.osmand.plus:string/grey_color_slope without required default value.
     warn: removing resource net.osmand.plus:string/index_settings without required default value.
     warn: removing resource net.osmand.plus:string/ltr_or_rtl_combine without required default value.
     warn: removing resource net.osmand.plus:string/map_widget_fps_info without required default value.
     warn: removing resource net.osmand.plus:string/poi_callable without required default value.
     warn: removing resource net.osmand.plus:string/poi_callable_no without required default value.
     warn: removing resource net.osmand.plus:string/poi_callable_yes without required default value.
     warn: removing resource net.osmand.plus:string/poi_car_yes without required default value.
     warn: removing resource net.osmand.plus:string/poi_playground_type without required default value.
     warn: removing resource net.osmand.plus:string/poi_truck_yes without required default value.
     warn: removing resource net.osmand.plus:string/pro_widgets without required default value.
     warn: removing resource net.osmand.plus:string/purchases_feature_desc_advanced_widgets without required default value.
     warn: removing resource net.osmand.plus:string/rendering_attr_OSMMapperAssistantWaterwayTunnels_description without required default value.
     warn: removing resource net.osmand.plus:string/rendering_attr_noNatureReserveBoundaries_description without required default value.
     warn: removing resource net.osmand.plus:string/rendering_attr_noNatureReserveBoundaries_name without required default value.
     warn: removing resource net.osmand.plus:string/rendering_attr_showMtbScaleUphill_description without required default value.
     warn: removing resource net.osmand.plus:string/rendering_attr_showMtbScaleUphill_name without required default value.
     net.osmand.plus.OsmAnd-OsmAnd-32:/layout/data_storage_list_item.xml:22: error: resource drawable/mm_storage_tank (aka net.osmand.plus:drawable/mm_storage_tank) not found.
     net.osmand.plus.OsmAnd-OsmAnd-32:/layout/data_storage_list_item.xml:84: error: resource drawable/mm_storage_tank (aka net.osmand.plus:drawable/mm_storage_tank) not found.
     net.osmand.plus.OsmAnd-OsmAnd-32:/layout/data_storage_memory_used_item.xml:15: error: resource drawable/mm_storage_tank (aka net.osmand.plus:drawable/mm_storage_tank) not found.
     net.osmand.plus.OsmAnd-OsmAnd-32:/layout/fragment_transport_lines.xml:48: error: resource drawable/mm_amenity_bus_station (aka net.osmand.plus:drawable/mm_amenity_bus_station) not found.
     net.osmand.plus.OsmAnd-OsmAnd-32:/layout/point_editor_button.xml:22: error: resource drawable/mx_special_star_stroked (aka net.osmand.plus:drawable/mx_special_star_stroked) not found.
     error: failed linking file resources.


* Try:
     error: failed linking file resources.
```