### PR TITLE
Plan route segments fix

### DIFF
--- a/OsmAnd/src/net/osmand/plus/measurementtool/command/ChangeRouteModeCommand.java
+++ b/OsmAnd/src/net/osmand/plus/measurementtool/command/ChangeRouteModeCommand.java
@@ -140,7 +140,7 @@ public class ChangeRouteModeCommand extends MeasurementModeCommand {
 		MeasurementEditingContext editingCtx = getEditingCtx();
 		editingCtx.getPoints().clear();
 		editingCtx.addPoints(newPoints);
-		if (newPoints.isEmpty()) {
+		if (newPoints.isEmpty() || newPoints.getLast().isGap()) {
 			editingCtx.setAppMode(newMode);
 		} else {
 			WptPt lastPoint = newPoints.get(newPoints.size() - 1);


### PR DESCRIPTION
Fixed a bug:
- Create track in Plan Route (with Car profile by example)
- Add new segment. Without any points
- Change routing profile (to Walking by example)

expected: new segment with Walking profile
reality: new segment with Straight line profile

---

Screenshots before / after:

<img width="300" alt="Screenshot 2025-04-25 at 17 06 28" src="https://github.com/user-attachments/assets/b2657ab6-3dac-4727-813b-b02f6d08859f" /> <img width="300" alt="Screenshot 2025-04-25 at 17 06 00" src="https://github.com/user-attachments/assets/7e4e3a69-ef06-4570-bee3-773116e66317" />

---

Video before:

https://github.com/user-attachments/assets/69cf3805-3e37-49bf-8b25-d5a9f482339b

Video after:

https://github.com/user-attachments/assets/1a966133-5d76-4325-b69a-85abe0237f1e

---

[ios related pr](https://github.com/osmandapp/OsmAnd-iOS/pull/4538)

