### PR TITLE
[hotfix] Revert "Avoid double call prepareResult (fix 1st/last seg) (#19117)"

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/RoutePlannerFrontEnd.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RoutePlannerFrontEnd.java
@@ -1207,11 +1207,7 @@ public class RoutePlannerFrontEnd {
 		}
 		addPrecalculatedToResult(recalculationEnd, result);
 		ctx.routingTime += ctx.calculationProgress.routingCalculatedTime;
-		if (hhConfig != null) {
-			return new RouteCalcResult(result); // HH: avoid double call prepareResult() (already done in C++)
-		} else {
-			return new RouteResultPreparation().prepareResult(ctx, result);
-		}
+		return new RouteResultPreparation().prepareResult(ctx, result);
 	}
 
 	private void addPrecalculatedToResult(RouteSegment recalculationEnd, List<RouteSegmentResult> result) {


### PR DESCRIPTION
Avoid prepareResult is a wrong way (no regions/data loaded in Java after Native)

This reverts commit 9cc00a8a1bd49fc28e60325c9674dc505d4dad4d.