### PR TITLE
Fix #17599 Crash on raster map download

### DIFF
--- a/OsmAnd/src/net/osmand/plus/plugins/rastermaps/DownloadTilesFragment.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/rastermaps/DownloadTilesFragment.java
@@ -41,6 +41,7 @@ import net.osmand.plus.helpers.AndroidUiHelper;
 import net.osmand.plus.plugins.rastermaps.CalculateMissingTilesTask.MissingTilesInfo;
 import net.osmand.plus.plugins.rastermaps.DownloadTilesHelper.DownloadType;
 import net.osmand.plus.resources.BitmapTilesCache;
+import net.osmand.plus.resources.SQLiteTileSource;
 import net.osmand.plus.settings.enums.MapLayerType;
 import net.osmand.plus.utils.AndroidUtils;
 import net.osmand.plus.utils.ColorUtilities;
@@ -115,7 +116,7 @@ public class DownloadTilesFragment extends BaseOsmAndFragment implements IMapLoc
 		downloadTilesHelper = app.getDownloadTilesHelper();
 		mapView = requireMapActivity().getMapView();
 		tilesPreviewDrawer = new TilesPreviewDrawer(app);
-		tileSource = settings.getLayerTileSource(layerToDownload.getMapLayerSettings(app), false);
+		tileSource = loadTileSource();
 		handler = new UpdateTilesHandler(() -> {
 			setupTilesDownloadInfo();
 			updateTilesPreview();
@@ -239,7 +240,7 @@ public class DownloadTilesFragment extends BaseOsmAndFragment implements IMapLoc
 				mapActivity.getMapLayers().selectMapLayer(mapActivity, false,
 						layerToDownload.getMapLayerSettings(app), mapSourceName -> {
 							if (shouldShowDialog(app)) {
-								tileSource = settings.getLayerTileSource(layerToDownload.getMapLayerSettings(app), false);
+								tileSource = loadTileSource();
 								int currentZoom = mapView.getZoom();
 								selectedMaxZoom = tileSource.getMaximumZoomSupported();
 								selectedMinZoom = Math.min(currentZoom, selectedMaxZoom);
@@ -608,6 +609,14 @@ public class DownloadTilesFragment extends BaseOsmAndFragment implements IMapLoc
 	private MapActivity getMapActivity() {
 		Activity activity = getActivity();
 		return activity == null ? null : ((MapActivity) activity);
+	}
+
+	private ITileSource loadTileSource() {
+		ITileSource tileSource = settings.getLayerTileSource(layerToDownload.getMapLayerSettings(app), false);
+		if (tileSource instanceof SQLiteTileSource) {
+			((SQLiteTileSource) tileSource).initDatabaseIfNeeded();
+		}
+		return tileSource;
 	}
 
 	public static boolean shouldShowDialog(@NonNull OsmandApplication app) {

--- a/OsmAnd/src/net/osmand/plus/resources/SQLiteTileSource.java
+++ b/OsmAnd/src/net/osmand/plus/resources/SQLiteTileSource.java
@@ -267,6 +267,10 @@ public class SQLiteTileSource implements ITileSource {
 		return Algorithms.stringsEqual(fileName, other.fileName);
 	}
 
+	public void initDatabaseIfNeeded() {
+		getDatabase();
+	}
+
 	protected synchronized SQLiteConnection getDatabase() {
 		if ((db == null || db.isClosed()) && file.exists()) {
 			LOG.debug("Open " + file.getAbsolutePath());


### PR DESCRIPTION
For SQLiteTileSource default 'maxZoom' parameter was initialized with wrong value (because value from the database was not pulled up in the right place). 
It caused a crash because the default maximum value could sometimes go ouside the allowed limits of the slider.