### PR TITLE
Fix "Turning off Nearby POIs doesn't mute instructions #21657"

### DIFF
--- a/OsmAnd/src/net/osmand/plus/helpers/WaypointHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/WaypointHelper.java
@@ -57,6 +57,7 @@ public class WaypointHelper {
 	private static final int ANNOUNCE_POI_LIMIT = 3;
 
 	OsmandApplication app;
+	OsmandSettings settings;
 	// every time we modify this collection, we change the reference (copy on write list)
 	public static final int TARGETS = 0;
 	public static final int WAYPOINTS = 1;
@@ -81,7 +82,8 @@ public class WaypointHelper {
 
 	public WaypointHelper(OsmandApplication application) {
 		app = application;
-		appMode = app.getSettings().getApplicationMode();
+		settings = app.getSettings();
+		appMode = settings.getApplicationMode();
 	}
 
 
@@ -213,7 +215,7 @@ public class WaypointHelper {
 	public AlarmInfo getMostImportantAlarm(SpeedConstants sc, boolean showCameras) {
 		Location lastProjection = app.getRoutingHelper().getLastProjection();
 		float mxspeed = route.getCurrentMaxSpeed(appMode.getRouteTypeProfile());
-		float delta = app.getSettings().SPEED_LIMIT_EXCEED_KMH.get() / 3.6f;
+		float delta = settings.SPEED_LIMIT_EXCEED_KMH.get() / 3.6f;
 		AlarmInfo speedAlarm = createSpeedAlarm(sc, mxspeed, lastProjection, delta);
 		if (speedAlarm != null) {
 			getVoiceRouter().announceSpeedAlarm(speedAlarm.getIntValue(), lastProjection.getSpeed());
@@ -262,22 +264,22 @@ public class WaypointHelper {
 		//An item will be displayed in the Waypoint list if either "Show..." or "Announce..." is selected for it in the Navigation settings
 		//Keep both "Show..." and "Announce..." Nav settings in sync when user changes what to display in the Waypoint list, as follows:
 		if (type == ALARMS) {
-			app.getSettings().SHOW_TRAFFIC_WARNINGS.setModeValue(appMode, enable);
-			app.getSettings().SPEAK_TRAFFIC_WARNINGS.setModeValue(appMode, enable);
-			app.getSettings().SHOW_PEDESTRIAN.setModeValue(appMode, enable);
-			app.getSettings().SPEAK_PEDESTRIAN.setModeValue(appMode, enable);
-			app.getSettings().SHOW_TUNNELS.setModeValue(appMode, enable);
-			app.getSettings().SPEAK_TUNNELS.setModeValue(appMode, enable);
+			settings.SHOW_TRAFFIC_WARNINGS.setModeValue(appMode, enable);
+			settings.SPEAK_TRAFFIC_WARNINGS.setModeValue(appMode, enable);
+			settings.SHOW_PEDESTRIAN.setModeValue(appMode, enable);
+			settings.SPEAK_PEDESTRIAN.setModeValue(appMode, enable);
+			settings.SHOW_TUNNELS.setModeValue(appMode, enable);
+			settings.SPEAK_TUNNELS.setModeValue(appMode, enable);
 			//But do not implicitly change speed_cam settings here because of legal restrictions in some countries, so Nav settings must prevail
 		} else if (type == POI) {
-			app.getSettings().SHOW_NEARBY_POI.setModeValue(appMode, enable);
-			app.getSettings().ANNOUNCE_NEARBY_POI.setModeValue(appMode, enable);
+			settings.SHOW_NEARBY_POI.setModeValue(appMode, enable);
+			settings.ANNOUNCE_NEARBY_POI.setModeValue(appMode, enable);
 		} else if (type == FAVORITES) {
-			app.getSettings().SHOW_NEARBY_FAVORITES.setModeValue(appMode, enable);
-			app.getSettings().ANNOUNCE_NEARBY_FAVORITES.setModeValue(appMode, enable);
+			settings.SHOW_NEARBY_FAVORITES.setModeValue(appMode, enable);
+			settings.ANNOUNCE_NEARBY_FAVORITES.setModeValue(appMode, enable);
 		} else if (type == WAYPOINTS) {
-			app.getSettings().SHOW_WPT.set(enable);
-			app.getSettings().ANNOUNCE_WPT.set(enable);
+			settings.SHOW_WPT.set(enable);
+			settings.ANNOUNCE_WPT.set(enable);
 		}
 		recalculatePoints(route, type, locationPoints);
 	}
@@ -301,13 +303,13 @@ public class WaypointHelper {
 
 	public boolean isTypeEnabled(int type) {
 		if (type == ALARMS) {
-			return app.getSettings().SHOW_ROUTING_ALARMS.get() && app.getSettings().SHOW_TRAFFIC_WARNINGS.getModeValue(appMode);
+			return settings.SHOW_ROUTING_ALARMS.get() && settings.SHOW_TRAFFIC_WARNINGS.getModeValue(appMode);
 		} else if (type == POI) {
-			return app.getSettings().SHOW_NEARBY_POI.getModeValue(appMode);
+			return settings.SHOW_NEARBY_POI.getModeValue(appMode);
 		} else if (type == FAVORITES) {
-			return app.getSettings().SHOW_NEARBY_FAVORITES.getModeValue(appMode);
+			return settings.SHOW_NEARBY_FAVORITES.getModeValue(appMode);
 		} else if (type == WAYPOINTS) {
-			return app.getSettings().SHOW_WPT.get();
+			return settings.SHOW_WPT.get();
 		}
 		return true;
 	}
@@ -317,7 +319,7 @@ public class WaypointHelper {
 		Location lastProjection = app.getRoutingHelper().getLastProjection();
 		if (route != null) {
 			float maxSpeed = route.getCurrentMaxSpeed(appMode.getRouteTypeProfile());
-			float delta = whenExceeded ? app.getSettings().SPEED_LIMIT_EXCEED_KMH.get() / 3.6f : maxSpeed * -1;
+			float delta = whenExceeded ? settings.SPEED_LIMIT_EXCEED_KMH.get() / 3.6f : maxSpeed * -1;
 			return createSpeedAlarm(constants, maxSpeed, lastProjection, delta);
 		}
 		return null;
@@ -326,7 +328,7 @@ public class WaypointHelper {
 	@Nullable
 	public AlarmInfo calculateSpeedLimitAlarm(@NonNull RouteDataObject object, @NonNull Location location, @NonNull SpeedConstants constants, boolean whenExceeded) {
 		float maxSpeed = object.getMaximumSpeed(object.bearingVsRouteDirection(location), appMode.getRouteTypeProfile());
-		float delta = whenExceeded ? app.getSettings().SPEED_LIMIT_EXCEED_KMH.get() / 3.6f : maxSpeed * -1;
+		float delta = whenExceeded ? settings.SPEED_LIMIT_EXCEED_KMH.get() / 3.6f : maxSpeed * -1;
 		return createSpeedAlarm(constants, maxSpeed, location, delta);
 	}
 
@@ -334,7 +336,7 @@ public class WaypointHelper {
 	public AlarmInfo calculateMostImportantAlarm(RouteDataObject ro, Location loc, MetricsConstants mc,
 	                                             SpeedConstants sc, boolean showCameras) {
 		float maxSpeed = ro.getMaximumSpeed(ro.bearingVsRouteDirection(loc), appMode.getRouteTypeProfile());
-		float delta = app.getSettings().SPEED_LIMIT_EXCEED_KMH.get() / 3.6f;
+		float delta = settings.SPEED_LIMIT_EXCEED_KMH.get() / 3.6f;
 		AlarmInfo speedAlarm = createSpeedAlarm(sc, maxSpeed, loc, delta);
 		if (speedAlarm != null) {
 			getVoiceRouter().announceSpeedAlarm(speedAlarm.getIntValue(), loc.getSpeed());
@@ -571,18 +573,18 @@ public class WaypointHelper {
 
 	protected void recalculatePoints(RouteCalculationResult route, int type, List<List<LocationPointWrapper>> locationPoints) {
 		boolean all = type == -1;
-		appMode = app.getSettings().getApplicationMode();
+		appMode = settings.getApplicationMode();
 		if (route != null && !route.isEmpty()) {
-			boolean showWaypoints = app.getSettings().SHOW_WPT.get(); // global
-			boolean announceWaypoints = app.getSettings().ANNOUNCE_WPT.get(); // global
+			boolean showWaypoints = settings.SHOW_WPT.get(); // global
+			boolean announceWaypoints = settings.ANNOUNCE_WPT.get(); // global
 
 			if (route.getAppMode() != null) {
 				appMode = route.getAppMode();
 			}
-			boolean showPOI = app.getSettings().SHOW_NEARBY_POI.getModeValue(appMode);
-			boolean showFavorites = app.getSettings().SHOW_NEARBY_FAVORITES.getModeValue(appMode);
-			boolean announceFavorites = app.getSettings().ANNOUNCE_NEARBY_FAVORITES.getModeValue(appMode);
-			boolean announcePOI = app.getSettings().ANNOUNCE_NEARBY_POI.getModeValue(appMode);
+			boolean showPOI = settings.SHOW_NEARBY_POI.getModeValue(appMode);
+			boolean showFavorites = settings.SHOW_NEARBY_FAVORITES.getModeValue(appMode);
+			boolean announceFavorites = settings.ANNOUNCE_NEARBY_FAVORITES.getModeValue(appMode);
+			boolean announcePOI = settings.ANNOUNCE_NEARBY_POI.getModeValue(appMode);
 
 			if ((type == FAVORITES || all)) {
 				List<LocationPointWrapper> array = clearAndGetArray(locationPoints, FAVORITES);
@@ -695,7 +697,6 @@ public class WaypointHelper {
 	}
 
 	private void calculateAlarms(RouteCalculationResult route, List<LocationPointWrapper> array, ApplicationMode mode) {
-		OsmandSettings settings = app.getSettings();
 		if (!settings.SHOW_ROUTING_ALARMS.getModeValue(mode)) {
 			return;
 		}

--- a/OsmAnd/src/net/osmand/plus/helpers/WaypointHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/WaypointHelper.java
@@ -659,17 +659,14 @@ public class WaypointHelper {
 
 
 	protected void sortList(List<LocationPointWrapper> list) {
-		Collections.sort(list, new Comparator<LocationPointWrapper>() {
-			@Override
-			public int compare(LocationPointWrapper olhs, LocationPointWrapper orhs) {
-				int lhs = olhs.routeIndex;
-				int rhs = orhs.routeIndex;
-				if (lhs == rhs) {
-					return Float.compare(olhs.deviationDistance, orhs.deviationDistance);
-				}
-				return lhs < rhs ? -1 : 1;
-			}
-		});
+		Collections.sort(list, (olhs, orhs) -> {
+            int lhs = olhs.routeIndex;
+            int rhs = orhs.routeIndex;
+            if (lhs == rhs) {
+                return Float.compare(olhs.deviationDistance, orhs.deviationDistance);
+            }
+            return lhs < rhs ? -1 : 1;
+        });
 	}
 
 

--- a/OsmAnd/src/net/osmand/plus/helpers/WaypointHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/WaypointHelper.java
@@ -688,13 +688,13 @@ public class WaypointHelper {
 
 	protected void sortList(List<LocationPointWrapper> list) {
 		Collections.sort(list, (olhs, orhs) -> {
-            int lhs = olhs.routeIndex;
-            int rhs = orhs.routeIndex;
-            if (lhs == rhs) {
-                return Float.compare(olhs.deviationDistance, orhs.deviationDistance);
-            }
-            return lhs < rhs ? -1 : 1;
-        });
+			int lhs = olhs.routeIndex;
+			int rhs = orhs.routeIndex;
+			if (lhs == rhs) {
+				return Float.compare(olhs.deviationDistance, orhs.deviationDistance);
+			}
+			return lhs < rhs ? -1 : 1;
+		});
 	}
 
 

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/MapRouteInfoMenu.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/MapRouteInfoMenu.java
@@ -1260,7 +1260,7 @@ public class MapRouteInfoMenu implements IRouteInformationListener, CardListener
 			View container = createToolbarSubOptionView(true, title, R.drawable.ic_action_remove_dark, true, v -> {
 				OsmandApplication app = getApp();
 				if (app != null) {
-					app.getWaypointHelper().enableWaypointType(waypointType, false);
+					app.getWaypointHelper().switchWaypointType(waypointType, false);
 					updateOptionsButtons();
 				}
 			});

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/MapRouteInfoMenu.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/MapRouteInfoMenu.java
@@ -1260,8 +1260,7 @@ public class MapRouteInfoMenu implements IRouteInformationListener, CardListener
 			View container = createToolbarSubOptionView(true, title, R.drawable.ic_action_remove_dark, true, v -> {
 				OsmandApplication app = getApp();
 				if (app != null) {
-					app.getWaypointHelper().switchWaypointType(waypointType, false);
-					updateOptionsButtons();
+					app.getWaypointHelper().switchWaypointTypeAsync(waypointType, false, this::updateOptionsButtons);
 				}
 			});
 			if (container != null) {

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/RouteOptionsBottomSheet.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/RouteOptionsBottomSheet.java
@@ -427,23 +427,20 @@ public class RouteOptionsBottomSheet extends MenuBottomSheetDialogFragment imple
 				.setIcon(getContentIcon((optionsItem.getActiveIconId())))
 				.setTitle(getString(R.string.show_along_the_route))
 				.setLayoutId(R.layout.bottom_sheet_item_simple_56dp)
-				.setOnClickListener(new View.OnClickListener() {
-					@Override
-					public void onClick(View view) {
-						routingOptionsHelper.addNewRouteMenuParameter(applicationMode, optionsItem);
-						FragmentManager fm = getFragmentManager();
-						if (fm == null) {
-							return;
-						}
-						Bundle args = new Bundle();
-						ShowAlongTheRouteBottomSheet fragment = new ShowAlongTheRouteBottomSheet();
-						fragment.setUsedOnMap(true);
-						fragment.setArguments(args);
-						fragment.setTargetFragment(RouteOptionsBottomSheet.this, ShowAlongTheRouteBottomSheet.REQUEST_CODE);
-						fragment.show(fm, ShowAlongTheRouteBottomSheet.TAG);
-						updateMenu();
-					}
-				}).create();
+				.setOnClickListener(view -> {
+                    routingOptionsHelper.addNewRouteMenuParameter(applicationMode, optionsItem);
+                    FragmentManager fm = getFragmentManager();
+                    if (fm == null) {
+                        return;
+                    }
+                    Bundle args = new Bundle();
+                    ShowAlongTheRouteBottomSheet fragment = new ShowAlongTheRouteBottomSheet();
+                    fragment.setUsedOnMap(true);
+                    fragment.setArguments(args);
+                    fragment.setTargetFragment(RouteOptionsBottomSheet.this, ShowAlongTheRouteBottomSheet.REQUEST_CODE);
+                    fragment.show(fm, ShowAlongTheRouteBottomSheet.TAG);
+                    updateMenu();
+                }).create();
 	}
 
 	private BaseBottomSheetItem createRouteSimulationItem(LocalRoutingParameter optionsItem) {

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/ShowAlongTheRouteBottomSheet.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/ShowAlongTheRouteBottomSheet.java
@@ -144,7 +144,7 @@ public class ShowAlongTheRouteBottomSheet extends MenuBottomSheetDialogFragment 
 					ContentItem radiusItem = new RadiusItem(i);
 					headerItem.subItems.add(radiusItem);
 				}
-				if (tp != null && tp.size() > 0) {
+				if (tp != null && !tp.isEmpty()) {
 					for (int j = 0; j < tp.size(); j++) {
 						LocationPointWrapper pointWrapper = tp.get(j);
 						if (!waypointHelper.isPointPassed(pointWrapper)) {
@@ -247,28 +247,22 @@ public class ShowAlongTheRouteBottomSheet extends MenuBottomSheetDialogFragment 
 				convertView = themedInflater.inflate(R.layout.along_the_route_point_item, parent, false);
 				WaypointDialogHelper.updatePointInfoView(app, mapActivity, convertView, item.point, true, nightMode, true, false);
 
-				convertView.findViewById(R.id.waypoint_container).setOnClickListener(new View.OnClickListener() {
-					@Override
-					public void onClick(View v) {
-						Fragment fragment = getTargetFragment();
-						if (fragment != null) {
-							fragment.onActivityResult(getTargetRequestCode(), SHOW_CONTENT_ITEM_REQUEST_CODE, null);
-						}
-						dismiss();
-						WaypointDialogHelper.showOnMap(app, mapActivity, item.point.getPoint(), false);
-					}
-				});
+				convertView.findViewById(R.id.waypoint_container).setOnClickListener(v -> {
+                    Fragment fragment = getTargetFragment();
+                    if (fragment != null) {
+                        fragment.onActivityResult(getTargetRequestCode(), SHOW_CONTENT_ITEM_REQUEST_CODE, null);
+                    }
+                    dismiss();
+                    WaypointDialogHelper.showOnMap(app, mapActivity, item.point.getPoint(), false);
+                });
 
 				ImageButton remove = convertView.findViewById(R.id.info_close);
 				remove.setImageDrawable(app.getUIUtilities().getThemedIcon(R.drawable.ic_action_remove_dark));
-				remove.setOnClickListener(new View.OnClickListener() {
-					@Override
-					public void onClick(View v) {
-						app.getWaypointHelper().removeVisibleLocationPoint(item.point);
-						group.subItems.remove(item);
-						adapter.notifyDataSetChanged();
-					}
-				});
+				remove.setOnClickListener(v -> {
+                    app.getWaypointHelper().removeVisibleLocationPoint(item.point);
+                    group.subItems.remove(item);
+                    adapter.notifyDataSetChanged();
+                });
 			}
 
 			View bottomDivider = convertView.findViewById(R.id.bottom_divider);
@@ -475,8 +469,7 @@ public class ShowAlongTheRouteBottomSheet extends MenuBottomSheetDialogFragment 
 		});
 	}
 
-	private void enableType(int type,
-	                        boolean enable) {
+	private void enableType(int type, boolean enable) {
 		new EnableWaypointsTypeTask(this, type, enable).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
 	}
 
@@ -527,7 +520,7 @@ public class ShowAlongTheRouteBottomSheet extends MenuBottomSheetDialogFragment 
 
 		@Override
 		protected Void doInBackground(Void... params) {
-			app.getWaypointHelper().enableWaypointType(type, enable);
+			app.getWaypointHelper().switchWaypointType(type, enable);
 			return null;
 		}
 

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/ShowAlongTheRouteBottomSheet.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/ShowAlongTheRouteBottomSheet.java
@@ -86,12 +86,7 @@ public class ShowAlongTheRouteBottomSheet extends MenuBottomSheetDialogFragment 
 		Drawable icBack = getContentIcon(AndroidUtils.getNavigationIconResId(ctx));
 		toolbar.setNavigationIcon(icBack);
 		toolbar.setNavigationContentDescription(R.string.access_shared_string_navigate_up);
-		toolbar.setNavigationOnClickListener(new View.OnClickListener() {
-			@Override
-			public void onClick(View v) {
-				dismiss();
-			}
-		});
+		toolbar.setNavigationOnClickListener(v -> dismiss());
 
 		SimpleBottomSheetItem titleItem = (SimpleBottomSheetItem) new SimpleBottomSheetItem.Builder()
 				.setCustomView(titleView)

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/ShowAlongTheRouteBottomSheet.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/ShowAlongTheRouteBottomSheet.java
@@ -470,68 +470,20 @@ public class ShowAlongTheRouteBottomSheet extends MenuBottomSheetDialogFragment 
 	}
 
 	private void enableType(int type, boolean enable) {
-		new EnableWaypointsTypeTask(this, type, enable).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+		waypointHelper.switchWaypointTypeAsync(type, enable, () -> {
+            if (isAdded()) {
+                updateAdapter();
+                updateMenu();
+            }
+        });
 	}
 
 	private void recalculatePoints(int type) {
-		new RecalculatePointsTask(this, type).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-	}
-
-	private static class RecalculatePointsTask extends AsyncTask<Void, Void, Void> {
-
-		private final OsmandApplication app;
-		private final WeakReference<ShowAlongTheRouteBottomSheet> fragmentRef;
-		private final int type;
-
-		RecalculatePointsTask(ShowAlongTheRouteBottomSheet fragment, int type) {
-			this.app = fragment.getMyApplication();
-			this.fragmentRef = new WeakReference<>(fragment);
-			this.type = type;
-		}
-
-		@Override
-		protected Void doInBackground(Void... params) {
-			app.getWaypointHelper().recalculatePoints(type);
-			return null;
-		}
-
-		@Override
-		protected void onPostExecute(Void aVoid) {
-			ShowAlongTheRouteBottomSheet fragment = fragmentRef.get();
-			if (fragment != null) {
-				fragment.updateAdapter();
-			}
-		}
-	}
-
-	private static class EnableWaypointsTypeTask extends AsyncTask<Void, Void, Void> {
-
-		private final OsmandApplication app;
-		private final WeakReference<ShowAlongTheRouteBottomSheet> fragmentRef;
-		private final int type;
-		private final boolean enable;
-
-		EnableWaypointsTypeTask(ShowAlongTheRouteBottomSheet fragment, int type, boolean enable) {
-			this.app = fragment.getMyApplication();
-			this.fragmentRef = new WeakReference<>(fragment);
-			this.type = type;
-			this.enable = enable;
-		}
-
-		@Override
-		protected Void doInBackground(Void... params) {
-			app.getWaypointHelper().switchWaypointType(type, enable);
-			return null;
-		}
-
-		@Override
-		protected void onPostExecute(Void aVoid) {
-			ShowAlongTheRouteBottomSheet fragment = fragmentRef.get();
-			if (fragment != null && fragment.isAdded()) {
-				fragment.updateAdapter();
-				fragment.updateMenu();
-			}
-		}
+		waypointHelper.recalculatePointsAsync(type, () -> {
+            if (isAdded()) {
+                updateAdapter();
+            }
+        });
 	}
 
 	private static class ContentItem {

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/ShowAlongTheRouteBottomSheet.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/ShowAlongTheRouteBottomSheet.java
@@ -248,21 +248,21 @@ public class ShowAlongTheRouteBottomSheet extends MenuBottomSheetDialogFragment 
 				WaypointDialogHelper.updatePointInfoView(app, mapActivity, convertView, item.point, true, nightMode, true, false);
 
 				convertView.findViewById(R.id.waypoint_container).setOnClickListener(v -> {
-                    Fragment fragment = getTargetFragment();
-                    if (fragment != null) {
-                        fragment.onActivityResult(getTargetRequestCode(), SHOW_CONTENT_ITEM_REQUEST_CODE, null);
-                    }
-                    dismiss();
-                    WaypointDialogHelper.showOnMap(app, mapActivity, item.point.getPoint(), false);
-                });
+					Fragment fragment = getTargetFragment();
+					if (fragment != null) {
+						fragment.onActivityResult(getTargetRequestCode(), SHOW_CONTENT_ITEM_REQUEST_CODE, null);
+					}
+					dismiss();
+					WaypointDialogHelper.showOnMap(app, mapActivity, item.point.getPoint(), false);
+				});
 
 				ImageButton remove = convertView.findViewById(R.id.info_close);
 				remove.setImageDrawable(app.getUIUtilities().getThemedIcon(R.drawable.ic_action_remove_dark));
 				remove.setOnClickListener(v -> {
-                    app.getWaypointHelper().removeVisibleLocationPoint(item.point);
-                    group.subItems.remove(item);
-                    adapter.notifyDataSetChanged();
-                });
+					app.getWaypointHelper().removeVisibleLocationPoint(item.point);
+					group.subItems.remove(item);
+					adapter.notifyDataSetChanged();
+				});
 			}
 
 			View bottomDivider = convertView.findViewById(R.id.bottom_divider);
@@ -471,19 +471,19 @@ public class ShowAlongTheRouteBottomSheet extends MenuBottomSheetDialogFragment 
 
 	private void enableType(int type, boolean enable) {
 		waypointHelper.switchWaypointTypeAsync(type, enable, () -> {
-            if (isAdded()) {
-                updateAdapter();
-                updateMenu();
-            }
-        });
+			if (isAdded()) {
+				updateAdapter();
+				updateMenu();
+			}
+		});
 	}
 
 	private void recalculatePoints(int type) {
 		waypointHelper.recalculatePointsAsync(type, () -> {
-            if (isAdded()) {
-                updateAdapter();
-            }
-        });
+			if (isAdded()) {
+				updateAdapter();
+			}
+		});
 	}
 
 	private static class ContentItem {


### PR DESCRIPTION
# Fix summary
The problem occurred due to the lack of automatic recalculation of user points when changing the settings for announcing these types of points in the "Voice Prompts" screen. In other parts of the app, points were recalculated if the "Show Points" feature was enabled. However, on the Voice Prompts settings screen, this recalculation was not triggered.

**Fix:**  
1. Added listeners to the settings and implemented automatic recalculation of points whenever voice prompt settings were changed.  
2. Introduced the variable `rejectPointsCalculation` to prevent excessive recalculations when the settings were modified internally within the `WaypointsHelper` class.
3. The update process is now triggered asynchronously from the UI to prevent potential freezes in case of a large number of points.

**Fix Reference:**  
The fix was implemented in the following [commit](https://github.com/osmandapp/OsmAnd/commit/8b49475bbb2073591a4a5589e210e8b183d21143).

**Additional Changes:**  
Other commits included minor visual improvements to the code.
