### PR TITLE
Missing Maps: Decrease DISTANCE_SPLIT to 15km

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/MissingMapsCalculator.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/MissingMapsCalculator.java
@@ -28,7 +28,7 @@ public class MissingMapsCalculator {
 
 	protected static final Log LOG = PlatformUtil.getLog(MissingMapsCalculator.class);
 
-	public static final double DISTANCE_SPLIT = 50000;
+	public static final double DISTANCE_SPLIT = 15000;
 	public static final double DISTANCE_SKIP = 10000;
 	private OsmandRegions or;
 	private BinaryMapIndexReader reader;


### PR DESCRIPTION
This request fixes some cases in Europe such as Austria (Salzburg) -> Germany -> Austria (Innsbruck), Switzerland -> France -> Switzerland where the fastest route should run by a highway not via mountain roads.

I've tested the performance on 2000+ km distance and Missing Maps calc speed was not degraded.