### PR TITLE
wait for brouter service only if needed

### DIFF
--- a/OsmAnd/src/net/osmand/plus/OsmandApplication.java
+++ b/OsmAnd/src/net/osmand/plus/OsmandApplication.java
@@ -953,9 +953,9 @@ public class OsmandApplication extends MultiDexApplication {
 	public synchronized IBRouterService reconnectToBRouter() {
 		try {
 			bRouterServiceConnection = BRouterServiceConnection.connect(this);
-			// a delay is necessary as the service process needs time to start..
-			Thread.sleep(800);
 			if (bRouterServiceConnection != null) {
+                // a delay is necessary as the service process needs time to start..
+                Thread.sleep(800);
 				return bRouterServiceConnection.getBrouterService();
 			}
 		} catch (Exception e) {


### PR DESCRIPTION
During the app initializatio there is a log: 
`Initialized BROUTER_INITIALIZED in 802 ms` where 800ms is just a thread sleep. It slows down the app startup even if the brouter is not installed. Moving the sleep to the if should reduce the startup time when the brouter app is not installed.