### PR TITLE
Replace magic value with constant CPP_NO_DIRECTION

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/NativeLibrary.java
+++ b/OsmAnd-java/src/main/java/net/osmand/NativeLibrary.java
@@ -252,7 +252,9 @@ public class NativeLibrary {
 		if (hhRoutingConfig != null) {
 			setHHNativeFilter(c);
 		}
-		return nativeRouting(c, hhRoutingConfig, c.config.initialDirection == null ? -2 * (float) Math.PI : c.config.initialDirection.floatValue(),
+		final float CPP_NO_DIRECTION = -2 * (float) Math.PI;
+		return nativeRouting(c, hhRoutingConfig, c.config.initialDirection == null ?
+				CPP_NO_DIRECTION : c.config.initialDirection.floatValue(),
 				regions, basemap);
 	}
 


### PR DESCRIPTION
See NO_DIRECTION in legacy repo:

`#define NO_DIRECTION ((float)(-2 * M_PI)) // -360 degrees in RADIANS for no-direction rule (Java uses ==null instead)`

Changed to constant because using `-2 * (float) Math.PI` in not so clear for this particular case.

Previously changed from broken value -360:

69eaaddd5622f8720d90fcb2b24fa858ee685d1a
