### PR TITLE
Increase precision of coordinates in live monitoring by using doubles instead of floats

### DIFF
--- a/OsmAnd/src/net/osmand/plus/plugins/monitoring/LiveMonitoringHelper.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/monitoring/LiveMonitoringHelper.java
@@ -56,7 +56,7 @@ public class LiveMonitoringHelper {
 		long locationTime = System.currentTimeMillis();
 
 		if (shouldRecordLocation(location, locationTime)) {
-			LiveMonitoringData data = new LiveMonitoringData((float) location.getLatitude(), (float) location.getLongitude(),
+			LiveMonitoringData data = new LiveMonitoringData(location.getLatitude(), location.getLongitude(),
 					(float) location.getAltitude(), location.getSpeed(), location.getAccuracy(), location.getBearing(), locationTime);
 			setupLiveDataTimeAndDistance(data, location, locationTime);
 			queue.add(data);
@@ -128,8 +128,8 @@ public class LiveMonitoringHelper {
 	private static class LiveMonitoringData {
 		public static final int NUMBER_OF_LIVE_DATA_FIELDS = 11;    //change the value after each addition\deletion of data field
 
-		private final float lat;
-		private final float lon;
+		private final double lat;
+		private final double lon;
 		private final float alt;
 		private final float speed;
 		private final float bearing;
@@ -147,7 +147,7 @@ public class LiveMonitoringHelper {
 			this.distanceToIntermediateOrFinish = distanceToIntermediateOrFinish;
 		}
 
-		public LiveMonitoringData(float lat, float lon, float alt, float speed, float hdop, float bearing, long time) {
+		public LiveMonitoringData(double lat, double lon, float alt, float speed, float hdop, float bearing, long time) {
 			this.lat = lat;
 			this.lon = lon;
 			this.alt = alt;

--- a/OsmAnd/src/net/osmand/plus/plugins/monitoring/LiveMonitoringHelper.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/monitoring/LiveMonitoringHelper.java
@@ -15,6 +15,7 @@ import net.osmand.plus.plugins.PluginsHelper;
 import net.osmand.plus.routing.RoutingHelper;
 import net.osmand.plus.settings.backend.OsmandSettings;
 import net.osmand.plus.utils.AndroidNetworkUtils;
+import net.osmand.shared.gpx.GpxFormatter;
 import net.osmand.util.MapUtils;
 
 import org.apache.commons.logging.Log;
@@ -247,10 +248,10 @@ public class LiveMonitoringHelper {
 		for (int i = 0; i < maxLen + 1; i++) {
 			switch (i) {
 				case 0:
-					prm.add(data.lat + "");
+					prm.add(GpxFormatter.INSTANCE.formatLatLon(data.lat));
 					break;
 				case 1:
-					prm.add(data.lon + "");
+					prm.add(GpxFormatter.INSTANCE.formatLatLon(data.lon));
 					break;
 				case 2:
 					prm.add(data.time + "");


### PR DESCRIPTION
LiveMonitoringData receives location coordinates as doubles, but converts them to floats, significantly reducing precision. You can spot this easily by comparing a recorded GPX track to the live locations sent during the same ride.

Green track: GPX trip recording
Red track: Live monitoring locations

<img width="1825" height="1254" alt="image" src="https://github.com/user-attachments/assets/9feaeda7-5aa0-4223-945d-a3f0b047f291" />

Removing the float cast should allow the live locations to be as precise as the GPX track.