### PR TITLE
Android Auto navigation improvements

### DIFF
--- a/OsmAnd/build.gradle
+++ b/OsmAnd/build.gradle
@@ -29,10 +29,10 @@ android {
 		}
 
 		publishing {
-			storeFile file("/var/lib/jenkins/osmand_key")
-			storePassword System.getenv("OSMAND_APK_PASSWORD")
-			keyAlias "osmand"
-			keyPassword System.getenv("OSMAND_APK_PASSWORD")
+			storeFile file("../keystores/debug.keystore")
+			storePassword "android"
+			keyAlias "androiddebugkey"
+			keyPassword "android"
 		}
 	}
 

--- a/OsmAnd/src/net/osmand/plus/NavigationService.java
+++ b/OsmAnd/src/net/osmand/plus/NavigationService.java
@@ -318,7 +318,7 @@ public class NavigationService extends Service {
 							false/*routingHelper.isRouteWasFinished()*/,
 							destinations, trip.getSteps(), destinationTravelEstimate,
 							lastStepTravelEstimate != null ? lastStepTravelEstimate.getRemainingDistance() : null,
-							false, true, null);
+							true, true, null);
 				}
 			}
 		}

--- a/OsmAnd/src/net/osmand/plus/auto/SurfaceRenderer.java
+++ b/OsmAnd/src/net/osmand/plus/auto/SurfaceRenderer.java
@@ -29,6 +29,7 @@ import net.osmand.plus.OsmAndConstants;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.auto.views.CarSurfaceView;
 import net.osmand.plus.helpers.MapDisplayPositionManager;
+import net.osmand.plus.helpers.DayNightHelper;
 import net.osmand.plus.plugins.PluginsHelper;
 import net.osmand.plus.views.OsmandMapTileView;
 import net.osmand.plus.views.corenative.NativeCoreContext;
@@ -64,6 +65,8 @@ public final class SurfaceRenderer implements DefaultLifecycleObserver, MapRende
 
 	private SurfaceRendererCallback callback;
 
+        private DayNightHelper daynight;
+
 	public void setCallback(@Nullable SurfaceRendererCallback callback) {
 		this.callback = callback;
 	}
@@ -83,7 +86,7 @@ public final class SurfaceRenderer implements DefaultLifecycleObserver, MapRende
 				SurfaceRenderer.this.surfaceContainer = surfaceContainer;
 				surface = surfaceContainer.getSurface();
 				surfaceView.setSurfaceParams(surfaceContainer.getWidth(), surfaceContainer.getHeight(), surfaceContainer.getDpi());
-				darkMode = carContext.isDarkMode();
+				darkMode = daynight.isNightMode();
 				OsmandMapTileView mapView = SurfaceRenderer.this.mapView;
 				if (mapView != null) {
 					mapView.setupRenderingView();
@@ -178,6 +181,7 @@ public final class SurfaceRenderer implements DefaultLifecycleObserver, MapRende
 		this.handler = new Handler();
 		this.carContext = carContext;
 		this.surfaceView = new CarSurfaceView(carContext, this);
+                this.daynight = new DayNightHelper(getApp());
 		lifecycle.addObserver(this);
 	}
 
@@ -392,7 +396,7 @@ public final class SurfaceRenderer implements DefaultLifecycleObserver, MapRende
 			// Surface is not available, or has been destroyed, skip this frame.
 			return;
 		}
