### PR TITLE
Fix various typos

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/CollatorStringMatcher.java
+++ b/OsmAnd-java/src/main/java/net/osmand/CollatorStringMatcher.java
@@ -133,7 +133,7 @@ public class CollatorStringMatcher implements StringMatcher {
 	 */
 	public static boolean cstartsWith(Collator collator, String fullTextP, String theStart, 
 			boolean checkBeginning, boolean checkSpaces, boolean equals) {
-		// FUTURE: This is not effective code, it runs on each comparision
+		// FUTURE: This is not effective code, it runs on each comparison
 		// It would be more efficient to normalize all strings in file and normalize search string before collator  
 		theStart = alignChars(theStart);
 		String searchIn = simplifyStringAndAlignChars(fullTextP);

--- a/OsmAnd-java/src/main/java/net/osmand/RenderingContext.java
+++ b/OsmAnd-java/src/main/java/net/osmand/RenderingContext.java
@@ -6,8 +6,8 @@ import net.osmand.render.RenderingRuleSearchRequest;
 
 public class RenderingContext {
 	public static enum ShadowRenderingMode {
-		// int shadowRenderingMode = 0; // no shadow (minumum CPU)
-		// int shadowRenderingMode = 1; // classic shadow (the implementaton in master)
+		// int shadowRenderingMode = 0; // no shadow (minimum CPU)
+		// int shadowRenderingMode = 1; // classic shadow (the implementation in master)
 		// int shadowRenderingMode = 2; // blur shadow (most CPU, but still reasonable)
 		// int shadowRenderingMode = 3; solid border (CPU use like classic version or even smaller)
 		NO_SHADOW(0), ONE_STEP(1), BLUR_SHADOW(2), SOLID_SHADOW(3);

--- a/OsmAnd-java/src/main/java/net/osmand/router/BinaryRoutePlanner.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/BinaryRoutePlanner.java
@@ -225,7 +225,7 @@ public class BinaryRoutePlanner {
 		if (segment.getSegmentStart() == 0 && !positiveDirection && segment.getRoad().getPointsLength() > 0) {
 			segment = loadSameSegment(ctx, segment, 1, reverseSearchWay);
 //		} else if (segment.getSegmentStart() == segment.getRoad().getPointsLength() - 1 && positiveDirection && segment.getSegmentStart() > 0) {
-		// assymetric cause we calculate initial point differently (segmentStart means that point is between ]segmentStart-1, segmentStart]
+		// asymmetric cause we calculate initial point differently (segmentStart means that point is between ]segmentStart-1, segmentStart]
 		} else if (segment.getSegmentStart() > 0 && positiveDirection) {
 			segment = loadSameSegment(ctx, segment, segment.getSegmentStart() - 1, reverseSearchWay);
 		}

--- a/OsmAnd-java/src/main/java/net/osmand/router/RoutePlannerFrontEnd.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RoutePlannerFrontEnd.java
@@ -369,7 +369,7 @@ public class RoutePlannerFrontEnd {
 	                                                GpxPoint start, GpxPoint next) throws IOException {
 		// step back to find to be sure 
 		// 1) route point is behind GpxPoint - minPointApproximation (end route point could slightly ahead)
-		// 2) we don't miss correct turn i.e. points could be attached to muliple routes
+		// 2) we don't miss correct turn i.e. points could be attached to multiple routes
 		// 3) to make sure that we perfectly connect to RoadDataObject points
 		double STEP_BACK_DIST = Math.max(gctx.ctx.config.minPointApproximation, gctx.ctx.config.minStepApproximation);
 		double d = 0;

--- a/OsmAnd-java/src/main/java/net/osmand/router/TestRouting.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/TestRouting.java
@@ -108,7 +108,7 @@ public class TestRouting {
 		if (!params.tests.isEmpty()) {
 			boolean allSuccess = runAllTests(params, lib);
 			if (allSuccess) {
-				System.out.println("All is successfull " + (System.currentTimeMillis() - time) + " ms");
+				System.out.println("All is successful " + (System.currentTimeMillis() - time) + " ms");
 			}
 		}
 		if(params.startLat != 0) {

--- a/OsmAnd-java/src/main/java/net/osmand/search/SearchUICore.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/SearchUICore.java
@@ -1146,7 +1146,7 @@ public class SearchUICore {
 				int r = step.compare(o1, o2, this);
 				steps.add(step);
 				if (r != 0) {
-					// debug crashes and identify non-transitive comparision
+					// debug crashes and identify non-transitive comparison
 					// LOG.debug(String.format("%d: %s o1='%s' o2='%s'", r, steps, o1, o2));
 					return r;
 				}

--- a/OsmAnd-java/src/main/java/net/osmand/util/LocationParser.java
+++ b/OsmAnd-java/src/main/java/net/osmand/util/LocationParser.java
@@ -286,7 +286,7 @@ public class LocationParser {
 				if (o.equals("°")) {
 					type = 0;
 				} else if (o.equals("′") /*o.equals("'")*/) {
-					// ' can be used as delimeter ignore it
+					// ' can be used as delimiter ignore it
 					type = 1;
 				} else if (o.equals("\"") || o.equals("″")) {
 					type = 2;

--- a/OsmAnd-java/src/main/java/net/osmand/util/MapAlgorithms.java
+++ b/OsmAnd-java/src/main/java/net/osmand/util/MapAlgorithms.java
@@ -214,7 +214,7 @@ public class MapAlgorithms {
 	/**
 	 * outx,outy are the coordinates out of the box 
 	 * inx,iny are the coordinates from the box (NOT IMPORTANT in/out, just one should be in second out)
-	 * @return -1 if there is no instersection or x<<32 | y
+	 * @return -1 if there is no intersection or x<<32 | y
 	 */
 	public static long calculateIntersection(int inx, int iny, int outx, int outy, int leftX, int rightX, int bottomY, int topY) {
 		int by = -1;

--- a/OsmAnd-java/src/main/java/net/osmand/util/MapUtils.java
+++ b/OsmAnd-java/src/main/java/net/osmand/util/MapUtils.java
@@ -179,7 +179,7 @@ public class MapUtils {
 		        Math.sin(dLon / 2) * Math.sin(dLon / 2);
 		//double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
 		//return R * c * 1000;
-		// simplyfy haversine:
+		// simplify haversine:
 		return (2 * R * 1000 * Math.asin(Math.sqrt(a)));
 	}
 
@@ -256,7 +256,7 @@ public class MapUtils {
 
 
 	/**
-	 * Theses methods operate with degrees (evaluating tiles & vice versa)
+	 * These methods operate with degrees (evaluating tiles & vice versa)
 	 * degree longitude measurements (-180, 180) [27.56 Minsk]
 	 * // degree latitude measurements (90, -90) [53.9]
 	 */

--- a/OsmAnd-java/src/main/java/net/osmand/util/SunriseSunset.java
+++ b/OsmAnd-java/src/main/java/net/osmand/util/SunriseSunset.java
@@ -256,7 +256,7 @@ public class SunriseSunset
 		// the signal of the values provided by the standard library
 		double dfTimeZoneIn = 1.0 * tzIn.getOffset(dateInputIn.getTime()) / 3600000;
 
-		// Copy values supplied as agruments to local variables.
+		// Copy values supplied as arguments to local variables.
 		dfLat 		= dfLatIn;
 		dfLon 		= dfLonIn;
 		dateInput 	= dateInputIn;
@@ -515,7 +515,7 @@ public class SunriseSunset
 	
 				tempD = Math.sqrt( tempD );					// SUNUP.BAS 620
 	
-				// Determine occurence of sunrise or sunset.
+				// Determine occurrence of sunrise or sunset.
 	
 				// Flags to identify occurrence during this day are 
 				// bSunriseToday and bSunsetToday, and are initialized false.

--- a/OsmAnd-telegram/src/net/osmand/aidl/IOsmAndAidlInterface.aidl
+++ b/OsmAnd-telegram/src/net/osmand/aidl/IOsmAndAidlInterface.aidl
@@ -207,7 +207,7 @@ interface IOsmAndAidlInterface {
      *
      * @param layerId (String) - layer id.
      * @param pointId (String) - point id.
-     * @param updateOpenedMenuAndMap (boolean) - flag to enable folowing mode and menu updates for point
+     * @param updateOpenedMenuAndMap (boolean) - flag to enable following mode and menu updates for point
      * @param shortName (String) - short name (single char). Displayed on the map.
      * @param fullName (String) - full name. Displayed in the context menu on first row.
      * @param typeName (String) - type name. Displayed in context menu on second row.
@@ -251,7 +251,7 @@ interface IOsmAndAidlInterface {
      * Import GPX file to OsmAnd (from URI or file).
      *
      * @param gpxUri (Uri) - URI created by FileProvider (preferable method).
-     * @param file (File) - File which represents GPX track (not recomended, OsmAnd should have rights to access file location).
+     * @param file (File) - File which represents GPX track (not recommended, OsmAnd should have rights to access file location).
      * @param fileName (String) - Destination file name. May contain dirs.
      * @param color (String) - color of gpx. Can be one of: "red", "orange", "lightblue", "blue", "purple",
      *                    "translucent_red", "translucent_orange", "translucent_lightblue",
@@ -590,7 +590,7 @@ interface IOsmAndAidlInterface {
      * Register OsmAnd widgets for availability.
      *
      * @param widgetKey (String) - widget id.
-     * @param appModKeys (List<String>)- ist of OsmAnd Application modes widget active with. Could be "null" for all modes.
+     * @param appModKeys (List<String>)- list of OsmAnd Application modes widget active with. Could be "null" for all modes.
      */
     boolean regWidgetAvailability(in SetWidgetsParams params);
 

--- a/OsmAnd/src/net/osmand/plus/helpers/FeedbackHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/FeedbackHelper.java
@@ -130,7 +130,7 @@ public class FeedbackHelper {
 		} catch (Throwable e) {
 		}
 		msg.append("\n")
-				.append("Exception occured in thread ")
+				.append("Exception occurred in thread ")
 				.append(thread)
 				.append(" : \n")
 				.append(out);

--- a/OsmAnd/src/net/osmand/plus/plugins/audionotes/MultimediaNotesFragment.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/audionotes/MultimediaNotesFragment.java
@@ -187,7 +187,7 @@ public class MultimediaNotesFragment extends BaseSettingsFragment implements Cop
 			mpix.add((psps.get(index)).width * (psps.get(index)).height);
 			picSizesValues.add(index);
 		}
-		// sort list for max resolution in begining of list
+		// sort list for max resolution in beginning of list
 		for (int i = 0; i < mpix.size(); i++) {
 			for (int j = 0; j < mpix.size() - i - 1; j++) {
 				if (mpix.get(j) < mpix.get(j + 1)) {
@@ -253,7 +253,7 @@ public class MultimediaNotesFragment extends BaseSettingsFragment implements Cop
 		Camera.Parameters parameters = cam.getParameters();
 
 		// focus mode settings
-		// show in menu only suppoted modes
+		// show in menu only supported modes
 		List<String> sfm = parameters.getSupportedFocusModes();
 		if (sfm == null) {
 			cameraFocusType.setVisible(false);

--- a/OsmAnd/src/net/osmand/plus/render/RendererRegistry.java
+++ b/OsmAnd/src/net/osmand/plus/render/RendererRegistry.java
@@ -174,7 +174,7 @@ public class RendererRegistry {
 			loadedRenderers.put(name, main);
 			try {
 				main.parseRulesFromXmlInputStream(is, (nm, ref) -> {
-					// reload every time to propogate rendering constants
+					// reload every time to propagate rendering constants
 					if (loadedRenderers.containsKey(nm)) {
 						log.warn("Possible Circular dependencies found " + nm);
 					}

--- a/OsmAnd/src/net/osmand/plus/resources/ResourceManager.java
+++ b/OsmAnd/src/net/osmand/plus/resources/ResourceManager.java
@@ -1277,7 +1277,7 @@ public class ResourceManager {
 			}
 		}
 
-		// Not using boundares results in very slow initial search if user has many maps installed
+		// Not using boundaries results in very slow initial search if user has many maps installed
 //		int left = 0;
 //		int top = 0;
 //		int right = Integer.MAX_VALUE;

--- a/OsmAnd/src/net/osmand/plus/resources/SQLiteTileSource.java
+++ b/OsmAnd/src/net/osmand/plus/resources/SQLiteTileSource.java
@@ -477,7 +477,7 @@ public class SQLiteTileSource implements ITileSource {
 		} finally {
 			if (LOG.isDebugEnabled()) {
 				long time = System.currentTimeMillis();
-				LOG.debug("Checking tile existance x = " + x + " y = " + y + " z = " + zoom + " for " + (System.currentTimeMillis() - time)); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+				LOG.debug("Checking tile existence x = " + x + " y = " + y + " z = " + zoom + " for " + (System.currentTimeMillis() - time)); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 			}
 		}
 	}
@@ -670,7 +670,7 @@ public class SQLiteTileSource implements ITileSource {
 		if (db == null || db.isReadOnly() || onlyReadonlyAvailable) {
 			return;
 		}
-		/*There is no sense to downoad and do not save. If needed, check should perform before downlad 
+		/*There is no sense to download and do not save. If needed, check should perform before download 
 		  if (exists(x, y, zoom)) {
 
 			return;

--- a/OsmAnd/src/net/osmand/plus/settings/backend/backup/SettingsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/backup/SettingsHelper.java
@@ -491,7 +491,7 @@ public abstract class SettingsHelper {
 						result.add(new FileSettingsItem(app, file));
 					}
 				} catch (IllegalArgumentException e) {
-					LOG.warn("Trying to export unsuported file type", e);
+					LOG.warn("Trying to export unsupported file type", e);
 				}
 			} else if (object instanceof FileSettingsItem) {
 				result.add((FileSettingsItem) object);

--- a/OsmAnd/src/net/osmand/plus/views/MapLayers.java
+++ b/OsmAnd/src/net/osmand/plus/views/MapLayers.java
@@ -180,7 +180,7 @@ public class MapLayers {
 		// 7.3 map markers layer
 		mapMarkersLayer = new MapMarkersLayer(app);
 		mapView.addLayer(mapMarkersLayer, 7.3f);
-		// 7.5 Impassible roads
+		// 7.5 Impassable roads
 		impassableRoadsLayer = new ImpassableRoadsLayer(app);
 		mapView.addLayer(impassableRoadsLayer, 7.5f);
 		// 7.8 radius ruler control layer

--- a/OsmAnd/src/net/osmand/plus/views/controls/SwipeDismissListViewTouchListener.java
+++ b/OsmAnd/src/net/osmand/plus/views/controls/SwipeDismissListViewTouchListener.java
@@ -441,7 +441,7 @@ public class SwipeDismissListViewTouchListener implements View.OnTouchListener {
 	/**
 	 * Sets the id of the view, that should be moved, when the user swipes an item.
 	 * Only the view with the specified id will move, while all other views in the list item, will
-	 * stay where they are. This might be usefull to have a background behind the view that is swiped
+	 * stay where they are. This might be useful to have a background behind the view that is swiped
 	 * out, to stay where it is (and maybe explain that the item is going to be deleted).
 	 * If you never call this method (or call it with 0), the whole view will be swiped. Also if there
 	 * is no view in a list item, with the given id, the whole view will be swiped.

--- a/OsmAnd/src/net/osmand/plus/views/layers/MapQuickActionLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/MapQuickActionLayer.java
@@ -361,7 +361,7 @@ public class MapQuickActionLayer extends OsmandMapLayer implements QuickActionUp
     private boolean isFollowPoint(RotatedTileBox tileBox, MapContextMenu menu) {
         return OsmAndLocationProvider.isLocationPermissionAvailable(getContext()) &&
                 app.getMapViewTrackingUtilities().isMapLinkedToLocation() ||
-                menu.isActive() && NativeUtilities.containsLatLon(getMapRenderer(), tileBox, menu.getLatLon());  // remove if not to folow if there is selected point on map
+                menu.isActive() && NativeUtilities.containsLatLon(getMapRenderer(), tileBox, menu.getLatLon());  // remove if not to follow if there is selected point on map
     }
 
     private void updateMapDisplayPosition() {

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/widgets/StreetNameWidget.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/widgets/StreetNameWidget.java
@@ -281,7 +281,7 @@ public class StreetNameWidget extends MapWidget {
 		float xSize = shield.getIntrinsicWidth();
 		float ySize = shield.getIntrinsicHeight();
 		float xyRatio = xSize / ySize;
-		//setting view propotions (height is fixed by toolbar size - 48dp);
+		//setting view proportions (height is fixed by toolbar size - 48dp);
 		int viewHeightPx = AndroidUtils.dpToPx(app, 48);
 		int viewWidthPx = (int) (viewHeightPx * xyRatio);
 


### PR DESCRIPTION
Fix a variety of typos, notably documentation related and user-facing.

Found via `codespell -q 3 -S "./OsmAnd/res/values-*,./OsmAnd-telegram/res/values-*" -L alocation,ans,currenty,finaly,initialy,isplay,nd,pres,ser,te`