### PR TITLE
Implement modern locale tag processing

### DIFF
--- a/OsmAnd/src/net/osmand/plus/configmap/ConfigureMapUtils.java
+++ b/OsmAnd/src/net/osmand/plus/configmap/ConfigureMapUtils.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 
 public class ConfigureMapUtils {
 
-	public static final String[] MAP_LANGUAGES_IDS = {"", "en", "af", "als", "ar", "az", "be", "ber", "bg", "bn", "bpy", "br", "bs", "ca", "ceb", "ckb", "cs", "cy", "da", "de", "el", "eo", "es", "et", "eu", "fa", "fi", "fr", "fy", "ga", "gl", "he", "hi", "hsb", "hr", "ht", "hu", "hy", "id", "is", "it", "ja", "ka", "kab", "kk", "kn", "ko", "ku", "la", "lb", "lo", "lt", "lv", "mk", "ml", "mr", "ms", "nds", "new", "nl", "nn", "no", "nv", "oc", "os", "pl", "pms", "pt", "ro", "ru", "sat", "sc", "sh", "sk", "sl", "sq", "sr", "sr-latn", "sv", "sw", "ta", "te", "th", "tl", "tr", "uk", "vi", "vo", "zh", "zh-Hans", "zh-Hant"};
+	public static final String[] MAP_LANGUAGES_IDS = {"", "en", "af", "als", "ar", "az", "be", "ber", "bg", "bn", "bpy", "br", "bs", "ca", "ceb", "ckb", "cs", "cy", "da", "de", "el", "eo", "es", "et", "eu", "fa", "fi", "fr", "fy", "ga", "gl", "he", "hi", "hsb", "hr", "ht", "hu", "hy", "id", "is", "it", "ja", "ka", "kab", "kk", "kn", "ko", "ku", "la", "lb", "lo", "lt", "lv", "mk", "ml", "mr", "ms", "nds", "new", "nl", "nn", "no", "nv", "oc", "os", "pl", "pms", "pt", "ro", "ru", "sat", "sc", "sh", "sk", "sl", "sq", "sr", "sr-Latn", "sv", "sw", "ta", "te", "th", "tl", "tr", "uk", "vi", "vo", "zh", "zh-Hans", "zh-Hant"};
 
 	@NonNull
 	public static Map<String, String> getSorterMapLanguages(@NonNull OsmandApplication app) {

--- a/OsmAnd/src/net/osmand/plus/helpers/LocaleHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/LocaleHelper.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 
 public class LocaleHelper {
@@ -41,10 +42,10 @@ public class LocaleHelper {
 	public LocaleHelper(@NonNull OsmandApplication app) {
 		this.app = app;
 		this.defaultLocale = Locale.getDefault();
-		localeListener = change -> preferredLocaleChanged();
+		localeListener = change -> onPreferredLocaleChanged();
 	}
 
-	private void preferredLocaleChanged() {
+	private void onPreferredLocaleChanged() {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
 			String preferredLocale = app.getSettings().PREFERRED_LOCALE.get();
 			if (!Algorithms.isEmpty(preferredLocale)) {
@@ -58,8 +59,9 @@ public class LocaleHelper {
 	public void checkPreferredLocale() {
 		OsmandSettings settings = app.getSettings();
 		String locale = settings.PREFERRED_LOCALE.get();
+
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-			String currentLocale = Locale.getDefault().toString();
+			String currentLocale = Locale.getDefault().toLanguageTag();
 			if (!Algorithms.stringsEqual(currentLocale, locale)) {
 				locale = currentLocale;
 				settings.PREFERRED_LOCALE.set(locale);
@@ -67,18 +69,59 @@ public class LocaleHelper {
 		}
 		settings.PREFERRED_LOCALE.addListener(localeListener);
 
-		String[] splitScript = locale.split("\\+");
-		String script = (splitScript.length > 1) ? splitScript[1] : "";
-		String[] splitCountry = splitScript[0].split("_");
-		String lang = splitCountry[0];
-		String country = (splitCountry.length > 1) ? splitCountry[1] : "";
+		boolean useSystemDefault = Algorithms.isEmpty(locale);
+		if (!useSystemDefault) {
+			Locale modernLocale = Locale.forLanguageTag(locale);
+			if (!Algorithms.isEmpty(modernLocale.toString())) {
+				preferredLocale = modernLocale;
+			} else {
+				preferredLocale = parseLegacyLanguageTag(locale, preferredLocale);
+			}
+		}
 
+		Locale selectedLocale = null;
+		Configuration config = app.getBaseContext().getResources().getConfiguration();
+
+		if (!useSystemDefault && !Objects.equals(config.getLocales().get(0), preferredLocale)) {
+			selectedLocale = preferredLocale;
+		} else if (useSystemDefault && defaultLocale != null && !Objects.equals(Locale.getDefault(), defaultLocale)) {
+			selectedLocale = defaultLocale;
+			preferredLocale = null;
+		}
+
+		updateTimeFormatting(selectedLocale != null ? selectedLocale : Locale.getDefault());
+
+		if (selectedLocale != null) {
+			Locale.setDefault(selectedLocale);
+			Configuration newConfig = new Configuration(config);
+
+			newConfig.setLocales(new android.os.LocaleList(selectedLocale));
+			newConfig.setLayoutDirection(selectedLocale);
+
+			Resources resources = app.getBaseContext().getResources();
+			resources.updateConfiguration(newConfig, resources.getDisplayMetrics());
+
+			localizedConf = new Configuration(newConfig);
+		}
+	}
+
+	@Nullable
+	private Locale parseLegacyLanguageTag(@NonNull String locale, @Nullable Locale defaultLocale) {
+		// Split locale into language, region, and script
+		String[] scriptSplit = locale.split("\\+");
+		String baseLocale = scriptSplit[0];
+		String script = (scriptSplit.length > 1) ? scriptSplit[1] : "";
+
+		String[] localeSplit = baseLocale.split("_");
+		String lang = localeSplit[0];
+		String country = (localeSplit.length > 1) ? localeSplit[1] : "";
+
+		// Construct Locale using Builder
 		if (!Algorithms.isEmpty(lang)) {
 			Locale.Builder builder = new Locale.Builder();
 			lang = backwardCompatibleNonIsoCodes(lang);
-			String langLowerCase = lang.toLowerCase();
 			for (String isoLang : Locale.getISOLanguages()) {
-				if (isoLang.toLowerCase().equals(langLowerCase)) {
+				if (isoLang.equalsIgnoreCase(lang)) {
 					builder.setLanguage(isoLang);
 					break;
 				}
@@ -89,30 +132,9 @@ public class LocaleHelper {
 			if (!Algorithms.isEmpty(script)) {
 				builder.setScript(script);
 			}
-			preferredLocale = builder.build();
+			return builder.build();
 		}
-
-		Locale selectedLocale = null;
-		Configuration config = app.getBaseContext().getResources().getConfiguration();
-		if (!Algorithms.isEmpty(lang) && !config.locale.equals(preferredLocale)) {
-			selectedLocale = preferredLocale;
-		} else if (Algorithms.isEmpty(lang) && defaultLocale != null && Locale.getDefault() != defaultLocale) {
-			selectedLocale = defaultLocale;
-			preferredLocale = null;
-		}
-
-		updateTimeFormatting(selectedLocale != null ? selectedLocale : Locale.getDefault());
-		if (selectedLocale != null) {
-			Locale.setDefault(selectedLocale);
-			config.locale = selectedLocale;
-			config.setLayoutDirection(selectedLocale);
-
-			Resources resources = app.getBaseContext().getResources();
-			resources.updateConfiguration(config, resources.getDisplayMetrics());
-			localizedConf = new Configuration(config);
-			localizedConf.locale = selectedLocale;
-
-		}
+		return defaultLocale;
 	}
 
 	private String backwardCompatibleNonIsoCodes(String lang) {

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -286,23 +286,20 @@ public class OsmandSettings {
 			return false;
 		}
 		if (preference == APPLICATION_MODE) {
-			if (value instanceof String) {
-				String appModeKey = (String) value;
+			if (value instanceof String appModeKey) {
 				ApplicationMode appMode = ApplicationMode.valueOfStringKey(appModeKey, null);
 				if (appMode != null) {
 					return setApplicationMode(appMode);
 				}
 			}
 		} else if (preference == DEFAULT_APPLICATION_MODE) {
-			if (value instanceof String) {
-				String appModeKey = (String) value;
+			if (value instanceof String appModeKey) {
 				ApplicationMode appMode = ApplicationMode.valueOfStringKey(appModeKey, null);
 				if (appMode != null) {
 					return DEFAULT_APPLICATION_MODE.set(appMode);
 				}
 			}
-		} else if (preference instanceof EnumStringPreference) {
-			EnumStringPreference enumPref = (EnumStringPreference) preference;
+		} else if (preference instanceof EnumStringPreference enumPref) {
 			if (value instanceof String) {
 				Enum<?> enumValue = enumPref.parseString((String) value);
 				if (enumValue != null) {

--- a/OsmAnd/src/net/osmand/plus/settings/fragments/BaseSettingsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/settings/fragments/BaseSettingsFragment.java
@@ -880,8 +880,8 @@ public abstract class BaseSettingsFragment extends PreferenceFragmentCompat impl
 	}
 
 	@NonNull
-	protected Preference requirePreference(@NonNull CharSequence key) {
-		Preference preference = findPreference(key);
+	protected <T extends Preference> T requirePreference(@NonNull CharSequence key) {
+		T preference = findPreference(key);
 		if (preference == null) {
 			throw new IllegalArgumentException("Preference with key '" + key + "' not found.");
 		}

--- a/OsmAnd/src/net/osmand/plus/settings/fragments/GlobalSettingsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/settings/fragments/GlobalSettingsFragment.java
@@ -211,7 +211,7 @@ public class GlobalSettingsFragment extends BaseSettingsFragment
 
 	private void setupPreferredLocalePref() {
 		boolean visible = Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU;
-		ListPreferenceEx preference = findPreference(settings.PREFERRED_LOCALE.getId());
+		ListPreferenceEx preference = requirePreference(settings.PREFERRED_LOCALE.getId());
 		preference.setVisible(visible);
 		if (visible) {
 			preference.setIcon(getContentIcon(R.drawable.ic_action_map_language));
@@ -224,7 +224,7 @@ public class GlobalSettingsFragment extends BaseSettingsFragment
 			preference.setEntryValues(languagesIds);
 
 			// Add " (Display language)" to menu title in Latin letters for all non-en languages
-			if (!getResources().getString(R.string.preferred_locale).equals(getResources().getString(R.string.preferred_locale_no_translate))) {
+			if (!getString(R.string.preferred_locale).equals(getString(R.string.preferred_locale_no_translate))) {
 				preference.setTitle(getString(R.string.preferred_locale) + " (" + getString(R.string.preferred_locale_no_translate) + ")");
 			}
 		}


### PR DESCRIPTION
### **Implemented modern IETF BCP 47 locale tag processing**  

#### **Problem & Initial Fix**  
The issue we aimed to fix was incorrect parsing of the **script** in a locale tag. This occurred because the system-provided locale tag used a different format than what our app expected—specifically, it used `#` instead of `+` to separate the script from other locale parameters.  

A quick fix was introduced in [PR #21908](https://github.com/osmandapp/OsmAnd/pull/21908), which addressed this formatting issue. However, it assumed that if a script was present, it would always be the third element in the locale tag. This assumption was incorrect, as scripts are optional, and other components like **extensions** could take the third position instead. Attempting to set an extension as a script in `Locale.Builder` caused crashes, since scripts must be **alpha-4 codes** as per ISO 15924 (all possible scripts can be found [here](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry) (search for "Type: script")).  

This issue arose due to a misunderstanding of the locale tag specification and how its components are structured.

#### **Solution**  
After further investigation, we discovered that `Locale.toString()` returns locale tags in an outdated format, whereas `Locale.toLanguageTag()` produces tags compliant with the **modern IETF BCP 47 standard**.  

To resolve this, we made the following changes:  
- **Parsing:** We now use `Locale.forLanguageTag()` to correctly interpret locale tags from system settings.  
- **Storing:** We save the locale in **modern BCP 47 format** using `Locale.toLanguageTag()`.  
- **Backward compatibility:** The previous locale handling remains for older Android versions where locale selection is still available within the app.  

This ensures:  
1. **Proper parsing of system locale settings** and avoidance of format inconsistencies.  
2. **Reduced complexity** when extracting locale parameters.  
3. **Stability** by preventing crashes due to incorrect script parsing.  

Since newer Android versions no longer display an in-app language selection option in OsmAnd (instead relying on system settings), this approach aligns with the platform's expected behavior.