### PR TITLE
deleting duplicated translations

### DIFF
--- a/OsmAnd-telegram/res/values-ar-rSA/strings.xml
+++ b/OsmAnd-telegram/res/values-ar-rSA/strings.xml
@@ -271,7 +271,6 @@
     <string name="logcat_buffer">لوجكات العازلة</string>
     <string name="logcat_buffer_descr">تحقق من السجلات التفصيلية للتطبيق وشاركها</string>
     <string name="send_report">إرسال تقرير</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="ltr_or_rtl_combine_via_colon">%1$s: %2$s</string>
     <string name="send_live_location_error">إرسال خطأ في الموقع المباشر: %1$s</string>
     <string name="shared_string_error">خطأ</string>

--- a/OsmAnd-telegram/res/values-he/strings.xml
+++ b/OsmAnd-telegram/res/values-he/strings.xml
@@ -270,7 +270,6 @@
     <string name="logcat_buffer">מכלא Logcat</string>
     <string name="logcat_buffer_descr">בדיקה ושיתוף יומני תיעוד מפורטים של היישומים</string>
     <string name="send_report">שליחת דיווח</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="ltr_or_rtl_combine_via_colon">%1$s: %2$s</string>
     <string name="shared_string_error">שגיאה</string>
     <string name="send_live_location_error">שגיאה בשליחת מיקום בזמן אמת: %1$s</string>

--- a/OsmAnd-telegram/res/values-hu/strings.xml
+++ b/OsmAnd-telegram/res/values-hu/strings.xml
@@ -274,6 +274,5 @@
     <string name="send_report">Jelentés küldése</string>
     <string name="shared_string_error">Hiba</string>
     <string name="send_live_location_error">Élő helymeghatározási hiba küldése: %1$s</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="ltr_or_rtl_combine_via_colon">%1$s: %2$s</string>
 </resources>

--- a/OsmAnd-telegram/res/values-id/strings.xml
+++ b/OsmAnd-telegram/res/values-id/strings.xml
@@ -149,7 +149,6 @@
     <string name="buffer_time">Waktu kadaluwarsa buffer</string>
     <string name="time_zone_descr">Pilih zona waktu untuk ditampilkan pada pesan lokasi Anda.</string>
     <string name="set_time_timeline_descr">Pilih waktu untuk ditampilkan</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="min_logging_accuracy_descr">Saring: tidak ada pencatatan kecuali akurasi dicapai</string>
     <string name="proxy_port">Port</string>
     <string name="shared_string_error">Terjadi kesalahan</string>

--- a/OsmAnd-telegram/res/values-pt-rPT/strings.xml
+++ b/OsmAnd-telegram/res/values-pt-rPT/strings.xml
@@ -271,7 +271,6 @@
     <string name="logcat_buffer">Buffer de logcat</string>
     <string name="logcat_buffer_descr">Verifique e compartilhe registos detalhados da app</string>
     <string name="send_report">Enviar o relatório</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="ltr_or_rtl_combine_via_colon">%1$s: %2$s</string>
     <string name="shared_string_error">Erro</string>
     <string name="send_live_location_error">Enviar erro de localização em tempo real: %1$s</string>

--- a/OsmAnd/res/values-ar/strings.xml
+++ b/OsmAnd/res/values-ar/strings.xml
@@ -3848,7 +3848,6 @@
 \nسيتوفر الرسم البياني بعد إعادة الحساب.</string>
     <string name="snowmobile_render_descr">للقيادة على الجليد مع طرق ومسارات مخصصة.</string>
     <string name="shared_string_graph">رسم بياني</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="shared_string_local_maps">الخرائط المحلية</string>
     <string name="icon_group_amenity">راحة</string>
     <string name="icon_group_special">خاص</string>

--- a/OsmAnd/res/values-ars/strings.xml
+++ b/OsmAnd/res/values-ars/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="ltr_or_rtl_combine_via_colon">%1$s: %2$s</string>
     <string name="touring_view_render_descr">أسلوب الملاحة مع التباين العالي والحد الأعلى من التفاصيل. يتضمن كل خيارات النمط الافتراضي أوسماند، مع عرض أكبر قدر ممكن من التفاصيل ، ولا سيما الطرق والمسارات وطرق السفر الأخرى. التمييز الواضح بين \"جولة الأطلس\" بين أنواع الطرق. مناسبة للاستخدام النهاري والليلي وفي الهواء الطلق.</string>
     <string name="shared_string_hillshade">التضاريس</string>

--- a/OsmAnd/res/values-ast/strings.xml
+++ b/OsmAnd/res/values-ast/strings.xml
@@ -512,7 +512,6 @@
     <string name="shared_string_color">Color</string>
     <string name="file_can_not_be_moved">Nun se pudo mover el ficheru.</string>
     <string name="shared_string_move">Mover</string>
-    <string name="routing_attr_driving_style_name">Driving style</string>
     <string name="altitude_descent">Descent</string>
     <string name="altitude_ascent">Ascent</string>
     <string name="average_altitude">Altitú media</string>
@@ -818,7 +817,6 @@
     <string name="of">%1$d de %2$d</string>
     <string name="ascent_descent">Ascent/Descent</string>
     <string name="home">Panel</string>
-    <string name="always_center_position_on_map">Display position always in center</string>
     <string name="lang_sr_latn">Serbian (latin)</string>
     <string name="lang_zh_hk">Chinu (Ḥong Kong)</string>
     <string name="lang_gn_py">Guaranín</string>
@@ -936,7 +934,6 @@
     <string name="altitude">Altitú</string>
     <string name="i_am_here">Toi equí</string>
     <string name="arrival_distance_factor_normally">Normal</string>
-    <string name="arrival_distance_factor_at_last">In the last meters</string>
     <string name="offline_edition">Edición ensin internet</string>
     <string name="offline_edition_descr">If offline editing is enabled, then changes will be saved locally first and uploaded by request, otherwise changes will be uploaded immediately.</string>
     <string name="local_openstreetmap_uploading">Xubiendo…</string>
@@ -1329,7 +1326,6 @@
     <string name="apply_filters">Apply filters</string>
     <string name="map_marker">Marcador del mapa</string>
     <string name="map_widget_plain_time">Hora actual</string>
-    <string name="routing_attr_weight_name">Weight limit</string>
     <string name="routing_attr_height_name">Llende d\'altor</string>
     <string name="route_is_too_long_v2">Pa distancies llongues: Amiesta destinos intermedios si nun s\'atopa nengún camín en 10 minutos.</string>
     <string name="speak_cameras">Radares de velocidá</string>
@@ -1372,8 +1368,6 @@
     <string name="price_free">Free</string>
     <string name="get_discount_title">Get %1$d %2$s at %3$s off.</string>
     <string name="get_discount_first_part">%1$s for the first %2$s</string>
-    <string name="get_discount_first_few_part">%1$s for the first %2$s</string>
-    <string name="get_discount_second_part">then %1$s</string>
     <string name="configure_profile_info">Settings for profile:</string>
     <string name="shared_string_example">Exemplu</string>
     <string name="wake_time">Timeout after wake-up</string>
@@ -1472,8 +1466,6 @@
     <string name="routing_attr_piste_type_downhill_description">Slopes for alpine or downhill skiing and access to ski lifts.</string>
     <string name="routing_attr_piste_type_downhill_name">Alpine and downhill skiing</string>
     <string name="quick_action_need_to_add_item_to_list">Add at least one item to the list in the \'Quick action\' settings</string>
-    <string name="routing_attr_avoid_sett_description">Avoids cobblestone and sett</string>
-    <string name="routing_attr_avoid_sett_name">No cobblestone or sett</string>
     <string name="run_full_osmand_msg">You are using {0} Map which is powered by OsmAnd. Do you want to launch OsmAnd full version\?</string>
     <string name="routeInfo_steepness_name">Steepness</string>
     <string name="routeInfo_smoothness_name">Smoothness</string>
@@ -1641,7 +1633,6 @@
     <string name="use_english_names_descr">Select between local and English names.</string>
     <string name="mark_point">Target</string>
     <string name="reload_tile">Reload tile</string>
-    <string name="update_tile">Update map</string>
     <string name="data_settings_descr">Specify language, download/reload data.</string>
     <string name="osm_settings_descr">Specify OpenStreetMap.org (OSM) settings needed for OSM submissions.</string>
     <string name="use_online_routing">Use online navigation</string>
@@ -1866,7 +1857,6 @@
     <string name="rendering_attr_hmRendered_name">Show more map detail</string>
     <string name="rendering_attr_hmRendered_description">Increase amount of map detail shown.</string>
     <string name="rendering_attr_contourLines_name">Show contour lines</string>
-    <string name="rendering_attr_contourLines_description">Display from zoom level (requires contour data):</string>
     <string name="rendering_attr_appMode_description">Optimize map for</string>
     <string name="rendering_attr_noPolygons_description">Make all areal land features on map transparent.</string>
     <string name="share_route_subject">Route shared via OsmAnd</string>
