### PR TITLE
Fix: incorrect transparency when raster plugin is turned off

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/MapLayers.java
+++ b/OsmAnd/src/net/osmand/plus/views/MapLayers.java
@@ -269,10 +269,12 @@ public class MapLayers {
 
 		// update transparency
 		int mapTransparency = 255;
-		if (rasterMapsEnabled && settings.MAP_UNDERLAY.get() != null) {
-			mapTransparency = settings.MAP_TRANSPARENCY.get();
-		} else if (rasterMapsEnabled && useOpenGLRender && settings.MAP_OVERLAY.get() != null) {
-			mapTransparency = 255 - settings.MAP_OVERLAY_TRANSPARENCY.get();
+		if (rasterMapsEnabled) {
+			if (settings.MAP_UNDERLAY.get() != null) {
+				mapTransparency = settings.MAP_TRANSPARENCY.get();
+			} else if (useOpenGLRender && settings.MAP_OVERLAY.get() != null) {
+				mapTransparency = 255 - settings.MAP_OVERLAY_TRANSPARENCY.get();
+			}
 		}
 		mapTileLayer.setAlpha(mapTransparency);
 		mapVectorLayer.setAlpha(mapTransparency);

--- a/OsmAnd/src/net/osmand/plus/views/MapLayers.java
+++ b/OsmAnd/src/net/osmand/plus/views/MapLayers.java
@@ -265,12 +265,13 @@ public class MapLayers {
 	public void updateMapSource(@NonNull OsmandMapTileView mapView, CommonPreference<String> settingsToWarnAboutMap) {
 		OsmandSettings settings = app.getSettings();
 		boolean useOpenGLRender = app.useOpenGlRenderer();
+		boolean rasterMapsEnabled = PluginsHelper.isEnabled(OsmandRasterMapsPlugin.class);
 
 		// update transparency
 		int mapTransparency = 255;
-		if (settings.MAP_UNDERLAY.get() != null) {
+		if (rasterMapsEnabled && settings.MAP_UNDERLAY.get() != null) {
 			mapTransparency = settings.MAP_TRANSPARENCY.get();
-		} else if (useOpenGLRender && settings.MAP_OVERLAY.get() != null) {
+		} else if (rasterMapsEnabled && useOpenGLRender && settings.MAP_OVERLAY.get() != null) {
 			mapTransparency = 255 - settings.MAP_OVERLAY_TRANSPARENCY.get();
 		}
 		mapTileLayer.setAlpha(mapTransparency);


### PR DESCRIPTION
### Problem
When the OsmandRasterMapsPlugin was disabled, transparency and (maybe) some other settings related to underlay/overlay layers were still being applied. This led to incorrect rendering (e.g., semi-transparent labels) even though the plugin was inactive.

### Solution
In the updateMapSource() method, we now check PluginsHelper.isEnabled(OsmandRasterMapsPlugin.class) before applying transparency values from MAP_UNDERLAY or MAP_OVERLAY_TRANSPARENCY. If the plugin is disabled, transparency defaults to 255, and the related settings are ignored.

### Next steps (optional future improvements)
* Check and unsubscribe from other related data and settings when the plugin is disabled