### PR TITLE
Spelling: Update map → Update

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -4853,7 +4853,7 @@ Download tile maps directly, or copy them as SQLite database files to OsmAnd\'s 
     <string name="data_settings_descr">Specify language, download/reload data.</string>
     <string name="data_settings">Data</string>
     <string name="additional_settings">Additional settings</string>
-    <string name="update_tile">Update map</string>
+    <string name="update_tile">Update</string>
     <string name="reload_tile">Reload tile</string>
     <string name="mark_point">Target</string>
     <string name="use_english_names_descr">Select between local and English names.</string>


### PR DESCRIPTION
This is shown in the Maps→Updates section for maps, but also for the Wikipedia files and Wikivoyage (which are not).
Having it be just "Update" works better, seeing as all entries already have a title. aka. "Travel guides" for Wikivoyage vs.
having dedicated entries for each "Update map" "Update travel guide" etc.

Could be that this "Update map" is used elsewhere, but there is a separate one for the context menu already.