@@ -2223,7 +2213,6 @@
     <string name="auto_zoom_farthest">To long-range</string>
     <string name="auto_zoom_far">To mid-range</string>
     <string name="auto_zoom_close">To close-up</string>
-    <string name="auto_zoom_none">No auto zoom</string>
     <string name="animate_routing_gpx">Simulate using GPX track</string>
     <string name="app_mode_boat">Embarcación</string>
     <string name="app_mode_hiking">Hiking</string>
@@ -2588,7 +2577,6 @@
     <string name="rendering_attr_showCycleRoutes_name">Cycle routes</string>
     <string name="rendering_attr_showSurfaces_name">Show road surface</string>
     <string name="rendering_attr_showSurfaceGrade_name">Show road quality</string>
-    <string name="rendering_attr_showAccess_name">Show access restrictions and toll</string>
     <string name="rendering_attr_hideAccess_name">Access restrictions</string>
     <string name="rendering_attr_lessDetailed_name">Menos detalles</string>
     <string name="rendering_attr_buildings15zoom_name">Buildings on zoom 15</string>
@@ -2652,7 +2640,6 @@
     <string name="delete_filter">Delete filter</string>
     <string name="create_custom_poi">Create custom filter</string>
     <string name="selected_categories">Selected categories</string>
-    <string name="edit_filter">Edit categories</string>
     <string name="translit_names">Transliterate names</string>
     <string name="rendering_attr_surfaceIntegrity_name">Road surface integrity</string>
     <string name="rendering_attr_contourColorScheme_name">Contour lines color scheme</string>
@@ -2762,7 +2749,6 @@
     <string name="download_wikipedia_files">Download additional Wikipedia data (%1$s MB)\?</string>
     <string name="lang_oc">Occitanu</string>
     <string name="lang_nv">Navajo</string>
-    <string name="quick_action_auto_zoom">Auto zoom map on/off</string>
     <string name="select_city">Select city</string>
     <string name="type_postcode">Teclexa\'l códigu postal</string>
     <string name="shared_string_in_name">in %1$s</string>
@@ -2771,7 +2757,6 @@
     <string name="animate_my_location_desc">Turn on animated map panning of \'My position\' during navigation.</string>
     <string name="favorite_group_name">Group name</string>
     <string name="display_zoom_level">Display zoom level: %1$s</string>
-    <string name="show_from_zoom_level">Display starting at zoom level</string>
     <string name="srtm_purchase_header">Buy and install the \'Contour lines\' plugin to show graded vertical areas.</string>
     <string name="srtm_menu_download_descr">Download the \'Contour line\' map for use in this region.</string>
     <string name="hide_from_zoom_level">Hide starting from zoom level</string>
@@ -3073,7 +3058,6 @@
     <string name="routing_attr_driving_style_prefer_unpaved_name">Prefer unpaved roads</string>
     <string name="shared_preference">Shared</string>
     <string name="apply_preference_to_all_profiles">Apply this change to all or the selected profile.</string>
-    <string name="quick_action_hillshade_descr">A button to show or hide hillshades on the map.</string>
     <string name="quick_action_contour_lines_descr">Button showing or hiding contour lines on the map.</string>
     <string name="layer_osm_edits">OSM edits</string>
     <string name="tts_initialization_error">Nun se pue aniciar el motor de testu a voz.</string>
@@ -3252,7 +3236,6 @@
     <string name="search_poi_types_descr">Combine POI types from different categories. Tap switch to select all, tap left side to category selection.</string>
     <string name="extra_maps_menu_group">Mapes adicionales</string>
     <string name="download_unsupported_action">Unsupported action %1$s</string>
-    <string name="tracker_item">OsmAnd tracker</string>
     <string name="mapillary_item">OsmAnd + Mapillary</string>
     <string name="quick_action_item">Aición rápida</string>
     <string name="radius_ruler_item">Radius ruler</string>
@@ -3299,7 +3282,6 @@
     <string name="height_limit_description">Apurri l\'altor del vehículu. Puen aplicase dalgunes torgues d\'encaminamientu pa vehículos altos.</string>
     <string name="weight_limit_description">Apurri\'l pesu del vehículu. Puen aplicase dalgunes torgues d\'encaminamientu pa vehículos pesaos.</string>
     <string name="lenght_limit_description">Apurri la llongura del vehículu. Puen aplicase dalgunes torgues d\'encaminamientu pa vehículos llongos.</string>
-    <string name="gpx_parse_error">OsmAnd GPX is not well formed, please contact the support team to investigate further.</string>
     <string name="shared_string_always">Siempres</string>
     <string name="screen_control">Screen control</string>
     <string name="system_screen_timeout_descr">Turns the screen off as per the system\'s screen timeout.</string>
@@ -3776,7 +3758,6 @@
     <string name="track_recording_description">¿Quies dexar de rexistrar\?
 \nVan perdese tolos datos ensin guardar.</string>
     <string name="on_pause">On pause</string>
-    <string name="app_restart_required">Application restart required to apply some settings.</string>
     <string name="routing_attr_height_obstacles_description">Routing could avoid strong uphills.</string>
     <string name="quick_action_coordinates_widget_descr">Un alternador p\'amosar/anubrir el widget Coordenaes nel mapa.</string>
     <string name="map_widget_distance_by_tap">Distance by tap</string>
@@ -3836,7 +3817,6 @@
     <string name="update_all_maps_added">Update all maps added to %1$s\?</string>
     <string name="shared_string_feet">pies</string>
     <string name="srtm_unit_format">Contour lines unit variant</string>
-    <string name="srtm_download_list_help_message">OsmAnd provides contour lines data in meters and feet. You will need to re-download the file to change the format.</string>
     <string name="srtm_download_single_help_message">Please select the variant. You will need to re-download the file to change the format.</string>
     <string name="exit_number">Númberu de les salíes</string>
     <string name="announce_when_exceeded">Announce when exceeded</string>
@@ -3947,7 +3927,6 @@
     <string name="message_graph_will_be_available_after_recalculation">Espera.
 \nEl gráficu va tar disponible dempués de volver calcular el camín.</string>
     <string name="shared_string_local_maps">Mapes llocales</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="icon_group_amenity">Amenity</string>
     <string name="icon_group_special">Special</string>
     <string name="icon_group_transport">Tresporte</string>
@@ -4073,7 +4052,6 @@
     <string name="osmand_cloud_help_descr">¿Precises ayuda\? Ponte en contautu con nós per %1$s</string>
     <string name="osmand_cloud_create_account_descr">Introduz la to direición de corréu pa recibir un códigu de verificación
 \ny enllaciar tolos datos con ella.</string>
-    <string name="osmand_cloud_login_descr">Please enter the e-mail address you registred with. A one-time password for the next step will be sent to it.</string>
     <string name="verify_email_address">Verify the e-mail address</string>
     <string name="verify_email_address_descr">El códigu de verificación unvióse a %1$s. Introduzlu nel campu d\'abaxo.</string>
     <string name="cloud_email_not_registered">This e-mail address is not registered for OsmAnd Cloud</string>
@@ -4135,7 +4113,6 @@
     <string name="send_crash_log">Send crash log</string>
     <string name="send_logcat_log">Send logcat log</string>
     <string name="purchases_feature_desc_nautical">Get access to nautical depth information</string>
-    <string name="purchases_feature_desc_terrain">Terrain contour lines, full hillshade map with dark shades and slope maps with colors to show peaks and lowlands.</string>
     <string name="purchases_feature_desc_wikivoyage">Esplora Wikivoyage ensin internet. Los artículos dixébrense per países y rexones, y tán disponibles en toles llingües.</string>
     <string name="purchases_feature_desc_wikipedia">Esplora Wikipedia ensin internet. Los artículos dixébrense per países y rexones, y tán disponibles en toles llingües.</string>
     <string name="purchases_feature_desc_combined_wiki">Explore Wikipedia articles on the go, without an internet connection. Offline data divided by countries and available in all languages.</string>
@@ -4205,7 +4182,6 @@
     <string name="rendering_value_walkingRoutesOSMC_description">Color routes according to their individual local color (if present on OpenStreetMap) and hiking shield symbol.</string>
     <string name="rendering_value_walkingRoutesScopeOSMC_description">Color by network affiliation.</string>
     <string name="rendering_value_walkingRoutesOSMCNodes_description">Color routes according to their node network type (international, regional, local).</string>
-    <string name="walking_route_osmc_description">Color routes according to their individual local color (if present on OpenStreetMap) and type (international, regional, local).</string>
     <string name="travel_routes">Travel routes</string>
     <string name="setting_supported_by_style">This setting is provided by map style \'%1$s\'</string>
     <string name="direct_line_maps_required_descr">El cálculu de la ruta tarda más de lo normal.

