### PR TITLE
Use increased file size only where it was used before

### DIFF
--- a/OsmAnd/src/net/osmand/plus/importfiles/ImportHelper.java
+++ b/OsmAnd/src/net/osmand/plus/importfiles/ImportHelper.java
@@ -523,10 +523,10 @@ public class ImportHelper {
 		File dir = app.getAppPath(GPX_INDEX_DIR);
 		List<GPXInfo> gpxInfoList = GpxUiHelper.getSortedGPXFilesInfoByDate(dir, true);
 		for (GPXInfo gpxInfo : gpxInfoList) {
-			String fileName = gpxInfo.getFileName();
-			String nameWithoutDirs = Algorithms.getFileWithoutDirs(fileName);
-			if (nameWithoutDirs.equals(name) && gpxInfo.getFileSize() == fileSize) {
-				return fileName;
+			String filePath = gpxInfo.getFileName();
+			String fileName = Algorithms.getFileWithoutDirs(filePath);
+			if (Algorithms.objectEquals(name, fileName) && gpxInfo.getFileSize() == fileSize) {
+				return filePath;
 			}
 		}
 		return null;

--- a/OsmAnd/src/net/osmand/plus/myplaces/ui/AvailableGPXFragment.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/ui/AvailableGPXFragment.java
@@ -744,7 +744,7 @@ public class AvailableGPXFragment extends OsmandExpandableListFragment implement
 			item.setIconId(R.drawable.ic_notification_track);
 
 			items.add(item);
-			size[0] += gpxInfo.getFileSize();
+			size[0] += gpxInfo.getIncreasedFileSize();
 		}
 		List<SelectableItem<GPXInfo>> selectedItems = new ArrayList<>(items);
 		FragmentManager manager = activity.getSupportFragmentManager();
@@ -1562,8 +1562,8 @@ public class AvailableGPXFragment extends OsmandExpandableListFragment implement
 			String date = "";
 			String size = "";
 
-			if (child.getFileSize() > 0) {
-				size = AndroidUtils.formatSize(v.getContext(), child.getFileSize());
+			if (child.getIncreasedFileSize() > 0) {
+				size = AndroidUtils.formatSize(v.getContext(), child.getIncreasedFileSize());
 			}
 			DateFormat df = app.getResourceManager().getDateFormat();
 			long lastModified = child.getLastModified();

--- a/OsmAnd/src/net/osmand/plus/plugins/osmedit/dialogs/UploadMultipleGPXBottomSheet.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/osmedit/dialogs/UploadMultipleGPXBottomSheet.java
@@ -56,7 +56,7 @@ public class UploadMultipleGPXBottomSheet extends MultipleSelectionBottomSheet<G
 	private void updateSizeDescription() {
 		long size = 0;
 		for (SelectableItem<GPXInfo> item : selectedItems) {
-			size += item.getObject().getFileSize();
+			size += item.getObject().getIncreasedFileSize();
 		}
 		String total = getString(R.string.shared_string_total);
 		titleDescription.setText(getString(R.string.ltr_or_rtl_combine_via_colon, total,

--- a/OsmAnd/src/net/osmand/plus/track/helpers/GPXInfo.java
+++ b/OsmAnd/src/net/osmand/plus/track/helpers/GPXInfo.java
@@ -4,7 +4,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import net.osmand.gpx.GPXFile;
-import net.osmand.plus.track.helpers.GpxUiHelper;
 
 import java.io.File;
 
@@ -25,7 +24,7 @@ public class GPXInfo {
 		this.file = file;
 		this.fileName = fileName;
 		this.name = GpxUiHelper.getGpxTitle(fileName);
-		this.fileSize = file != null ? file.length() + 512 : 0;
+		this.fileSize = file != null ? file.length() : 0;
 		this.lastModified = file != null ? file.lastModified() : 0;
 	}
 
@@ -45,6 +44,15 @@ public class GPXInfo {
 
 	public long getFileSize() {
 		return fileSize;
+	}
+
+	/**
+	 * @return a file size increased by 512 bytes,
+	 * which allows for proper rounding of small files less than 1KB in size.
+	 * Without this rounding, the file size may be displayed as 0KB, which is inaccurate.
+	 */
+	public long getIncreasedFileSize() {
+		return fileSize > 0 ? fileSize + 512 : 0;
 	}
 
 	@Nullable


### PR DESCRIPTION
Retained the logic proposed as a fix (https://github.com/osmandapp/OsmAnd/commit/cd1097a95a3efe77ff1ac8fe75e2e4b6b03464de) for this problem (#1239), but also made it possible to get the real (not increased) file size in places where it is needed.