### PR TITLE
Added title (textPrefix) to Architect field in Amenity menu UI.

### DIFF
--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/AmenityUIHelper.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/AmenityUIHelper.java
@@ -186,6 +186,7 @@ public class AmenityUIHelper extends MenuBuilder {
 			boolean isWiki = false;
 			boolean isText = false;
 			boolean isDescription = false;
+			boolean isArchitect = false;
 			boolean needLinks = !(CollectionUtils.equalsToAny(key, Amenity.OPENING_HOURS, "population", "height"));
 			boolean needIntFormatting = "population".equals(key);
 			boolean isPhoneNumber = false;
@@ -349,12 +350,13 @@ public class AmenityUIHelper extends MenuBuilder {
 					} else {
 						isText = true;
 						isDescription = iconId == R.drawable.ic_action_note_dark;
+						isArchitect = iconId == R.drawable.mx_architect;
 						textPrefix = pType.getTranslation();
 						if (needIntFormatting) {
 							vl = getFormattedInt(vl);
 						}
 					}
-					if (!isDescription && icon == null) {
+					if (!isDescription && !isArchitect && icon == null) {
 						icon = getRowIcon(view.getContext(), pType.getIconKeyName());
 						if (isText && icon != null) {
 							textPrefix = "";


### PR DESCRIPTION
This is a fix for the issue reported here: https://github.com/osmandapp/OsmAnd/discussions/19099

This adds the "Architect" label to POIs that have this label. It has an unintended side effect of changing the icon to an Architect-specific one, I can't understand why - but I think this is a good change. 

A cleaner fix would be to remove the code that blanks out the textPrefix (title) for these items, which results in all the text fields getting a title, not just the Description and those without icons. But, I guess there are reasons it is done that way - if so I would be interested to hear them. If there are other suggestions from maintainers about how to solve this problem or how to improve this UI I would be happy to implement them. 