### PR TITLE
Implement multiAmenitiesByType to fix broken POI types

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/osm/edit/EntityParser.java
+++ b/OsmAnd-java/src/main/java/net/osmand/osm/edit/EntityParser.java
@@ -177,7 +177,7 @@ public class EntityParser {
 						}
 					}
 					for (Amenity am : multiAmenitiesByType.values()) {
-						addAmenity(entity, amenitiesList, ts, am); // TODO: How to deal with duplicated OSM id?
+						addAmenity(entity, amenitiesList, ts, am);
 					}
 				} else {
 					Amenity am = poiTypes.parseAmenity(key, value, purerelation, ts);


### PR DESCRIPTION
https://github.com/osmandapp/OsmAnd/issues/22824

https://www.openstreetmap.org/node/2481221905#map=19/35.923912/14.489093

Was:
```
sustenance: bar;nightclub Footloose;Gentlemen's Club Lat 35.923916 Lon 14.489089 osmid=2481221905  cities:[name=San Ġiljan name:en=Saint Julian's name:ru=Сан Джулианс name:it=San Giuliano name:es=San Julián name:ml=സാൻ ജൂലിയൻ place=town ]
```

Now:
```
entertainment: nightclub Footloose;Gentlemen's Club Lat 35.923916 Lon 14.489089 osmid=2481221905  cities:[name=San Ġiljan name:en=Saint Julian's name:ru=Сан Джулианс name:it=San Giuliano name:es=San Julián name:ml=സാൻ ജൂലിയൻ place=town ]
sustenance: bar Footloose;Gentlemen's Club Lat 35.923916 Lon 14.489089 osmid=2481221905  cities:[name=San Ġiljan name:en=Saint Julian's name:ru=Сан Джулианс name:it=San Giuliano name:es=San Julián name:ml=സാൻ ജൂലിയൻ place=town ]
```

TODO: How to deal with duplicated OSM id?