### PR TITLE
Pass MapActivity context to PublicTransportCard views

### DIFF
--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/PublicTransportCard.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/PublicTransportCard.java
@@ -413,8 +413,9 @@ public class PublicTransportCard extends MapBaseCard {
 	}
 
 	private View createArrow() {
-		LinearLayout container = new LinearLayout(app);
-		ImageView arrow = new ImageView(app);
+		MapActivity mapActivity = getMapActivity();
+		LinearLayout container = new LinearLayout(mapActivity);
+		ImageView arrow = new ImageView(mapActivity);
 		Drawable icArrow = getContentIcon(R.drawable.ic_action_arrow_forward_16);
 		arrow.setImageDrawable(AndroidUtils.getDrawableForDirection(app, icArrow));
 		container.addView(arrow, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, AndroidUtils.dpToPx(app, 28)));


### PR DESCRIPTION
The `createArrow` method in `PublicTransportCard` was updated to use the `MapActivity` context when creating `LinearLayout` and `ImageView` instances. This resolving issues related to resource access in logs on opening navigation panel for public transport (look at attached image).
 
```
Tried to access the API:ViewConfiguration which needs to have proper configuration from a non-UI Context:net.osmand.plus.OsmandApplication@964d618 The API:ViewConfiguration needs a proper configuration. Use UI contexts such as an activity or a context created via createWindowContext(Display, int, Bundle) or  createConfigurationContext(Configuration) with a proper configuration.
java.lang.IllegalAccessException: Tried to access the API:ViewConfiguration which needs to have proper configuration from a non-UI Context:net.osmand.plus.OsmandApplication@964d618
	at android.os.StrictMode.assertConfigurationContext(StrictMode.java:2430)
	at android.view.ViewConfiguration.get(ViewConfiguration.java:595)
	at android.view.View.<init>(View.java:5868)
	at android.widget.ImageView.<init>(ImageView.java:182)
	at net.osmand.plus.routepreparationmenu.cards.PublicTransportCard.createArrow(PublicTransportCard.java:417)
	at net.osmand.plus.routepreparationmenu.cards.PublicTransportCard.createRouteBadges(PublicTransportCard.java:332)
	at net.osmand.plus.routepreparationmenu.cards.PublicTransportCard.updateContent(PublicTransportCard.java:112)
	at net.osmand.plus.routepreparationmenu.cards.BaseCard.update(BaseCard.java:93)
	at net.osmand.plus.routepreparationmenu.cards.BaseCard.build(BaseCard.java:138)
	at net.osmand.plus.routepreparationmenu.MapRouteInfoMenu.build(MapRouteInfoMenu.java:448)
	at net.osmand.plus.routepreparationmenu.MapRouteInfoMenu.setupCards(MapRouteInfoMenu.java:651)
	at net.osmand.plus.routepreparationmenu.MapRouteInfoMenu.updateCards(MapRouteInfoMenu.java:640)
	at net.osmand.plus.routepreparationmenu.MapRouteInfoMenu.updateInfo(MapRouteInfoMenu.java:468)
	at net.osmand.plus.routepreparationmenu.MapRouteInfoMenuFragment.updateInfo(MapRouteInfoMenuFragment.java:325)
	at net.osmand.plus.routepreparationmenu.MapRouteInfoMenuFragment.updateInfo(MapRouteInfoMenuFragment.java:320)
	at net.osmand.plus.routepreparationmenu.MapRouteInfoMenu.routeCalculationFinished(MapRouteInfoMenu.java:375)
	at net.osmand.plus.helpers.MapRouteCalculationProgressListener.lambda$onCalculationFinish$4(MapRouteCalculationProgressListener.java:87)
	at net.osmand.plus.helpers.MapRouteCalculationProgressListener.$r8$lambda$MXEZHWU-x-yCDA9jOZTnR8kJ2zM(Unknown Source:0)
	at net.osmand.plus.helpers.MapRouteCalculationProgressListener$$ExternalSyntheticLambda1.run(D8$$SyntheticClass:0)
	at android.os.Handler.handleCallback(Handler.java:995)
	at android.os.Handler.dispatchMessage(Handler.java:103)
	at android.os.Looper.loopOnce(Looper.java:248)
	at android.os.Looper.loop(Looper.java:338)
	at android.app.ActivityThread.main(ActivityThread.java:9067)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:593)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:932)
```

<img width="260" height="530" alt="image" src="https://github.com/user-attachments/assets/eec69745-fb0c-49e6-9604-019a394b83b4" />