### PR TITLE
Fix NPE when PlatformUtil.getOsmandRegions() is not ready

### DIFF
--- a/OsmAnd/src/net/osmand/plus/auto/NavigationSession.java
+++ b/OsmAnd/src/net/osmand/plus/auto/NavigationSession.java
@@ -79,6 +79,7 @@ import net.osmand.util.GeoParsedPoint;
 import net.osmand.util.GeoPointParserUtil;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -704,8 +705,12 @@ public class NavigationSession extends Session implements NavigationListener, Os
 						}
 					}
 					if (event == ROUTING_CONFIG_INITIALIZED) {
-						if (app.getRegions() != null) {
-							restoreNavigationHelper.checkRestoreRoutingMode();
+						try {
+							if (PlatformUtil.getOsmandRegions() != null) {
+								restoreNavigationHelper.checkRestoreRoutingMode();
+							}
+						} catch (IOException e) {
+							LOG.warn("getOsmandRegions", e);
 						}
 					}
 				}


### PR DESCRIPTION
Fixes multiple NPE (was displayed as a toast) when Navigation started immediately after OsmAnd start (previous navigation and/or quick navigation to any point is the action to reproduce).

The problem might happen when PlatformUtil.getOsmandRegions() is still not ready, searchRoute() starts and MissingMapsCalculator requires non-null regions.

On slow devices, the bug might happen even in 5-10 seconds after OsmAnd is loaded and UI is ready.

Now the frightening NPE message in the toast changed to "Calculating route…" from strings.xml

PS. Additionally, the same issue in NavigationSession should be fixed by this request, because `if (app.getRegions() != null)` seems as incorrect way to validate regions.

```
14:43:41.270  E  RouteProvider Runtime error: Attempt to invoke virtual method 'net.osmand.map.WorldRegion net.osmand.map.OsmandRegions.getRegionDataByDownloadName(java.lang.String)' on a null object reference {pool-4-thread-1}
                 java.lang.NullPointerException: Attempt to invoke virtual method 'net.osmand.map.WorldRegion net.osmand.map.OsmandRegions.getRegionDataByDownloadName(java.lang.String)' on a null object reference
                   at net.osmand.router.MissingMapsCalculator.checkIfThereAreMissingMaps(MissingMapsCalculator.java:75)
                   at net.osmand.router.RoutePlannerFrontEnd.searchRoute(RoutePlannerFrontEnd.java:400)
                   at net.osmand.router.RoutePlannerFrontEnd.searchRoute(RoutePlannerFrontEnd.java:220)
                   at net.osmand.plus.routing.RouteProvider.calcOfflineRouteImpl(RouteProvider.java:901)
                   at net.osmand.plus.routing.RouteProvider.findVectorMapsRoute(RouteProvider.java:822)
                   at net.osmand.plus.routing.RouteProvider.calculateRouteImpl(RouteProvider.java:141)
                   at net.osmand.plus.routing.RouteRecalculationHelper$RouteRecalculationTask.run(RouteRecalculationHelper.java:373)
                   at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:459)
                   at java.util.concurrent.FutureTask.run(FutureTask.java:266)
                   at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
                   at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
                   at java.lang.Thread.run(Thread.java:764)
14:43:41.660  E  RouteProvider Runtime error: Attempt to invoke virtual method 'net.osmand.map.WorldRegion net.osmand.map.OsmandRegions.getRegionDataByDownloadName(java.lang.String)' on a null object reference {main}
                 java.lang.NullPointerException: Attempt to invoke virtual method 'net.osmand.map.WorldRegion net.osmand.map.OsmandRegions.getRegionDataByDownloadName(java.lang.String)' on a null object reference
                   at net.osmand.router.MissingMapsCalculator.checkIfThereAreMissingMaps(MissingMapsCalculator.java:75)
                   at net.osmand.router.RoutePlannerFrontEnd.searchRoute(RoutePlannerFrontEnd.java:400)
                   at net.osmand.plus.routing.RouteProvider.calcOfflineRouteImpl(RouteProvider.java:890)
                   at net.osmand.plus.routing.RouteProvider.findVectorMapsRoute(RouteProvider.java:822)
                   at net.osmand.plus.routing.RouteProvider.calculateRouteImpl(RouteProvider.java:141)
                   at net.osmand.plus.routing.RouteRecalculationHelper$RouteRecalculationTask.run(RouteRecalculationHelper.java:373)
```