### PR TITLE
Don't limit display size for tiles stored as SQLite DB

### DIFF
--- a/OsmAnd/src/net/osmand/plus/download/local/CollectLocalIndexesAlgorithm.java
+++ b/OsmAnd/src/net/osmand/plus/download/local/CollectLocalIndexesAlgorithm.java
@@ -104,8 +104,7 @@ public class CollectLocalIndexesAlgorithm {
 	}
 
 	private void addSeparatelyCalculationItemIfNeeded(@NonNull LocalItem item) {
-		LocalItemType type = item.getType();
-		Long limit = rules.getCalculationSizeLimit(type);
+		Long limit = rules.getCalculationSizeLimit(item);
 		if (limit != null && !separateSizeCalculationItems.contains(item)) {
 			separateSizeCalculationItems.add(item);
 			item.setSizeCalculationLimit(limit);

--- a/OsmAnd/src/net/osmand/plus/download/local/LocalItemsLoaderTask.java
+++ b/OsmAnd/src/net/osmand/plus/download/local/LocalItemsLoaderTask.java
@@ -7,6 +7,7 @@ import android.os.AsyncTask;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import net.osmand.IndexConstants;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.settings.backend.OsmandSettings;
 import net.osmand.util.Algorithms;
@@ -52,7 +53,14 @@ public class LocalItemsLoaderTask extends AsyncTask<Void, Void, Map<CategoryType
 				.addDirectoryIfNotPresent(internalDir, false)
 				.addDirectoryIfNotPresent(externalDir, true)
 				.addForcedAddUnknownDirectory(noBackupDir)
-				.addTypeToCalculateSizeSeparately(TILES_DATA, TILES_SIZE_CALCULATION_LIMIT)
+				.setSizeLimitCondition(localItem -> {
+					if (localItem.getType() == TILES_DATA) {
+						File file = localItem.getFile();
+						boolean isSQLite = file.getName().endsWith(IndexConstants.SQLITE_EXT);
+						return !isSQLite ? TILES_SIZE_CALCULATION_LIMIT : -1;
+					}
+					return null;
+				})
 				.build();
 
 		return CollectLocalIndexesAlgorithm.execute(collectingRules);


### PR DESCRIPTION
This request has to fix problem described here: https://github.com/osmandapp/OsmAnd/issues/21252#issuecomment-2462754169

The problem comes from the new conditions we set to calculate the size of the tiles (Issue: https://github.com/osmandapp/OsmAnd/issues/20974), however we shouldn't set these limits for tiles those are stored as one SQLite file, because there is only one file and it calculates anyway.