### PR TITLE
Trip recording: fix widgets not updating after starting new segment

### DIFF
--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxFile.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxFile.kt
@@ -100,6 +100,13 @@ class GpxFile : GpxExtensions {
 		return points.contains(point)
 	}
 
+	fun clearData() {
+		clearPoints()
+		tracks.clear()
+		generalSegment = null
+		generalTrack = null
+	}
+
 	fun clearPoints() {
 		points.clear()
 		pointsGroups.clear()

--- a/OsmAnd/src/net/osmand/plus/plugins/monitoring/SavingTrackHelper.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/monitoring/SavingTrackHelper.java
@@ -330,8 +330,11 @@ public class SavingTrackHelper extends SQLiteOpenHelper implements IRouteInforma
 		duration = 0;
 		trkPoints = 0;
 		currentTrackIndex++;
-		app.getSelectedGpxHelper().clearPoints(currentTrack.getModifiableGpxFile());
-		currentTrack.getModifiableGpxFile().getTracks().clear();
+
+		GpxFile gpxFile = currentTrack.getModifiableGpxFile();
+		gpxFile.clearData();
+		app.getSelectedGpxHelper().syncGpxWithMarkers(gpxFile);
+
 		currentTrack.clearSegmentsToDisplay();
 		currentTrack.getModifiableGpxFile().setModifiedTime(time);
 		currentTrack.getModifiableGpxFile().setPointsModifiedTime(time);
@@ -339,7 +342,7 @@ public class SavingTrackHelper extends SQLiteOpenHelper implements IRouteInforma
 	}
 
 	public Map<String, GpxFile> collectRecordedData() {
-		Map<String, GpxFile> data = new LinkedHashMap<String, GpxFile>();
+		Map<String, GpxFile> data = new LinkedHashMap<>();
 		SQLiteDatabase db = getReadableDatabase();
 		if (db != null && db.isOpen()) {
 			try {
@@ -619,7 +622,7 @@ public class SavingTrackHelper extends SQLiteOpenHelper implements IRouteInforma
 			currentTrack.addEmptySegmentToDisplay();
 		}
 		boolean segmentAdded = false;
-		if (track.getSegments().size() == 0 || newSegment) {
+		if (track.getSegments().isEmpty() || newSegment) {
 			track.getSegments().add(new TrkSegment());
 			segmentAdded = true;
 		}

--- a/OsmAnd/src/net/osmand/plus/track/helpers/GpxSelectionHelper.java
+++ b/OsmAnd/src/net/osmand/plus/track/helpers/GpxSelectionHelper.java
@@ -433,11 +433,6 @@ public class GpxSelectionHelper {
 		}
 	}
 
-	public void clearPoints(GpxFile gpxFile) {
-		gpxFile.clearPoints();
-		syncGpxWithMarkers(gpxFile);
-	}
-
 	public void addPoint(WptPt point, GpxFile gpxFile) {
 		gpxFile.addPoint(point);
 		syncGpxWithMarkers(gpxFile);
@@ -454,7 +449,7 @@ public class GpxSelectionHelper {
 		return res;
 	}
 
-	private void syncGpxWithMarkers(GpxFile gpxFile) {
+	public void syncGpxWithMarkers(GpxFile gpxFile) {
 		MapMarkersHelper mapMarkersHelper = app.getMapMarkersHelper();
 		MapMarkersGroup group = mapMarkersHelper.getMarkersGroup(gpxFile);
 		if (group != null) {

--- a/OsmAnd/src/net/osmand/plus/track/helpers/SelectedGpxFile.java
+++ b/OsmAnd/src/net/osmand/plus/track/helpers/SelectedGpxFile.java
@@ -172,14 +172,18 @@ public class SelectedGpxFile {
 
 	public final void appendTrackPointToDisplay(@NonNull WptPt point, @NonNull OsmandApplication app) {
 		TrkSegment lastSegment;
-		if (processedPointsToDisplay.size() == 0) {
+		if (processedPointsToDisplay.isEmpty()) {
 			lastSegment = new TrkSegment();
 			processedPointsToDisplay.add(lastSegment);
 		} else {
 			lastSegment = processedPointsToDisplay.get(processedPointsToDisplay.size() - 1);
 		}
-
 		lastSegment.getPoints().add(point);
+
+		TrkSegment generalSegment = gpxFile != null ? gpxFile.getGeneralSegment() : null;
+		if (generalSegment != null) {
+			generalSegment.getPoints().add(point);
+		}
 
 		boolean hasCalculatedBounds = !bounds.hasInitialState();
 		if (hasCalculatedBounds) {


### PR DESCRIPTION
**Problem**
UI updates froze after starting a new segment because the *general segment* was used for displaying data but:

* points were never added to it,
* it was not cleared at the end of recording.

As a result, the UI looked stuck, even though internal segments continued to receive data correctly. Saved tracks were fine, but the preview still contained the “phantom” general segment.

**Fix**
We cleaned up the logic of `GpxFile`, `SavingTrackHelper` and `SelectedGpxFile`:

* properly clear general segment and related data when finishing recording,
* avoid keeping unused points in display segments,
* ensure UI widgets receive updates continuously across new segments.