### PR TITLE
Fix "Crash when trying to observe image details" #21579

### DIFF
--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/cards/ImageCard.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/cards/ImageCard.java
@@ -125,7 +125,8 @@ public abstract class ImageCard extends AbstractCard {
 					this.externalLink = imageObject.getBoolean("externalLink");
 				}
 				if (imageObject.has("topIcon") && !imageObject.isNull("topIcon")) {
-					this.topIconId = AndroidUtils.getDrawableId(getMyApplication(), imageObject.getString("topIcon"));
+					String topIcon = imageObject.getString("topIcon");
+					this.topIconId = AndroidUtils.getDrawableId(getMyApplication(), topIcon);
 				}
 				if (imageObject.has("buttonIcon") && !imageObject.isNull("buttonIcon")) {
 					this.buttonIconId = AndroidUtils.getDrawableId(getMyApplication(), imageObject.getString("buttonIcon"));

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/gallery/GalleryDetailsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/gallery/GalleryDetailsFragment.java
@@ -128,7 +128,10 @@ public class GalleryDetailsFragment extends BaseOsmAndFragment implements Downlo
 		}
 
 		int iconId = card.getTopIconId();
-		buildItem(container, getString(R.string.shared_string_source), getSourceTypeName(card), iconId, false, false);
+		String source = getSourceTypeName(card);
+		if (!Algorithms.isEmpty(source) || iconId != 0) {
+			buildItem(container, getString(R.string.shared_string_source), source, iconId, false, false);
+		}
 
 		String license = metadata != null ? metadata.getLicense() : null;
 		if (!Algorithms.isEmpty(license)) {
@@ -155,7 +158,7 @@ public class GalleryDetailsFragment extends BaseOsmAndFragment implements Downlo
 
 		int defaultIconColor = ColorUtilities.getDefaultIconColor(app, nightMode);
 		ImageView iconView = view.findViewById(R.id.icon);
-		Drawable drawable = !defaultColor ? app.getUIUtilities().getIcon(iconId) : app.getUIUtilities().getPaintedIcon(iconId, defaultIconColor);
+		Drawable drawable = !defaultColor ? uiUtilities.getIcon(iconId) : uiUtilities.getPaintedIcon(iconId, defaultIconColor);
 		iconView.setImageDrawable(drawable);
 
 		TextView titleView = view.findViewById(R.id.title);


### PR DESCRIPTION
# Fix Summary

The issue occurs due to missing necessary data (e.g., the source icon for the image) in the response sent from the OsmAnd server. The server currently provides only the URL but lacks other metadata about the image (e.g., author, upload date, license, source). It might be a good idea to add these params on the server side if such data can be retrieved.

> **Tip:** To get images from OsmAnd server make sure the **Mapillary Plugin** is enabled.

For one of the locations mentioned in the issue, the server returns the following JSON image data:
```
{
  "type": "wikimedia-photo",
  "lat": 48.12747,
  "lon": 8.088678,
  "timestamp": "2024-11-09T09:05:24Z",
  "key": "File:Dorerbühl-Huette_01.jpg",
  "title": "Dorerbühl-Huette 01.jpg",
  "url": "https://commons.wikimedia.org/wiki/File:Dorerb%C3%BChl-Huette_01.jpg",
  "externalLink": false,
  "username": "Uli@wiki",
  "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/Dorerb%C3%BChl-Huette_01.jpg/576px-Dorerb%C3%BChl-Huette_01.jpg",
  "imageHiresUrl": "https://upload.wikimedia.org/wikipedia/commons/8/8b/Dorerb%C3%BChl-Huette_01.jpg",
  "is360": false
}
```

During the parsing of this JSON object in the `ImageCard` constructor, the `topIcon` parameter is missing, which leads to a resource not found issue and ultimately causes a crash.
The parsing takes place here:
[ImageCard.java#L127](https://github.com/osmandapp/OsmAnd/blob/83bfc66a78f3cdb057d7f56af1dc38ca3286bd91/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/cards/ImageCard.java#L127)

Additionally, other useful parameters are missing from the JSON response, which could be added on the server side to provide more details about the image.

In the current fix, the crash has been addressed by ensuring we don't attempt to fetch or display source data if it is missing.