### PR TITLE
Allow to completely disable map rotation using gesture.

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -1541,6 +1541,8 @@ You need to activate the sensor so OsmAnd can find it.</string>
     <string name="please_provide_point_name_error">Please provide a name for the point</string>
     <string name="use_volume_buttons_as_zoom">Volume buttons as zoom</string>
     <string name="use_volume_buttons_as_zoom_descr">Control the map-zoom level using the volume buttons on the device.</string>
+    <string name="map_rotation_using_two_pointers_rotation_gesture">Allow map rotation using gesture</string>
+    <string name="map_rotation_using_two_pointers_rotation_gesture_descr">Control the map rotation using the two-finger rotation gesture. If disabled, only two-finger zooming will be allowed. Disable this to avoid accidentally rotating the map while zooming.</string>
     <string name="quick_action_remove_next_destination">Delete next destination point</string>
     <string name="app_mode_inline_skates">Inline skates</string>
     <string name="speed_cameras_removed_descr">This device doesn\'t have speed cameras.</string>

--- a/OsmAnd/res/xml/general_profile_settings.xml
+++ b/OsmAnd/res/xml/general_profile_settings.xml
@@ -88,6 +88,13 @@
 		android:title="@string/use_volume_buttons_as_zoom"
 		tools:icon="@drawable/ic_action_zoom_volume_buttons" />
 
+	<net.osmand.plus.settings.preferences.SwitchPreferenceEx
+		android:key="map_rotation_using_two_pointers_rotation_gesture"
+		android:layout="@layout/preference_with_descr_dialog_and_switch"
+		android:summaryOff="@string/shared_string_disabled"
+		android:summaryOn="@string/shared_string_enabled"
+		android:title="@string/map_rotation_using_two_pointers_rotation_gesture" />
+
 	<net.osmand.plus.settings.preferences.ListPreferenceEx
 		android:key="external_input_device"
 		android:layout="@layout/preference_with_descr"

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -1274,6 +1274,7 @@ public class OsmandSettings {
 	public final OsmandPreference<Boolean> USE_MAGNETIC_FIELD_SENSOR_COMPASS = new BooleanPreference(this, "use_magnetic_field_sensor_compass", false).makeProfile().cache();
 	public final OsmandPreference<Boolean> USE_KALMAN_FILTER_FOR_COMPASS = new BooleanPreference(this, "use_kalman_filter_compass", true).makeProfile().cache();
 	public final OsmandPreference<Boolean> USE_VOLUME_BUTTONS_AS_ZOOM = new BooleanPreference(this, "use_volume_buttons_as_zoom", false).makeProfile().cache();
+	public final OsmandPreference<Boolean> MAP_ROTATION_USING_TWO_POINTERS_ROTATION_GESTURE = new BooleanPreference(this, "map_rotation_using_two_pointers_rotation_gesture", true).makeProfile().cache();
 
 	public final OsmandPreference<Boolean> DO_NOT_SHOW_STARTUP_MESSAGES = new BooleanPreference(this, "do_not_show_startup_messages", false).makeGlobal().makeShared().cache();
 	public final OsmandPreference<Boolean> SHOW_DOWNLOAD_MAP_DIALOG = new BooleanPreference(this, "show_download_map_dialog", true).makeGlobal().makeShared().cache();

--- a/OsmAnd/src/net/osmand/plus/settings/fragments/GeneralProfileSettingsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/settings/fragments/GeneralProfileSettingsFragment.java
@@ -63,6 +63,7 @@ public class GeneralProfileSettingsFragment extends BaseSettingsFragment {
 		setupSpeedSystemPref();
 
 		setupVolumeButtonsAsZoom();
+		setupMapRotationUsingTwoPointersRotationGesture();
 		setupKalmanFilterPref();
 		setupMagneticFieldSensorPref();
 		setupMapEmptyStateAllowedPref();
@@ -231,6 +232,12 @@ public class GeneralProfileSettingsFragment extends BaseSettingsFragment {
 		volumeButtonsPref.setDescription(getString(R.string.use_volume_buttons_as_zoom_descr));
 		Drawable icon = getPersistentPrefIcon(R.drawable.ic_action_zoom_volume_buttons);
 		volumeButtonsPref.setIcon(icon);
+	}
+
+	private void setupMapRotationUsingTwoPointersRotationGesture() {
+		SwitchPreferenceEx mapRotationUsingTwoPointersRotationGesturePref = findPreference(settings.MAP_ROTATION_USING_TWO_POINTERS_ROTATION_GESTURE.getId());
+		mapRotationUsingTwoPointersRotationGesturePref.setTitle(getString(R.string.map_rotation_using_two_pointers_rotation_gesture));
+		mapRotationUsingTwoPointersRotationGesturePref.setDescription(getString(R.string.map_rotation_using_two_pointers_rotation_gesture_descr));
 	}
 
 	private void setupKalmanFilterPref() {

--- a/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
+++ b/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
@@ -1999,13 +1999,17 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 
 		@Override
 		public void onZoomingOrRotating(double relativeToStart, float relAngle) {
+			boolean rotatingAllowedInSettings = settings.MAP_ROTATION_USING_TWO_POINTERS_ROTATION_GESTURE.get();
+			boolean rotatingAllowedInLayers = mapGestureAllowed(MapGestureType.TWO_POINTERS_ROTATION);
+			boolean rotatingAllowed = rotatingAllowedInSettings && rotatingAllowedInLayers;
+
 			double deltaZoom = calculateDeltaZoom(relativeToStart);
-			if (Math.abs(deltaZoom) <= ZONE_0_ZOOM_THRESHOLD && !startZooming) {
+			if (rotatingAllowed && Math.abs(deltaZoom) <= ZONE_0_ZOOM_THRESHOLD && !startZooming) {
 				deltaZoom = 0; // keep only rotating
 			} else {
 				startZooming = true;
 			}
-			if (mapGestureAllowed(MapGestureType.TWO_POINTERS_ROTATION) && isAngleOverThreshold(Math.abs(relAngle), Math.abs(deltaZoom))) {
+			if (rotatingAllowed && isAngleOverThreshold(Math.abs(relAngle), Math.abs(deltaZoom))) {
 				startRotating = true;
 			} else {
 				relAngle = 0;


### PR DESCRIPTION
The map rotation using gesture was possible even when "North is up" is set as Map orientation. So, create a separate independent setting to disallow the gesture. Actually, the setting can be useful even in other Map orientation modes.

By default, the gesture is enabled, so the app behaves as before.

Disabling the rotation gesture allows users to avoid accidental rotation when zooming was intended. The problem manifests itself e.g. in these scenarios:
- (1) I zoom the map. The map rotates while zooming. I need to click the compass icon to revert to North is up. Actually I needed to build the habit of "checking if north is up" after each zooming, which is annoying.
- (2) I zoom the map. The map rotates while zooming. I do not notice this. Later, I notice "something is wrong with the map". Click the compass icon.
- (3) During some activity (geocaching, bike, sport) I accidentally rotate the map without the intention to do anything. Usually I do not notice this and it continues as in (2).

This supports the issue 15660 and some related issues.