--- a/OsmAnd/res/values-az/strings.xml
+++ b/OsmAnd/res/values-az/strings.xml
@@ -2051,7 +2051,6 @@
     <string name="shared_string_is_saved">saxlanıldı</string>
     <string name="sort_name_descending">Ad: Z – A</string>
     <string name="sort_name_ascending">Ad: A – Z</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="icon_group_sport">İdman</string>
     <string name="login_account">Hesab</string>
     <string name="user_login">İstifadəçi adı</string>

--- a/OsmAnd/res/values-b+hsb/strings.xml
+++ b/OsmAnd/res/values-b+hsb/strings.xml
@@ -1497,7 +1497,6 @@
     <string name="shared_string_icon">Symbol</string>
     <string name="manage_profiles">Profile aplikacije zarjadować…</string>
     <string name="in_app_purchase">Kupy w aplikaciji</string>
-    <string name="wikivoyage_offline">Wikivoyage offline</string>
     <string name="unlimited_downloads">Njewobmjezowane sćehnjenja</string>
     <string name="wikipedia_offline">Wikipedija offline</string>
     <string name="get_unlimited_access">Wobstaraj sej njewobmjezowany přistup</string>

--- a/OsmAnd/res/values-b+sr+Latn/strings.xml
+++ b/OsmAnd/res/values-b+sr+Latn/strings.xml
@@ -3053,7 +3053,6 @@
     <string name="message_graph_will_be_available_after_recalculation">Molimo sačekaj.
 \nGrafikon će biti dostupan nakon ponovnog izračunavanja rute.</string>
     <string name="shared_string_local_maps">Lokalne mape</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="icon_group_amenity">Slobodno vreme</string>
     <string name="icon_group_special">Specijalna</string>
     <string name="icon_group_transport">Prevoz</string>

--- a/OsmAnd/res/values-be/strings.xml
+++ b/OsmAnd/res/values-be/strings.xml
@@ -3796,7 +3796,6 @@
     <string name="message_graph_will_be_available_after_recalculation">Калі ласка, пачакайце.
 \nГрафік будзе даступны пасля пераразліку маршруту.</string>
     <string name="shared_string_local_maps">Лакальныя мапы</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="icon_group_amenity">Выгоды</string>
     <string name="icon_group_special">Адмысловыя</string>
     <string name="icon_group_transport">Транспарт</string>

--- a/OsmAnd/res/values-bg/strings.xml
+++ b/OsmAnd/res/values-bg/strings.xml
@@ -2208,7 +2208,6 @@
     <string name="message_graph_will_be_available_after_recalculation">Изчакайте.
 \nГрафиката ще е достъпна след преизчисляване на маршрута.</string>
     <string name="shared_string_local_maps">Местни карти</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="icon_group_amenity">Удобства</string>
     <string name="icon_group_special">Специални</string>
     <string name="icon_group_transport">Транспорт</string>

--- a/OsmAnd/res/values-ca/strings.xml
+++ b/OsmAnd/res/values-ca/strings.xml
@@ -1454,7 +1454,6 @@
     <string name="mark_to_delete">Marqueu per esborrar</string>
     <string name="simulate_your_location">Simula la vostra ubicació</string>
     <string name="drawer">Llista senzilla</string>
-    <string name="short_location_on_map">Lat %1$s\nLon %2$s</string>
     <string name="tips_and_tricks_descr">Preguntes més freqüents, canvis recents i altres.</string>
     <string name="routing_settings_2">Paràmetres de navegació</string>
     <string name="general_settings_2">Paràmetres generals</string>
@@ -3680,7 +3679,6 @@
     <string name="shared_string_always">Sempre</string>
     <string name="screen_control">Control de pantalla</string>
     <string name="development">Desenvolupament</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="use_native_pt_desc">Canvieu el càlcul de rutes de Transport Public a Java (segur)</string>
     <string name="start_finish_icons">Icones d\'inici i final</string>
     <string name="contour_lines_thanks">Gràcies per comprar \'Corbes de nivell\'</string>

--- a/OsmAnd/res/values-cs/strings.xml
+++ b/OsmAnd/res/values-cs/strings.xml
@@ -3477,7 +3477,6 @@
     <string name="message_need_calculate_route_before_show_graph">Údaje %1$s jsou dostupné pouze na cestách, pro jejich zobrazení musíte vypočítat trasu pomocí “Trasa mezi body”.</string>
     <string name="message_graph_will_be_available_after_recalculation">Prosím čekejte.
 \nGraf bude dostupný po přepočtu trasy.</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="pseudo_mercator_projection">Pseudo-Mercatorovo zobrazení</string>
     <string name="one_image_per_tile">Jeden obrazový soubor pro každou dlaždici</string>
     <string name="sqlite_db_file">Soubor SQLiteDB</string>
@@ -4346,7 +4345,6 @@
     <string name="continue_with">Pokračovat s %1$s</string>
     <string name="you_can_get_feature_as_part_of_pattern">Získejte “%1$s” jako součást předplatného (%2$s). Srovnání:</string>
     <string name="nautical_depth">Námořní hloubka</string>
-    <string name="offline_wikivoyage">Offline Wikivoyage</string>
     <string name="wikipedia_and_wikivoyage_offline">Wikipedie a Wikivoyage offline</string>
     <string name="unlimited_map_downloads">Neomezený počet map ke stažení</string>
     <string name="purchases_feature_desc_combined_wiki">Prozkoumejte články Wikipedie bez připojení na internet. Offline data jsou rozdělena podle zemí a dostupná ve všech jazycích.</string>
@@ -4562,7 +4560,6 @@
     <string name="rendering_attr_showMtbScale_description">Zobrazit trasy podle jejich stupnice MTB.</string>
     <string name="rendering_attr_showMtbScale_name">Zobrazit stupnici MTB</string>
     <string name="co2_mission">Emise CO2</string>
-    <string name="import_export">Import/export</string>
     <string name="export_to_file">Export do souboru</string>
     <string name="shared_string_expires">Platnost končí</string>
     <string name="shared_string_purchased_on">Zakoupeno dne</string>

--- a/OsmAnd/res/values-cy/strings.xml
+++ b/OsmAnd/res/values-cy/strings.xml
@@ -346,7 +346,6 @@
     <string name="shared_string_add_profile">Ychwanegu proffil</string>
     <string name="add_online_source">Ychwanegu ffynhonnell ar-lein</string>
     <string name="add_address">Ychwanegu cyfeiriad</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="shared_string_add_photo">Ychwanegu llun</string>
     <string name="ltr_or_rtl_combine_via_star">%1$s * %2$s</string>
     <string name="plan_route_add_new_segment">Ychwanegu segment newydd</string>

--- a/OsmAnd/res/values-da/strings.xml
+++ b/OsmAnd/res/values-da/strings.xml
@@ -2657,7 +2657,6 @@
     <string name="in_app_purchase">Køb i app</string>
     <string name="in_app_purchase_desc">Engangsbetaling</string>
     <string name="purchase_unlim_title">Køb - %1$s</string>
-    <string name="wikivoyage_offline">Wikivoyage offline</string>
     <string name="unlimited_downloads">Ubegrænset hentninger</string>
     <string name="wikipedia_offline">Wikipedia offline</string>
     <string name="unlock_all_features">Lås op for alle funktioner i OsmAnd</string>
@@ -3497,7 +3496,6 @@
     <string name="favorites_item">Favoritter</string>
     <string name="subscription_osmandlive_item">Abonnement - OsmAnd Live</string>
     <string name="navigation_profiles_item">Navigationsprofiler</string>
-    <string name="tracker_item">OsmAnd tracker</string>
     <string name="osmand_purchases_item">OsmAnd køb</string>
     <string name="quick_action_transport_descr">En knap til at vise eller skjule offentlig transport på kortet.</string>
     <string name="create_edit_poi">Opret eller rediger IP</string>
@@ -3635,7 +3633,6 @@
     <string name="all_next_segments_will_be_recalc">Alle efterfølgende segmenter genberegnes ved hjælp af den valgte profil.</string>
     <string name="all_previous_segments_will_be_recalc">Alle tidligere segmenter genberegnes ved hjælp af den valgte profil.</string>
     <string name="start_finish_icons">Start- og slutikoner</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="export_not_enough_space">Der er ikke plads nok</string>
     <string name="routing_attr_length_name">Længde</string>
     <string name="contour_lines_thanks">Tak for dit køb af \'Topografi\'</string>
@@ -3929,7 +3926,6 @@
     <string name="unlimited_map_downloads">Ubegrænset download af kort</string>
     <string name="wikipedia_and_wikivoyage_offline">Wikipedia og Wikivoyage offline</string>
     <string name="offline_wikipeadia">Offline Wikipedia</string>
