### PR TITLE
Restore correct map zoom on relief

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/data/RotatedTileBox.java
+++ b/OsmAnd-java/src/main/java/net/osmand/data/RotatedTileBox.java
@@ -11,6 +11,7 @@ public class RotatedTileBox {
 	/// primary fields
 	private double lat;
 	private double lon;
+	private float height;
 	private float rotate;
 	private float density;
 	private int zoom;
@@ -369,6 +370,10 @@ public class RotatedTileBox {
 		calculateDerivedFields();
 	}
 
+	public void setHeight(float height) {
+		this.height = height;
+	}
+
 	public void setRotate(float rotate) {
 		this.rotate = rotate;
 		calculateDerivedFields();
@@ -478,6 +483,10 @@ public class RotatedTileBox {
 	public void setZoom(int zoom) {
 		this.zoom = zoom;
 		calculateDerivedFields();
+	}
+
+	public float getHeight() {
+		return height;
 	}
 
 	public float getRotate() {

--- a/OsmAnd/src/net/osmand/plus/activities/MapActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/MapActivity.java
@@ -42,6 +42,7 @@ import net.osmand.SecondSplashScreenFragment;
 import net.osmand.StateChangedListener;
 import net.osmand.aidl.AidlMapPointWrapper;
 import net.osmand.aidl.OsmandAidlApi.AMapPointUpdateListener;
+import net.osmand.core.android.MapRendererView;
 import net.osmand.data.LatLon;
 import net.osmand.data.PointDescription;
 import net.osmand.data.QuadRect;
@@ -620,6 +621,7 @@ public class MapActivity extends OsmandActionBarActivity implements DownloadEven
 		if (settings.isLastKnownMapLocation()) {
 			LatLon l = settings.getLastKnownMapLocation();
 			mapView.setLatLon(l.getLatitude(), l.getLongitude());
+			mapView.setHeight(settings.getLastKnownMapHeight());
 			mapView.setZoomWithFloatPart(settings.getLastKnownMapZoom(), settings.getLastKnownMapZoomFloatPart());
 			mapView.initMapRotationByCompassMode();
 		}
@@ -1027,6 +1029,9 @@ public class MapActivity extends OsmandActionBarActivity implements DownloadEven
 					animatedThread.getTargetIntZoom());
 		}
 
+		MapRendererView mapRenderer = mapView.getMapRenderer();
+		if (mapRenderer != null)
+			settings.setLastKnownMapHeight(mapRenderer.getMapTargetHeightInMeters());
 		settings.setLastKnownMapZoom(mapView.getZoom());
 		settings.setLastKnownMapZoomFloatPart(mapView.getZoomFloatPart());
 		settings.setLastKnownMapRotation(mapView.getRotate());

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -2299,7 +2299,7 @@ public class OsmandSettings {
 	public static final String LAST_KNOWN_MAP_LON = "last_known_map_lon";
 	public static final String LAST_KNOWN_MAP_ZOOM = "last_known_map_zoom";
 	public static final String LAST_KNOWN_MAP_ZOOM_FLOAT_PART = "last_known_map_zoom_float_part";
-
+	public static final String LAST_KNOWN_MAP_HEIGHT = "last_known_map_height";
 	public static final String MAP_LABEL_TO_SHOW = "map_label_to_show";
 	public static final String MAP_LAT_TO_SHOW = "map_lat_to_show";
 	public static final String MAP_LON_TO_SHOW = "map_lon_to_show";
@@ -2417,6 +2417,14 @@ public class OsmandSettings {
 
 	public void setLastKnownMapZoomFloatPart(float zoomFloatPart) {
 		settingsAPI.edit(globalPreferences).putFloat(LAST_KNOWN_MAP_ZOOM_FLOAT_PART, zoomFloatPart).commit();
+	}
+
+	public float getLastKnownMapHeight() {
+		return settingsAPI.getFloat(globalPreferences, LAST_KNOWN_MAP_HEIGHT, 0.0f);
+	}
+
+	public void setLastKnownMapHeight(float height) {
+		settingsAPI.edit(globalPreferences).putFloat(LAST_KNOWN_MAP_HEIGHT, height).commit();
 	}
 
 	private final CommonPreference<Float> LAST_KNOWN_MAP_ROTATION = new FloatPreference(this, "last_known_map_rotation", 0).makeProfile();

--- a/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
+++ b/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
@@ -594,6 +594,14 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 		}
 	}
 
+	public void setHeight(float height) {
+		MapRendererView mapRenderer = getMapRenderer();
+		if (mapRenderer != null)
+			mapRenderer.restoreFlatZoom(height);
+		else
+			currentViewport.setHeight(height);
+	}
+
 	public boolean isShowMapPosition() {
 		return showMapPosition;
 	}
@@ -922,6 +930,11 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 			setElevationAngle(elevationAngle);
 			setMapDensityImpl(getSettingsMapDensity());
 			refreshBufferImage(drawSettings);
+			float height = currentViewport.getHeight();
+			if (height > 0.0f && mapRenderer != null) {
+				currentViewport.setHeight(0.0f);
+				mapRenderer.restoreFlatZoom(height);
+			}
 		}
 		if (view instanceof SurfaceView) {
 			SurfaceHolder holder = ((SurfaceView) view).getHolder();


### PR DESCRIPTION
Use terrain elevation value to restore correct map zoom on relief when heightmaps is not yet loaded