### PR TITLE
Fix "Battery optimization settings" feature after UI review

### DIFF
--- a/OsmAnd/AndroidManifest.xml
+++ b/OsmAnd/AndroidManifest.xml
@@ -19,6 +19,7 @@
 	<uses-permission android:name="android.permission.RECORD_AUDIO" />
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 	<uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+	<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
 	<uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 

--- a/OsmAnd/res/layout/bottom_sheet_icon_title_description.xml
+++ b/OsmAnd/res/layout/bottom_sheet_icon_title_description.xml
@@ -31,6 +31,7 @@
 		android:layout_height="wrap_content"
 		android:textColor="?android:textColorPrimary"
 		android:textSize="@dimen/default_list_text_size"
+		android:lineSpacingExtra="@dimen/titleLineSpacingExtra"
 		tools:text="@string/speed_cameras_legal_descr" />
 
 </LinearLayout>

--- a/OsmAnd/src/net/osmand/plus/settings/controllers/BatteryOptimizationController.java
+++ b/OsmAnd/src/net/osmand/plus/settings/controllers/BatteryOptimizationController.java
@@ -8,6 +8,7 @@ import static net.osmand.plus.base.dialog.data.DialogExtra.TITLE;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.os.PowerManager;
 import android.provider.Settings;
 
@@ -98,7 +99,9 @@ public class BatteryOptimizationController extends BaseDialogController
 
 	public void openBatteryOptimizationSettings() {
 		Intent intent = new Intent();
-		intent.setAction(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS);
+		intent.setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS);
+		String packageName = app.getPackageName();
+		intent.setData(Uri.parse("package:" + packageName));
 		AndroidUtils.startActivityIfSafe(app, intent);
 	}
 


### PR DESCRIPTION
Fixes after UI Review: https://github.com/osmandapp/OsmAnd/issues/14958#issuecomment-1916542271
+ Open system settings for a particular application (OsmAnd) instead of opening list of all applications (when user click on "Battery optimization settings" option).
+ Fix line spacing for description.