-    <string name="offline_wikivoyage">Offline Wikivoyage</string>
     <string name="you_can_get_feature_as_part_of_pattern">Få \"%1$s\" som en del af %2$s abonnementet. Sammenligning:</string>
     <string name="ltr_or_rtl_combine_via_or">%1$s af %2$s</string>
     <string name="continue_with">Fortsæt med %1$s</string>

--- a/OsmAnd/res/values-de/strings.xml
+++ b/OsmAnd/res/values-de/strings.xml
@@ -2674,7 +2674,6 @@
     <string name="in_app_purchase_desc">Einmalige Zahlung</string>
     <string name="in_app_purchase_desc_ex">Nach dem Kauf steht es Ihnen dauerhaft zur Verfügung.</string>
     <string name="purchase_unlim_title">Kaufen - %1$s</string>
-    <string name="wikivoyage_offline">Wikivoyage offline</string>
     <string name="unlimited_downloads">Unbegrenzte Downloads</string>
     <string name="wikipedia_offline">Wikipedia offline</string>
     <string name="unlock_all_features">Alle OsmAnd-Funktionen freischalten</string>
@@ -3525,7 +3524,6 @@
     <string name="map_markers_item">Kartenmarkierungen</string>
     <string name="favorites_item">Favoriten</string>
     <string name="divider_descr">Elemente unterhalb dieses Punktes werden durch einen Trenner getrennt.</string>
-    <string name="tracker_item">OsmAnd Tracker</string>
     <string name="mapillary_item">OsmAnd + Mapillary</string>
     <string name="travel_item">Reisen (Wikivoyage und Wikipedia)</string>
     <string name="subscription_osmandlive_item">Abonnement - OsmAnd Live</string>
@@ -3786,7 +3784,6 @@
     <string name="perform_oauth_authorization_description">Anmelden mit OAuth zur Nutzung der osmedit-Funktionen</string>
     <string name="use_two_phase_routing">2-Phasen-A*-Routing-Algorithmus verwenden</string>
     <string name="message_need_calculate_route_before_show_graph">%1$s Daten sind nur auf Straßen verfügbar, Sie müssen eine Route mit „Route zwischen Punkten“ berechnen, um eine grafische Darstellung zu erhalten.</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="navigate_point_mgrs">MGRS</string>
     <string name="message_graph_will_be_available_after_recalculation">Bitte warten Sie.
 \nDie Grafik wird nach der Neuberechnung der Route verfügbar sein.</string>
@@ -4979,7 +4976,6 @@
     <string name="shared_string_do_not_exist">Nicht vorhanden</string>
     <string name="backup_error_failed_to_fetch_remote_items">Fehler beim Abrufen der Dateiliste vom Server.</string>
     <string name="last_sync">Letzte Synchronisierung</string>
-    <string name="import_export">Import/Export</string>
     <string name="export_to_file">In Datei exportieren</string>
     <string name="res_unknown">Unbekannt</string>
     <string name="shared_string_modified">Geändert</string>

--- a/OsmAnd/res/values-el/strings.xml
+++ b/OsmAnd/res/values-el/strings.xml
@@ -3682,7 +3682,6 @@
     <string name="wiki_menu_download_descr">Απαιτούνται πρόσθετοι χάρτες για να προβάλετε τα ΣΕ της Wikipedia στον χάρτη.</string>
     <string name="select_wikipedia_article_langs">Επιλέξτε τις γλώσσες για τα άρθρα Wikipedia στον χάρτη. Αλλάξτε σε οποιαδήποτε διαθέσιμη γλώσσα κατά την ανάγνωση του άρθρου.</string>
     <string name="radius_ruler_item">Χάρακας ακτίνας</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="map_markers_desc">Το γραφικό στοιχείο δείχνει την απόσταση ή την εκτιμώμενη ώρα άφιξης (ETA) για τους δύο πρώτους δείκτες στη λίστα δεικτών χάρτη.</string>
     <string name="shared_string_next_sunset">Επόμενο ηλιοβασίλεμα</string>
     <string name="shared_string_next_sunrise">Επόμενη ανατολή</string>

--- a/OsmAnd/res/values-eo/strings.xml
+++ b/OsmAnd/res/values-eo/strings.xml
@@ -3776,7 +3776,6 @@
     <string name="message_need_calculate_route_before_show_graph">Datumoj de %1$s estas disponeblaj nur por vojoj, kalkulu la kurson uzante “kalkuli kurson inter punktoj” por montri diagramon.</string>
     <string name="message_graph_will_be_available_after_recalculation">Bonvolu atendi.
 \nDiagramo estos videbla post rekalkuli kurson.</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="shared_string_local_maps">Lokaj mapoj</string>
     <string name="icon_group_amenity">Oportunaĵo</string>
     <string name="icon_group_special">Specialaj</string>

--- a/OsmAnd/res/values-es-rAR/strings.xml
+++ b/OsmAnd/res/values-es-rAR/strings.xml
@@ -3515,7 +3515,6 @@
 \nGestiona o cancela las suscripciones cuando quieras, en los ajustes de Google Play.</string>
     <string name="search_poi_types">Buscar por tipos de PDI</string>
     <string name="search_poi_types_descr">Combina tipos de PDI de diferentes categorías. Pulsa «Alternar» para marcar todo y el lado izquierdo para elegir una categoría.</string>
-    <string name="tracker_item">OsmAnd Tracker</string>
     <string name="mapillary_item">OsmAnd + Mapillary</string>
     <string name="quick_action_item">Acción rápida</string>
     <string name="radius_ruler_item">Regla radial</string>
@@ -3779,7 +3778,6 @@
     <string name="message_need_calculate_route_before_show_graph">Los datos de «%1$s» sólo están disponibles con los caminos, calcula una ruta usando «Ruta entre puntos» para ver los gráficos.</string>
     <string name="message_graph_will_be_available_after_recalculation">Ten paciencia.
 \nEl gráfico estará disponible al recalcular la ruta.</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s – %2$s</string>
     <string name="shared_string_local_maps">Mapas locales</string>
     <string name="icon_group_amenity">Comodidad</string>
     <string name="icon_group_special">Especial</string>

--- a/OsmAnd/res/values-es-rUS/strings.xml
+++ b/OsmAnd/res/values-es-rUS/strings.xml
@@ -3477,7 +3477,6 @@
     <string name="mapillary_item">OsmAnd + Mapillary</string>
     <string name="ltr_or_rtl_combine_via_slash_with_space">%1$s / %2$s</string>
     <string name="travel_item">Viajes (Wikiviajes y Wikipedia)</string>
-    <string name="tracker_item">OsmAnd Tracker</string>
     <string name="subscription_osmandlive_item">Suscripción - OsmAnd Live</string>
     <string name="some_articles_may_not_available_in_lang">Es posible que algunos artículos de Wikipedia no estén disponibles en tu idioma.</string>
     <string name="select_wikipedia_article_langs">Marca los idiomas de los artículos de Wikipedia en el mapa. Cambia a cualquier idioma disponible mientras lees el artículo.</string>
@@ -3781,7 +3780,6 @@
     <string name="message_need_calculate_route_before_show_graph">Los datos de «%1$s» sólo están disponibles con los caminos, calcula una ruta usando «Ruta entre puntos» para ver los gráficos.</string>
     <string name="message_graph_will_be_available_after_recalculation">Ten paciencia.
 \nEl gráfico estará disponible al recalcular la ruta.</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s – %2$s</string>
     <string name="icon_group_travel">Viaje</string>
     <string name="icon_group_transport">Transporte</string>
     <string name="icon_group_symbols">Símbolos</string>

--- a/OsmAnd/res/values-es/strings.xml
+++ b/OsmAnd/res/values-es/strings.xml
@@ -3601,7 +3601,6 @@
     <string name="lang_ur">Urdu</string>
     <string name="lang_tg">Tayiko</string>
     <string name="lang_bar">Bávaro</string>
-    <string name="tracker_item">OsmAnd Tracker</string>
     <string name="legend_item_description">La guía para la simbología de un mapa.</string>
     <string name="parking_positions">Posiciones de aparcamiento</string>
     <string name="turn_screen_on_power_button_disabled">Desactivado. Es necesario activar «Mantener la pantalla encendida» en «Tiempo de espera al encender».</string>
@@ -3760,7 +3759,6 @@
     <string name="development">Desarrollo</string>
     <string name="file_already_imported">El archivo ya fue importado en OsmAnd</string>
     <string name="shared_string_local_maps">Mapas locales</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s – %2$s</string>
     <string name="icon_group_amenity">Comodidad</string>
     <string name="icon_group_special">Especial</string>
     <string name="icon_group_transport">Transporte</string>

