### PR TITLE
Display Maidenhead locator as extra location info

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/LocationConvert.java
+++ b/OsmAnd-java/src/main/java/net/osmand/LocationConvert.java
@@ -18,6 +18,7 @@ public class LocationConvert {
 	public static final int MGRS_FORMAT = 5;
 	public static final int SWISS_GRID_FORMAT = 6;
 	public static final int SWISS_GRID_PLUS_FORMAT = 7;
+	public static final int MAIDENHEAD_FORMAT = 100;
 	private static final char DELIM = ':';
 	private static final char DELIMITER_DEGREES = '°';
 	private static final char DELIMITER_MINUTES = '′';

--- a/OsmAnd-java/src/main/java/net/osmand/util/LocationParser.java
+++ b/OsmAnd-java/src/main/java/net/osmand/util/LocationParser.java
@@ -8,6 +8,7 @@ import com.jwetherell.openmap.common.UTMPoint;
 
 import net.osmand.data.LatLon;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/OsmAnd-java/src/main/java/net/osmand/util/MaidenheadConverter.java
+++ b/OsmAnd-java/src/main/java/net/osmand/util/MaidenheadConverter.java
@@ -1,0 +1,143 @@
+package net.osmand.util;
+
+import net.osmand.data.LatLon;
+
+/**
+ * <p>Maidenhead locator conversion utilities.</p>
+ * <p>For more information about the Maidenhead Locator System,
+ * see <a href="https://en.wikipedia.org/wiki/Maidenhead_Locator_System">Wikipedia:Maidenhead Locator System</a>.</p>
+ * <p>Their format is as follows: AA00AA... (alternating pairs of letters and numbers)<br>
+ * where the first character of a pair designates longitude and the second latitude.
+ * The first pair has a range of A..R, numbers are always 0..9, and subsequent letters are A..X.
+ * Each pair increases precision by the number of subdivisions at that step.</p>
+ * <p>These locators are commonly used by radio amateurs to express geographical locations of
+ * radio stations. 3 pairs are commonly used, resulting in a precision of 2.5' latitude and
+ * 5' longitude, which corresponds with a maximum grid distance of 10.4km.</p>
+ * <p>The maidenheadToLatLon function will parse as many pairs as possible, and
+ * latLonToMaidenhead accepts a second argument to express the number of groups desired.
+ * There's also a latLonToMaidenhead variant that generates the default precision of 3 pairs.</p>
+ * <p>The grid is based on WGS-84, so you need to make sure that latitude and longitude are
+ * specified correctly. No correction is done to the coordinates, except for aligning them to the
+ * Maidenhead grid, which starts at the South pole (90° South / -90°) and at the
+ * Greenwich antimeridian (180° West / -180°).</p>
+ */
+public class MaidenheadConverter {
+	private final static int[] LAT_DIVISIONS_STEP = {18, 10, 24, 10, 24, 10, 24, 10, 24, 10};
+	private final static double[] LAT_DIVISIONS_TOTAL = new double[LAT_DIVISIONS_STEP.length];
+	private final static char[] BASE = {'A', '0', 'A', '0', 'A', '0', 'A', '0', 'A', '0'};
+
+	static {
+		double div = 1.0;
+		for (int i = 0; i < LAT_DIVISIONS_STEP.length; i++) {
+			div *= LAT_DIVISIONS_STEP[i];
+			LAT_DIVISIONS_TOTAL[i] = div;
+		}
+	}
+
+	/**
+	 * <p>Convert a Maidenhead locator into matching WGS-84 grid coordinates.</p>
+	 * <p>The chosen coordinate pair is at the lower (Southern/Western) corner of the grid square.</p>
+	 * <p>Locators with invalid characters are rejected and will throw an IllegalArgumentException.
+	 * If the locator has an odd number of characters, the extra character at the end will be ignored.
+	 * Both lower case and upper case letters are accepted.</p>
+	 * @param maidenhead a Maidenhead locator
+	 * @return a WGS-84 coordinate pair
+	 * @exception IllegalArgumentException if the locator cannot be parsed.
+	 */
+	public static LatLon maidenheadToLatLon(String maidenhead) {
+		// enforce upper case notation - we don't really case which one is used
+		char[] loc = maidenhead.toUpperCase().toCharArray();
+		int pairs = loc.length / 2;
+		double lat = 0.0;
+		double lon = 0.0;
+		double xscale = 360.0;
+		double yscale = 180.0;
+		for (int i = 0; i < pairs; i++) {
+			double div = LAT_DIVISIONS_STEP[i];
+			double x = (loc[i * 2] - BASE[i]) / div;
+			if (x < 0.0 || x >= 1.0) {
+				throw new IllegalArgumentException("Invalid range for longitude component");
+			}
+			double y = (loc[i * 2 + 1] - BASE[i]) / div;
+			if (y < 0.0 || y >= 1.0) {
+				throw new IllegalArgumentException("Invalid range for latitude component");
+			}
+			lon += x * xscale;
+			lat += y * yscale;
+			xscale /= div;
+			yscale /= div;
+		}
+		// apply MH easting and northing
+		return new LatLon(lat - 90.0, lon - 180.0);
+	}
+
+	/**
+	 * Convert WGS-83 coordinates into the corresponding Maidenhead grid square with standard precision (3 pairs).
+	 * @param latlon a WGS-83 coordinate pair. Latitude must be in range -90° to 90° (inclusive), and longitude
+	 *               must be from -180° to 180° (inclusive). Both extremes will be mapped to the bottom value.
+	 * @return a Maidenhead locator in standard notation (upper case letters and numbers) with 3 pairs.
+	 */
+	public static String latLonToMaidenhead(LatLon latlon) {
+		return latLonToMaidenhead(latlon, 3);
+	}
+
+	/**
+	 * Convert WGS-83 coordinates into the corresponding Maidenhead grid square.
+	 * The precision can be specified with the pairs parameter.
+	 * @param latlon a WGS-83 coordinate pair. Latitude must be in range -90° to 90° (inclusive), and longitude
+	 *               must be from -180° to 180° (inclusive). Both extremes will be mapped to the bottom value.
+	 * @param pairs the number of coordinate pairs to generate. This determines the precision of the locator.
+	 * @return a Maidenhead locator in standard notation (upper case letters and numbers)
+	 *         with the specified number of pairs.
+	 */
+	public static String latLonToMaidenhead(LatLon latlon, int pairs) {
+		if (pairs < 1 || pairs > LAT_DIVISIONS_TOTAL.length) {
+			throw new IllegalArgumentException("Invalid number of pairs");
+		}
+		// apply MH easting by 180° and scale to 0..1
+		// we accept both extreme values: -180.0° is the bottom edge, and +180.0° will be wrapped around to 0.0
+		double lon = (latlon.getLongitude() + 180.0) / 360.0;
+		if (lon < 0.0 || lon > 1.0) {
+			throw new IllegalArgumentException("Invalid range for longitude");
+		}
+		// apply MH northing by 90° and scale to 0..1
+		// we accept both extreme values: -90.0° is the bottom edge, and +90.0° will be wrapped around to -90.0
+		double lat = (latlon.getLatitude() + 90.0) / 180.0;
+		if (lat < 0.0 || lat > 1.0) {
+			throw new IllegalArgumentException("Invalid range for latitude");
+		}
+		StringBuilder ret = new StringBuilder();
+		for (int i = 0; i < pairs; i++) {
+			double div = LAT_DIVISIONS_STEP[i];
+			lon = lon % 1.0 * div;
+			lat = lat % 1.0 * div;
+			ret.append((char) ((int) lon + BASE[i]));
+			ret.append((char) ((int) lat + BASE[i]));
+		}
+		return ret.toString();
+	}
+
+	/**
+	 * Get the size of a grid square for a specific locator.
+	 * This is equivalent to the precision of the locator.
+	 * @param locator the locator to measure.
+	 * @return the size of a single grid square in degrees latitude and longitude.
+	 */
+	public static LatLon precision(String locator) {
+		int pairs = locator.length() / 2;
+		return precision(pairs);
+	}
+
+	/**
+	 * Get the size of a grid square for a specific number of pairs in a locator.
+	 * This is equivalent to the precision of the locator.
+	 * @param pairs the size of the locator (number of pairs).
+	 * @return the size of a single grid square in degrees latitude and longitude.
+	 */
+	public static LatLon precision(int pairs) {
+		if (pairs < 1 || pairs > LAT_DIVISIONS_TOTAL.length) {
+			throw new IllegalArgumentException("Invalid number of pairs");
+		}
+		return new LatLon(180.0 / LAT_DIVISIONS_TOTAL[pairs - 1], 360.0 / LAT_DIVISIONS_TOTAL[pairs - 1]);
+	}
+}

--- a/OsmAnd-java/src/test/java/net/osmand/util/MaidenheadConverterTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/util/MaidenheadConverterTest.java
@@ -1,0 +1,110 @@
+package net.osmand.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import net.osmand.data.LatLon;
+
+public class MaidenheadConverterTest {
+	@Test
+	public void testAccuracyString() {
+		final String[] in = {
+			"AA",
+			"AA00",
+			"AA00AA",
+			"AA00AA00",
+			"AA00AA00AA",
+			"AA00AA00AA00",
+			"AA00AA00AA00AA",
+			"AA00AA00AA00AA00",
+			"AA00AA00AA00AA00AA",
+			"AA00AA00AA00AA00AA00",
+		};
+		final double[] out = {
+			180.0 / 18.0,
+			180.0 / (18.0 * 10),
+			180.0 / (18.0 * 10 * 24),
+			180.0 / (18.0 * 10 * 24 * 10),
+			180.0 / (18.0 * 10 * 24 * 10 * 24),
+			180.0 / (18.0 * 10 * 24 * 10 * 24 * 10),
+			180.0 / (18.0 * 10 * 24 * 10 * 24 * 10 * 24),
+			180.0 / (18.0 * 10 * 24 * 10 * 24 * 10 * 24 * 10),
+			180.0 / (18.0 * 10 * 24 * 10 * 24 * 10 * 24 * 10 * 24),
+			180.0 / (18.0 * 10 * 24 * 10 * 24 * 10 * 24 * 10 * 24 * 10),
+		};
+		for (int i = 0; i < in.length; i++) {
+			String loc = in[i];
+			LatLon res = MaidenheadConverter.precision(loc);
+			double exp = out[i];
+			Assert.assertEquals(exp * 2.0, res.getLongitude(), 0.0000000000000001);
+			Assert.assertEquals(exp, res.getLatitude(), 0.0000000000000001);
+		}
+	}
+
+	@Test
+	public void testAccuracyNumber() {
+		final double[] out = {
+			180.0 / 18.0,
+			180.0 / (18.0 * 10),
+			180.0 / (18.0 * 10 * 24),
+			180.0 / (18.0 * 10 * 24 * 10),
+			180.0 / (18.0 * 10 * 24 * 10 * 24),
+			180.0 / (18.0 * 10 * 24 * 10 * 24 * 10),
+			180.0 / (18.0 * 10 * 24 * 10 * 24 * 10 * 24),
+			180.0 / (18.0 * 10 * 24 * 10 * 24 * 10 * 24 * 10),
+			180.0 / (18.0 * 10 * 24 * 10 * 24 * 10 * 24 * 10 * 24),
+			180.0 / (18.0 * 10 * 24 * 10 * 24 * 10 * 24 * 10 * 24 * 10),
+		};
+		for (int i = 0; i < out.length; i++) {
+			LatLon res = MaidenheadConverter.precision(i + 1);
+			double exp = out[i];
+			Assert.assertEquals(exp * 2.0, res.getLongitude(), 0.0000000000000001);
+			Assert.assertEquals(exp, res.getLatitude(), 0.0000000000000001);
+		}
+	}
+
+	@Test
+	public void testStandardMaidenheadToLatLon() {
+		final String[] in = {
+			"AA00AA",
+			"AA00aa",
+			"JJ55MM",
+			"RR99XX",
+		};
+		final LatLon[] out = {
+			new LatLon(-90.0, -180.0),
+			new LatLon(-90.0, -180.0),
+			new LatLon(5.5, 11.0),
+			new LatLon(89.95833333333333, 179.91666666666667),
+		};
+		// the 3-pair Maidenhead locator is accurate up to 5' longitude (=0.08333°) and 2.5' latitude (=0.04167°)
+		double precision = 180.0 / (18.0 * 10 * 24);
+		for (int i = 0; i < in.length; i++) {
+			LatLon res = MaidenheadConverter.maidenheadToLatLon(in[i]);
+			LatLon exp = out[i];
+			Assert.assertEquals(exp.getLongitude(), res.getLongitude(), 2.0 * precision);
+			Assert.assertEquals(exp.getLatitude(), res.getLatitude(), precision);
+		}
+	}
+
+	@Test
+	public void testStandardLatLonToMaidenhead() {
+		final LatLon[] in = {
+			new LatLon(-90.0, -180.0),
+			new LatLon(5.5, 11.0),
+			new LatLon(89.95833333333333, 179.91666666666667),
+			new LatLon(90.0, 180.0),
+		};
+		final String[] out = {
+			"AA00AA",
+			"JJ55MM",
+			"RR99XX",
+			"AA00AA",
+		};
+		for (int i = 0; i < in.length; i++) {
+			String res = MaidenheadConverter.latLonToMaidenhead(in[i]);
+			String exp = out[i];
+			Assert.assertEquals(exp, res);
+			Assert.assertEquals(exp, res);
+		}
+	}
+}

--- a/OsmAnd/res/layout/search_advanced_coords.xml
+++ b/OsmAnd/res/layout/search_advanced_coords.xml
@@ -504,7 +504,7 @@
                         android:id="@+id/swissGridNorthImage"
                         android:layout_width="54dp"
                         android:layout_height="wrap_content"
-                        app:srcCompat="@drawable/ic_action_coordinates_longitude"/>
+                        app:srcCompat="@drawable/ic_action_coordinates_longitude" />
 
                     <FrameLayout
                         android:layout_width="match_parent"
@@ -513,8 +513,8 @@
                         <com.google.android.material.textfield.TextInputLayout
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginRight="16dp"
-                            android:layout_marginEnd="16dp">
+                            android:layout_marginEnd="16dp"
+                            android:layout_marginRight="16dp">
 
                             <EditText
                                 android:id="@+id/swissGridNorthEditText"
@@ -522,7 +522,7 @@
                                 android:layout_height="wrap_content"
                                 android:hint="North Coordinate"
                                 android:imeOptions="actionDone"
-                                tools:text="22.12345"/>
+                                tools:text="22.12345" />
 
                         </com.google.android.material.textfield.TextInputLayout>
 
@@ -532,10 +532,56 @@
                             android:layout_width="48dp"
                             android:layout_height="48dp"
                             android:layout_gravity="end"
+                            android:layout_marginEnd="4dp"
                             android:layout_marginRight="4dp"
                             android:contentDescription="@string/shared_string_clear"
-                            app:srcCompat="@drawable/ic_action_remove_dark"
-                            android:layout_marginEnd="4dp" />
+                            app:srcCompat="@drawable/ic_action_remove_dark" />
+
+                    </FrameLayout>
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/maidenheadLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:paddingTop="16dp"
+                    android:visibility="gone">
+
+                    <FrameLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content">
+
+                        <com.google.android.material.textfield.TextInputLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="54dp"
+                            android:layout_marginLeft="54dp"
+                            android:layout_marginEnd="16dp"
+                            android:layout_marginRight="16dp">
+
+                            <EditText
+                                android:id="@+id/maidenheadEditText"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:hint="@string/navigate_point_maidenhead"
+                                android:imeOptions="actionDone"
+                                android:inputType="textCapCharacters|textNoSuggestions"
+                                tools:text="22.12345" />
+
+                        </com.google.android.material.textfield.TextInputLayout>
+
+                        <ImageButton
+                            android:id="@+id/maidenheadClearButton"
+                            style="@style/Widget.AppCompat.ActionButton"
+                            android:layout_width="48dp"
+                            android:layout_height="48dp"
+                            android:layout_gravity="end"
+                            android:layout_marginEnd="4dp"
+                            android:layout_marginRight="4dp"
+                            android:contentDescription="@string/shared_string_clear"
+                            app:srcCompat="@drawable/ic_action_remove_dark" />
 
                     </FrameLayout>
 

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -2151,6 +2151,7 @@ You need to activate the sensor so OsmAnd can find it.</string>
     <string name="navigate_point_format_olc">Open Location Code</string>
     <string name="navigate_point_format_swiss_grid">Swiss Grid (CH1903)</string>
     <string name="navigate_point_format_swiss_grid_plus">Swiss Grid (CH1903+)</string>
+    <string name="navigate_point_format_maidenhead">Maidenhead Locator</string>
     <string name="coordinates_format_info">The selected format will be applied throughout the app.</string>
     <string name="pref_selected_by_default_for_profiles">This setting is selected by default for profiles: %s</string>
     <string name="change_default_settings">Change setting</string>
@@ -3707,6 +3708,7 @@ Download tile maps directly, or copy them as SQLite database files to OsmAnd\'s 
     <string name="navigate_point_olc_info_area">Valid full OLC\nRepresents area: %1$s x %2$s</string>
     <string name="navigate_point_northing">Northing</string>
     <string name="navigate_point_easting">Easting</string>
+    <string name="navigate_point_maidenhead">Maidenhead Locator</string>
     <string name="download_tab_downloads">All Downloads</string>
     <string name="download_tab_updates">Updates</string>
     <string name="download_tab_local">Local</string>

--- a/OsmAnd/res/xml/coordinates_format.xml
+++ b/OsmAnd/res/xml/coordinates_format.xml
@@ -2,7 +2,7 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:tools="http://schemas.android.com/tools"
 	android:title="@string/coordinates_format">
-	
+
 	<CheckBoxPreference
 		android:key="format_degrees"
 		android:layout="@layout/preference_radio_button"
@@ -50,5 +50,11 @@
 		android:layout="@layout/preference_radio_button"
 		android:persistent="false"
 		android:title="@string/navigate_point_format_swiss_grid_plus" />
+
+	<CheckBoxPreference
+		android:key="maidenhead_format"
+		android:layout="@layout/preference_radio_button"
+		android:persistent="false"
+		android:title="@string/navigate_point_format_maidenhead" />
 
 </PreferenceScreen>

--- a/OsmAnd/src/net/osmand/data/PointDescription.java
+++ b/OsmAnd/src/net/osmand/data/PointDescription.java
@@ -185,6 +185,7 @@ public class PointDescription {
 		String mgrs = OsmAndFormatter.getFormattedCoordinates(lat, lon, OsmAndFormatter.MGRS_FORMAT);
 		String swissGrid = OsmAndFormatter.getFormattedCoordinates(lat, lon, OsmAndFormatter.SWISS_GRID_FORMAT);
 		String swissGridPlus = OsmAndFormatter.getFormattedCoordinates(lat, lon, OsmAndFormatter.SWISS_GRID_PLUS_FORMAT);
+		String maidenhead = OsmAndFormatter.getFormattedCoordinates(lat, lon, OsmAndFormatter.MAIDENHEAD_FORMAT);
 
 		try {
 			latLonString = OsmAndFormatter.getFormattedCoordinates(lat, lon, OsmAndFormatter.FORMAT_DEGREES_SHORT);
@@ -207,6 +208,7 @@ public class PointDescription {
 		results.put(OsmAndFormatter.MGRS_FORMAT, mgrs);
 		results.put(OsmAndFormatter.SWISS_GRID_FORMAT, swissGrid);
 		results.put(OsmAndFormatter.SWISS_GRID_PLUS_FORMAT, swissGridPlus);
+		results.put(OsmAndFormatter.MAIDENHEAD_FORMAT, maidenhead);
 
 		try {
 			int zoom = ctx.getMapView().getZoom();
@@ -237,6 +239,8 @@ public class PointDescription {
 			results.put(LOCATION_LIST_HEADER, swissGrid);
 		} else if (format == PointDescription.SWISS_GRID_PLUS_FORMAT) {
 			results.put(LOCATION_LIST_HEADER, swissGridPlus);
+		} else if (format == PointDescription.MAIDENHEAD_FORMAT) {
+			results.put(LOCATION_LIST_HEADER, maidenhead);
 		} else if (format == PointDescription.FORMAT_DEGREES) {
 			results.put(LOCATION_LIST_HEADER, latLonDeg);
 		} else if (format == PointDescription.FORMAT_MINUTES) {
@@ -432,6 +436,7 @@ public class PointDescription {
 	public static final int MGRS_FORMAT = LocationConvert.MGRS_FORMAT;
 	public static final int SWISS_GRID_FORMAT = LocationConvert.SWISS_GRID_FORMAT;
 	public static final int SWISS_GRID_PLUS_FORMAT = LocationConvert.SWISS_GRID_PLUS_FORMAT;
+	public static final int MAIDENHEAD_FORMAT = LocationConvert.MAIDENHEAD_FORMAT;
 
 	public static String formatToHumanString(Context ctx, int format) {
 		switch (format) {
@@ -451,6 +456,8 @@ public class PointDescription {
 				return ctx.getString(R.string.navigate_point_format_swiss_grid);
 			case LocationConvert.SWISS_GRID_PLUS_FORMAT:
 				return ctx.getString(R.string.navigate_point_format_swiss_grid_plus);
+			case LocationConvert.MAIDENHEAD_FORMAT:
+				return ctx.getString(R.string.navigate_point_format_maidenhead);
 			default:
 				return "Unknown format";
 		}

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/MenuBuilder.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/MenuBuilder.java
@@ -895,6 +895,9 @@ public class MenuBuilder {
 			} else if (line.getKey() == OsmAndFormatter.SWISS_GRID_PLUS_FORMAT) {
 				ssb.append("CH1903+: ");
 				ssb.setSpan(new ForegroundColorSpan(getColor(R.color.text_color_secondary_light)), 0, 8, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+			} else if (line.getKey() == OsmAndFormatter.MAIDENHEAD_FORMAT) {
+				ssb.append("Maidenhead: ");
+				ssb.setSpan(new ForegroundColorSpan(getColor(R.color.text_color_secondary_light)), 0, 11, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
 			}
 			ssb.append(line.getValue());
 			button.setText(ssb);

--- a/OsmAnd/src/net/osmand/plus/settings/fragments/CoordinatesFormatFragment.java
+++ b/OsmAnd/src/net/osmand/plus/settings/fragments/CoordinatesFormatFragment.java
@@ -38,6 +38,7 @@ public class CoordinatesFormatFragment extends BaseSettingsFragment {
 	private static final String OLC_FORMAT = "olc_format";
 	private static final String SWISS_GRID_FORMAT = "swiss_grid_format";
 	private static final String SWISS_GRID_PLUS_FORMAT = "swiss_grid_plus_format";
+	private static final String MAIDENHEAD_FORMAT = "maidenhead_format";
 
 	@Override
 	protected void setupPreferences() {
@@ -49,6 +50,7 @@ public class CoordinatesFormatFragment extends BaseSettingsFragment {
 		CheckBoxPreference olcPref = findPreference(OLC_FORMAT);
 		CheckBoxPreference swissGridPref = findPreference(SWISS_GRID_FORMAT);
 		CheckBoxPreference swissGridPlusPref = findPreference(SWISS_GRID_PLUS_FORMAT);
+		CheckBoxPreference maidenheadPref = findPreference(MAIDENHEAD_FORMAT);
 
 		Location loc = app.getLocationProvider().getLastKnownLocation();
 
@@ -60,6 +62,7 @@ public class CoordinatesFormatFragment extends BaseSettingsFragment {
 		olcPref.setSummary(getCoordinatesFormatSummary(loc, PointDescription.OLC_FORMAT));
 		swissGridPref.setSummary(getCoordinatesFormatSummary(loc, PointDescription.SWISS_GRID_FORMAT));
 		swissGridPlusPref.setSummary(getCoordinatesFormatSummary(loc, PointDescription.SWISS_GRID_PLUS_FORMAT));
+		maidenheadPref.setSummary(getCoordinatesFormatSummary(loc, PointDescription.MAIDENHEAD_FORMAT));
 
 		int currentFormat = settings.COORDINATES_FORMAT.getModeValue(getSelectedAppMode());
 		String currentPrefKey = getCoordinatesKeyForFormat(currentFormat);
@@ -198,6 +201,8 @@ public class CoordinatesFormatFragment extends BaseSettingsFragment {
 				return PointDescription.SWISS_GRID_FORMAT;
 			case SWISS_GRID_PLUS_FORMAT:
 				return PointDescription.SWISS_GRID_PLUS_FORMAT;
+			case MAIDENHEAD_FORMAT:
+				return PointDescription.MAIDENHEAD_FORMAT;
 			default:
 				return -1;
 		}
@@ -221,6 +226,8 @@ public class CoordinatesFormatFragment extends BaseSettingsFragment {
 				return SWISS_GRID_FORMAT;
 			case PointDescription.SWISS_GRID_PLUS_FORMAT:
 				return SWISS_GRID_PLUS_FORMAT;
+			case PointDescription.MAIDENHEAD_FORMAT:
+				return MAIDENHEAD_FORMAT;
 			default:
 				return "Unknown format";
 		}

--- a/OsmAnd/src/net/osmand/plus/utils/OsmAndFormatter.java
+++ b/OsmAnd/src/net/osmand/plus/utils/OsmAndFormatter.java
@@ -35,6 +35,8 @@ import net.osmand.plus.settings.enums.AngularConstants;
 import net.osmand.plus.settings.enums.MetricsConstants;
 import net.osmand.plus.settings.enums.SpeedConstants;
 import net.osmand.util.Algorithms;
+import net.osmand.util.LocationParser;
+import net.osmand.util.MaidenheadConverter;
 
 import java.text.DateFormat;
 import java.text.DateFormatSymbols;
@@ -82,6 +84,7 @@ public class OsmAndFormatter {
 	public static final int MGRS_FORMAT = LocationConvert.MGRS_FORMAT;
 	public static final int SWISS_GRID_FORMAT = LocationConvert.SWISS_GRID_FORMAT;
 	public static final int SWISS_GRID_PLUS_FORMAT = LocationConvert.SWISS_GRID_PLUS_FORMAT;
+	public static final int MAIDENHEAD_FORMAT = LocationConvert.MAIDENHEAD_FORMAT;
 	private static final char DELIMITER_DEGREES = '°';
 	private static final char DELIMITER_MINUTES = '′';
 	private static final char DELIMITER_SECONDS = '″';
@@ -781,6 +784,9 @@ public class OsmAndFormatter {
 			formatSymbols.setGroupingSeparator(' ');
 			DecimalFormat swissGridFormat = new DecimalFormat("###,###.##", formatSymbols);
 			result.append(swissGridFormat.format(swissGrid[0]) + ", " + swissGridFormat.format(swissGrid[1]));
+		} else if (outputFormat == MAIDENHEAD_FORMAT) {
+			String mh = MaidenheadConverter.latLonToMaidenhead(new LatLon(lat, lon));
+			result.append(mh);
 		}
 		return result.toString();
 	}

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/widgets/CoordinatesBaseWidget.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/widgets/CoordinatesBaseWidget.java
@@ -31,6 +31,8 @@ import net.osmand.plus.views.layers.MapInfoLayer;
 import net.osmand.plus.views.layers.MapInfoLayer.TextState;
 import net.osmand.plus.views.mapwidgets.WidgetType;
 import net.osmand.plus.views.mapwidgets.WidgetsPanel;
+import net.osmand.util.LocationParser;
+import net.osmand.util.MaidenheadConverter;
 
 import org.apache.commons.logging.Log;
 
@@ -115,6 +117,8 @@ public abstract class CoordinatesBaseWidget extends MapWidget {
 			showSwissGrid(lat, lon, false);
 		} else if (format == PointDescription.SWISS_GRID_PLUS_FORMAT){
 			showSwissGrid(lat, lon, true);
+		} else if (format == PointDescription.MAIDENHEAD_FORMAT){
+			showMaidenhead(lat, lon);
 		} else {
 			showStandardCoordinates(lat, lon, format);
 		}
@@ -160,6 +164,12 @@ public abstract class CoordinatesBaseWidget extends MapWidget {
 
 		firstCoordinate.setText(swissGridFormat.format(swissGrid[0]));
 		secondCoordinate.setText(swissGridFormat.format(swissGrid[1]));
+	}
+
+	private void showMaidenhead(double lat, double lon) {
+		String mh = MaidenheadConverter.latLonToMaidenhead(new LatLon(lat, lon));
+		setupForNonStandardFormat();
+		firstCoordinate.setText(mh);
 	}
 
 	private void setupForNonStandardFormat() {


### PR DESCRIPTION
This pull request implements support for the Maidenhead locator, in the same manner as other extra location information data.

Fixes: #17325

Unit tests for the conversion functions have been added, but the changes are completely untested otherwise. I haven't managed to build Osmand locally yet, and was thus unable to run the modified version.

I agree to release the modifications under the terms of the MIT license, as stated in PULL_REQUEST.MIT.LICENSE.
Copyright of the modifications is mine, 2023.