### PR TITLE
Backport C++ car 2-phase fix legacy/pull/185

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/BinaryRoutePlanner.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/BinaryRoutePlanner.java
@@ -349,6 +349,12 @@ public class BinaryRoutePlanner {
 
 	private void initQueuesWithStartEnd(final RoutingContext ctx, RouteSegmentPoint start, RouteSegmentPoint end,
 			PriorityQueue<RouteSegmentCost> graphDirectSegments, PriorityQueue<RouteSegmentCost> graphReverseSegments) {
+		if (ctx.precalculatedRouteDirection != null) {
+			ctx.precalculatedRouteDirection.updatePreciseStartEnd(
+					(start != null) ? start.preciseX : 0, (start != null) ? start.preciseY : 0,
+					(end != null) ? end.preciseX : 0, (end != null) ? end.preciseY : 0
+			);
+		}
 		if (start != null) {
 			ctx.startX = start.preciseX;
 			ctx.startY = start.preciseY;
@@ -427,17 +433,16 @@ public class BinaryRoutePlanner {
 		if (ctx.dijkstraMode != 0) {
 			return 0;
 		}
-		double distToFinalPoint = squareRootDist(begX, begY, endX, endY);
-		double result = distToFinalPoint / ctx.getRouter().getMaxSpeed();
 		if (ctx.precalculatedRouteDirection != null) {
 			float te = ctx.precalculatedRouteDirection.timeEstimate(begX, begY, endX, endY);
 			if (te > 0) {
 				return te;
 			}
 		}
+		double distToFinalPoint = squareRootDist(begX, begY, endX, endY);
+		double result = distToFinalPoint / ctx.getRouter().getMaxSpeed();
 		return (float) result;
 	}
-
 
 	private static void println(String logMsg) {
 //		log.info(logMsg);

--- a/OsmAnd-java/src/main/java/net/osmand/router/PrecalculatedRouteDirection.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/PrecalculatedRouteDirection.java
@@ -283,7 +283,20 @@ public class PrecalculatedRouteDirection {
 		return routeDirection;
 	}
 
-
-	
-
+	public void updatePreciseStartEnd(int sx, int sy, int ex, int ey) {
+		if (sx > 0 && sy > 0) {
+			int ind = getIndex(sx, sy);
+			if (ind != -1) {
+				startPoint = calc(sx, sy);
+				startFinishTime = (float) BinaryRoutePlanner.squareRootDist(pointsX[ind], pointsY[ind], sx, sy) / maxSpeed;
+			}
+		}
+		if (ex > 0 && ey > 0) {
+			int ind = getIndex(ex, ey);
+			if (ind != -1) {
+				endPoint = calc(ex, ey);
+				endFinishTime = (float) BinaryRoutePlanner.squareRootDist(pointsX[ind], pointsY[ind], ex, ey) / maxSpeed;
+			}
+		}
+	}
 }


### PR DESCRIPTION
Original C++ request: https://github.com/osmandapp/OsmAnd-core-legacy/pull/185

C++ code needs that fixes to fix broken match of 2-phase start/end and to fix incorrect 2-phase detection at all.

Java methods have correct 2-phase startPoint/endPoint (for today, but who knows what might happen later).

Reasons to approve:

1. This request will sync Java and C++ code

3. Addionally, BRP h() method will be faster because old implementation was not optimal for 2-phase.