### PR TITLE
Fix NPE after WikivoyageSearchHistoryItem

### DIFF
--- a/OsmAnd/src/net/osmand/plus/wikivoyage/data/WikivoyageSearchHistoryItem.java
+++ b/OsmAnd/src/net/osmand/plus/wikivoyage/data/WikivoyageSearchHistoryItem.java
@@ -33,15 +33,15 @@ public class WikivoyageSearchHistoryItem {
 	}
 
 	public String getArticleTitle() {
-		return articleTitle;
+		return articleTitle != null ? articleTitle : "";
 	}
 
 	public String getLang() {
-		return lang;
+		return lang != null ? lang : "";
 	}
 
 	public String getIsPartOf() {
-		return isPartOf;
+		return isPartOf != null ? isPartOf : "";
 	}
 
 	public long getLastAccessed() {


### PR DESCRIPTION
```
Version  OsmAnd 5.2.13
30.12.2025 5:55:05
Apk Version : 5.2.13 5213
Exception occurred in thread Thread[main,5,main] : 
java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.String.startsWith(java.lang.String)' on a null object reference
  at net.osmand.plus.wikivoyage.WikivoyageUtils.getTitleWithoutPrefix(WikivoyageUtils.java:126)
  at net.osmand.plus.wikivoyage.search.SearchRecyclerViewAdapter.onBindViewHolder(SearchRecyclerViewAdapter.java:92)
  at androidx.recyclerview.widget.RecyclerView$Adapter.onBindViewHolder(RecyclerView.java:7065)
  at androidx.recyclerview.widget.RecyclerView$Adapter.bindViewHolder(RecyclerView.java:7107)
  at androidx.recyclerview.widget.RecyclerView$Recycler.tryBindViewHolderByDeadline(RecyclerView.java:6012)
  at androidx.recyclerview.widget.RecyclerView$Recycler.tryGetViewHolderForPositionByDeadline(RecyclerView.java:6279)
  at androidx.recyclerview.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:6118)
  at androidx.recyclerview.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:6114)
```