### PR TITLE
Add support for more capacity:* subkeys and service:bicycle:stand

### DIFF
--- a/OsmAnd/res/values-de/phrases.xml
+++ b/OsmAnd/res/values-de/phrases.xml
@@ -1357,6 +1357,12 @@
     <string name="poi_capacity_parent_yes">Elternplätze</string>
     <string name="poi_capacity_parent_no">Keine Elternplätze</string>
     <string name="poi_capacity_parent">Elternplätze</string>
+    <string name="poi_capacity_charging_yes">E-Ladeplätze</string>
+    <string name="poi_capacity_charging_no">Keine E-Ladeplätze</string>
+    <string name="poi_capacity_charging">E-Ladeplätze</string>
+    <string name="poi_capacity_cargo_bike_yes">Lastenradplätze</string>
+    <string name="poi_capacity_cargo_bike_no">Keine Lastenradplätze</string>
+    <string name="poi_capacity_cargo_bike">Lastenradplätze</string>
     <string name="poi_aerialway_occupancy">Kabinen-, Gondel-, Sesselkapazität</string>
     <string name="poi_aerialway_capacity">Kapazität pro Stunde</string>
     <string name="poi_aerialway_duration">Durchschnittliche Fahrzeit, Minuten</string>
@@ -2000,6 +2006,8 @@
     <string name="poi_service_bicycle_chaintool_no">Fahrradkettenwerkzeug: nein</string>
     <string name="poi_service_bicycle_second_hand_yes">Verkauf von Gebrauchtfahrrädern;Gebrauchtfahrrad</string>
     <string name="poi_service_bicycle_second_hand_no">Verkauf von Gebrauchtfahrrädern: nein</string>
+    <string name="poi_service_bicycle_stand_yes">Reparaturständer;Fahrradständer;Fahrradreparaturständer</string>
+    <string name="poi_service_bicycle_stand_no">Reparaturständer: nein</string>
     <string name="poi_wildlife_hide">Wildbeobachtungsplatz</string>
     <string name="poi_training_language">Ausbildung: Sprache</string>
     <string name="poi_training_music">Ausbildung: Musik</string>

--- a/OsmAnd/res/values/phrases.xml
+++ b/OsmAnd/res/values/phrases.xml
@@ -1675,6 +1675,12 @@
 	<string name="poi_capacity_parent_yes">Dedicated places for parents</string>
 	<string name="poi_capacity_parent_no">No dedicated places for parents</string>
 	<string name="poi_capacity_parent">Dedicated places for parents</string>
+	<string name="poi_capacity_charging_yes">Dedicated places for charging</string>
+	<string name="poi_capacity_charging_no">No dedicated places for charging</string>
+	<string name="poi_capacity_charging">Dedicated places for charging</string>
+	<string name="poi_capacity_cargo_bike_yes">Dedicated places for cargo bikes</string>
+	<string name="poi_capacity_cargo_bike_no">No dedicated places for cargo bikes</string>
+	<string name="poi_capacity_cargo_bike">Dedicated places for cargo bikes</string>
 
 	<string name="poi_aerialway_occupancy">Cabin/chair/car capacity</string>
 	<string name="poi_aerialway_capacity">Capacity per hour</string>
@@ -2247,6 +2253,8 @@
 	<string name="poi_service_bicycle_second_hand_no">Retail sale of second-hand bicycles: no</string>
 	<string name="poi_service_bicycle_charging_yes">Charging: yes;Bicycle charging;Bike charging;Electric bicycle charging;Electric bike charging</string>
 	<string name="poi_service_bicycle_charging_no">Charging: no</string>
+	<string name="poi_service_bicycle_stand_yes">Repair stand: yes;Bicycle stand;Bike stand;Bicycle repair stand;Bike repair stand</string>
+	<string name="poi_service_bicycle_stand_no">Repair stand: no</string>
 	<string name="poi_bicycle_repair_station">Bicycle repair station;Bicycle self-repair station;Bike repair station;Bike self-repair station</string>
 
 	<string name="poi_wildlife_hide">Place to observe wildlife</string>


### PR DESCRIPTION
This is supposed to add some tags to the POI information (shown when you click on a POI). I added English and German translations. The added tags are:

Tag | Uses
---|---
`capacity:charging` | 6.2k
`capacity:cargo_bike` | 1k
`service:bicycle:stand` | 1.6k