### PR TITLE
Fix crash MapTiledCollectionProvider

### DIFF
--- a/OsmAnd/src/net/osmand/plus/measurementtool/MeasurementToolLayer.java
+++ b/OsmAnd/src/net/osmand/plus/measurementtool/MeasurementToolLayer.java
@@ -1031,6 +1031,7 @@ public class MeasurementToolLayer extends OsmandMapLayer implements IContextMenu
 		clearCachedCounters();
 		clearCachedRenderables();
 		clearPointsProvider();
+		clearXAxisPoints();
 		multiProfileGeometry.clearWay();
 	}
 

--- a/OsmAnd/src/net/osmand/plus/views/layers/GPXLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/GPXLayer.java
@@ -1778,6 +1778,14 @@ public class GPXLayer extends OsmandMapLayer implements IContextMenuProvider, IM
 		}
 	}
 
+	@Override
+	public void destroyLayer() {
+		super.destroyLayer();
+		clearXAxisPoints();
+		clearPoints();
+		clearSelectedFilesSplits();
+	}
+
 	private void syncGpx(GPXFile gpxFile) {
 		MapMarkersGroup group = app.getMapMarkersHelper().getMarkersGroup(gpxFile);
 		if (group != null) {

--- a/OsmAnd/src/net/osmand/plus/views/layers/RouteLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/RouteLayer.java
@@ -811,6 +811,12 @@ public class RouteLayer extends BaseRouteLayer implements IContextMenuProvider {
 		return false;
 	}
 
+	@Override
+	public void destroyLayer() {
+		super.destroyLayer();
+		clearXAxisPoints();
+	}
+
 	/** OpenGL */
 	private void resetLayer() {
 		clearXAxisPoints();


### PR DESCRIPTION
Apk Version : 4.3.2 4302
Exception occured in thread Thread[Thread-27936,5,main] : 
java.lang.NullPointerException: null upcall object in OsmAnd::interface_MapTiledCollectionProvider::getPoint31