### PR TITLE
Adding new parameter - custom gpx filename - to AIDL gpx navigation

### DIFF
--- a/OsmAnd-api/src/net/osmand/aidlapi/navigation/NavigateGpxParams.java
+++ b/OsmAnd-api/src/net/osmand/aidlapi/navigation/NavigateGpxParams.java
@@ -16,6 +16,7 @@ public class NavigateGpxParams extends AidlParams {
 	private boolean snapToRoad;
 	private String snapToRoadMode;
 	private int snapToRoadThreshold;
+	private String customGpxFileName;
 
 	public NavigateGpxParams(String data, boolean force, boolean needLocationPermission) {
 		this.data = data;
@@ -93,6 +94,11 @@ public class NavigateGpxParams extends AidlParams {
 		return needLocationPermission;
 	}
 
+	public String getCustomGpxFileName() { return customGpxFileName; }
+
+	public void setCustomGpxFileName(String customGpxFileName) { this.customGpxFileName = customGpxFileName; }
+
+
 	@Override
 	public void writeToBundle(Bundle bundle) {
 		bundle.putString("data", data);
@@ -103,6 +109,7 @@ public class NavigateGpxParams extends AidlParams {
 		bundle.putBoolean("snapToRoad", snapToRoad);
 		bundle.putString("snapToRoadMode", snapToRoadMode);
 		bundle.putInt("snapToRoadThreshold", snapToRoadThreshold);
+		bundle.putString("customGpxFileName", customGpxFileName);
 	}
 
 	@Override
@@ -115,5 +122,6 @@ public class NavigateGpxParams extends AidlParams {
 		snapToRoad = bundle.getBoolean("snapToRoad");
 		snapToRoadMode = bundle.getString("snapToRoadMode");
 		snapToRoadThreshold = bundle.getInt("snapToRoadThreshold");
+		customGpxFileName = bundle.getString("customGpxFileName");
 	}
 }

--- a/OsmAnd/src/net/osmand/aidl/OsmandAidlApi.java
+++ b/OsmAnd/src/net/osmand/aidl/OsmandAidlApi.java
@@ -207,6 +207,7 @@ public class OsmandAidlApi {
 	private static final String AIDL_SNAP_TO_ROAD = "aidl_snap_to_road";
 	private static final String AIDL_SNAP_TO_ROAD_MODE = "aidl_snap_to_road_mode";
 	private static final String AIDL_SNAP_TO_ROAD_THRESHOLD = "aidl_snap_to_road_threshold";
+	private static final String AIDL_CUSTOM_GPX_FILENAME = "aidl_custom_gpx_filename";
 	private static final String AIDL_SEARCH_QUERY = "aidl_search_query";
 	private static final String AIDL_SEARCH_LAT = "aidl_search_lat";
 	private static final String AIDL_SEARCH_LON = "aidl_search_lon";
@@ -764,6 +765,7 @@ public class OsmandAidlApi {
 						params.setSnapToRoad(intent.getBooleanExtra(AIDL_SNAP_TO_ROAD, false));
 						params.setSnapToRoadMode(intent.getStringExtra(AIDL_SNAP_TO_ROAD_MODE));
 						params.setSnapToRoadThreshold(intent.getIntExtra(AIDL_SNAP_TO_ROAD_THRESHOLD, 50));
+						params.setCustomGpxFileName(intent.getStringExtra(AIDL_CUSTOM_GPX_FILENAME));
 						ExternalApiHelper.saveAndNavigateGpx(mapActivity, gpx, params);
 					}
 				}
@@ -1866,7 +1868,7 @@ public class OsmandAidlApi {
 
 	boolean navigateGpxV2(String data, Uri uri, boolean force, boolean requestLocationPermission,
 	                      boolean passWholeRoute, boolean snapToRoad, String snapToRoadMode,
-	                      int snapToRoadThreshold) {
+	                      int snapToRoadThreshold, String customGpxFileName) {
 		Intent intent = new Intent();
 		intent.setAction(AIDL_NAVIGATE_GPX);
 		intent.putExtra(AIDL_DATA, data);
@@ -1877,6 +1879,7 @@ public class OsmandAidlApi {
 		intent.putExtra(AIDL_SNAP_TO_ROAD, snapToRoad);
 		intent.putExtra(AIDL_SNAP_TO_ROAD_MODE, snapToRoadMode);
 		intent.putExtra(AIDL_SNAP_TO_ROAD_THRESHOLD, snapToRoadThreshold);
+		intent.putExtra(AIDL_CUSTOM_GPX_FILENAME, customGpxFileName);
 		app.sendBroadcast(intent);
 		return true;
 	}

--- a/OsmAnd/src/net/osmand/aidl/OsmandAidlServiceV2.java
+++ b/OsmAnd/src/net/osmand/aidl/OsmandAidlServiceV2.java
@@ -716,7 +716,8 @@ public class OsmandAidlServiceV2 extends Service implements AidlCallbackListener
 				OsmandAidlApi api = getApi("navigateGpx");
 				return params != null && api != null && api.navigateGpxV2(params.getData(), params.getUri(),
 						params.isForce(), params.isNeedLocationPermission(), params.isPassWholeRoute(),
-						params.isSnapToRoad(), params.getSnapToRoadMode(), params.getSnapToRoadThreshold());
+						params.isSnapToRoad(), params.getSnapToRoadMode(), params.getSnapToRoadThreshold(),
+						params.getCustomGpxFileName());
 			} catch (Exception e) {
 				handleException(e);
 				return false;

--- a/OsmAnd/src/net/osmand/plus/helpers/ExternalApiHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/ExternalApiHelper.java
@@ -657,13 +657,13 @@ public class ExternalApiHelper {
 			if (errorMessage == null && AndroidUtils.isActivityNotDestroyed(activity)) {
 				navigateGpx_ShowOnMap(activity, gpxFile, params);
 			}
-		});
+		}, params.getCustomGpxFileName());
 	}
 
