### PR TITLE
Fix lastModified for deactivated maps (DateFormat)

### DIFF
--- a/OsmAnd/src/net/osmand/plus/resources/ResourceManager.java
+++ b/OsmAnd/src/net/osmand/plus/resources/ResourceManager.java
@@ -1569,9 +1569,10 @@ public class ResourceManager {
 		if (file != null && file.isDirectory()) {
 			File[] lf = file.listFiles();
 			if (lf != null) {
+				DateFormat dateFormat = getDateFormat();
 				for (File f : lf) {
 					if (f != null && f.getName().endsWith(IndexConstants.BINARY_MAP_INDEX_EXT)) {
-						map.put(f.getName(), getDateFormat().format(f.lastModified()));
+						map.put(f.getName(), dateFormat.format(f.lastModified()));
 					}
 				}
 			}

--- a/OsmAnd/src/net/osmand/plus/resources/ResourceManager.java
+++ b/OsmAnd/src/net/osmand/plus/resources/ResourceManager.java
@@ -1571,7 +1571,7 @@ public class ResourceManager {
 			if (lf != null) {
 				for (File f : lf) {
 					if (f != null && f.getName().endsWith(IndexConstants.BINARY_MAP_INDEX_EXT)) {
-						map.put(f.getName(), AndroidUtils.formatDate(context, f.lastModified()));
+						map.put(f.getName(), getDateFormat().format(f.lastModified()));
 					}
 				}
 			}


### PR DESCRIPTION
```
16:04:17.723  E  DownloadResources java.text.ParseException: Unparseable date: "12/1/24" {AsyncTask #2}
16:04:17.723  E  DownloadResources java.text.ParseException: Unparseable date: "11/11/24" {AsyncTask #2}
16:04:17.725  E  DownloadResources java.text.ParseException: Unparseable date: "12/1/24" {AsyncTask #2}
16:04:17.725  E  DownloadResources java.text.ParseException: Unparseable date: "12/1/24" {AsyncTask #2}
```