### PR TITLE
Hotfix containsUnsupportedRouteTags (route_road_1)

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/network/NetworkRouteSelector.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/network/NetworkRouteSelector.java
@@ -230,7 +230,9 @@ public class NetworkRouteSelector {
 	public static boolean containsUnsupportedRouteTags(Map<String, String> tags) {
 		for (OsmRouteType routeType : OsmRouteType.getAllValues()) {
 			if (routeType.getRenderingPropertyAttr() == null) {
-				if (tags.containsKey("route_" + routeType.getName())) {
+				String routeName = "route_" + routeType.getName();
+				String routeNameWithSuffixFirst = routeName + "_1";
+				if (tags.containsKey(routeName) || tags.containsKey(routeNameWithSuffixFirst)) {
 					return true;
 				}
 			}


### PR DESCRIPTION
Ignore click on "route_road_1" as well as previously on "route_road" (and other unsupported routes.)

![em525](https://github.com/user-attachments/assets/b84ec760-265d-4b53-9f64-9e0c18cf87ad)
