### PR TITLE
Fix unnecessary requests to legacy rendering

### DIFF
--- a/OsmAnd/src/net/osmand/plus/auto/SurfaceRenderer.java
+++ b/OsmAnd/src/net/osmand/plus/auto/SurfaceRenderer.java
@@ -399,7 +399,7 @@ public final class SurfaceRenderer implements DefaultLifecycleObserver, MapRende
 							mapRendererContext.setMapRendererView(offscreenMapRendererView);
 							mapView.setMinAllowedElevationAngle(MIN_ALLOWED_ELEVATION_ANGLE_AA);
 							float elevationAngle = mapView.normalizeElevationAngle(getApp().getSettings().getLastKnownMapElevation());
-							mapView.setMapRenderer(offscreenMapRendererView);
+							mapView.setMapRenderer(offscreenMapRendererView, false);
 							mapView.setElevationAngle(elevationAngle);
 							mapView.addElevationListener(this);
 							getApp().getOsmandMap().getMapLayers().updateMapSource(mapView, null);

--- a/OsmAnd/src/net/osmand/plus/views/MapViewWithLayers.java
+++ b/OsmAnd/src/net/osmand/plus/views/MapViewWithLayers.java
@@ -83,9 +83,9 @@ public class MapViewWithLayers extends FrameLayout {
 			setupAtlasMapRendererView();
 			mapLayersView.setMapView(mapView);
 			app.getMapViewTrackingUtilities().setMapView(mapView);
-			mapView.setMapRenderer(atlasMapRendererView);
+			mapView.setMapRenderer(atlasMapRendererView, false);
 		} else if (!useAndroidAuto) {
-			mapView.setMapRenderer(null);
+			mapView.setMapRenderer(null, false);
 			resetMapRendererView();
 		}
 		AndroidUiHelper.updateVisibility(surfaceView, !useAndroidAuto && !useOpenglRender);
@@ -108,7 +108,7 @@ public class MapViewWithLayers extends FrameLayout {
 			if (atlasMapRendererView != null && mapRendererContext.getMapRendererView() == atlasMapRendererView)
 				return;
 			if (mapView.getMapRenderer() != null)
-				mapView.setMapRenderer(null);
+				mapView.setMapRenderer(null, true);
 			if (mapRendererContext.getMapRendererView() != null) {
 				mapRendererView = mapRendererContext.getMapRendererView();
 				mapRendererContext.setMapRendererView(null);
@@ -162,7 +162,7 @@ public class MapViewWithLayers extends FrameLayout {
 		if (atlasMapRendererView != null) {
 			NavigationSession carNavigationSession = app.getCarNavigationSession();
 			if (carNavigationSession == null || !carNavigationSession.hasStarted()) {
-				mapView.setMapRenderer(null);
+				mapView.setMapRenderer(null, true);
 				resetMapRendererView();
 				atlasMapRendererView.handleOnDestroy();
 			}

--- a/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
+++ b/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
@@ -2024,7 +2024,7 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 		return true;
 	}
 
-	public void setMapRenderer(@Nullable MapRendererView mapRenderer) {
+	public void setMapRenderer(@Nullable MapRendererView mapRenderer, boolean disable) {
 		List<OsmandMapLayer> layers = getLayers();
 		for (OsmandMapLayer layer : layers) {
 			layer.onMapRendererChange(this.mapRenderer, mapRenderer);
@@ -2035,7 +2035,7 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 			this.mapRenderer.resetElevationDataProvider();
 		}
 		this.mapRenderer = mapRenderer;
-		if (!isSteplessZoomSupported()) {
+		if (!isSteplessZoomSupported() && !disable) {
 			setZoomWithFloatPart(getZoom(), 0);
 		}
 	}


### PR DESCRIPTION
Don't use legacy rendering methods when switching renderers.