### PR TITLE
Fix map location lose on screen orientation change

### DIFF
--- a/OsmAnd/src/net/osmand/plus/OsmandApplication.java
+++ b/OsmAnd/src/net/osmand/plus/OsmandApplication.java
@@ -545,8 +545,9 @@ public class OsmandApplication extends MultiDexApplication {
 
 			OsmandMap osmandMap = getOsmandMap();
 			if (osmandMap != null) {
-				osmandMap.getMapView().updateDisplayMetrics(displayMetrics, displayMetrics.widthPixels,
-						displayMetrics.heightPixels - AndroidUtils.getStatusBarHeight(this));
+				int width = displayMetrics.widthPixels;
+				int height = displayMetrics.heightPixels - AndroidUtils.getStatusBarHeight(this);
+				osmandMap.getMapView().updateDisplayMetrics(displayMetrics, width, height);
 			}
 		}
 

--- a/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
+++ b/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
@@ -313,16 +313,40 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 
 	public void updateDisplayMetrics(DisplayMetrics dm, int width, int height) {
 		this.dm = dm;
-		LatLon ll = settings.getLastKnownMapLocation();
-		currentViewport = new RotatedTileBoxBuilder()
-				.setLocation(ll.getLatitude(), ll.getLongitude())
-				.setZoom(settings.getLastKnownMapZoom())
-				.setZoomFloatPart(settings.getLastKnownMapZoomFloatPart())
-				.setRotate(settings.getLastKnownMapRotation())
-				.setPixelDimensions(width, height)
-				.build();
-		currentViewport.setDensity(dm.density);
+		currentViewport = buildViewportForCurrentState(width, height, dm.density);
 		setMapDensityImpl(getSettingsMapDensity());
+	}
+
+	@NonNull
+	private RotatedTileBox buildViewportForCurrentState(int width, int height, float density) {
+		double lat, lon;
+		int zoom;
+		double zoomFloatPart;
+		float rotate;
+
+		if (currentViewport == null) {
+			LatLon location = settings.getLastKnownMapLocation();
+			lat = location.getLatitude();
+			lon = location.getLongitude();
+			zoom = settings.getLastKnownMapZoom();
+			zoomFloatPart = settings.getLastKnownMapZoomFloatPart();
+			rotate = settings.getLastKnownMapRotation();
+		} else {
+			lat = currentViewport.getLatitude();
+			lon = currentViewport.getLongitude();
+			zoom = currentViewport.getZoom();
+			zoomFloatPart = currentViewport.getZoomFloatPart();
+			rotate = currentViewport.getRotate();
+		}
+
+		return new RotatedTileBoxBuilder()
+				.setLocation(lat, lon)
+				.setZoom(zoom)
+				.setZoomFloatPart(zoomFloatPart)
+				.setRotate(rotate)
+				.setPixelDimensions(width, height)
+				.density(density)
+				.build();
 	}
 
 	private float getCurrentDensity() {


### PR DESCRIPTION
### Fix incorrect viewport rebuild after density change

Previously, when onConfigurationChanged() detected a density change, currentViewport was rebuilt before MapActivity.onPause() had a chance to save the actual map state.
This caused the viewport to be recreated using outdated “last known” values (location, zoom, zoomFloatPart, rotation), which resulted in the map jumping back to an older position after density-related configuration updates.

The logic still rebuilds the viewport only when density changes, but now it uses the actual current viewport state if available, falling back to last known settings only on first initialization.
This prevents loss of the real camera position and ensures correct behaviour during display-metrics changes.