### PR TITLE
Hide Wiki POIs like other types when showing search filter on map

### DIFF
--- a/OsmAnd/src/net/osmand/plus/poi/PoiFiltersHelper.java
+++ b/OsmAnd/src/net/osmand/plus/poi/PoiFiltersHelper.java
@@ -52,10 +52,8 @@ public class PoiFiltersHelper {
 	private PoiUIFilter showAllPOIFilter;
 	private PoiUIFilter topWikiPoiFilter;
 	private List<PoiUIFilter> cacheTopStandardFilters = null;
-	private Set<PoiUIFilter> overwrittenSelectedPoiFilters = new TreeSet<>();
 	private Set<PoiUIFilter> selectedPoiFilters = new TreeSet<>();
-	private boolean useOverwrittenFilters;
-
+	private Set<PoiUIFilter> overwrittenPoiFilters = null;
 
 	public PoiFiltersHelper(@NonNull OsmandApplication app) {
 		this.app = app;
@@ -468,32 +466,15 @@ public class PoiFiltersHelper {
 
 	@NonNull
 	public Set<PoiUIFilter> getSelectedPoiFilters() {
-		return useOverwrittenFilters ? overwrittenSelectedPoiFilters : selectedPoiFilters;
+		return overwrittenPoiFilters != null ? overwrittenPoiFilters : selectedPoiFilters;
 	}
 
-	public void replaceSelectedPoiFilters(PoiUIFilter filter) {
-		Set<PoiUIFilter> overwrittenSelectedPoiFilters = new TreeSet<>();
-		overwrittenSelectedPoiFilters.add(filter);
-		PoiUIFilter wiki = getTopWikiPoiFilter();
-		if (isPoiFilterSelected(wiki)) {
-			overwrittenSelectedPoiFilters.add(wiki);
-		}
-		this.overwrittenSelectedPoiFilters = overwrittenSelectedPoiFilters;
-		useOverwrittenFilters = true;
+	public void replaceSelectedPoiFilters(@NonNull PoiUIFilter filter) {
+		overwrittenPoiFilters = new TreeSet<>(Set.of(filter));
 	}
 
 	public void restoreSelectedPoiFilters() {
-		PoiUIFilter wiki = getTopWikiPoiFilter();
-		if (wiki != null) {
-			Set<PoiUIFilter> selectedPoiFilters = new TreeSet<>(this.selectedPoiFilters);
-			if (isPoiFilterSelected(wiki)) {
-				selectedPoiFilters.add(wiki);
-			} else {
-				selectedPoiFilters.remove(wiki);
-			}
-			this.selectedPoiFilters = selectedPoiFilters;
-		}
-		useOverwrittenFilters = false;
+		overwrittenPoiFilters = null;
 	}
 
 	public void addSelectedPoiFilter(PoiUIFilter filter) {
@@ -547,8 +528,8 @@ public class PoiFiltersHelper {
 	}
 
 	private void setSelectedPoiFilters(@NonNull Set<PoiUIFilter> filters) {
-		if (useOverwrittenFilters) {
-			overwrittenSelectedPoiFilters = filters;
+		if (overwrittenPoiFilters != null) {
+			overwrittenPoiFilters = filters;
 		} else {
 			selectedPoiFilters = filters;
 			saveSelectedPoiFilters(selectedPoiFilters);


### PR DESCRIPTION
Reverting part of the logic introduced in this pull request: https://github.com/osmandapp/OsmAnd/pull/20468/files (which was related to fixing this issue: https://github.com/osmandapp/OsmAnd/issues/17944).  

Keeping the Wikipedia POI type visible when displaying the POI filter in Search can obstruct the user's view of relevant points on the map. Therefore, the logic for preserving Wikipedia visibility is unnecessary and excessive.  

Additionally, due to an incomplete implementation of this logic, a bug occurred:  
- If the Wikipedia layer was disabled, and the user searched for Wikipedia POIs in Search and displayed the results on the map, upon returning from the Search screen, the Wikipedia layer remained visible, which was incorrect behavior.
