### PR TITLE
Added check to prevent rotation if in North Up mode.

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
+++ b/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
@@ -2089,7 +2089,7 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 			} else {
 				startZooming = true;
 			}
-			if (mapGestureAllowed(MapGestureType.TWO_POINTERS_ROTATION) && isAngleOverThreshold(Math.abs(relAngle), Math.abs(deltaZoom))) {
+			if (settings.getCompassMode() != CompassMode.NORTH_IS_UP && mapGestureAllowed(MapGestureType.TWO_POINTERS_ROTATION) && isAngleOverThreshold(Math.abs(relAngle), Math.abs(deltaZoom))) {
 				startRotating = true;
 			} else {
 				relAngle = 0;


### PR DESCRIPTION
Fixes, resolves and closes #17979 , #16836 , #17884 , #17086 

Disallow rotation when in North-Up compass mode. Being able to rotate when in north-up mode is a contradiction and makes OsmAnd unintuitive to use. This change still allows users who want manual rotation to select that mode and manually rotate, or, if you have the compass icon active, to toggle through the different modes without having to fiddle in settings by tapping the compass. 

I'd be ok with making the default compass mode "manually rotated" so that OsmAnd behaves how some users have become accustomed to using it, but having a separate "north-up" mode is pointless if rotation is still allowed in this mode.