### PR TITLE
Remove tracks folder immediately from UI after it was deleted

### DIFF
--- a/OsmAnd/src/net/osmand/plus/myplaces/tracks/dialogs/BaseTrackFolderFragment.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/tracks/dialogs/BaseTrackFolderFragment.java
@@ -481,7 +481,7 @@ public abstract class BaseTrackFolderFragment extends BaseOsmAndFragment impleme
 
 	@Override
 	public void onFolderDeleted() {
-		reloadTracks();
+		reloadTracks(true);
 	}
 
 	@Override


### PR DESCRIPTION
Fix bug that tracks folder didn't disappear immediately from UI on `My Places` -> `Tracks` after it had been deleted