--- a/OsmAnd/res/values-et/strings.xml
+++ b/OsmAnd/res/values-et/strings.xml
@@ -3711,7 +3711,6 @@
     <string name="use_live_routing">OsmAnd andmed reaalajas</string>
     <string name="use_live_public_transport">OsmAnd andmed reaalajas</string>
     <string name="snowmobile_render_descr">Mootorsaanide sõitmine eraldi määratud teedel ja radadel.</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="icon_group_special">Eriteenused</string>
     <string name="icon_group_amenity">Mugavus</string>
     <string name="shared_string_local_maps">Kohalikud kaardid</string>

--- a/OsmAnd/res/values-eu/strings.xml
+++ b/OsmAnd/res/values-eu/strings.xml
@@ -1470,7 +1470,6 @@
     <string name="waypoint_visit_before">Bisitatu aurretik</string>
     <string name="simulate_your_location">Simulatu zure kokapena</string>
     <string name="drawer">Zerrenda soila</string>
-    <string name="short_location_on_map">Lat %1$s\nLon %2$s</string>
     <string name="tips_and_tricks_descr">Maiz egindako galderak, azken aldaketak, eta bestelakoak.</string>
     <string name="routing_settings_2">Nabigazio ezarpenak</string>
     <string name="shared_string_deselect">Desautatu</string>
@@ -3783,7 +3782,6 @@
     <string name="message_graph_will_be_available_after_recalculation">Itxaron mesedez.
 \nIbilbidea birkalkulatu ondoren grafikoa eskuragarri egongo da.</string>
     <string name="shared_string_local_maps">Tokiko mapak</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="icon_group_special">Berezia</string>
     <string name="icon_group_transport">Garraioa</string>
     <string name="icon_group_service">Zerbitzua</string>

--- a/OsmAnd/res/values-fa/strings.xml
+++ b/OsmAnd/res/values-fa/strings.xml
@@ -3511,7 +3511,6 @@
 \nاشتراک شما به‌طور خودکار تمدید می‌شود مگر اینکه پیش از دورهٔ تمدید انتخاب‌شده لغو شود.
 \n
 \nهر زمان که خواستید از طریق تنظیمات گوگل‌پلی اشتراک خود را مدیریت یا لغو کنید.</string>
-    <string name="tracker_item">OsmAnd tracker</string>
     <string name="legend_item_description">راهنمای نمادشناسی نقشه.</string>
     <string name="navigation_profiles_item">نمایه‌های ناوبری</string>
     <string name="lang_zhyue">کانتونی</string>
@@ -3799,7 +3798,6 @@
     <string name="message_need_calculate_route_before_show_graph">دادهٔ %1$s فقط در جاده‌ها ارائه می‌شود. با استفاده از «مسیریابی بین نقطه‌ها» مسیری محاسبه کنید تا نمودارها را ببینید.</string>
     <string name="message_graph_will_be_available_after_recalculation">لطفاً منتظر بمانید.
 \nنمودار پس از بازمحاسبهٔ مسیر فراهم می‌شود.</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="message_you_need_add_two_points_to_show_graphs">دست‌کم دو نقطه اضافه کنید</string>
     <string name="login_open_street_map">ورود به اوپن‌استریت‌مپ</string>
     <string name="login_open_street_map_org">ورود به OpenStreetMap.org</string>

--- a/OsmAnd/res/values-fi/strings.xml
+++ b/OsmAnd/res/values-fi/strings.xml
@@ -2637,7 +2637,6 @@
     <string name="osm_edit_logout_success">Kirjautunut ulos</string>
     <string name="message_you_need_add_two_points_to_show_graphs">Lisää ainakin kaksi pistettä</string>
     <string name="plugin_global_prefs_info">Nämä laajennusasetukset ovat globaaleja ja vaikuttavat kaikkiin profiileihin</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="use_two_phase_routing">Käytä kaksivaiheista A*-reititys algoritmiä</string>
     <string name="shared_string_graph">Graafi</string>
     <string name="message_need_calculate_route_before_show_graph">%1$s data on käytettävissä ainoastaan teillä, laske reitti käyttäen \"Reitti pisteiden välillä\" nähdäksesi graafit.</string>
@@ -3187,7 +3186,6 @@
     <string name="no_recalculation_setting">Ei uudelleenlaskentaa</string>
     <string name="restore_all_profile_settings_descr">Kaikki profiilin asetukset palautetaan alkuperäiseen tilaansa tämän profiilin luomisen/tuonnin jälkeen.</string>
     <string name="lang_bar">Baijeri</string>
-    <string name="tracker_item">OsmAnd Tracker</string>
     <string name="create_edit_poi">Luo tai muokkaa KP:tä</string>
     <string name="parking_positions">Pysäköintipaikat</string>
     <string name="add_edit_favorite">Lisää tai muokkaa suosikkia</string>
@@ -3699,7 +3697,6 @@
     <string name="unlimited_map_downloads">Rajoittamattomat karttalataukset</string>
     <string name="wikipedia_and_wikivoyage_offline">Wikipedia ja Wikivoyage offline-tilassa</string>
     <string name="offline_wikipeadia">Offline Wikipedia</string>
-    <string name="offline_wikivoyage">Offline Wikivoyage</string>
     <string name="nautical_depth">Merellinen syvyys</string>
     <string name="you_can_get_feature_as_part_of_pattern">Hanki \"%1$s\" osana %2$s suunnitelmaa. Vertailu:</string>
     <string name="ltr_or_rtl_combine_via_or">%1$s tai %2$s</string>

--- a/OsmAnd/res/values-fr/strings.xml
+++ b/OsmAnd/res/values-fr/strings.xml
@@ -3517,7 +3517,6 @@
     <string name="radius_ruler_item">Règle de mesure par rayon</string>
     <string name="map_markers_item">Marques</string>
     <string name="legend_item_description">Guide des symboles cartographiques</string>
-    <string name="tracker_item">OsmAnd Tracker</string>
     <string name="mapillary_item">OsmAnd + Mapillary</string>
     <string name="quick_action_item">Action rapide</string>
     <string name="measure_distance_item">Mesurer une distance</string>
@@ -3778,7 +3777,6 @@
 \nLe graphique sera disponible à l\'issue du calcul d\'itinéraire.</string>
     <string name="snowmobile_render_descr">Pour la conduite en motoneige avec des routes et des pistes dédiées.</string>
     <string name="shared_string_graph">Graphique</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s - %2$s</string>
     <string name="shared_string_local_maps">Cartes locales</string>
     <string name="icon_group_amenity">Loisir</string>
     <string name="icon_group_special">Spécial</string>

--- a/OsmAnd/res/values-ga/strings.xml
+++ b/OsmAnd/res/values-ga/strings.xml
@@ -1146,7 +1146,6 @@
     <string name="shared_string_trip">Turas</string>
     <string name="average_altitude">Airde mheánach</string>
     <string name="subcategories">Fochatagóirí</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="south_abbreviation">D</string>
     <string name="regular_price">Gnáthphraghas</string>
     <string name="shared_string_read">Léigh</string>

--- a/OsmAnd/res/values-gl/strings.xml
+++ b/OsmAnd/res/values-gl/strings.xml
@@ -3778,7 +3778,6 @@
     <string name="file_already_imported">O ficheiro xa foi importado no OsmAnd</string>
     <string name="use_two_phase_routing">Usar algoritmo de enrutamento A* de 2 fases</string>
     <string name="shared_string_graph">Gráfica</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="navigate_point_mgrs">MGRS</string>
     <string name="navigate_point_format_mgrs">MGRS</string>
     <string name="mgrs_format_descr">O OsmAnd emprega MGRS, que é semellante ó formato UTM NATO.</string>

--- a/OsmAnd/res/values-hu/strings.xml
+++ b/OsmAnd/res/values-hu/strings.xml
@@ -3773,7 +3773,6 @@
     <string name="osm_edit_logout_success">Kijelentkezett</string>
     <string name="use_two_phase_routing">Kétszakaszos A* útvonaltervezési algoritmus használata</string>
     <string name="file_already_imported">A fájl már importálva van az OsmAndba</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="snowmobile_render_descr">Motorosszán vezetéshez külön utakkal és pályákkal.</string>
     <string name="shared_string_graph">Grafikon</string>
     <string name="message_need_calculate_route_before_show_graph">%1$s adatok csak utakról állnak rendelkezésre. Az ábrák megtekintéséhez az „Útvonal tervezése pontok között” funkcióval számítsa ki az útvonalat.</string>

--- a/OsmAnd/res/values-in/strings.xml
+++ b/OsmAnd/res/values-in/strings.xml
@@ -1693,7 +1693,6 @@
     <string name="route_descr_lat_lon">Lin %1$.3f, buj %2$.3f</string>
     <string name="ltr_or_rtl_triple_combine_via_space">%1$s %2$s %3$s</string>
     <string name="ltr_or_rtl_combine_via_star">%1$s * %2$s</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="ltr_or_rtl_combine_via_slash_with_space">%1$s / %2$s</string>
     <string name="n_items_of_z">%1$s / %2$s</string>
     <string name="poi_remove_confirm_template">Hapus {0} (komentar)\?</string>

