### PR TITLE
Fix speed value extraction from nested extensions

### DIFF
--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxUtilities.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxUtilities.kt
@@ -1113,7 +1113,7 @@ object GpxUtilities {
 												getExtensionsSupportedTag(t.lowercase())
 											parse.getExtensionsToWrite()[supportedTag] = value
 											if (parse is WptPt) {
-												when (tag) {
+												when (t) {
 													POINT_SPEED -> {
 														try {
 															parse.speed = value.toDouble()


### PR DESCRIPTION
As described in #24215 we can observe that OsmAnd ignores recorded speed values of tracks recorded with [OpenTracks](https://opentracksapp.com/) (and possibly all other apps using the [TrackPointExtension](https://www8.garmin.com/xmlschemas/TrackPointExtensionv2.xsd) specs as provided by Garmin).

To investigate this further, I did some live debugging of the [`loadGpsFile`](https://github.com/osmandapp/OsmAnd/blob/0846d984e04b2d982306f3188de58942b65a3b30/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxUtilities.kt#L1028) method on my phone while importing the following track: [2025-12-23_10_11_41.418_2025-12-23T10_11+01.gpx](https://github.com/user-attachments/files/24400331/2025-12-23_10_11_41.418_2025-12-23T10_11%2B01.gpx.tar.gz)

The list of track points contained in this file looks like follows:
```xml
...
<trkpt lat="47.255535" lon="11.842574">
  <ele>2061</ele>
  <time>2025-12-23T11:53:50.162+01:00</time>
  <extensions>
    <gpxtpx:TrackPointExtension>
      <gpxtpx:speed>2.6</gpxtpx:speed>
    </gpxtpx:TrackPointExtension>
    <opentracks:accuracy_horizontal>6.813</opentracks:accuracy_horizontal></extensions>
</trkpt>
...
```

We can see in the source code of `loadGpsFile` that the method ignores all namespacing and typically loads any `<X:speed>` values found in `<extensions>` correctly. This generally works except for the special case that  `<X:speed>` is wrapped itself in a nested extension, like `<gpxtpx:TrackPointExtension>` in this example.

If that is the case, the method `readTextMap` is used to [load all contained values into a map](https://github.com/osmandapp/OsmAnd/blob/0846d984e04b2d982306f3188de58942b65a3b30/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxUtilities.kt#L1109). It is obvious that the author considered this case and intended to scan this map for `speed` and `bearing` values and use them accordingly for the resulting `WptPt` object.

However, there seems to be a small typo which led to the situation that not the actual name of the nested values (which would be `speed` or `bearing` etc.), but rather the name of the nesting structure itself (which would be `TrackPointExtension`) is looked at and thus the `speed` and `bearing` values are always ignored when contained in a nested extension.

This tiny patch is fixing that. Feel free to ask any questions if something is not clear.

PS: I have found the original commit https://github.com/osmandapp/OsmAnd/commit/37794feb229ed8f8d17c566561b6b30f2311abaa which was supposed to add Garmin gpx file support. The bug  this PR is fixing most likely arose during copy & pasting the code for the special treatment of speed values which was originally written for a different context without updating the field which is looked at for comparison.