### PR TITLE
Fix 18275 Top buttons jump when open Context Menu

### DIFF
--- a/OsmAnd/res/layout/map_hud_top.xml
+++ b/OsmAnd/res/layout/map_hud_top.xml
@@ -229,7 +229,6 @@
 						android:contentDescription="@string/map_widget_search"
 						android:layout_width="@dimen/map_small_button_size"
 						android:layout_height="@dimen/map_small_button_size"
-						android:layout_marginLeft="@dimen/map_small_button_margin"
 						android:layout_marginStart="@dimen/map_small_button_margin"
 						android:background="@drawable/btn_inset_circle_trans"
 						tools:src="@drawable/ic_action_remove_dark"/>

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/MapContextMenuFragment.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/MapContextMenuFragment.java
@@ -1542,7 +1542,6 @@ public class MapContextMenuFragment extends BaseOsmAndFragment implements Downlo
 		}
 	}
 
-	@TargetApi(Build.VERSION_CODES.JELLY_BEAN)
 	private void runLayoutListener() {
 		if (view != null) {
 			ViewTreeObserver vto = view.getViewTreeObserver();
@@ -1975,7 +1974,7 @@ public class MapContextMenuFragment extends BaseOsmAndFragment implements Downlo
 
 	private int addStatusBarHeightIfNeeded(int res) {
 		MapActivity mapActivity = getMapActivity();
-		if (Build.VERSION.SDK_INT >= 21 && mapActivity != null) {
+		if (mapActivity != null) {
 			// One pixel is needed to fill a thin gap between the status bar and the fragment.
 			return res + AndroidUtils.getStatusBarHeight(mapActivity) - 1;
 		}

--- a/OsmAnd/src/net/osmand/plus/views/controls/SideWidgetsPanel.java
+++ b/OsmAnd/src/net/osmand/plus/views/controls/SideWidgetsPanel.java
@@ -249,10 +249,13 @@ public class SideWidgetsPanel extends FrameLayout {
 
 	@Override
 	public void setVisibility(int visibility) {
-		super.setVisibility(visibility);
 		if (!selfVisibilityChanging) {
 			selfShowAllowed = visibility == VISIBLE;
 		}
+		if (visibility == VISIBLE && !hasVisibleWidgets()) {
+			return;
+		}
+		super.setVisibility(visibility);
 	}
 
 	/**


### PR DESCRIPTION
The problem seems to be caused by trying to display the left widget panel above the map hud top buttons when that panel is empty (has no widgets to display).
In this case, the visibility panel becomes visible for a moment, and then automatically becomes invisible when the panel refreshes and realizes that it has nothing to display.

In this fix, we prevent the panel from becoming visible if it has nothing to display (however, we keep the ability to become visible in the future if visible widgets appear on it).