### PR TITLE
Fix vector map symbols shown over online map

### DIFF
--- a/OsmAnd/src/net/osmand/core/android/MapRendererContext.java
+++ b/OsmAnd/src/net/osmand/core/android/MapRendererContext.java
@@ -341,7 +341,7 @@ public class MapRendererContext {
 		if (obfsCollection != null) {
 			obfsCollection.removeDirectory(dirPath);
 		}
-		recreateRasterAndSymbolsProvider(ProviderType.MAIN);
+		recreateRasterAndSymbolsProvider(this.providerType);
 	}
 
 	public void addDirectory(String dirPath) {
@@ -349,7 +349,7 @@ public class MapRendererContext {
 		if (obfsCollection != null && !obfsCollection.hasDirectory(dirPath)) {
 			obfsCollection.addDirectory(dirPath);
 		}
-		recreateRasterAndSymbolsProvider(ProviderType.MAIN);
+		recreateRasterAndSymbolsProvider(this.providerType);
 	}
 
 	public void recreateRasterAndSymbolsProvider(@NonNull ProviderType providerType) {


### PR DESCRIPTION
Don't show vector map symbols on online map layer