### PR TITLE
Trip Recording: Do Not Discard Filtered Points

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -4481,6 +4481,8 @@ Download tile maps directly, or copy them as SQLite database files to OsmAnd\'s 
     <string name="stop_navigation_service">Stop</string>
     <string name="confirm_every_run">Always ask</string>
     <string name="save_global_track_interval">General logging interval</string>
+    <string name="save_track_unfiltered_title">Save full track</string>
+    <string name="save_track_unfiltered_descr">If enabled, both full and filtered tracks will be saved</string>
     <string name="background_service_int">GPS Wake-up interval</string>
     <string name="enable_sleep_mode">Enable GPS background mode</string>
     <string name="save_track_to_gpx_globally_headline">On demand track logging</string>

--- a/OsmAnd/res/xml/monitoring_settings.xml
+++ b/OsmAnd/res/xml/monitoring_settings.xml
@@ -57,6 +57,13 @@
 		android:layout="@layout/preference_category_with_descr"
 		android:title="@string/save_track_logging_accuracy" />
 
+	<net.osmand.plus.settings.preferences.SwitchPreferenceEx
+		android:key="save_track_unfiltered"
+		android:layout="@layout/preference_with_descr_dialog_and_switch"
+		android:summaryOff="@string/shared_string_disabled"
+		android:summaryOn="@string/shared_string_enabled"
+		android:title="@string/save_track_unfiltered_title" />
+
 	<net.osmand.plus.settings.preferences.ListPreferenceEx
 		android:key="save_global_track_interval"
 		android:layout="@layout/preference_with_descr"

