### PR TITLE
Try to fix ANR during OpenGL shader compilation

### DIFF
--- a/OsmAnd/src/net/osmand/core/android/MapRendererContext.java
+++ b/OsmAnd/src/net/osmand/core/android/MapRendererContext.java
@@ -490,7 +490,7 @@ public class MapRendererContext {
 			shadersCache.mkdir();
 		}
 		mapRendererView.setupOptions.setPathToOpenGLShadersCache(shadersCache.getAbsolutePath());
-		mapRendererView.setupOptions.setMaxNumberOfRasterMapLayersInBatch(8);
+		mapRendererView.setupOptions.setMaxNumberOfRasterMapLayersInBatch(4);
 		mapRendererView.setMSAAEnabled(MSAAEnabled);
 	}
 


### PR DESCRIPTION
Reduce maximum layers count to four in a single pass of OpenGL shader execution.