### PR TITLE
Missing Maps: allow several countries for 1 point

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/MissingMapsCalculationResult.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/MissingMapsCalculationResult.java
@@ -6,6 +6,7 @@ import net.osmand.map.WorldRegion;
 import net.osmand.util.Algorithms;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -29,9 +30,16 @@ public class MissingMapsCalculationResult {
 		this.missingMapsPoints = missingMapsPoints;
 	}
 	
-	public void addMissingMaps(String region) {
-		missingMaps.add(region);
-		mapsToDownload.add(region);
+	public void addMissingMapsByRegionsWithDistinctCountries(List<String> regions) {
+		Set<String> addedCountries = new HashSet<>();
+		for (String r : regions) {
+			String country = r.split("_")[0];
+			if (!addedCountries.contains(country)) {
+				missingMaps.add(r);
+				mapsToDownload.add(r);
+				addedCountries.add(country);
+			}
+		}
 	}
 	
 	public void addUsedMaps(String region) {

--- a/OsmAnd-java/src/main/java/net/osmand/router/MissingMapsCalculator.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/MissingMapsCalculator.java
@@ -103,8 +103,7 @@ public class MissingMapsCalculator {
 		for (Point p : pointsToCheck) {
 			if (p.hhEditions == null) {
 				if (p.regions.size() > 0) {
-					result.addMissingMaps(p.regions.get(0));
-					
+					result.addMissingMapsByRegionsWithDistinctCountries(p.regions);
 				}
 			} else if (checkHHEditions) {
 				if (presentTimestamps == null) {
@@ -115,7 +114,6 @@ public class MissingMapsCalculator {
 			} else {
 				if (p.regions.size() > 0) {
 					result.addUsedMaps(p.regions.get(0));
-					
 				}
 			}
 		}


### PR DESCRIPTION
There are some interesting locations, such as Pamir Highway, that are located along the border between countries.

All the points along the border belong to both regions (in example case, Tajikistan and Afghanistan) and our current algorithm offers only one country with longer name (Afghanistan) even when the points are located at Tajikistan's side.

For example:

Tajikistan Qal’ai Khumb and Rushon are located at Tajikistan's side.

Both points belong to 2 regions:

afghanistan_asia
tajikistan_asia

Current algorithm consider only 1st region with the longest name - afghanistan_asia.

Finally, on Tajikistan's side Pamir Highway, users will be always offered to download Afghanistan instead of Tajikistan.

The request solves this problem by adding all regions by distinct countries (skipping already added countries).

The fine point might be a way of parsing country: /^(XXXXXXXX)_.*/ but in the worst case the method will result with only 1st region, which is absolutely the same result as original method.

I've tested many border points with new method in Asia (Pamir) and Europe (Austria, Switzerland, Germany) and have not found any problems.