### PR TITLE
Fix BinaryInspector

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/data/Amenity.java
+++ b/OsmAnd-java/src/main/java/net/osmand/data/Amenity.java
@@ -302,9 +302,9 @@ public class Amenity extends MapObject {
 					if (pt2 != null) {
 						String cat = pt2.getCategory().getKeyName();
 						if (poi_type.containsKey(cat)) {
-							val = poi_type.get(cat) + ";" + val;
+							key = poi_type.get(cat) + ";" + key;
 						}
-						poi_type.put(pt2.getCategory().getKeyName(), val);
+						poi_type.put(pt2.getCategory().getKeyName(), key);
 					} else {
 						text.put(key, val);
 					}


### PR DESCRIPTION
Fix man_made=eductation - non present in poi_types.xml, man_made is category for poi landuse_education

To issue https://github.com/osmandapp/OsmAnd/issues/21993