### PR TITLE
update Danish phrases

### DIFF
--- a/OsmAnd/res/values-da/phrases.xml
+++ b/OsmAnd/res/values-da/phrases.xml
@@ -252,7 +252,7 @@
     <string name="poi_running_track">Løbebane</string>
     <string name="poi_bicycle_track">Cykelbane</string>
     <string name="poi_horse_track">Travbane</string>
-    <string name="poi_raceway">Vædeløbsbane</string>
+    <string name="poi_raceway">Væddeløbsbane</string>
     <string name="poi_9pin">Keglespil</string>
     <string name="poi_10pin">Bowling</string>
     <string name="poi_archery">Bueskydning</string>
@@ -337,14 +337,14 @@
     <string name="poi_religion_shinto">Shinto</string>
     <string name="poi_religion_taoist">Taoisme</string>
     <string name="poi_monastery">Kloster</string>
-    <string name="poi_wayside_cross">Vejside kors</string>
+    <string name="poi_wayside_cross">Vejsidekors</string>
     <string name="poi_wayside_shrine">Vejkantsalter</string>
     <string name="poi_information">Information</string>
     <string name="poi_clock">Ur</string>
     <string name="poi_travel_agent">Rejsebureau</string>
     <string name="poi_viewpoint">Udsigtspunkt</string>
     <string name="poi_camp_site">Campingplads</string>
-    <string name="poi_caravan_site">Campingvognsplads</string>
+    <string name="poi_caravan_site">Autocamperplads</string>
     <string name="poi_picnic_site">Picnic-plads</string>
     <string name="poi_spring">Kilde</string>
     <string name="poi_cemetery">Gravplads</string>


### PR DESCRIPTION
some spelling issues.
and caravan_site should be "autocamplerplads". On most caravan_sites "campingvogn" is not allowed or not possible.