### PR TITLE
"General Store" > "Shop"

### DIFF
--- a/OsmAnd/res/values/phrases.xml
+++ b/OsmAnd/res/values/phrases.xml
@@ -308,7 +308,7 @@
 	<string name="poi_garden_centre">Garden center</string>
 	<string name="poi_garden_furniture">Garden furniture store</string>
 	<string name="poi_gas">Liquid gas store</string>
-	<string name="poi_shop_yes">General store</string>
+	<string name="poi_shop_yes">Shop</string>
 	<string name="poi_gift">Gift shop</string>
 	<string name="poi_glaziery">Glaziery</string>
 	<string name="poi_hardware">Hardware store</string>


### PR DESCRIPTION
Attribute ``shop=yes`` is used to describe a shop without any other information, like shop category.

Source: https://wiki.openstreetmap.org/wiki/Key:shop 

"General store" means a shop where all (or, at least, many) types of items are sold.

I think just "Shop" is more correct than "General Store" in this case.

Thanks!

Edit: I think, "General Store" is corresponding with ``shop=general`` tag.