### PR TITLE
Fix bug with volume buttons for key event listener

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/MapActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/MapActivity.java
@@ -1422,6 +1422,22 @@ public class MapActivity extends OsmandActionBarActivity implements DownloadEven
 		return super.onKeyUp(keyCode, event);
 	}
 
+	@Override
+	public boolean onKeyLongPress(int keyCode, KeyEvent event) {
+		if (keyEventHelper != null && keyEventHelper.onKeyLongPress(keyCode, event)) {
+			return true;
+		}
+		return super.onKeyLongPress(keyCode, event);
+	}
+
+	@Override
+	public boolean onKeyMultiple(int keyCode, int repeatCount, KeyEvent event) {
+		if (keyEventHelper != null && keyEventHelper.onKeyMultiple(keyCode, repeatCount, event)) {
+			return true;
+		}
+		return super.onKeyMultiple(keyCode, repeatCount, event);
+	}
+
 	public void showMapControls() {
 		MapLayers mapLayers = getMapLayers();
 		if (!getDashboard().isVisible() && mapLayers.getMapControlsLayer() != null) {

--- a/OsmAnd/src/net/osmand/plus/keyevent/devices/NoneDeviceProfile.java
+++ b/OsmAnd/src/net/osmand/plus/keyevent/devices/NoneDeviceProfile.java
@@ -10,11 +10,6 @@ public class NoneDeviceProfile extends InputDeviceProfile {
 	}
 
 	@Override
-	protected void collectCommands() {
-		// No commands
-	}
-
-	@Override
 	protected InputDeviceProfile newInstance() {
 		return new NoneDeviceProfile();
 	}

--- a/OsmAnd/src/net/osmand/plus/keyevent/devices/base/DefaultInputDeviceProfile.java
+++ b/OsmAnd/src/net/osmand/plus/keyevent/devices/base/DefaultInputDeviceProfile.java
@@ -2,11 +2,8 @@ package net.osmand.plus.keyevent.devices.base;
 
 import android.view.KeyEvent;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 
-import net.osmand.StateChangedListener;
-import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.keyevent.commands.BackToLocationCommand;
 import net.osmand.plus.keyevent.commands.EmitNavigationHintCommand;
 import net.osmand.plus.keyevent.commands.MapScrollCommand;
@@ -20,18 +17,8 @@ import net.osmand.plus.keyevent.commands.ToggleDrawerCommand;
 
 public abstract class DefaultInputDeviceProfile extends InputDeviceProfile {
 
-	private StateChangedListener<Boolean> volumeButtonsPrefListener;
-
 	public DefaultInputDeviceProfile(int id, @StringRes int titleId) {
 		super(id, titleId);
-	}
-
-	@Override
-	public void initialize(@NonNull OsmandApplication app) {
-		super.initialize(app);
-		// Update commands when related preferences updated
-		volumeButtonsPrefListener = aBoolean -> updateCommands();
-		settings.USE_VOLUME_BUTTONS_AS_ZOOM.addListener(volumeButtonsPrefListener);
 	}
 
 	/**
@@ -40,14 +27,12 @@ public abstract class DefaultInputDeviceProfile extends InputDeviceProfile {
 	 */
 	@Override
 	protected void collectCommands() {
+		super.collectCommands();
+
 		// Default map zoom keycodes
 		bindCommand(KeyEvent.KEYCODE_PLUS, MapZoomCommand.ZOOM_IN_ID);
 		bindCommand(KeyEvent.KEYCODE_EQUALS, MapZoomCommand.ZOOM_IN_ID);
 		bindCommand(KeyEvent.KEYCODE_MINUS, MapZoomCommand.ZOOM_OUT_ID);
-		if (settings.USE_VOLUME_BUTTONS_AS_ZOOM.get()) {
-			bindCommand(KeyEvent.KEYCODE_VOLUME_DOWN, MapZoomCommand.CONTINUOUS_ZOOM_OUT_ID);
-			bindCommand(KeyEvent.KEYCODE_VOLUME_UP, MapZoomCommand.CONTINUOUS_ZOOM_IN_ID);
-		}
 
 		// Default map scroll keycodes
 		bindCommand(KeyEvent.KEYCODE_DPAD_UP, MapScrollCommand.SCROLL_UP_ID);

--- a/OsmAnd/src/net/osmand/plus/keyevent/devices/base/InputDeviceProfile.java
+++ b/OsmAnd/src/net/osmand/plus/keyevent/devices/base/InputDeviceProfile.java
@@ -1,14 +1,17 @@
 package net.osmand.plus.keyevent.devices.base;
 
 import android.content.Context;
+import android.view.KeyEvent;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
+import net.osmand.StateChangedListener;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.keyevent.KeyEventCommandsFactory;
 import net.osmand.plus.keyevent.commands.KeyEventCommand;
+import net.osmand.plus.keyevent.commands.MapZoomCommand;
 import net.osmand.plus.settings.backend.OsmandSettings;
 
 import java.util.HashMap;
@@ -23,6 +26,7 @@ public abstract class InputDeviceProfile {
 	private final int id;
 	private final int titleId;
 
+	private final Map<String, Object> globalVariables = new HashMap<>();
 	private final Map<Integer, KeyEventCommand> mappedCommands = new HashMap<>();
 
 	public InputDeviceProfile(int id, @StringRes int titleId) {
@@ -39,13 +43,23 @@ public abstract class InputDeviceProfile {
 		this.settings = app.getSettings();
 		this.commandsFactory = app.getKeyEventHelper().getCommandsFactory();
 		collectCommands();
+
+		// Update commands when related preferences updated
+		StateChangedListener<Boolean> volumeButtonsPrefListener = aBoolean -> updateCommands();
+		globalVariables.put("volume_button_pref_listener", volumeButtonsPrefListener);
+		settings.USE_VOLUME_BUTTONS_AS_ZOOM.addListener(volumeButtonsPrefListener);
 	}
 
 	/**
 	 * Override this method to add or update bindings between
 	 * keycodes and commands for a specific input device profile.
 	 */
-	protected abstract void collectCommands();
+	protected void collectCommands() {
+		if (settings.USE_VOLUME_BUTTONS_AS_ZOOM.get()) {
+			bindCommand(KeyEvent.KEYCODE_VOLUME_DOWN, MapZoomCommand.CONTINUOUS_ZOOM_OUT_ID);
+			bindCommand(KeyEvent.KEYCODE_VOLUME_UP, MapZoomCommand.CONTINUOUS_ZOOM_IN_ID);
+		}
+	}
 
 	protected void updateCommands() {
 		clearCommands();


### PR DESCRIPTION
When device profile is "None", volume buttons were also dissabled, but in settings they could be enabled in the same time.
Also small code appearance improvements.