### PR TITLE
Fix broken conditionals with live updates "repeated" types

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteConditionalHelper.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteConditionalHelper.java
@@ -80,20 +80,21 @@ public class RouteConditionalHelper {
 								if (vl != 0) {
 									BinaryMapRouteReaderAdapter.RouteTypeRule rtr = rdo.region.quickGetEncodingRule(vl);
 									String nonCondTag = rtr.getTag();
-									int ks;
-									for (ks = 0; ks < rdo.pointTypes[i].length; ks++) {
-										BinaryMapRouteReaderAdapter.RouteTypeRule toReplace = rdo.region.quickGetEncodingRule(rdo.pointTypes[i][ks]);
+									boolean appendAsNewType = true;
+									for (int ks = 0; ks < rdo.pointTypes[i].length; ks++) {
+										BinaryMapRouteReaderAdapter.RouteTypeRule toReplace =
+												rdo.region.quickGetEncodingRule(rdo.pointTypes[i][ks]);
 										if (toReplace != null && toReplace.getTag().contentEquals(nonCondTag)) {
-											break;
+											appendAsNewType = false;
+											pTypes[ks] = vl;
 										}
 									}
-									if (ks == pTypes.length) {
-										int[] ntypes = new int[pTypes.length + 1];
-										System.arraycopy(pTypes, 0, ntypes, 0, pTypes.length);
-										pTypes = ntypes;
+									if (appendAsNewType) {
+										int[] nTypes = new int[pTypes.length + 1];
+										System.arraycopy(pTypes, 0, nTypes, 0, pTypes.length);
+										nTypes[nTypes.length - 1] = vl;
+										pTypes = nTypes;
 									}
-									pTypes[ks] = vl;
-
 								}
 							}
 						}
@@ -115,19 +116,20 @@ public class RouteConditionalHelper {
 
 	public void updateTypesByTagRuleId(RouteDataObject rdo, String tag, int ruleId) {
 		if (ruleId > 0) {
-			int ks;
-			for (ks = 0; ks < rdo.types.length; ks++) {
+			boolean appendAsNewType = true;
+			for (int ks = 0; ks < rdo.types.length; ks++) {
 				BinaryMapRouteReaderAdapter.RouteTypeRule toReplace = rdo.region.quickGetEncodingRule(rdo.types[ks]);
 				if (toReplace != null && toReplace.getTag().equals(tag)) {
-					break;
+					appendAsNewType = false;
+					rdo.types[ks] = ruleId;
 				}
 			}
-			if (ks == rdo.types.length) {
-				int[] ntypes = new int[rdo.types.length + 1];
-				System.arraycopy(rdo.types, 0, ntypes, 0, rdo.types.length);
-				rdo.types = ntypes;
+			if (appendAsNewType) {
+				int[] nTypes = new int[rdo.types.length + 1];
+				System.arraycopy(rdo.types, 0, nTypes, 0, rdo.types.length);
+				nTypes[nTypes.length - 1] = ruleId;
+				rdo.types = nTypes;
 			}
-			rdo.types[ks] = ruleId;
 		}
 	}
 }


### PR DESCRIPTION
https://github.com/osmandapp/OsmAnd/issues/21977

Germany_nordrhein-westfalen_europe_25_05_00.obf

Road 5408488865 osmid 84507638 highway='residential' lit='yes' maxspeed='30' **oneway**='yes' **oneway**:conditional='no @ 2025 Jan 1-Dec 31' surface='asphalt' osmand_highway_integrity_brouting='0' highway='residential' lit='yes' maxspeed='30' **oneway**='yes' **oneway**:conditional='no @ 2025 Jan 1-Dec 31' surface='asphalt' osmand_highway_integrity_brouting='0' osmand_ele_start='58' osmand_ele_end='59' name="Landsberger Straße" pointtypes [[5. osmand_ele_asc='0.75' osmand_ele_incline_='1' osmand_ele_incline_max='3' ][7. crossing='uncontrolled' highway='crossing' osmand_ele_desc='0.5' osmand_ele_decline_max='3' osmand_ele_decline_3='1' ][13. barrier:conditional='jersey_barrier @ 2025 Jan 1-Dec 31' bicycle:conditional='dismount @ 2025 Jan 1-Dec 31' vehicle:conditional='no @ 2025 Jan 1-Dec 31' ][25. osmand_ele_desc='0.25' ][26. osmand_ele_asc='0.25' ][28. osmand_ele_asc='0.25' ][30. osmand_ele_desc='0.25' osmand_ele_decline_max='1' osmand_ele_decline_1='1' ][31. osmand_ele_asc='0.25' osmand_ele_incline_='1' osmand_ele_incline_max='1' ]]