### PR TITLE
Fix Android Studio "prepareKotlinBuildScriptModel" error

### DIFF
--- a/OsmAnd/build.gradle
+++ b/OsmAnd/build.gradle
@@ -222,3 +222,7 @@ dependencies {
 	amazonFreeImplementation "com.amazon:in-app-purchasing:2.0.76@jar"
 	amazonFullImplementation "com.amazon:in-app-purchasing:2.0.76@jar"
 }
+
+// Fix Android Studio problem when `android` and `tools` projects are open at the same time.
+// Error: Task 'prepareKotlinBuildScriptModel' not found in project ':OsmAnd'.
+task prepareKotlinBuildScriptModel { }


### PR DESCRIPTION
**Fix Android Studio problem when `android` and `tools` projects are opened at the same time.**

Error: Task 'prepareKotlinBuildScriptModel' not found in project ':OsmAnd'.

Before:
![1](https://github.com/osmandapp/OsmAnd/assets/90444451/44346135-9ee7-473c-8784-f31a43995bc9)

After:
![2](https://github.com/osmandapp/OsmAnd/assets/90444451/f7266c63-dd0f-4f8c-8da2-08aabc62e346)

Links:

https://github.com/gradle/gradle/issues/14889#issuecomment-988134777

https://stackoverflow.com/questions/64290545/task-preparekotlinbuildscriptmodel-not-found-in-project-app/64418715