--- a/OsmAnd/res/values-is/strings.xml
+++ b/OsmAnd/res/values-is/strings.xml
@@ -3784,7 +3784,6 @@
 \n
 \nÞú getur stýrt og aflýst áskriftunum þínum með því að fara í AppGallery stillingarnar þínar.</string>
     <string name="shared_string_graph">Graf</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s - %2$s</string>
     <string name="shared_string_local_maps">Staðkort</string>
     <string name="icon_group_amenity">Aðstaða</string>
     <string name="icon_group_special">Sértákn</string>

--- a/OsmAnd/res/values-it/strings.xml
+++ b/OsmAnd/res/values-it/strings.xml
@@ -2602,7 +2602,6 @@
     <string name="in_app_purchase_desc">Pagamento unico</string>
     <string name="in_app_purchase_desc_ex">Una volta acquistato, sarà permanentemente a vostra disposizione.</string>
     <string name="purchase_unlim_title">Acquista - %1$s</string>
-    <string name="wikivoyage_offline">Wikivoyage offline</string>
     <string name="unlimited_downloads">Download illimitati</string>
     <string name="wikipedia_offline">Wikipedia offline</string>
     <string name="unlock_all_features">Sblocca tutte le funzionalità di OsmAnd</string>
@@ -3772,7 +3771,6 @@
     <string name="message_need_calculate_route_before_show_graph">%1$s dati disponibili solo sulle strade, calcola un percorso utilizzando \"Percorso tra punti\" per visualizzare il grafico.</string>
     <string name="message_graph_will_be_available_after_recalculation">Attendere prego... 
 \nIl grafo sarà disponibile dopo il ricalcolo del percorso.</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="navigate_point_mgrs">MGRS</string>
     <string name="navigate_point_format_mgrs">MGRS</string>
     <string name="mgrs_format_descr">OsmAnd utilizza MGRS, che è simile al formato UTM NATO.</string>

--- a/OsmAnd/res/values-iw/strings.xml
+++ b/OsmAnd/res/values-iw/strings.xml
@@ -3782,7 +3782,6 @@
     <string name="shared_string_graph">תרשים</string>
     <string name="message_graph_will_be_available_after_recalculation">נא להמתין.
 \nהתרשים יהיה זמין לאחר חישוב מחדש.</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="shared_string_local_maps">מפות מקומיות</string>
     <string name="icon_group_amenity">שירות לציבור</string>
     <string name="icon_group_special">מיוחד</string>

--- a/OsmAnd/res/values-ja/strings.xml
+++ b/OsmAnd/res/values-ja/strings.xml
@@ -3498,7 +3498,6 @@ POIの更新は利用できません</string>
     <string name="ui_customization">ユーザーインターフェイスのカスタマイズ</string>
     <string name="extra_maps_menu_group">追加マップ</string>
     <string name="download_unsupported_action">%1$sのアクションはサポートされていません</string>
-    <string name="tracker_item">OsmAnd Tracker</string>
     <string name="mapillary_item">OsmAnd + Mapillary</string>
     <string name="quick_action_item">クイックアクション</string>
     <string name="radius_ruler_item">半径定規</string>
@@ -3779,7 +3778,6 @@ POIの更新は利用できません</string>
     <string name="file_already_imported">ファイルはすでにOsmAndにインポートされています</string>
     <string name="icon_group_amenity">店舗・施設</string>
     <string name="shared_string_local_maps">ローカルマップ</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="icon_group_special">特別</string>
     <string name="icon_group_transport">交通</string>
     <string name="icon_group_service">設備・技術</string>

--- a/OsmAnd/res/values-ka/strings.xml
+++ b/OsmAnd/res/values-ka/strings.xml
@@ -1707,7 +1707,6 @@
     <string name="routing_attr_length_name">სიგრძე</string>
     <string name="item_deleted">%1$s წაშლილია</string>
     <string name="routing_attr_difficulty_preference_name">არჩეული სირთულე</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s - %2$s</string>
     <string name="icon_group_amenity">კომფორტი</string>
     <string name="icon_group_special">სპეციალური</string>
     <string name="icon_group_transport">ტრანსპორტი</string>

--- a/OsmAnd/res/values-ko/strings.xml
+++ b/OsmAnd/res/values-ko/strings.xml
@@ -3952,7 +3952,6 @@
     <string name="token_is_not_valid">토큰은 유효하지 않습니다</string>
     <string name="check_for_updates">업데이트 확인</string>
     <string name="download_cloud_version">클라우드 버전 다운로드</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="select_layer">레이어 선택</string>
     <string name="beats_per_minute_short">bpm</string>
     <string name="ant_plus_searching">찾는 중</string>

--- a/OsmAnd/res/values-lt/strings.xml
+++ b/OsmAnd/res/values-lt/strings.xml
@@ -2898,7 +2898,6 @@ Tai yra puikus būdas paremti OsmAnd ir OSM, jei jie jums patinka.</string>
     <string name="quick_action_switch_day_mode">Dienos režimas</string>
     <string name="quick_action_add_gpx_descr">Mygtukas, skirtas pridėti GPX kelio tašką ekrano viduryje.</string>
     <string name="quick_action_navigation_voice_descr">Perjungiklis, skirtas išjungti arba įjungti balso nurodymus navigacijos metu.</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="ltr_or_rtl_combine_via_colon">%1$s: %2$s</string>
     <string name="custom_color">Pasirinktinė spalva</string>
     <string name="lang_mn">Mongolų</string>

--- a/OsmAnd/res/values-lv/strings.xml
+++ b/OsmAnd/res/values-lv/strings.xml
@@ -3282,7 +3282,6 @@ No Afganistānas līdz Zimbabvei, no Austrālijas līdz ASV, Argentīna, Brazīl
     <string name="message_graph_will_be_available_after_recalculation">Gaidiet maršruta pārrēķināšanu.
 \nGrafika būs redzama pēc brīža.</string>
     <string name="shared_string_local_maps">Vietējās kartes</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="icon_group_special">Speciālais</string>
     <string name="icon_group_transport">Transports</string>
     <string name="icon_group_service">Serviss</string>

--- a/OsmAnd/res/values-mk/strings.xml
+++ b/OsmAnd/res/values-mk/strings.xml
@@ -1024,7 +1024,6 @@
     <string name="icon_group_transport">Transport</string>
     <string name="icon_group_special">Poesbno</string>
     <string name="icon_group_amenity">Udobnost</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="shared_string_local_maps">Lokalni karti</string>
     <string name="osm_edit_logout_success">Odjaven</string>
     <string name="clear_osm_token">Isčistete go OpenStreetMap OAuth tokenot</string>

--- a/OsmAnd/res/values-nb/strings.xml
+++ b/OsmAnd/res/values-nb/strings.xml
@@ -3719,7 +3719,6 @@
     <string name="file_already_imported">Filen er allerede importert i OsmAnd</string>
     <string name="message_graph_will_be_available_after_recalculation">Vent.
 \nGraf vil være tilgjengelig etter omberegning av ruten.</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="shared_string_graph">Graf</string>
     <string name="message_need_calculate_route_before_show_graph">%1$s-data er tilgjengelig kun på veiene, beregn en rute med “Rute mellom punkter” for å se grafer.</string>
     <string name="shared_string_gpx_route">Spor rute</string>

--- a/OsmAnd/res/values-nl/strings.xml
+++ b/OsmAnd/res/values-nl/strings.xml
@@ -2562,7 +2562,6 @@
     <string name="in_app_purchase_desc">Eenmalige betaling</string>
     <string name="in_app_purchase_desc_ex">Eens aangekocht, kun je het permanent blijven gebruiken.</string>
     <string name="purchase_unlim_title">%1$s Kopen</string>
-    <string name="wikivoyage_offline">Wikivoyage offline</string>
     <string name="unlimited_downloads">Onbeperkte downloads</string>
     <string name="wikipedia_offline">Wikipedia offline</string>
     <string name="unlock_all_features">Ontgrendel alle OsmAnd-functies</string>
@@ -3365,7 +3364,6 @@
     <string name="search_poi_types_descr">Combineer POI-types uit verschillende categorieën. Tik op \"Selecteer alles\" om alles binnen een categorie te selecteren, of kies individuele types.</string>
     <string name="extra_maps_menu_group">Extra kaarten</string>
     <string name="download_unsupported_action">Niet ondersteunde actie %1$s</string>
-    <string name="tracker_item">OsmAnd tracker</string>
     <string name="mapillary_item">OsmAnd + Mapillary</string>
     <string name="quick_action_item">Sneltoets</string>
     <string name="radius_ruler_item">Radius liniaal</string>
