### PR TITLE
Remove useless GPX reloading for isTempFile tracks (avoid double-call to getAnalysis, etc)

### DIFF
--- a/OsmAnd/src/net/osmand/plus/track/fragments/TrackMenuFragment.java
+++ b/OsmAnd/src/net/osmand/plus/track/fragments/TrackMenuFragment.java
@@ -330,11 +330,6 @@ public class TrackMenuFragment extends ContextMenuScrollFragment implements Card
 			}
 		} else if (selectedGpxFile != null) {
 			onSelectedGpxFileAvailable();
-			if (FileUtils.isTempFile(app, getGpx().getPath())) {
-				GpxSelectionParams params = GpxSelectionParams.newInstance()
-						.selectedByUser().syncGroup().addToMarkers().addToHistory().saveSelection();
-				selectedGpxFile = gpxSelectionHelper.selectGpxFile(selectedGpxFile.getGpxFile(), params);
-			}
 		}
 
 		activity.getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {


### PR DESCRIPTION
Tested on NetworkRouteSelector, TravelGpx and ClickableWay.

Click from map = OK
Click from search = OK
Save to permanent GPX = OK