### PR TITLE
Fix "Can't click on graph Road Type in Plan Route #18316"

### DIFF
--- a/OsmAnd/src/net/osmand/plus/measurementtool/graph/ChartAdapterHelper.java
+++ b/OsmAnd/src/net/osmand/plus/measurementtool/graph/ChartAdapterHelper.java
@@ -26,6 +26,8 @@ public class ChartAdapterHelper {
 	public static final String BIND_GRAPH_ADAPTERS_KEY = "bind_graph_adapters_key";
 	public static final String BIND_TO_MAP_KEY = "bind_to_map_key";
 
+	private static final int MAX_HIGHLIGHT_DISTANCE_DP = 10_000;
+
 	public static void bindGraphAdapters(CommonChartAdapter mainGraphAdapter,
 	                                     List<BaseChartAdapter> otherGraphAdapters,
 	                                     ViewGroup mainView) {
@@ -50,6 +52,7 @@ public class ChartAdapterHelper {
 			return false;
 		};
 		mainChart.setOnTouchListener(mainChartTouchListener);
+		mainChart.setMaxHighlightDistance(MAX_HIGHLIGHT_DISTANCE_DP);
 
 		mainGraphAdapter.addValueSelectedListener(BIND_GRAPH_ADAPTERS_KEY,
 				new ExternalValueSelectedListener() {

--- a/OsmAnd/src/net/osmand/plus/measurementtool/graph/ChartAdapterHelper.java
+++ b/OsmAnd/src/net/osmand/plus/measurementtool/graph/ChartAdapterHelper.java
@@ -86,7 +86,7 @@ public class ChartAdapterHelper {
 		for (BaseChartAdapter adapter : otherGraphAdapters) {
 			if (adapter.getChart() != null) {
 				if (adapter.getChart() instanceof BarChart) {
-					// maybe we should find min and max axis from all charters
+					// maybe we should find min and max axis from all charts
 					BarChart barChart = (BarChart) adapter.getChart();
 					barChart.getAxisRight().setAxisMinimum(mainChart.getXChartMin());
 					barChart.getAxisRight().setAxisMaximum(mainChart.getXChartMax());

--- a/OsmAnd/src/net/osmand/plus/measurementtool/graph/CustomChartAdapter.java
+++ b/OsmAnd/src/net/osmand/plus/measurementtool/graph/CustomChartAdapter.java
@@ -1,5 +1,7 @@
 package net.osmand.plus.measurementtool.graph;
 
+import static net.osmand.plus.measurementtool.graph.CustomChartAdapter.LegendViewType.ALL_AS_LIST;
+import static net.osmand.plus.measurementtool.graph.CustomChartAdapter.LegendViewType.ONE_ELEMENT;
 import static net.osmand.plus.track.cards.ColorsCard.MINIMUM_CONTRAST_RATIO;
 
 import android.content.Context;
@@ -13,6 +15,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.graphics.ColorUtils;
 
 import com.github.mikephil.charting.charts.HorizontalBarChart;
@@ -66,7 +69,7 @@ public class CustomChartAdapter extends BaseChartAdapter<HorizontalBarChart, Bar
 				if (i >= 0 && elems.size() > i) {
 					selectedPropertyName = elems.get(i).getPropertyName();
 					updateBottomInfo();
-				} else if (LegendViewType.ONE_ELEMENT == legendViewType && elems.size() == 1) {
+				} else if (ONE_ELEMENT == legendViewType && elems.size() == 1) {
 					selectedPropertyName = elems.get(0).getPropertyName();
 					updateBottomInfo();
 				}
@@ -96,22 +99,15 @@ public class CustomChartAdapter extends BaseChartAdapter<HorizontalBarChart, Bar
 	@Override
 	protected void attachBottomInfo() {
 		List<RouteSegmentAttribute> attributes = getSegmentsList();
-		if (attributes == null) {
-			return;
-		}
-
-		switch (legendViewType) {
-			case ONE_ELEMENT:
-				for (RouteSegmentAttribute attribute : attributes) {
-					if (attribute.getPropertyName().equals(selectedPropertyName)) {
-						attachLegend(Collections.singletonList(attribute), null);
-						break;
-					}
+		if (legendViewType == ALL_AS_LIST) {
+			attachLegend(attributes, selectedPropertyName);
+		} else if (legendViewType == ONE_ELEMENT) {
+			for (RouteSegmentAttribute attribute : attributes) {
+				if (attribute.getPropertyName().equals(selectedPropertyName)) {
+					attachLegend(Collections.singletonList(attribute), null);
+					break;
 				}
-				break;
-			case ALL_AS_LIST:
-				attachLegend(attributes, selectedPropertyName);
-				break;
+			}
 		}
 	}
 
@@ -141,8 +137,8 @@ public class CustomChartAdapter extends BaseChartAdapter<HorizontalBarChart, Bar
 		}
 	}
 
-	private Spannable getSpanLegend(String title,
-	                                RouteSegmentAttribute segment,
+	private Spannable getSpanLegend(@NonNull String title,
+	                                @NonNull RouteSegmentAttribute segment,
 	                                boolean fullSpan) {
 		String formattedDistance = OsmAndFormatter.getFormattedDistance(segment.getDistance(), app);
 		title = Algorithms.capitalizeFirstLetter(title);
@@ -155,10 +151,12 @@ public class CustomChartAdapter extends BaseChartAdapter<HorizontalBarChart, Bar
 		return spannable;
 	}
 
+	@NonNull
 	private List<RouteSegmentAttribute> getSegmentsList() {
-		return getStatistics() != null ? new ArrayList<>(getStatistics().partition.values()) : null;
+		return getStatistics() != null ? new ArrayList<>(getStatistics().partition.values()) : new ArrayList<>();
 	}
 
+	@Nullable
 	private RouteStatistics getStatistics() {
 		return additionalData;
 	}


### PR DESCRIPTION
Quick fix for https://github.com/osmandapp/OsmAnd/issues/18316

The problem was observed on Android 13.
The bug arose due to the connection of the main chart (LineChart) with secondary charts (HorizontalBarChart).

When HorizontalBarChart is Clicked, the MotionEvent is passed to the main chart (LineChart).
After that main chart searches for the nearest highlight, update its position and distributes this position to child graphs.

For unknown reasons on new versions of Android (the bug is absent on Android 11, but present on Android 13), the click event on HorizontalBarChart came with too much displacement along the Y-axis (On Android 11, it seems like the "y" coordinate was calculated relative to local coordinates within the HorizontalBarChart itself, while on Adnroid 13 it seems like the "y" coordinate returns as a location relative to the upper border of the screen).

The bug arose because the graphics library set a default limit in the distance between the highlight and the point of clicking on the chart, after which it does not respond to clicking. Сhild charts delegates click processing to the parent, its highlight is much higher on the Y-axis and therefore not at the default distance.

Thus, a quick fix was to increase the mMaxHighlightDistance parameter to an arbitrary value in dp, which is exactly enough to find the highlight on all current screens where the program can be launched at the moment.