### PR TITLE
Fix incorrect Intermediate point caption size

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/layers/PointNavigationLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/PointNavigationLayer.java
@@ -42,6 +42,8 @@ import java.util.List;
 public class PointNavigationLayer extends OsmandMapLayer implements
 		IContextMenuProvider, IMoveObjectProvider {
 
+	private static final float CAPTION_TEXT_SIZE = 18f;
+
 	private final TargetPointsHelper targetPoints;
 
 	private boolean carView;
@@ -215,7 +217,7 @@ public class PointNavigationLayer extends OsmandMapLayer implements
 
 	private void updateTextSize() {
 		float density = view.getDensity();
-		float textSize = 18f * textScale * density;
+		float textSize = CAPTION_TEXT_SIZE * textScale * density;
 		mTextPaint.setTextSize(textSize);
 	}
 

--- a/OsmAnd/src/net/osmand/plus/views/layers/SelectLocationLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/SelectLocationLayer.java
@@ -25,6 +25,8 @@ import net.osmand.plus.views.layers.base.OsmandMapLayer;
 
 public class SelectLocationLayer extends OsmandMapLayer {
 
+	private static final float CAPTION_TEXT_SIZE = 18f;
+
 	private final Paint bitmapPaint;
 	private final Paint mTextPaint;
 	private Bitmap defaultIconDay;
@@ -88,7 +90,7 @@ public class SelectLocationLayer extends OsmandMapLayer {
 
 	private void updateTextSize() {
 		float density = Resources.getSystem().getDisplayMetrics().density;
-		float textSize = 18f * textScale * density;
+		float textSize = CAPTION_TEXT_SIZE * textScale * density;
 		mTextPaint.setTextSize(textSize);
 	}
 


### PR DESCRIPTION
Use Configure Map -> "Text size" preference to choose correct intermediate point caption size