@@ -3664,7 +3662,6 @@
     <string name="shared_string_graph">Grafiek</string>
     <string name="message_graph_will_be_available_after_recalculation">Wacht totdat route herberekend is.
 \nNa herberekening is de grafiek zichtbaar.</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="import_track_descr">Kies een trackbestand om te volgen of importeer het vanaf je apparaat.</string>
     <string name="shared_string_custom">Aangepast</string>
     <string name="perform_oauth_authorization_description">Voer een OAuth-login uit om osm edit functies te gebruiken</string>
@@ -4363,7 +4360,6 @@
     <string name="shared_string_not_included">Niet inbegrepen</string>
     <string name="cancel_anytime_in_gplay">Annuleer het abonnement op elk moment via Google Play.</string>
     <string name="nautical_depth">Zeediepte</string>
-    <string name="offline_wikivoyage">Offline Wikivoyage</string>
     <string name="send_crash_log">Crashrapport verzenden</string>
     <string name="you_can_get_feature_as_part_of_pattern">Verkrijg \"%1$s\" als onderdeel van het %2$s abonnement. Vergelijking:</string>
     <string name="offline_wikipeadia">Offline Wikipedia</string>

--- a/OsmAnd/res/values-oc/strings.xml
+++ b/OsmAnd/res/values-oc/strings.xml
@@ -1882,7 +1882,6 @@
     <string name="app_mode_kayak">Caiac</string>
     <string name="icon_group_travel">Viatge</string>
     <string name="icon_group_symbols">Simbòl</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="message_graph_will_be_available_after_recalculation">Esperatz.
 \nLo grafic serà disponible après lo recalcul dau percors.</string>
     <string name="use_live_routing">Donadas d\'OsmAnd Live</string>

--- a/OsmAnd/res/values-pl/strings.xml
+++ b/OsmAnd/res/values-pl/strings.xml
@@ -3627,7 +3627,6 @@
     <string name="item_deleted">Usunięto %1$s</string>
     <string name="speed_cameras_restart_descr">Uruchom ponownie aplikację, aby usunąć wszystkie dane o fotoradarach.</string>
     <string name="shared_string_uninstall_and_restart">Odinstaluj i zrestartuj</string>
-    <string name="tracker_item">OsmAnd Tracker</string>
     <string name="lenght_limit_description">Podaj długość pojazdu, niektóre ograniczenia tras mogą być stosowane dla długich pojazdów.</string>
     <string name="speed_cameras_removed_descr">To urządzenie nie ma fotoradarów.</string>
     <string name="use_volume_buttons_as_zoom_descr">Steruj poziomem powiększenia mapy za pomocą przycisków głośności na urządzeniu.</string>
@@ -3772,7 +3771,6 @@
     <string name="clear_osm_token">Wyczyść token OpenStreetMap OAuth</string>
     <string name="osm_edit_logout_success">Wylogowano</string>
     <string name="file_already_imported">Plik jest już zaimportowany do OsmAnd</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="navigate_point_mgrs">MGRS</string>
     <string name="navigate_point_format_mgrs">MGRS</string>
     <string name="use_two_phase_routing">Użyj 2-fazowego algorytmu routingu A *</string>

--- a/OsmAnd/res/values-pt-rBR/strings.xml
+++ b/OsmAnd/res/values-pt-rBR/strings.xml
@@ -2608,7 +2608,6 @@
     <string name="in_app_purchase_desc">Pagamento uma só vez</string>
     <string name="in_app_purchase_desc_ex">Uma vez adquirido, ele sempre será disponível para você.</string>
     <string name="purchase_unlim_title">Comprar - %1$s</string>
-    <string name="wikivoyage_offline">Wikivoyage offline</string>
     <string name="unlimited_downloads">Downloads ilimitados</string>
     <string name="wikipedia_offline">Wikipédia offline</string>
     <string name="purchase_dialog_title">Escolher plano</string>
@@ -3774,7 +3773,6 @@
     <string name="message_need_calculate_route_before_show_graph">Dados de %1$s disponíveis apenas em estradas, calcule uma rota usando “Rota entre pontos” para ver os gráficos.</string>
     <string name="message_graph_will_be_available_after_recalculation">Por favor, espere.
 \nO gráfico estará disponível após o recálculo da rota.</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="shared_string_local_maps">Mapas locais</string>
     <string name="icon_group_amenity">Amenidade</string>
     <string name="icon_group_special">Especial</string>

--- a/OsmAnd/res/values-pt/strings.xml
+++ b/OsmAnd/res/values-pt/strings.xml
@@ -2176,7 +2176,6 @@
     <string name="in_app_purchase_desc">Pagamento de uma só vez</string>
     <string name="in_app_purchase_desc_ex">Uma vez comprado, estará sempre disponível para si.</string>
     <string name="purchase_unlim_title">Comprar - %1$s</string>
-    <string name="wikivoyage_offline">Wikivoyage offline</string>
     <string name="unlimited_downloads">Descarregamentos ilimitados</string>
     <string name="wikipedia_offline">Wikipédia offline</string>
     <string name="unlock_all_features">Desbloquear todas as características do OsmAnd</string>
@@ -3481,7 +3480,6 @@
     <string name="wiki_menu_download_descr">São necessários mapas adicionais para visualizar os POIs da Wikipédia no mapa.</string>
     <string name="select_wikipedia_article_langs">Selecione os idiomas dos artigos da Wikipédia no mapa. Pode mudar para qualquer idioma disponível enquanto lê um artigo da Wikipédia.</string>
     <string name="mapillary_item">OsmAnd + Mapillary</string>
-    <string name="tracker_item">OsmAnd tracker</string>
     <string name="quick_action_item">Botão de ações rápidas</string>
     <string name="radius_ruler_item">Régua radial</string>
     <string name="measure_distance_item">Medir distância</string>
@@ -3780,7 +3778,6 @@
     <string name="message_need_calculate_route_before_show_graph">Dados de %1$s disponíveis apenas em estradas, calcule uma rota usando \"Rota entre pontos\" para ver os gráficos.</string>
     <string name="message_graph_will_be_available_after_recalculation">Aguarde um momento.
 \nO gráfico estará disponível após a rota ser recalculada.</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s – %2$s</string>
     <string name="navigate_point_mgrs">MGRS</string>
     <string name="navigate_point_format_mgrs">MGRS</string>
     <string name="mgrs_format_descr">O OsmAnd utiliza o MGRS, que é semelhante ao formato UTM NATO.</string>

--- a/OsmAnd/res/values-ro/strings.xml
+++ b/OsmAnd/res/values-ro/strings.xml
@@ -3197,7 +3197,6 @@
     <string name="message_graph_will_be_available_after_recalculation">Vă rugăm să așteptați.
 \nGraficul va fi disponibil după recalcularea traseului.</string>
     <string name="shared_string_local_maps">Hărți locale</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="icon_group_amenity">Facilități</string>
     <string name="icon_group_special">Speciale</string>
     <string name="icon_group_transport">Transporturi</string>
@@ -4975,7 +4974,6 @@
     <string name="cloud_no_conflicts">Nu sunt conflicte.</string>
     <string name="shared_string_do_not_exist">Nu există</string>
     <string name="last_sync">Ultima sincronizare</string>
-    <string name="import_export">Import/Export</string>
     <string name="export_to_file">Exportă în fișier</string>
     <string name="shared_string_expires">Expiră</string>
     <string name="open_weather_action_description">Vă permite să deschideți un ecran cu informații meteo detaliate.</string>

--- a/OsmAnd/res/values-ru/strings.xml
+++ b/OsmAnd/res/values-ru/strings.xml
@@ -3792,7 +3792,6 @@
     <string name="snowmobile_render_descr">Для езды на снегоходах по выделенным дорогам и трассам.</string>
     <string name="development">Разработка</string>
     <string name="shared_string_local_maps">Местная карта</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="icon_group_amenity">Удобства</string>
     <string name="icon_group_transport">Транспорт</string>
     <string name="icon_group_symbols">Символы</string>

--- a/OsmAnd/res/values-sc/strings.xml
+++ b/OsmAnd/res/values-sc/strings.xml
@@ -3778,7 +3778,6 @@
     <string name="shared_string_graph">Gràficu</string>
     <string name="message_graph_will_be_available_after_recalculation">Pro praghere iseta.
 \nSu gràficu at a èssere a disponimentu a pustis de su càrculu nou de s\'àndala.</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="icon_group_emergency">Apretu/Emergèntzia</string>
     <string name="icon_group_special">Ispetziales</string>
     <string name="icon_group_transport">Trasportu</string>

--- a/OsmAnd/res/values-sk/strings.xml
+++ b/OsmAnd/res/values-sk/strings.xml
@@ -2687,7 +2687,6 @@
     <string name="in_app_purchase_desc">Jednorazová platba</string>
     <string name="in_app_purchase_desc_ex">Po zakúpení bude pre vás trvalo dostupné.</string>
     <string name="purchase_unlim_title">Kúpiť - %1$s</string>
