### PR TITLE
Add several recycling waste types

### DIFF
--- a/OsmAnd/res/values-en-rGB/phrases.xml
+++ b/OsmAnd/res/values-en-rGB/phrases.xml
@@ -78,6 +78,7 @@
 	<string name="poi_railway_buffer_stop">Railway buffer stop</string>
 
     <string name="poi_recycling_centre">Type: recycling centre</string>
+    <string name="poi_recycling_aluminium_cans">Aluminium cans</string>
 
     <string name="poi_waste_disposal">Waste disposal</string>
 	<string name="poi_waste_basket">Waste basket</string>

--- a/OsmAnd/res/values-ru/phrases.xml
+++ b/OsmAnd/res/values-ru/phrases.xml
@@ -288,6 +288,10 @@
     <string name="poi_recycling_car_batteries">Автомобильные аккумуляторы</string>
     <string name="poi_recycling_cars">Автомобили</string>
     <string name="poi_recycling_bicycles">Велосипеды</string>
+    <string name="poi_recycling_plastic_bottle_caps">Крышки от пластиковых бутылок</string>
+    <string name="poi_recycling_aluminium_cans">Алюминиевые банки</string>
+    <string name="poi_recycling_pet_drink_bottles">PET-бутылки из под напитков</string>
+    <string name="poi_recycling_textiles">Текстиль</string>
     <string name="poi_surveillance">Камера видеонаблюдения</string>
     <string name="poi_construction">Стройка</string>
     <string name="poi_works">Завод</string>

--- a/OsmAnd/res/values-uk/phrases.xml
+++ b/OsmAnd/res/values-uk/phrases.xml
@@ -341,6 +341,10 @@
     <string name="poi_recycling_car_batteries">Акумулятори автомобільні</string>
     <string name="poi_recycling_cars">Автомобілі</string>
     <string name="poi_recycling_bicycles">Велосипеди</string>
+    <string name="poi_recycling_plastic_bottle_caps">Кришки від пластикових пляшок</string>
+    <string name="poi_recycling_aluminium_cans">Алюмінієві банки</string>
+    <string name="poi_recycling_pet_drink_bottles">PET-пляшки від напоїв</string>
+    <string name="poi_recycling_textiles">Текстиль</string>
     <string name="poi_landfill">Звалище</string>
     <string name="poi_industrial">Промислова зона</string>
     <string name="poi_quarry">Карʼєр</string>

--- a/OsmAnd/res/values/phrases.xml
+++ b/OsmAnd/res/values/phrases.xml
@@ -600,6 +600,10 @@
 	<string name="poi_recycling_car_batteries">Car batteries</string>
 	<string name="poi_recycling_cars">Cars</string>
 	<string name="poi_recycling_bicycles">Bicycles</string>
+	<string name="poi_recycling_plastic_bottle_caps">Plastic bottle caps</string>
+	<string name="poi_recycling_aluminium_cans">Aluminum cans</string>
+	<string name="poi_recycling_pet_drink_bottles">PET beverage bottles</string>
+	<string name="poi_recycling_textiles">Textiles</string>
 
 	<string name="poi_landfill">Landfill</string>
 	<string name="poi_landfill_waste_nuclear">Nuclear waste</string>


### PR DESCRIPTION
This adds strings for four new types of recycling waste that I see in OSM. They are all present in the table for [`amenity=recycling`][table].

This PR replaces https://github.com/osmandapp/OsmAnd-iOS/pull/2593 and https://github.com/osmandapp/OsmAnd-resources/pull/937.

How can I test this change locally on iOS? I don't know how to sync these `phrases.xml`s to `ios`.
* I tried `resources/poi/copy_phrases.sh`, but it prints a lot of errors like `cp: directory phrases/en does not exist`;
* tried `ios/Scripts/add_translations.swift`, and killed it after ~15 minutes of running, it only updated `Resources/Localizations/*.lproj/Localizable.strings` files;
* running `ios/prepare.sh` doesn't update any `xml`s.

I was able to generate a piece of the map with the modified `poi_types.xml` https://github.com/osmandapp/OsmAnd-resources/pull/937/files#diff-b62dc5852daf08d35f4ece3641ea4bc251e0e09788f1e6935c0c2467158a46feR4592, so the current iOS version shows `Recycling_Plastic_Bottle_Caps: yes`:
<img width="375" alt="recycling@2x" src="https://user-images.githubusercontent.com/9215359/221371569-77a13f73-b9b0-456a-b188-1a5949952f32.png">
https://github.com/osmandapp/OsmAnd-resources/pull/937 was closed, but do I still need to update `poi_types.xml` somehow?

[table]: https://wiki.openstreetmap.org/wiki/Tag:amenity=recycling#Accepts