### PR TITLE
Call a BRouter profile by name

### DIFF
--- a/OsmAnd/src/net/osmand/plus/routing/RouteProvider.java
+++ b/OsmAnd/src/net/osmand/plus/routing/RouteProvider.java
@@ -1287,6 +1287,8 @@ public class RouteProvider {
 		bpars.putDoubleArray("nogoLats", nogoLats);
 		bpars.putDoubleArray("nogoLons", nogoLons);
 		bpars.putDoubleArray("nogoRadi", nogoRadi);
+		bpars.putString("fast", params.fast ? "1" : "0");
+		bpars.putString("v", mode);
 		bpars.putString("trackFormat", "gpx");
 		bpars.putString("turnInstructionFormat", "osmand");
 		bpars.putString("acceptCompressedResult", "true");
@@ -1300,9 +1302,6 @@ public class RouteProvider {
 				if (brouter_Profile_Name.length() > 0) {
 					//  set the profile-name in the new parameter "profile" to transmit the profile-name to the brouter
 					bpars.putString("profile", brouter_Profile_Name );
-				} else {
-					bpars.putString("fast", params.fast ? "1" : "0");
-					bpars.putString("v", mode);
 				}
 			}
 		}

--- a/OsmAnd/src/net/osmand/plus/routing/RouteProvider.java
+++ b/OsmAnd/src/net/osmand/plus/routing/RouteProvider.java
@@ -1291,18 +1291,18 @@ public class RouteProvider {
 		bpars.putString("turnInstructionFormat", "osmand");
 		bpars.putString("acceptCompressedResult", "true");
 
- 	  String osmand_Profile_Name = params.mode.getUserProfileName();
-    if ( osmand_Profile_Name.indexOf("Brouter") == 0) { 
-      if ( osmand_Profile_Name .indexOf("[") != -1 && osmand_Profile_Name .indexOf("]") != -1) {
-        String  brouter_Profile_Name = osmand_Profile_Name.substring(osmand_Profile_Name .indexOf("[") + 1, osmand_Profile_Name .indexOf("]"));
+		String osmand_Profile_Name = params.mode.getUserProfileName();
+		if ( osmand_Profile_Name.indexOf("Brouter") == 0) { 
+			if ( osmand_Profile_Name .indexOf("[") != -1 && osmand_Profile_Name .indexOf("]") != -1) {
+				String  brouter_Profile_Name = osmand_Profile_Name.substring(osmand_Profile_Name .indexOf("[") + 1, osmand_Profile_Name .indexOf("]"));
 
-        // log.info (" BROUTER_PROFILE_NAME = " + brouter_Profile_Name );
-        if (brouter_Profile_Name.length() > 0) {
+				// log.info (" BROUTER_PROFILE_NAME = " + brouter_Profile_Name );
+				if (brouter_Profile_Name.length() > 0) {
 					//  set the profile-name in the new parameter "profile" to transmit the profile-name to the brouter
-          bpars.putString("profile", brouter_Profile_Name );
-        } else {
-      		bpars.putString("fast", params.fast ? "1" : "0");
-		      bpars.putString("v", mode);
+					bpars.putString("profile", brouter_Profile_Name );
+				} else {
+					bpars.putString("fast", params.fast ? "1" : "0");
+					bpars.putString("v", mode);
 				}
 			}
 		}

--- a/OsmAnd/src/net/osmand/plus/routing/RouteProvider.java
+++ b/OsmAnd/src/net/osmand/plus/routing/RouteProvider.java
@@ -1287,11 +1287,25 @@ public class RouteProvider {
 		bpars.putDoubleArray("nogoLats", nogoLats);
 		bpars.putDoubleArray("nogoLons", nogoLons);
 		bpars.putDoubleArray("nogoRadi", nogoRadi);
-		bpars.putString("fast", params.fast ? "1" : "0");
-		bpars.putString("v", mode);
 		bpars.putString("trackFormat", "gpx");
 		bpars.putString("turnInstructionFormat", "osmand");
 		bpars.putString("acceptCompressedResult", "true");
+
+ 	  String osmand_Profile_Name = params.mode.getUserProfileName();
+    if ( osmand_Profile_Name.indexOf("Brouter") == 0) { 
+      if ( osmand_Profile_Name .indexOf("[") != -1 && osmand_Profile_Name .indexOf("]") != -1) {
+        String  brouter_Profile_Name = osmand_Profile_Name.substring(osmand_Profile_Name .indexOf("[") + 1, osmand_Profile_Name .indexOf("]"));
+
+        // log.info (" BROUTER_PROFILE_NAME = " + brouter_Profile_Name );
+        if (brouter_Profile_Name.length() > 0) {
+					//  set the profile-name in the new parameter "profile" to transmit the profile-name to the brouter
+          bpars.putString("profile", brouter_Profile_Name );
+        } else {
+      		bpars.putString("fast", params.fast ? "1" : "0");
+		      bpars.putString("v", mode);
+				}
+			}
+		}
 
 		OsmandApplication ctx = params.ctx;
 		List<Location> res = new ArrayList<Location>();


### PR DESCRIPTION
In keeping with #18865, here is an update for the RouteProvider so that a BRouter profile can be called directly.