### PR TITLE
Fix NPE p.getIconName/p.getBackgroundType is null

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/gpx/GPXUtilities.java
+++ b/OsmAnd-java/src/main/java/net/osmand/gpx/GPXUtilities.java
@@ -1290,10 +1290,10 @@ public class GPXUtilities {
 			if (p.getColor() == pointsGroup.color) {
 				extensions.remove(COLOR_NAME_EXTENSION);
 			}
-			if (p.getIconName().equals(pointsGroup.iconName)) {
+			if (Algorithms.stringsEqual(p.getIconName(), pointsGroup.iconName)) {
 				extensions.remove(ICON_NAME_EXTENSION);
 			}
-			if (p.getBackgroundType().equals(pointsGroup.backgroundType)) {
+			if (Algorithms.stringsEqual(p.getBackgroundType(), pointsGroup.backgroundType)) {
 				extensions.remove(BACKGROUND_TYPE_EXTENSION);
 			}
 		}


### PR DESCRIPTION
Hardy, please approve a little fix.

PS. Kotlin GpxUtilities seems OK.

```
2024-09-07 21:36:14.151 ERROR [http-nio-127.0.0.1-8090-exec-2]: Error saving gpx
java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because the return value of "net.osmand.gpx.GPXUtilities$WptPt.getBackgroundType()" is null
        at net.osmand.gpx.GPXUtilities.writeWpt(GPXUtilities.java:1296)
        at net.osmand.gpx.GPXUtilities.writePoints(GPXUtilities.java:1125)
        at net.osmand.gpx.GPXUtilities.writeGpx(GPXUtilities.java:1031)
        at net.osmand.gpx.GPXUtilities.writeGpxFile(GPXUtilities.java:998)
        at net.osmand.server.controllers.pub.GpxController.saveTrackData(GpxController.java:280)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205)
```