### PR TITLE
Fix subcategories POI reading (bits operation)

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/binary/BinaryMapPoiReaderAdapter.java
+++ b/OsmAnd-java/src/main/java/net/osmand/binary/BinaryMapPoiReaderAdapter.java
@@ -112,7 +112,7 @@ public class BinaryMapPoiReaderAdapter {
 				tl = (id >> 1) & ((1 << 5) - 1);
 				sl = id >> 6;
 			} else {
-				tl = (id >> 1) & ((1 << 16) - 1);
+				tl = (id >> 1) & ((1 << 15) - 1);
 				sl = id >> 16;
 			}
 			if (subTypes.size() > tl) {


### PR DESCRIPTION
To issue https://github.com/osmandapp/OsmAnd/issues/16397

Before we had not problem with this because subcategories always was single. After adding top_index_brand subcategories increase to 100 pcs.

It is backshift operation to this:
this.targetId = (valueId << 16) | (catId << 1) | 1;