### PR TITLE
Fix unnecessary map redrawing after device unlock

### DIFF
--- a/OsmAnd/src/net/osmand/plus/render/UpdateVectorRendererAsyncTask.java
+++ b/OsmAnd/src/net/osmand/plus/render/UpdateVectorRendererAsyncTask.java
@@ -45,7 +45,7 @@ public class UpdateVectorRendererAsyncTask extends AsyncTask<Void, Void, Boolean
 		if (mapView.hasMapRenderer()) {
 			MapRendererContext rendererContext = NativeCoreContext.getMapRendererContext();
 			if (rendererContext != null) {
-				rendererContext.updateMapSettings(true);
+				rendererContext.updateMapSettings(false);
 			}
 		}
 		return changed;


### PR DESCRIPTION
Don't redraw map after unlocking the device