### PR TITLE
Fix using of "Day / Night" strings for "Route Line Appearance" dialog

### DIFF
--- a/OsmAnd/src/net/osmand/plus/settings/controllers/RouteLineColorController.java
+++ b/OsmAnd/src/net/osmand/plus/settings/controllers/RouteLineColorController.java
@@ -92,7 +92,7 @@ public class RouteLineColorController extends ColoringCardController implements 
 
 				@NonNull
 				private PaletteMode createPaletteMode(boolean night) {
-					String title = app.getString(night ? R.string.night : R.string.day);
+					String title = app.getString(night ? R.string.daynight_mode_night : R.string.daynight_mode_day);
 					int tag = night ? PALETTE_MODE_ID_NIGHT : PALETTE_MODE_ID_DAY;
 					return new PaletteMode(title, tag);
 				}


### PR DESCRIPTION
Use correct strings "Day" and "Night" on the "Route Line Appearance" dialog (fix #11570).
Original fix: https://github.com/osmandapp/OsmAnd/pull/19232