### PR TITLE
Fix first time import for road/travel/wiki obf(s)

### DIFF
--- a/OsmAnd/src/net/osmand/plus/importfiles/tasks/ObfImportTask.java
+++ b/OsmAnd/src/net/osmand/plus/importfiles/tasks/ObfImportTask.java
@@ -29,6 +29,10 @@ public class ObfImportTask extends BaseImportAsyncTask<Void, Void, String> {
 		boolean unzip = name.endsWith(IndexConstants.ZIP_EXT);
 		String fileName = unzip ? name.replace(IndexConstants.ZIP_EXT, "") : name;
 		File dest = getObfDestFile(fileName);
+		File parent = dest.getParentFile();
+		if (parent != null) {
+			parent.mkdirs();
+		}
 		String error = ImportHelper.copyFile(app, dest, uri, false, unzip);
 		if (error == null) {
 			app.getResourceManager().reloadIndexes(IProgress.EMPTY_PROGRESS, new ArrayList<>());


### PR DESCRIPTION
```
01-20 16:43:22.714  8934 28729 W System.err: java.io.FileNotFoundException: /storage/emulated/0/Android/data/net.osmand.plus/files/travel/malta.travel.obf: open failed: ENOENT (No such file or directory)
01-20 16:43:22.714  8934 28729 W System.err:  at libcore.io.IoBridge.open(IoBridge.java:574)
01-20 16:43:22.714  8934 28729 W System.err:  at java.io.FileOutputStream.<init>(FileOutputStream.java:259)
01-20 16:43:22.714  8934 28729 W System.err:  at java.io.FileOutputStream.<init>(FileOutputStream.java:208)
01-20 16:43:22.714  8934 28729 W System.err:  at net.osmand.plus.importfiles.ImportHelper.copyFile(ImportHelper.java:419)
01-20 16:43:22.714  8934 28729 W System.err:  at net.osmand.plus.importfiles.ImportHelper.copyFile(ImportHelper.java:387)
01-20 16:43:22.714  8934 28729 W System.err:  at net.osmand.plus.importfiles.tasks.ObfImportTask.doInBackground(ObfImportTask.java:32)
01-20 16:43:22.714  8934 28729 W System.err:  at net.osmand.plus.importfiles.tasks.ObfImportTask.doInBackground(ObfImportTask.java:16)
01-20 16:43:22.714  8934 28729 W System.err:  at android.os.AsyncTask$3.call(AsyncTask.java:394)
01-20 16:43:22.714  8934 28729 W System.err:  at java.util.concurrent.FutureTask.run(FutureTask.java:264)
01-20 16:43:22.714  8934 28729 W System.err:  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
01-20 16:43:22.714  8934 28729 W System.err:  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
01-20 16:43:22.714  8934 28729 W System.err:  at java.lang.Thread.run(Thread.java:1012)
01-20 16:43:22.714  8934 28729 W System.err: Caused by: android.system.ErrnoException: open failed: ENOENT (No such file or directory)
```