### PR TITLE
Missing Maps: avoid adding SRTM-only regions

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/MissingMapsCalculator.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/MissingMapsCalculator.java
@@ -20,6 +20,7 @@ import net.osmand.PlatformUtil;
 import net.osmand.binary.BinaryMapIndexReader;
 import net.osmand.data.LatLon;
 import net.osmand.map.OsmandRegions;
+import net.osmand.map.WorldRegion;
 import net.osmand.util.Algorithms;
 import net.osmand.util.CollectionUtils;
 import net.osmand.util.MapUtils;
@@ -72,8 +73,8 @@ public class MissingMapsCalculator {
 			rmap.downloadName = Algorithms.getRegionName(r.getFile().getName());
 			rmap.reader = r;
 			rmap.standard = or.getRegionDataByDownloadName(rmap.downloadName) != null;
-			if (rmap.downloadName.toLowerCase().startsWith("world_")) {
-				continue;
+			if (rmap.downloadName.toLowerCase().startsWith(WorldRegion.WORLD + "_")) {
+				continue; // avoid including World_seamarks
 			}
 			knownMaps.put(rmap.downloadName, rmap);
 			for (HHRouteRegion rt : r.getHHRoutingIndexes()) {
@@ -188,10 +189,16 @@ public class MissingMapsCalculator {
 		boolean onlyJointMap = true;
 		List<String> regions = new ArrayList<String>();
 		for (BinaryMapDataObject o : resList) {
-			regions.add(or.getDownloadName(o));
-			if (!or.isDownloadOfType(o, OsmandRegions.MAP_JOIN_TYPE)
-					&& !or.isDownloadOfType(o, OsmandRegions.ROADS_JOIN_TYPE)) {
-				onlyJointMap = false;
+			if (or.isDownloadOfType(o, OsmandRegions.MAP_TYPE)
+					|| or.isDownloadOfType(o, OsmandRegions.ROADS_TYPE)
+					|| or.isDownloadOfType(o, OsmandRegions.MAP_JOIN_TYPE)
+					|| or.isDownloadOfType(o, OsmandRegions.ROADS_JOIN_TYPE)
+			) {
+				regions.add(or.getDownloadName(o));
+				if (!or.isDownloadOfType(o, OsmandRegions.MAP_JOIN_TYPE)
+						&& !or.isDownloadOfType(o, OsmandRegions.ROADS_JOIN_TYPE)) {
+					onlyJointMap = false;
+				}
 			}
 		}
 		Collections.sort(regions, new Comparator<String>() {

--- a/OsmAnd-java/src/main/java/net/osmand/router/MissingMapsCalculator.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/MissingMapsCalculator.java
@@ -189,14 +189,13 @@ public class MissingMapsCalculator {
 		boolean onlyJointMap = true;
 		List<String> regions = new ArrayList<String>();
 		for (BinaryMapDataObject o : resList) {
-			if (or.isDownloadOfType(o, OsmandRegions.MAP_TYPE)
-					|| or.isDownloadOfType(o, OsmandRegions.ROADS_TYPE)
-					|| or.isDownloadOfType(o, OsmandRegions.MAP_JOIN_TYPE)
-					|| or.isDownloadOfType(o, OsmandRegions.ROADS_JOIN_TYPE)
-			) {
+			boolean hasMapType = or.isDownloadOfType(o, OsmandRegions.MAP_TYPE);
+			boolean hasRoadsType = or.isDownloadOfType(o, OsmandRegions.ROADS_TYPE);
+			boolean hasMapJoinType = or.isDownloadOfType(o, OsmandRegions.MAP_JOIN_TYPE);
+			boolean hasRoadsJoinType = or.isDownloadOfType(o, OsmandRegions.ROADS_JOIN_TYPE);
+			if (hasMapType || hasRoadsType || hasMapJoinType || hasRoadsJoinType) {
 				regions.add(or.getDownloadName(o));
-				if (!or.isDownloadOfType(o, OsmandRegions.MAP_JOIN_TYPE)
-						&& !or.isDownloadOfType(o, OsmandRegions.ROADS_JOIN_TYPE)) {
+				if (!hasMapJoinType && !hasRoadsJoinType) {
 					onlyJointMap = false;
 				}
 			}


### PR DESCRIPTION
The problem. We have SRTM-only (sub)regions such as Afghanistan, Egypt, Libya, Chile, etc.

That SRTM-only regions (no map, no routing, only contours) are added regions List and a few lines later the list is sorted to get 1st only String from regions finally.

In case of Afghanistan + Tajikistan, the sorted result is:

afghanistan_baghlan_asia - the longest name, sorted to the top = get(0)
afghanistan_asia (ignored)
tajikistan_asia (ignored)

As a result, afghanistan_baghlan_asia is the only mapsToDownload region, which is obviously NOT A MAP/roads, not allowed to download as a map/roads, and finally we have the EMPTY list of Missing Maps and the disabled Download button.

The bugfix just excludes NOT map/roads regions from List.