### PR TITLE
Order PoiTypeResult by: top, categories, types, additionals

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/search/core/SearchCoreFactory.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/core/SearchCoreFactory.java
@@ -792,27 +792,29 @@ public class SearchCoreFactory {
 			// }
 			for (PoiCategory c : categories) {
 				PoiTypeResult res = checkPoiType(nm, c);
-				if(res != null) {
+				if (res != null) {
 					results.put(res.pt.getKeyName(), res);
 				}
 				if (nmAdditional != null) {
 					addAditonals(nmAdditional, results, c);
 				}
 			}
+			Map<String, PoiTypeResult> additionals = new LinkedHashMap<>();
 			Iterator<Entry<String, PoiType>> it = translatedNames.entrySet().iterator();
 			while (it.hasNext()) {
 				Entry<String, PoiType> e = it.next();
 				PoiType pt = e.getValue();
 				if (pt.getCategory() != types.getOtherMapCategory() && !pt.isReference()) {
 					PoiTypeResult res = checkPoiType(nm, pt);
-					if(res != null) {
+					if (res != null) {
 						results.put(res.pt.getKeyName(), res);
 					}
 					if (nmAdditional != null) {
-						addAditonals(nmAdditional, results, pt);
+						addAditonals(nmAdditional, additionals, pt);
 					}
 				}
 			}
+			results.putAll(additionals); // results ordered by: top, categories, types, additional
 			return results;
 		}
 


### PR DESCRIPTION
- [ ] port commit to ios
- [ ] think about potential situation when `foundWords` come from translations and they might overlap with other translations and/or with fixed values defined in poi_types.xml

SearchCoreFactory.java:1250

```
for (PoiTypeResult poiTypeResult : poiTypeResults.values()) {
  for (String foundName : poiTypeResult.foundWords) {
    CollatorStringMatcher csm = new CollatorStringMatcher(foundName, StringMatcherMode.CHECK_ONLY_STARTS_WITH);
    // matches only completely
    int mwords = SearchPhrase.countWords(foundName);
    if (csm.matches(phrase.getUnknownSearchPhrase()) && countExtraWords < mwords) {
      countExtraWords = SearchPhrase.countWords(foundName);
      List<String> otherSearchWords = phrase.getUnknownSearchWords();
      nameFilter = null;
      if (countExtraWords - 1 < otherSearchWords.size()) {
        nameFilter = "";
        for (int k = countExtraWords - 1; k < otherSearchWords.size(); k++) {
          if (nameFilter.length() > 0) {
            nameFilter += SearchPhrase.DELIMITER;
          }
          nameFilter += otherSearchWords.get(k);
        }
      }
      poiTypeFilter = getPoiTypeFilter(poiTypeResult.pt, poiAdditionals);
```