### PR TITLE
Reverse geocoding code porting from iOS

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/binary/GeocodingUtilities.java
+++ b/OsmAnd-java/src/main/java/net/osmand/binary/GeocodingUtilities.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.Log;
 import java.io.IOException;
 import java.text.Collator;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -55,6 +56,38 @@ public class GeocodingUtilities {
 			return Double.compare(o1.getDistance(), o2.getDistance());
 		}
 	};
+
+	public static final Map<String, List<String>> GEOCODING_ACCESS = initGeocodingAccess();
+	private static Map<String, List<String>> initGeocodingAccess() {
+		Map<String, List<String>> map = new HashMap<>();
+
+		map.put("highway", Arrays.asList(
+				"motorway",
+				"motorway_link",
+				"trunk",
+				"trunk_link",
+				"primary",
+				"primary_link",
+				"secondary",
+				"secondary_link",
+				"tertiary",
+				"tertiary_link",
+				"unclassified",
+				"road",
+				"residential",
+				"track",
+				"service",
+				"living_street",
+				"pedestrian"
+		));
+
+		map.put("route", Arrays.asList(
+				"ferry",
+				"shuttle_train"
+		));
+
+		return map;
+	}
 
 	public static class GeocodingResult {
 		public GeocodingResult() {
@@ -453,5 +486,25 @@ public class GeocodingUtilities {
 		Collections.sort(complete, DISTANCE_COMPARATOR);
 		return complete;
 
+	}
+
+	public boolean hasGeocodingAccess(RouteDataObject obj) {
+		if (obj == null) {
+			return false;
+		}
+		List<Integer> types = new ArrayList<>();
+		int[] t = obj.getTypes();
+        for (int j : t) {
+            types.add(j);
+        }
+		for (Map.Entry<String, List<String>> entry : GEOCODING_ACCESS.entrySet()) {
+			for (String val : entry.getValue()) {
+				int type = obj.region.findOrCreateRouteType(entry.getKey(), val);
+				if (types.contains(type)) {
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 }

--- a/OsmAnd-java/src/main/java/net/osmand/binary/GeocodingUtilities.java
+++ b/OsmAnd-java/src/main/java/net/osmand/binary/GeocodingUtilities.java
@@ -494,9 +494,9 @@ public class GeocodingUtilities {
 		}
 		List<Integer> types = new ArrayList<>();
 		int[] t = obj.getTypes();
-        for (int j : t) {
-            types.add(j);
-        }
+		for (int j : t) {
+			types.add(j);
+		}
 		for (Map.Entry<String, List<String>> entry : GEOCODING_ACCESS.entrySet()) {
 			for (String val : entry.getValue()) {
 				int type = obj.region.findOrCreateRouteType(entry.getKey(), val);

--- a/OsmAnd-java/src/main/java/net/osmand/router/GeneralRouter.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/GeneralRouter.java
@@ -333,6 +333,9 @@ public class GeneralRouter implements VehicleRouter {
 
 	@Override
 	public boolean acceptLine(RouteDataObject way) {
+		if (way != null && profileName.equals("geocoding")) {
+			return true;
+		}
 		Float res = getCache(RouteDataObjectAttribute.ACCESS, way);
 		if (res == null) {
 			res = (float) getObjContext(RouteDataObjectAttribute.ACCESS).evaluateInt(way, 0);

--- a/OsmAnd/src/net/osmand/plus/helpers/CurrentPositionHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/CurrentPositionHelper.java
@@ -238,9 +238,9 @@ public class CurrentPositionHelper {
 	private void justifyResult(List<GeocodingResult> res, ResultMatcher<GeocodingResult> result) {
 		List<GeocodingResult> complete = new ArrayList<>();
 		double minBuildingDistance = 0;
+		GeocodingUtilities utilities = new GeocodingUtilities();
 		if (res != null) {
 			List<BinaryMapIndexReader> readers = new ArrayList<>();
-			GeocodingUtilities utilities = new GeocodingUtilities();
 			for (GeocodingResult r : res) {
 				BinaryMapIndexReader foundRepo = null;
 				List<BinaryMapReaderResource> rts  = usedReaders;
@@ -294,6 +294,7 @@ public class CurrentPositionHelper {
 			app.runInUIThread(() -> result.publish(null));
 			return;
 		}
+		complete.removeIf(entry -> entry.building == null && entry.street == null && !utilities.hasGeocodingAccess(entry.point.getRoad()));
 		GeocodingResult rts = complete.size() > 0 ? complete.get(0) : new GeocodingResult();
 		app.runInUIThread(() -> result.publish(rts));
 	}


### PR DESCRIPTION
Porting lines from iOS/core:
- [const QHash<QString, QStringList> GEOCODING_ACCESS](https://github.com/osmandapp/OsmAnd-core/blob/0ebc8d0b726cf8db863dd348d4550cdfef29690c/src/Data/Road.cpp#L10)
- [const bool OsmAnd::Road::hasGeocodingAccess() const](https://github.com/osmandapp/OsmAnd-core/blob/0ebc8d0b726cf8db863dd348d4550cdfef29690c/src/Data/Road.cpp#L50)
- [result.erase(std::remove_if(result.begin(), result.end(), ... !entry->road->hasGeocodingAccess())](https://github.com/osmandapp/OsmAnd-core/blob/0ebc8d0b726cf8db863dd348d4550cdfef29690c/src/Search/ReverseGeocoder_P.cpp#L217)

To issue https://github.com/osmandapp/OsmAnd/issues/21248

Result:
Android:
<img src="https://github.com/user-attachments/assets/ee14183a-7d14-43cc-91dd-457929d569ad" width="400" />

iOS:
![Знімок екрана 2025-04-11 о 19 13 39](https://github.com/user-attachments/assets/0057867c-acab-48df-92cc-c6da9d73c485)

