### PR TITLE
tts: implement coarse volume amplification for TTS navigation

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -6247,4 +6247,5 @@ Download tile maps directly, or copy them as SQLite database files to OsmAnd\'s 
     <string name="routing_attr_freeride_policy_name">Off-piste</string>
     <string name="routing_attr_freeride_policy_description">\'Freeride\' and \'Off-piste\' are unofficial routes and passages. Typically ungroomed, unmaintained and not checked in the evening. Enter at your own risk.</string>
     <string name="voice_prompts_timetable">Voice prompts times</string>
+    <string name="voice_volume_title">Voice Volume</string>
 </resources>

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -1964,6 +1964,9 @@ public class OsmandSettings {
 		AUDIO_USAGE[5] = new IntPreference(this, "audio_usage_5", 5).makeGlobal().makeShared().cache(); /*AudioManager.STREAM_NOTIFICATION -> AudioAttributes.USAGE_NOTIFICATION*/
 	}
 
+	// "low" is +5db, "normal" is +10db, "loud" is +15db
+	public final OsmandPreference<Float> VOICE_AMP_VOLUME = new FloatPreference(this, "voice_amp_volume", 10.0f).makeProfile().cache();
+
 	// For now this can be changed only in TestVoiceActivity
 	public final OsmandPreference<Integer>[] VOICE_PROMPT_DELAY = new IntPreference[10];
 

--- a/OsmAnd/src/net/osmand/plus/settings/fragments/voice/VoiceAnnouncesFragment.java
+++ b/OsmAnd/src/net/osmand/plus/settings/fragments/voice/VoiceAnnouncesFragment.java
@@ -97,6 +97,7 @@ public class VoiceAnnouncesFragment extends BaseSettingsFragment {
 
 		setupKeepInformingPref();
 		setupArrivalAnnouncementPref();
+		setupVoiceVolumePref();
 
 		setupAudioStreamGuidancePref();
 		setupInterruptMusicPref();
@@ -153,6 +154,18 @@ public class VoiceAnnouncesFragment extends BaseSettingsFragment {
 		ListPreferenceEx keepInforming = findPreference(settings.KEEP_INFORMING.getId());
 		keepInforming.setEntries(keepInformingNames);
 		keepInforming.setEntryValues(keepInformingValues);
+	}
+
+	private void setupVoiceVolumePref() {
+		Float[] volumeValues = {5.0f, 10.0f, 15.0f};
+		String[] volumeNames = {
+				"Quieter",
+				"Normal",
+				"Louder"
+		};
+
+		ListPreferenceEx volumePref = createListPreferenceEx(settings.VOICE_AMP_VOLUME.getId(), volumeNames, volumeValues, "Voice guidance volume", R.layout.preference_with_descr);
+		getPreferenceScreen().addPreference(volumePref);
 	}
 
 	private void setupArrivalAnnouncementPref() {


### PR DESCRIPTION
When navigating by bicycle, the default TTS volume can be rather difficult to hear even if any background music has its volume ducked.

This implements a new per-profile setting for TTS amplification using the android DynamicsProcessing API.

A single-band compressor is applied to the audio stream, with some sensible defaults to allow user-configurable post-processing amplification.

In turn, this changes the 'default' audio volume to include a +10db amplification which, after comression, sounds generally identical to the unaltered stream. Additionally a 'quieter' and 'louder' setting adjusts the amplification to +5db and +15db, respectively.

This is my first PR against OsmAnd and first work on an android project since many years, so I'm not entirely sure if this is the right approach. In particular, some of the strings are not yet translatable and I can't figure out how to move the new settings entry to be grouped along with the existing voice options.

Fixes osmandapp/OsmAnd#17828

For comparison, here are some audio samples recorded using the android studio emulator:

- Original audio without this patch: https://nextcloud.malloc.hackerbots.net/nextcloud/index.php/s/6AxGHKEnT28rQmK
- 5db "Quieter" setting: https://nextcloud.malloc.hackerbots.net/nextcloud/index.php/s/e5zS5APnZq537Ys
- 10db "Normal" setting: https://nextcloud.malloc.hackerbots.net/nextcloud/index.php/s/yTPCs5kk6W5cgCo
- 15db "Louder" setting: https://nextcloud.malloc.hackerbots.net/nextcloud/index.php/s/PGXPJeZpqBBczdG