### PR TITLE
Fix 2 rare route recalculation problems (connected with iOS Issue #3617)

### DIFF
--- a/OsmAnd/src/net/osmand/plus/routing/RoutingHelper.java
+++ b/OsmAnd/src/net/osmand/plus/routing/RoutingHelper.java
@@ -418,8 +418,12 @@ public class RoutingHelper {
 
 				// 2. Analyze if we need to recalculate route
 				// >100m off current route (sideways) or parameter (for Straight line)
-				if (currentRoute > 0 && allowableDeviation > 0) {
-					distOrth = RoutingHelperUtils.getOrthogonalDistance(currentLocation, routeNodes.get(currentRoute - 1), routeNodes.get(currentRoute));
+				if (allowableDeviation > 0) {
+					if (currentRoute == 0) {
+						distOrth = currentLocation.distanceTo(routeNodes.get(currentRoute)); // deviation at the start
+					} else {
+						distOrth = RoutingHelperUtils.getOrthogonalDistance(currentLocation, routeNodes.get(currentRoute - 1), routeNodes.get(currentRoute));
+					}
 					if (distOrth > allowableDeviation) {
 						log.info("Recalculate route, because correlation  : " + distOrth); //$NON-NLS-1$
 						isDeviatedFromRoute = true;
@@ -656,7 +660,8 @@ public class RoutingHelper {
 						deviceHasBearing = true;
 					}
 					// lastFixedLocation.bearingTo -  gives artefacts during u-turn, so we avoid for devices with bearing
-					if (currentLocation.hasBearing() || (!deviceHasBearing && lastFixedLocation != null)) {
+					if ((currentRoute > 0 || newCurrentRoute > 0) &&
+							(currentLocation.hasBearing() || (!deviceHasBearing && lastFixedLocation != null))) {
 						float bearingToRoute = currentLocation.bearingTo(routeNodes.get(currentRoute));
 						float bearingRouteNext = routeNodes.get(newCurrentRoute).bearingTo(routeNodes.get(newCurrentRoute + 1));
 						float bearingMotion = currentLocation.hasBearing() ? currentLocation.getBearing() : lastFixedLocation


### PR DESCRIPTION
1. calculateCurrentRoute() might set processed=true incorrectly due to **tiny** difference between `distanceTo()` and `getOrthogonalDistance()` for 1st segment for the same location (Java "always recalc" - fixed)

2. setCurrentLocation() might miss route recalculation when location deviates at the start because `currentRoute > 0` is incorrect condition that just ignores start segment (iOS "broken recalc" - fixed)