### PR TITLE
Fix crash when rotating screen while adding a new quick action #23271

### DIFF
--- a/OsmAnd/src/net/osmand/plus/quickaction/AddQuickActionFragment.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/AddQuickActionFragment.java
@@ -13,6 +13,7 @@ import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.activity.ComponentActivity;
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -102,10 +103,7 @@ public class AddQuickActionFragment extends BaseFullScreenFragment implements It
 					setSearchMode(false);
 				} else {
 					this.setEnabled(false);
-					FragmentActivity activity = getActivity();
-					if (activity != null) {
-						activity.onBackPressed();
-					}
+					callActivity(FragmentActivity::onBackPressed);
 				}
 			}
 		};
@@ -210,9 +208,11 @@ public class AddQuickActionFragment extends BaseFullScreenFragment implements It
 
 	@Override
 	public void onSaveInstanceState(@NonNull Bundle outState) {
-		String searchQuery = adapter.getSearchQuery();
-		if (!Algorithms.isEmpty(searchQuery)) {
-			outState.putString(QUICK_ACTION_SEARCH_KEY, adapter.getSearchQuery());
+		if (adapter != null) {
+			String searchQuery = adapter.getSearchQuery();
+			if (!Algorithms.isEmpty(searchQuery)) {
+				outState.putString(QUICK_ACTION_SEARCH_KEY, adapter.getSearchQuery());
+			}
 		}
 		outState.putBoolean(QUICK_ACTION_SEARCH_MODE_KEY, searchMode);
 		super.onSaveInstanceState(outState);
@@ -220,15 +220,14 @@ public class AddQuickActionFragment extends BaseFullScreenFragment implements It
 
 	@Override
 	public void onItemClick(@NonNull QuickActionType quickActionType) {
-		FragmentActivity activity = getActivity();
-		if (activity != null) {
+		callActivity(activity -> {
 			FragmentManager manager = activity.getSupportFragmentManager();
 			if (quickActionType.getId() != 0) {
 				CreateEditActionDialog.showInstance(manager, quickActionType.getId());
 			} else {
 				AddCategoryQuickActionFragment.showInstance(manager, quickActionType.getCategory());
 			}
-		}
+		});
 	}
 
 	@Override
@@ -239,19 +238,13 @@ public class AddQuickActionFragment extends BaseFullScreenFragment implements It
 	@Override
 	public void onResume() {
 		super.onResume();
-		FragmentActivity activity = getActivity();
-		if (activity instanceof MapActivity) {
-			((MapActivity) activity).disableDrawer();
-		}
+		callMapActivity(MapActivity::disableDrawer);
 	}
 
 	@Override
 	public void onPause() {
 		super.onPause();
-		FragmentActivity activity = getActivity();
-		if (activity instanceof MapActivity) {
-			((MapActivity) activity).enableDrawer();
-		}
+		callMapActivity(MapActivity::enableDrawer);
 	}
 
 	public static void showInstance(@NonNull FragmentManager manager) {


### PR DESCRIPTION
It turns out these are actually different screens.
On the main "Add Quick Action" screen we display the list of categories along with the search bar, and in this case when rotating the screen we restore the search query and save it in onSaveInstanceState. If this screen is visible, everything works as expected.

However, if we navigate into a specific category, then on the first rotation the adapter in the parent fragment is still not null, so the state is saved without issues. But after that the base fragment is recreated — onCreate() is called, but onCreateView() is not (since its view is not needed while it’s not visible). This means the adapter is never re-initialized. On the next rotation, the adapter is null, which leads to the NPE.

In this case the simplest and correct fix is just adding a null check for the adapter, since the search query is always empty when a category is selected.