### PR TITLE
Increase compatibility to JavaVersion.VERSION_1_8

### DIFF
--- a/OsmAnd-java/build.gradle
+++ b/OsmAnd-java/build.gradle
@@ -6,11 +6,11 @@ configurations {
 	android
 }
 
-//tasks.withType(JavaCompile) {
-//	sourceCompatibility = "1.7"
-//	targetCompatibility = "1.7"
-//	options.encoding = 'UTF-8'
-//}
+tasks.withType(JavaCompile) {
+	sourceCompatibility = JavaVersion.VERSION_1_8
+	targetCompatibility = JavaVersion.VERSION_1_8
+	options.encoding = 'UTF-8'
+}
 
 task collectRoutingResources(type: Sync) {
 	from "../../resources/routing"


### PR DESCRIPTION
It's incorrect to build Android with disabled sourceCompatibility/targetCompatibility.

Sooner or later, somebody may include incompatible code into OsmAnd-java classes.

For example, Java-tools is allowed to use Java 11 and its higher limit is inherited to OsmAnd-java in Tools project.

Therefore, the Compatibility should be limited to Android SDK max allowed = Java 8.
