### PR TITLE
Fix crash #16755 Use default layoutId unless otherwise specified

### DIFF
--- a/OsmAnd/src/net/osmand/plus/widgets/popup/PopUpMenuDisplayData.java
+++ b/OsmAnd/src/net/osmand/plus/widgets/popup/PopUpMenuDisplayData.java
@@ -5,11 +5,13 @@ import android.view.View;
 import androidx.annotation.ColorInt;
 import androidx.annotation.LayoutRes;
 
+import net.osmand.plus.R;
+
 import java.util.List;
 
 public class PopUpMenuDisplayData {
 	public View anchorView;
-	public @LayoutRes int layoutId;
+	public @LayoutRes int layoutId = R.layout.popup_menu_item;
 	public @ColorInt int bgColor;
 	public boolean nightMode;
 	public PopUpMenuWidthMode widthMode = PopUpMenuWidthMode.AS_ANCHOR_VIEW;


### PR DESCRIPTION
Fix crash that appeared after refactoring PopUpMenu in this commit: https://github.com/osmandapp/OsmAnd/pull/16317/commits/b113ca7fc0d168d2c2f80822e5bb4187082a741a

In this commit the default layoutId for a popup menu item was accidentally lost.