### PR TITLE
Change DATE_FORMAT in  Export Settings Filename to ISO8601

### DIFF
--- a/OsmAnd/src/net/osmand/plus/settings/fragments/ExportSettingsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/settings/fragments/ExportSettingsFragment.java
@@ -54,7 +54,7 @@ public class ExportSettingsFragment extends BaseSettingsListFragment {
 	private static final String PROGRESS_VALUE_KEY = "progress_value_key";
 	private static final String SELECTED_TYPES = "selected_types";
 
-	private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("dd-MM-yy", Locale.US);
+	private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
 
 	private ProgressDialog progress;
 	private ApplicationMode appMode;


### PR DESCRIPTION
dd-MM-yy is easily confused with the ISO 8601 standard for dates, so I suggest to stick to the standard.

For further reference: https://xkcd.com/1179/