### PR TITLE
Make pebble integration optional 

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -905,6 +905,7 @@ You need to activate the sensor so OsmAnd can find it.</string>
     • Default-speed adjustable forecast for elevation-dependent walking/hiking/running trip times\n\n
     • Fixed audio output and volume slider behavior\n\n
     </string>
+    <string name="pebble_voice">Send Pebble Voice notifications</string>
     <string name="speak_gps_signal_status">Announce GPS signal loss and recovery</string>
     <string name="speak_route_recalculation">Announce route recalculation</string>
     <string name="map_center_widget">Coordinates: Map center</string>

--- a/OsmAnd/res/xml/voice_announces.xml
+++ b/OsmAnd/res/xml/voice_announces.xml
@@ -141,6 +141,11 @@
 		android:layout="@layout/preference_switch"
 		android:title="@string/speak_route_deviation" />
 
+	<SwitchPreferenceCompat
+		android:key="pebble_voice"
+		android:layout="@layout/preference_switch"
+		android:title="@string/pebble_voice" />
+
 	<Preference
 		android:key="speed_limit_divider"
 		android:layout="@layout/simple_divider_item"

--- a/OsmAnd/src/net/osmand/plus/routing/VoiceRouter.java
+++ b/OsmAnd/src/net/osmand/plus/routing/VoiceRouter.java
@@ -165,6 +165,10 @@ public class VoiceRouter {
 		settings.VOICE_MUTE.setModeValue(mode, mute);
 	}
 
+	public boolean pebbleVoiceEnabled() {
+		return settings.PEBBLE_VOICE.get();
+	}
+
 	public boolean isMute() {
 		return settings.VOICE_MUTE.get();
 	}

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -3111,6 +3111,8 @@ public class OsmandSettings {
 
 	public final OsmandPreference<Boolean> USE_OSM_LIVE_FOR_PUBLIC_TRANSPORT = new BooleanPreference(this, "enable_osmc_public_transport", false).makeProfile();
 
+	public final OsmandPreference<Boolean> PEBBLE_VOICE = new BooleanPreference(this, "pebble_voice", true).makeProfile().cache();
+
 	public final OsmandPreference<Boolean> VOICE_MUTE = new BooleanPreference(this, "voice_mute", false).makeProfile().cache();
 
 	// for background service

--- a/OsmAnd/src/net/osmand/plus/voice/JsTtsCommandPlayer.java
+++ b/OsmAnd/src/net/osmand/plus/voice/JsTtsCommandPlayer.java
@@ -169,7 +169,9 @@ public class JsTtsCommandPlayer extends CommandPlayer {
 		for (String s : execute) {
 			bld.append(s).append(' ');
 		}
-		sendAlertToPebble(bld.toString());
+		if (voiceRouter.pebbleVoiceEnabled()) {
+			sendAlertToPebble(bld.toString());
+		}
 		if (mTts != null && !voiceRouter.isMute() && speechAllowed) {
 			if (ttsRequests++ == 0) {
 				requestAudioFocus();


### PR DESCRIPTION
Add a setting in the voice prompts settings tab to disable the Pebble Voice notification added in 3f9a611b125adf6c49ff451e4675504ac205fb95

This hopes to resolve #4686 where the "integration" Voice notification shows less information and is generally less helpful than the normal notification, but that notification cannot be disabled normally.

I wonder why this integration exists at all, but in good faith I just want it to be optional. If someone knows a good use case for it please let me know as I'm curious.