--- a/OsmAnd/src/net/osmand/plus/plugins/monitoring/MonitoringSettingsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/monitoring/MonitoringSettingsFragment.java
@@ -110,7 +110,7 @@ public class MonitoringSettingsFragment extends BaseSettingsFragment implements 
 	protected void setupPreferences() {
 		setupDisableBatteryOptimizationPref();
 		setupShowStartDialog();
-
+		setupSaveTrackUnfiltered();
 		setupSaveTrackToGpxPref();
 		setupSaveTrackIntervalPref();
 
@@ -145,6 +145,11 @@ public class MonitoringSettingsFragment extends BaseSettingsFragment implements 
 		SwitchPreferenceEx showStartDialog = findPreference(settings.SHOW_TRIP_REC_START_DIALOG.getId());
 		showStartDialog.setDescription(getString(R.string.trip_recording_show_start_dialog_setting));
 		showStartDialog.setIcon(getPersistentPrefIcon(R.drawable.ic_action_dialog));
+	}
+
+	private void setupSaveTrackUnfiltered() {
+		SwitchPreferenceEx showStartDialog = findPreference(settings.SAVE_TRACK_UNFILTERED.getId());
+		showStartDialog.setDescription(getString(R.string.save_track_unfiltered_descr));
 	}
 
 	private void setupSaveTrackToGpxPref() {

--- a/OsmAnd/src/net/osmand/plus/plugins/monitoring/OsmandMonitoringPlugin.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/monitoring/OsmandMonitoringPlugin.java
@@ -90,6 +90,7 @@ public class OsmandMonitoringPlugin extends OsmandPlugin {
 		pluginPreferences.add(settings.SAVE_TRACK_INTERVAL);
 		pluginPreferences.add(settings.SAVE_TRACK_MIN_DISTANCE);
 		pluginPreferences.add(settings.SAVE_TRACK_PRECISION);
+		pluginPreferences.add(settings.SAVE_TRACK_UNFILTERED);
 		pluginPreferences.add(settings.AUTO_SPLIT_RECORDING);
 		pluginPreferences.add(settings.DISABLE_RECORDING_ONCE_APP_KILLED);
 		pluginPreferences.add(settings.SHOW_TRIP_REC_NOTIFICATION);

--- a/OsmAnd/src/net/osmand/plus/plugins/monitoring/SavingTrackHelper.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/monitoring/SavingTrackHelper.java
@@ -96,14 +96,12 @@ public class SavingTrackHelper extends SQLiteOpenHelper implements IRouteInforma
 
 	private int currentTrackIndex = 1;
 	private boolean shouldAutomaticallyRecord = true;
-	//todo : remove
 	private LatLon lastPoint;
 	private float distance;
 	private long duration;
 	private int points;
 	private int trkPoints;
 
-	//todo : remove
 	private long lastTimeUpdated;
 	private long lastTimeFileSaved;
 
@@ -202,7 +200,7 @@ public class SavingTrackHelper extends SQLiteOpenHelper implements IRouteInforma
 					if (has) {
 						return true;
 					}
-					q = db.query(false, POINT_NAME, new String[]{POINT_COL_LAT, POINT_COL_LON}, null, null, null, null, null, null);
+					q = db.query(false, POINT_NAME, new String[] {POINT_COL_LAT, POINT_COL_LON}, null, null, null, null, null, null);
 					has = q.moveToFirst();
 					while (has) {
 						if (q.getDouble(0) != 0 || q.getDouble(1) != 0) {
@@ -277,18 +275,20 @@ public class SavingTrackHelper extends SQLiteOpenHelper implements IRouteInforma
 					return new SaveGpxResult(warnings, new HashMap<>());
 				}
 
-                File dir_un = new File(dir, "unfiltered");
-				File fout_un = new File(dir_un, fileName + IndexConstants.GPX_FILE_EXT);
-                int ind = 1;
-                while (fout_un.exists()) {
-                    fout_un = new File(dir_un, fileName + "_" + (++ind) + "_unfiltered" + IndexConstants.GPX_FILE_EXT); //$NON-NLS-1$
-                }
+				if (settings.SAVE_TRACK_UNFILTERED.get()) {
+					File dir_un = new File(dir, "unfiltered");
+					File fout_un = new File(dir_un, fileName + IndexConstants.GPX_FILE_EXT);
+					int ind = 1;
+					while (fout_un.exists()) {
+						fout_un = new File(dir_un, fileName + "_" + (++ind) + "_unfiltered" + IndexConstants.GPX_FILE_EXT); //$NON-NLS-1$
+					}
 
-				KFile fKout_un = SharedUtil.kFile(fout_un);
-				warn = SharedUtil.writeGpxFile(fKout_un, gpx);
-				if (warn != null) {
-					warnings.add(warn.getMessage());
-					return new SaveGpxResult(warnings, new HashMap<>());
+					KFile fKout_un = SharedUtil.kFile(fout_un);
+					warn = SharedUtil.writeGpxFile(fKout_un, gpx);
+					if (warn != null) {
+						warnings.add(warn.getMessage());
+						return new SaveGpxResult(warnings, new HashMap<>());
+					}
 				}
 
 				GpxDataItem item = new GpxDataItem(fKout);
@@ -336,8 +336,8 @@ public class SavingTrackHelper extends SQLiteOpenHelper implements IRouteInforma
 			if (db != null) {
 				try {
 					if (db.isOpen()) {
-						db.execSQL("DELETE FROM " + TRACK_NAME + " WHERE " + TRACK_COL_DATE + " <= ?", new Object[]{time});
-						db.execSQL("DELETE FROM " + POINT_NAME + " WHERE " + POINT_COL_DATE + " <= ?", new Object[]{time});
+						db.execSQL("DELETE FROM " + TRACK_NAME + " WHERE " + TRACK_COL_DATE + " <= ?", new Object[] {time});
+						db.execSQL("DELETE FROM " + POINT_NAME + " WHERE " + POINT_COL_DATE + " <= ?", new Object[] {time});
 					}
 				} finally {
 					db.close();
@@ -369,16 +369,6 @@ public class SavingTrackHelper extends SQLiteOpenHelper implements IRouteInforma
 			}
 		}
 		return data;
-	}
-
-	public Map<String, GpxFile> filterRecordedData(@NonNull Map<String, GpxFile> data) {
-		Map<String, GpxFile> res = new LinkedHashMap<String, GpxFile>();
-
-		for (Map.Entry<String, GpxFile> entry : data.entrySet()) {
-			GpxFile filteredGpx = SavedTrackFilter.filterGpxFile(entry.getValue(), settings);
-			res.put(entry.getKey(), filteredGpx);
-		};
-		return res;
 	}
 
 	private void collectDBPoints(@NonNull SQLiteDatabase db, @NonNull Map<String, GpxFile> dataTracks) {
@@ -551,7 +541,6 @@ public class SavingTrackHelper extends SQLiteOpenHelper implements IRouteInforma
 			lastRoutingApplicationMode = null;
 		}
 
-		//log.debug("updateLocation at " + time);
 		heading = getAdjustedHeading(heading);
 
 		WptPt wptPt = new WptPt(location.getLatitude(), location.getLongitude(), time,
@@ -816,7 +805,6 @@ public class SavingTrackHelper extends SQLiteOpenHelper implements IRouteInforma
 	}
 
 	public void loadGpxFromDatabase() {
-		//todo : filter here ?
 		Map<String, GpxFile> files = collectRecordedData();
 		List<Track> tracks = new ArrayList<>();
 		for (Map.Entry<String, GpxFile> entry : files.entrySet()) {
@@ -917,8 +905,8 @@ public class SavingTrackHelper extends SQLiteOpenHelper implements IRouteInforma
 	}
 
 	private static class SavedTrackFilter {
-		LatLon lastPoint = null;
-		long lastTimeUpdated = -1;
+		LatLon lastFilteredPoint = null;
+		long lastFilteredTime = -1;
 		OsmandSettings settings;
 
 		public static GpxFile filterGpxFile(@NonNull GpxFile gpx, @NonNull OsmandSettings settings) {
@@ -964,19 +952,19 @@ public class SavingTrackHelper extends SQLiteOpenHelper implements IRouteInforma
 				// && SimulationProvider.isNotSimulatedLocation(location)
 					&& PluginsHelper.isActive(OsmandMonitoringPlugin.class)) {
 //				if (isRecordingAutomatically() &&
-				if(		locationTime - lastTimeUpdated > settings.SAVE_TRACK_INTERVAL.get()) {
-					lastTimeUpdated = locationTime;
+				if(		locationTime - lastFilteredTime > settings.SAVE_TRACK_INTERVAL.get()) {
+					lastFilteredTime = locationTime;
 					record = true;
 				} else if (settings.SAVE_GLOBAL_TRACK_TO_GPX.get()
-						&& locationTime - lastTimeUpdated > settings.SAVE_GLOBAL_TRACK_INTERVAL.get()) {
-					lastTimeUpdated = locationTime;
+						&& locationTime - lastFilteredTime > settings.SAVE_GLOBAL_TRACK_INTERVAL.get()) {
+					lastFilteredTime = locationTime;
 					record = true;
 				}
 				float minDistance = settings.SAVE_TRACK_MIN_DISTANCE.get();
-				if (minDistance > 0 && lastPoint != null
-						&& MapUtils.getDistance(lastPoint, location) < minDistance) {
+				if (minDistance > 0 && lastFilteredPoint != null
+						&& MapUtils.getDistance(lastFilteredPoint, location) < minDistance) {
 					record = false;
-					lastPoint = location;
+					lastFilteredPoint = location;
 				}
 				float precision = settings.SAVE_TRACK_PRECISION.get();
 				if (precision > 0 && (Double.isNaN(accuracy) || accuracy > precision)) {

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -1585,6 +1585,8 @@ public class OsmandSettings {
 		SAVE_TRACK_TO_GPX.setModeDefaultValue(ApplicationMode.PEDESTRIAN, false);
 	}
 
+	public final CommonPreference<Boolean> SAVE_TRACK_UNFILTERED = new BooleanPreference(this, "save_track_unfiltered", false).makeProfile().cache();
+
 	public static final Integer REC_DIRECTORY = 0;
 	public static final Integer MONTHLY_DIRECTORY = 1;
 //	public static final Integer DAILY_DIRECTORY = 2;


### PR DESCRIPTION
Optionally save all trackpoints (including ones filtered according to the recoding plugin settings) in a separate .gpx file.
Full tracklog is saved in `/rec/unfiltered/<track_filename>_unfiltered.gpx`
Saving of full tracklogs is default disabled with a new boolean flag added into the plugin settings.

Note : 
Automatic purge of full tracklogs after some time interval (as suggested in https://github.com/osmandapp/OsmAnd/issues/22567) is not implemented.
Size of full tracklogs shouldn't be an issue with modern amount of storage (single point is ~250 bytes, 24hrs of unfiltered tracklog recorded at 1Hz is ~21Mb), even if it's explicitly enabled by the user.