### PR TITLE
Fix "Elevation Correction doesn't work"

### DIFF
--- a/OsmAnd/src/net/osmand/plus/measurementtool/MeasurementEditingContext.java
+++ b/OsmAnd/src/net/osmand/plus/measurementtool/MeasurementEditingContext.java
@@ -824,22 +824,24 @@ public class MeasurementEditingContext implements IRouteSettingsListener {
 		if (!segments.isEmpty()) {
 			for (TrkSegment segment : segments) {
 				TrkSegment segmentForSnap = new TrkSegment();
-				for (int i = 0; i < segment.getPoints().size() - 1; i++) {
-					WptPt point = points.get(i);
-					WptPt nextPoint = segment.getPoints().get(i + 1);
+				List<WptPt> segmentPoints = segment.getPoints();
+				List<WptPt> segmentForSnapPoints = segmentForSnap.getPoints();
+				for (int i = 0; i < segmentPoints.size() - 1; i++) {
+					WptPt point = segmentPoints.get(i);
+					WptPt nextPoint = segmentPoints.get(i + 1);
 					RoadSegmentData data = this.roadSegmentData.get(new Pair<>(point, nextPoint));
 					List<WptPt> pts = data != null ? data.getPoints() : null;
 					if (pts != null) {
-						segmentForSnap.getPoints().addAll(pts);
+						segmentForSnapPoints.addAll(pts);
 					} else {
 						if (calculateIfNeeded && roadSegmentIndexes.contains(segmentsForSnap.size())) {
 							scheduleRouteCalculateIfNotEmpty();
 						}
-						segmentForSnap.getPoints().addAll(Arrays.asList(point, nextPoint));
+						segmentForSnapPoints.addAll(Arrays.asList(point, nextPoint));
 					}
 				}
-				if (segmentForSnap.getPoints().isEmpty()) {
-					segmentForSnap.getPoints().addAll(segment.getPoints());
+				if (segmentForSnapPoints.isEmpty()) {
+					segmentForSnapPoints.addAll(segmentPoints);
 				}
 				segmentsForSnap.add(segmentForSnap);
 			}

--- a/OsmAnd/src/net/osmand/plus/measurementtool/MeasurementEditingContext.java
+++ b/OsmAnd/src/net/osmand/plus/measurementtool/MeasurementEditingContext.java
@@ -837,7 +837,10 @@ public class MeasurementEditingContext implements IRouteSettingsListener {
 						if (calculateIfNeeded && roadSegmentIndexes.contains(segmentsForSnap.size())) {
 							scheduleRouteCalculateIfNotEmpty();
 						}
-						segmentForSnapPoints.addAll(Arrays.asList(point, nextPoint));
+						if (segmentForSnapPoints.isEmpty()) {
+							segmentForSnapPoints.add(point);
+						}
+						segmentForSnapPoints.add(nextPoint);
 					}
 				}
 				if (segmentForSnapPoints.isEmpty()) {


### PR DESCRIPTION
## Fix Summary
This pull request addresses the issue described in https://github.com/osmandapp/OsmAnd/issues/21418.

#### Problem Description
The issue occurred exclusively for tracks recorded manually via **Trip Recording** and did not affect tracks created with **Plan Route** or exported from navigation routes.

The root cause was point duplication in tracks, resulting in a mismatch between the number of points in GPX tracks and segments in the editing context. This problem is described in detail [here](https://github.com/osmandapp/OsmAnd/issues/21418#issuecomment-2561959908) and [here](https://github.com/osmandapp/OsmAnd/issues/21418#issuecomment-2573242477).

#### Analysis and Fix
- The duplication was traced back to code added over 8 years ago, which caused errors in elevation calculations.
- All potential use cases for duplication were analyzed to ensure it was not intentional behavior. Findings revealed no beneficial use of duplication:
  - **MeasurementToolLayer**: Duplication had no effect on line rendering.
  - **SaveGpxRouteAsyncTask**: Duplication doubled the number of points in tracks during "simplified track" saving.
  - **getSegmentsPoints**: Duplication applied only if the number of points ≤ 2, a rare case.
  - **calculateHeightmapTrack**: This was where the issue described in the Issue originated.
- An analysis of the code where duplication was first introduced [link](https://github.com/osmandapp/OsmAnd/pull/4341/files#diff-4e6a93ac0bfa769e71aa589955c0fddcd69e8b08b4ece23b4852aca767675329R215) revealed no intended usage.

#### Testing
- Key functions related to **Plan Route** and **Snap to Road** were tested. No new bugs were found after removing duplication.
- Tested saving "simplified tracks" with 126 points. The number of points in the track now remains consistent after saving.
- Videos showing the functionality before and after the fix are provided below.

### Elevation correction
<table style="width:100%">
  <tr>
    <th>Before fix</th>
    <th>After fix</th>
  </tr>
  <tr>
    <td style="text-align:center">
      <video width="300" height="auto" controls src="https://github.com/user-attachments/assets/37c54123-a19f-45c9-a894-c8f34f808fd4"/>
    </td>
    <td style="text-align:center">
      <video width="300" height="auto" controls src="https://github.com/user-attachments/assets/f0bfd432-5c1c-4561-a518-6b9ac11c78ed"/>
    </td>
  </tr>
<tr>
    <td style="text-align:center">Chart data is the same before and after using "Elevation correction" feature.</td>
    <td style="text-align:center">This demonstrates the corrected functionality after removing duplication.</td>
  </tr>
</table>

### Save as a new "simplified track"
<table style="width:100%">
  <tr style="width:50%">
    <th style="width:50%">Before fix</th>
    <th style="width:50%">After fix</th>
  </tr>
  <tr>
    <td style="text-align:center">
      <video width="300" height="auto" controls src="https://github.com/user-attachments/assets/8cf2dd99-382e-4f65-8ede-d163a4ce4bb3"/>
    </td>
    <td style="text-align:center">
      <video width="300" height="auto" controls src="https://github.com/user-attachments/assets/87a9c938-7ceb-40ff-91dc-595961ae552c"/>
    </td>
  </tr>
<tr style="width:50%">
    <td style="text-align:center">The number of points increased after saving as "simplified track" from 126 to 250 (it displays in the header of the dialog).</td>
    <td style="text-align:center">The number of points remains unchanged (126) after saving as a new "simplified track".</td>
  </tr>
</table>

#### Outcome
The functions now work correctly after the changes, and the bug described in the Issue has been successfully resolved.