-	private static void saveGpx(MapActivity mapActivity, GPXFile gpxFile, SaveGpxListener listener) {
+	private static void saveGpx(MapActivity mapActivity, GPXFile gpxFile, SaveGpxListener listener, String gpxFileName) {
 		if (Algorithms.isEmpty(gpxFile.path)) {
 			OsmandApplication app = mapActivity.getMyApplication();
-			String destFileName = "route" + IndexConstants.GPX_FILE_EXT;
+			String destFileName = (gpxFileName == null || gpxFileName.isEmpty() ? "route" : gpxFileName) + IndexConstants.GPX_FILE_EXT;
 			File destDir = app.getAppPath(IndexConstants.GPX_IMPORT_DIR);
 			File destFile = app.getAppPath(IndexConstants.GPX_IMPORT_DIR + destFileName);
 			while (destFile.exists()) {

--- a/OsmAnd/src/net/osmand/plus/helpers/GpxNavigationParams.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/GpxNavigationParams.java
@@ -8,6 +8,7 @@ public class GpxNavigationParams {
 	private boolean snapToRoad;
 	private String snapToRoadMode;
 	private int snapToRoadThreshold;
+	private String customGpxFileName;
 
 	public boolean isForce() {
 		return force;
@@ -56,4 +57,7 @@ public class GpxNavigationParams {
 	public void setSnapToRoadThreshold(int snapToRoadThreshold) {
 		this.snapToRoadThreshold = snapToRoadThreshold;
 	}
+	public String getCustomGpxFileName() { return customGpxFileName; }
+
+	public void setCustomGpxFileName(String customGpxFileName) { this.customGpxFileName = customGpxFileName; }
 }


### PR DESCRIPTION
Based on the current implementation all gpx filenames used bei gpx navigation routines have the "same" filename: route (x).gpx. Adding the ability to set the filename makes it a lot easier to delete specific gpx files.