### PR TITLE
Avoid show ref is shields was created

### DIFF
--- a/OsmAnd/src/net/osmand/plus/routing/CurrentStreetName.java
+++ b/OsmAnd/src/net/osmand/plus/routing/CurrentStreetName.java
@@ -62,14 +62,14 @@ public class CurrentStreetName {
 			RouteSegmentResult rs = routingHelper.getCurrentSegmentResult();
 			if (rs != null) {
 				text = getRouteSegmentStreetName(routingHelper, rs, false);
-				if (Algorithms.isEmpty(text)) {
+				showMarker = true;
+				shields = RoadShield.create(rs.getObject());
+				if (Algorithms.isEmpty(text) && shields.isEmpty()) {
 					text = getRouteSegmentStreetName(routingHelper, rs, true);
 					isSet = !Algorithms.isEmpty(text);
 				} else {
 					isSet = true;
 				}
-				showMarker = true;
-				shields = RoadShield.create(rs.getObject());
 			}
 		}
 		// 3. display next road street name if this one empty

--- a/OsmAnd/src/net/osmand/plus/routing/CurrentStreetName.java
+++ b/OsmAnd/src/net/osmand/plus/routing/CurrentStreetName.java
@@ -66,10 +66,8 @@ public class CurrentStreetName {
 				shields = RoadShield.create(rs.getObject());
 				if (Algorithms.isEmpty(text) && shields.isEmpty()) {
 					text = getRouteSegmentStreetName(routingHelper, rs, true);
-					isSet = !Algorithms.isEmpty(text);
-				} else {
-					isSet = true;
 				}
+				isSet = !Algorithms.isEmpty(text) || !shields.isEmpty();
 			}
 		}
 		// 3. display next road street name if this one empty


### PR DESCRIPTION
Avoid to create street name based on _ref_ if shields was already created. In most cases shields already based on the _ref_ in different combinations.

To issue https://github.com/osmandapp/OsmAnd/issues/21362
<img width="300" src="https://github.com/user-attachments/assets/6de8cab0-8c8c-42e8-ac98-ee89b2de3f7d" />