-    <string name="wikivoyage_offline">Wikivoyage offline</string>
     <string name="unlimited_downloads">Neobmedzené sťahovania</string>
     <string name="wikipedia_offline">Wikipédia offline</string>
     <string name="unlock_all_features">Odomknite všetky funkcie OsmAnd</string>
@@ -3774,7 +3773,6 @@
     <string name="message_need_calculate_route_before_show_graph">Údaje %1$s sú dostupné len na cestách, pre ich získanie musíte vypočítať trasu pomocou “Trasa medzi bodmi”.</string>
     <string name="message_graph_will_be_available_after_recalculation">Počkajte na prepočet trasy.
 \nGraf bude dostupný po prepočte.</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="shared_string_local_maps">Lokálne mapy</string>
     <string name="icon_group_amenity">Občianska vybavenosť</string>
     <string name="icon_group_special">Špeciálne</string>
@@ -4119,7 +4117,6 @@
     <string name="unlimited_map_downloads">Neobmedzený počet stiahnutých máp</string>
     <string name="wikipedia_and_wikivoyage_offline">Wikipedia a Wikivoyage offline</string>
     <string name="offline_wikipeadia">Offline Wikipédia</string>
-    <string name="offline_wikivoyage">Offline Wikivoyage</string>
     <string name="nautical_depth">Námorná hĺbka</string>
     <string name="you_can_get_feature_as_part_of_pattern">Získajte “%1$s” ako súčasť: predplatné %2$s. Porovnanie:</string>
     <string name="ltr_or_rtl_combine_via_or">%1$s alebo %2$s</string>
@@ -4974,7 +4971,6 @@
     <string name="download_cloud_version">Stiahnuť verziu z cloudu</string>
     <string name="shared_string_do_not_exist">Neexistuje</string>
     <string name="last_sync">Posledná synchronizácia</string>
-    <string name="import_export">Import/export</string>
     <string name="export_to_file">Exportovať do súboru</string>
     <string name="si_nm_mt">Námorné míle/metre</string>
     <string name="si_nm_ft">Námorné míle/stopy</string>

--- a/OsmAnd/res/values-sl/strings.xml
+++ b/OsmAnd/res/values-sl/strings.xml
@@ -4033,7 +4033,6 @@
     <string name="speed_camera_pois">Hitrostne kamere</string>
     <string name="delete_all_actions_message_q">Nepreklicno izbrisati %d hitrih dejanj\?</string>
     <string name="shared_string_delete_all_q">Izbrisati vse\?</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="icon_group_amenity">Dobrine</string>
     <string name="routing_attr_length_description">Določi omejitev dolžine vozila, ki bo dovoljena na poteh.</string>
     <string name="shared_string_legal">Zakonito</string>

--- a/OsmAnd/res/values-sr/strings.xml
+++ b/OsmAnd/res/values-sr/strings.xml
@@ -3809,7 +3809,6 @@
     <string name="message_graph_will_be_available_after_recalculation">Молимо сачекајте.
 \nГрафикон ће бити доступан након поновног израчунавања путање.</string>
     <string name="shared_string_local_maps">Местне карте</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="icon_group_amenity">Пријатност</string>
     <string name="icon_group_special">Нарочита</string>
     <string name="icon_group_transport">Превоз</string>

--- a/OsmAnd/res/values-sv/strings.xml
+++ b/OsmAnd/res/values-sv/strings.xml
@@ -3030,7 +3030,6 @@
     <string name="message_graph_will_be_available_after_recalculation">Vänligen vänta.
 \nGrafen kommer bli tillgänglig efter att färdvägen omberäknats.</string>
     <string name="shared_string_local_maps">Lokala kartor</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s - %2$s</string>
     <string name="ltr_or_rtl_combine_via_star">%1$s * %2$s</string>
     <string name="icon_group_transport">Kollektivtrafik</string>
     <string name="icon_group_amenity">bekvämligheter</string>
@@ -4077,7 +4076,6 @@
     <string name="cloud_all_changes_uploaded">Alla ändringar har laddats upp</string>
     <string name="cloud_all_changes_downloaded">Alla ändringar är nedladdade</string>
     <string name="backup_error_failed_to_fetch_remote_items">Misslyckades att hämta listan över filer från servern.</string>
-    <string name="import_export">Import/export</string>
     <string name="export_to_file">Exportera till fil</string>
     <string name="shared_string_purchased_on">Köpt</string>
     <string name="open_weather_action_description">Ger dig möjlighet att öppna en vy med detaljerad väderinformation.</string>

--- a/OsmAnd/res/values-tr/strings.xml
+++ b/OsmAnd/res/values-tr/strings.xml
@@ -3785,7 +3785,6 @@
     <string name="navigate_point_format_mgrs">MGRS</string>
     <string name="mgrs_format_descr">OsmAnd, UTM NATO biçimine benzer olan MGRS\'yi kullanmaktadır.</string>
     <string name="shared_string_local_maps">Yerel haritalar</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="icon_group_amenity">Tesis</string>
     <string name="icon_group_special">Özel</string>
     <string name="icon_group_transport">Ulaşım</string>

--- a/OsmAnd/res/values-tt/strings.xml
+++ b/OsmAnd/res/values-tt/strings.xml
@@ -91,7 +91,6 @@
     <string name="monitoring_control_start">REC</string>
     <string name="use_live_routing">OsmAnd Live мәгълүматы</string>
     <string name="use_live_public_transport">OsmAnd Live мәгълүматы</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="icon_group_sport">Спорт</string>
     <string name="use_login_password">Логин һәм парол куллану</string>
     <string name="login_account">Хисап язмасы</string>

--- a/OsmAnd/res/values-tzm/strings.xml
+++ b/OsmAnd/res/values-tzm/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <resources>
     <string name="shared_string_local_maps">Takaṛḍa tadɣarant</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="icon_group_service">Tanafut</string>
     <string name="shared_string_name"/>
     <string name="shared_string_all"/>

--- a/OsmAnd/res/values-uk/strings.xml
+++ b/OsmAnd/res/values-uk/strings.xml
@@ -3787,7 +3787,6 @@
     <string name="message_need_calculate_route_before_show_graph">%1$s дані доступні лише для доріг, прокладіть маршрут за допомогою «Маршрут між точками», щоб побачити графіки.</string>
     <string name="message_graph_will_be_available_after_recalculation">Будь ласка, зачекайте.
 \nГрафік буде доступний після перебудування маршруту.</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="shared_string_local_maps">Місцеві мапи</string>
     <string name="icon_group_amenity">Зручності</string>
     <string name="icon_group_special">Спеціальні</string>

--- a/OsmAnd/res/values-zh-rCN/strings.xml
+++ b/OsmAnd/res/values-zh-rCN/strings.xml
@@ -3288,7 +3288,6 @@
     <string name="message_graph_will_be_available_after_recalculation">请稍候。
 \n图表将在重新计算路线后可用。</string>
     <string name="shared_string_local_maps">本地地图</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="icon_group_amenity">便利设施</string>
     <string name="icon_group_special">特殊</string>
     <string name="voice_prompts_timetable">语音提示时间</string>

--- a/OsmAnd/res/values-zh-rTW/strings.xml
+++ b/OsmAnd/res/values-zh-rTW/strings.xml
@@ -3508,7 +3508,6 @@
 \n隨時從您的 Google Play 設定中管理或取消您的訂閱。</string>
     <string name="search_poi_types">搜尋 POI 類型</string>
     <string name="search_poi_types_descr">組合來自不同分類的 POI 類型。點擊開關以全選，點擊左側選取分類。</string>
-    <string name="tracker_item">OsmAnd tracker</string>
     <string name="mapillary_item">OsmAnd + Mapillary</string>
     <string name="quick_action_item">快速動作</string>
     <string name="radius_ruler_item">半徑尺規</string>
@@ -3771,7 +3770,6 @@
     <string name="message_need_calculate_route_before_show_graph">%1$s 資料僅供道路使用，請使用「兩點間的路線」計算路線以檢視圖表。</string>
     <string name="message_graph_will_be_available_after_recalculation">請稍候。
 \n重新計算路線後即可使用圖表。</string>
-    <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
     <string name="shared_string_local_maps">本機地圖</string>
     <string name="icon_group_amenity">便利設施</string>
     <string name="icon_group_special">特殊</string>


### PR DESCRIPTION
[ios task](https://github.com/osmandapp/OsmAnd-iOS/pull/4026/)

Hi. I deleted some translations strings, that were duplicated with english translation file. 
Because these strings were added by ios-translation script in and could overwrite the correct translations in ios.
I guess that Android just will be using strings from English translation file instead deleted strings. 

<img width="1206" alt="Screenshot 2024-09-28 at 22 38 32" src="https://github.com/user-attachments/assets/efdb0d3a-c8e6-4917-8c1c-17e3045ed9df">