-		DrawSettings drawSettings = new DrawSettings(carContext.isDarkMode(), false);
+		DrawSettings drawSettings = new DrawSettings(daynight.isNightMode(), false);
 		RotatedTileBox tileBox = mapView.getCurrentRotatedTileBox().copy();
 		try {
 			renderFrame(tileBox, drawSettings);
@@ -408,7 +412,7 @@ public final class SurfaceRenderer implements DefaultLifecycleObserver, MapRende
 		}
 		Canvas canvas = surface.lockCanvas(null);
 		try {
-			boolean newDarkMode = carContext.isDarkMode();
+			boolean newDarkMode = daynight.isNightMode();
 			boolean updateVectorRendering = drawSettings.isUpdateVectorRendering() || darkMode != newDarkMode;
 			darkMode = newDarkMode;
 			drawSettings = new DrawSettings(newDarkMode, updateVectorRendering);

--- a/OsmAnd/src/net/osmand/plus/auto/TripHelper.java
+++ b/OsmAnd/src/net/osmand/plus/auto/TripHelper.java
@@ -150,18 +150,12 @@ public class TripHelper {
 				turnBuilder = new Maneuver.Builder(Maneuver.TYPE_UNKNOWN);
 			}
 			Maneuver maneuver = turnBuilder.build();
-			AnnounceTimeDistances atd = app.getRoutingHelper().getVoiceRouter().getAnnounceTimeDistances();
-			if (nextDirInfo != null && atd != null) {
-				float speed = atd.getSpeed(currentLocation);
+			if (nextDirInfo != null) {
 				int dist = nextDirInfo.distanceTo;
-				if (atd.isTurnStateActive(speed, dist, STATE_TURN_IN)) {
-					NextDirectionInfo nextNextDirInfo = routingHelper.getNextRouteDirectionInfoAfter(nextDirInfo, new NextDirectionInfo(), true);
-					if (nextNextDirInfo != null && nextNextDirInfo.directionInfo != null &&
-							(atd.isTurnStateActive(speed, nextNextDirInfo.distanceTo, STATE_TURN_NOW)
-							|| !atd.isTurnStateNotPassed(speed, nextNextDirInfo.distanceTo, STATE_TURN_IN))) {
-						nextTurnType = nextNextDirInfo.directionInfo.getTurnType();
-					}
-				}
+                                NextDirectionInfo nextNextDirInfo = routingHelper.getNextRouteDirectionInfoAfter(nextDirInfo, new NextDirectionInfo(), true);
+                                if (nextNextDirInfo != null && nextNextDirInfo.directionInfo != null) {
+                                  nextTurnType = nextNextDirInfo.directionInfo.getTurnType();
+                                }
 			}
 			String cue = turnType != null ? nextTurnsToString(app, turnType, nextTurnType) : "";
 			stepBuilder.setManeuver(maneuver);

--- a/OsmAnd/src/net/osmand/plus/auto/screens/LandingScreen.kt
+++ b/OsmAnd/src/net/osmand/plus/auto/screens/LandingScreen.kt
@@ -7,6 +7,7 @@ import androidx.car.app.model.*
 import androidx.car.app.navigation.model.PlaceListNavigationTemplate
 import androidx.core.graphics.drawable.IconCompat
 import net.osmand.plus.R
+import net.osmand.plus.helpers.DayNightHelper
 import net.osmand.plus.auto.NavigationSession
 
 class LandingScreen(
@@ -14,6 +15,8 @@ class LandingScreen(
     private val settingsAction: Action) : BaseAndroidAutoScreen(carContext) {
     @DrawableRes
     private var compassResId = R.drawable.ic_compass_niu
+
+    private var daynight = DayNightHelper(app)
 
     override fun onGetTemplate(): Template {
         val listBuilder = ItemList.Builder()
@@ -93,7 +96,7 @@ class LandingScreen(
 
     private fun updateCompass() {
         val settings = app.settings
-        val nightMode = carContext.isDarkMode
+        val nightMode = daynight.isNightMode()
         val compassMode = settings.compassMode
         compassResId = compassMode.getIconId(nightMode)
     }

--- a/OsmAnd/src/net/osmand/plus/auto/screens/NavigationScreen.java
+++ b/OsmAnd/src/net/osmand/plus/auto/screens/NavigationScreen.java
@@ -36,6 +36,7 @@ import net.osmand.plus.auto.NavigationListener;
 import net.osmand.plus.auto.NavigationSession;
 import net.osmand.plus.auto.SurfaceRenderer;
 import net.osmand.plus.auto.SurfaceRenderer.SurfaceRendererCallback;
+import net.osmand.plus.helpers.DayNightHelper;
 import net.osmand.plus.routing.IRouteInformationListener;
 import net.osmand.plus.routing.RoutingHelper;
 import net.osmand.plus.settings.backend.OsmandSettings;
@@ -80,6 +81,8 @@ public final class NavigationScreen extends BaseAndroidAutoScreen implements Sur
 
 	private boolean panMode;
 
+        private DayNightHelper daynight;
+
 	public NavigationScreen(
 			@NonNull CarContext carContext,
 			@NonNull Action settingsAction,
@@ -89,6 +92,8 @@ public final class NavigationScreen extends BaseAndroidAutoScreen implements Sur
 		this.settingsAction = settingsAction;
 
 		OsmandApplication app = getApp();
+                this.daynight = new DayNightHelper(app);
+
 		alarmWidget = new AlarmWidget(app, null);
 		speedometerWidget = new SpeedometerWidget(app, null);
 
@@ -111,7 +116,7 @@ public final class NavigationScreen extends BaseAndroidAutoScreen implements Sur
 	public void onFrameRendered(@NonNull Canvas canvas, @NonNull Rect visibleArea, @NonNull Rect stableArea) {
 		SurfaceRenderer surfaceRenderer = getSurfaceRenderer();
 		if (surfaceRenderer != null) {
-			DrawSettings drawSettings = new DrawSettings(getCarContext().isDarkMode(), false, surfaceRenderer.getDensity());
+			DrawSettings drawSettings = new DrawSettings(daynight.isNightMode(), false, surfaceRenderer.getDensity());
 
 			alarmWidget.updateInfo(drawSettings, true);
 			speedometerWidget.updateInfo(drawSettings, true, drawSettings.isNightMode());
@@ -362,7 +367,7 @@ public final class NavigationScreen extends BaseAndroidAutoScreen implements Sur
 
 	private void updateCompass() {
 		OsmandSettings settings = getApp().getSettings();
-		boolean nightMode = getCarContext().isDarkMode();
+		boolean nightMode = daynight.isNightMode();
 		CompassMode compassMode = settings.getCompassMode();
 		compassResId = compassMode.getIconId(nightMode);
 	}

--- a/OsmAnd/src/net/osmand/plus/helpers/DayNightHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/DayNightHelper.java
@@ -141,7 +141,7 @@ public class DayNightHelper implements SensorEventListener {
 			dayNightMode = providedTheme != null ? providedTheme : dayNightMode;
 		}
 		NavigationSession carNavigationSession = app.getCarNavigationSession();
-		if (carNavigationSession != null && carNavigationSession.isStateAtLeast(State.CREATED)) {
+		if (false && carNavigationSession != null && carNavigationSession.isStateAtLeast(State.CREATED)) {
 			boolean carDarkMode = carNavigationSession.getCarContext().isDarkMode();
 			dayNightMode = carDarkMode ? DayNightMode.NIGHT : DayNightMode.DAY;
 		}

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 #
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
This is the result of a weekend project I did to make Android Auto work better for me.  It does the following:

- Uses sunrise/sunset to determine whether to use dark mode or not, not the data from the car.  The reason for this change is that my personal Android Auto instance erroneously tells mapping applications that it is night even during the day.  The car is fine: the headlights correctly come on at night and not during the day.  Android Auto must be buggy.  I see from searching the Internet that others have experienced this bug as well, and the symmetrical bug where Android Auto is erroneously rendering day mode at night.  So, I'd say better to just use sunrise/sunset than rely on Android Auto to give correct information.

- Enables "turn after next" information reporting and gives "turn after next" information unconditionally, not just when the next turn is imminent.  I find this very useful so I can pick the correct lane when making a turn.

I know that Google Play has idiotic PITA requirements for Android Auto navigation apps, so it may be that the features in this PR can't be implemented in an APK distributed on Google Play.  If that is the case, I'd suggest conditionally enabling the features in this PR such that they are at least available in the F-Droid APK.

I'd also suggest maybe adding a menu option for sunrise/sunset versus "use what the car says about day/night" and for "display turn after next".  Having a toggle might be helpful to some people.

Any such modifications, however, I'll have to leave as an exercise for the maintainers :)  Now that my copy of OsmAnd does what I want, I don't have the free time to make further revisions.  However, I do hope this code is useful to others, and I will be posting my APK on my personal website so that others can get it if they want.  (I will post the link in a comment later.)

Thanks for making a great app.  You guys rock.