### PR TITLE
Update turn outlay color everywhere it's used

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/MapActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/MapActivity.java
@@ -1654,6 +1654,7 @@ public class MapActivity extends OsmandActionBarActivity implements DownloadEven
 
 		app.getLocaleHelper().setLanguage(this);
 		app.runInUIThread(fragmentsHelper::updateFragments);
+		app.getNotificationHelper().refreshNotifications();
 	}
 
 	@Override

--- a/OsmAnd/src/net/osmand/plus/auto/TripHelper.java
+++ b/OsmAnd/src/net/osmand/plus/auto/TripHelper.java
@@ -265,6 +265,7 @@ public class TripHelper {
 		drawable.setBounds(0, 0, width, height);
 		drawable.setTurnType(turnType);
 		drawable.setTurnImminent(imminent, deviatedFromRoute);
+		drawable.updateColors(app.getDaynightHelper().isNightMode());
 		return drawableToBitmap(drawable, width, height);
 	}
 

--- a/OsmAnd/src/net/osmand/plus/notifications/NavigationNotification.java
+++ b/OsmAnd/src/net/osmand/plus/notifications/NavigationNotification.java
@@ -190,6 +190,7 @@ public class NavigationNotification extends OsmandNotification {
 					drawable.setBounds(0, 0, width, height);
 					drawable.setTurnType(turnType);
 					drawable.setTurnImminent(turnImminent, deviatedFromRoute);
+					drawable.updateColors(!app.getSettings().isLightSystemTheme());
 					turnBitmap = drawableToBitmap(drawable);
 				}
 

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/widgets/StreetNameWidget.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/widgets/StreetNameWidget.java
@@ -354,6 +354,9 @@ public class StreetNameWidget extends MapWidget {
 		ImageView removeImage = waypointInfoBar.findViewById(R.id.waypoint_close);
 		moreImage.setImageDrawable(iconsCache.getIcon(R.drawable.ic_overflow_menu_white, isNightMode()));
 		removeImage.setImageDrawable(iconsCache.getIcon(R.drawable.ic_action_remove_dark, isNightMode()));
+
+		turnDrawable.updateColors(nightMode);
+		turnDrawable.invalidateSelf();
 	}
 
 	@Override


### PR DESCRIPTION
We also added an update to the **`onConfigurationChanged`** method of the **`MapActivity`** class to ensure that the colors of the turn drawable are updated in the notification as well.

Here is an example of successfully updating colors in notification when changing the device's system theme:

[Screen_recording_20250107_171411.webm](https://github.com/user-attachments/assets/73c6cf54-514a-452f-b3c1-87b66b196e06)
