### PR TITLE
Remove some surplus end-of-gesture map redraw and reduce flicker

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
+++ b/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
@@ -2416,7 +2416,8 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 					mapRenderer.setMapTarget(new PointI(multiTouchFirstX, multiTouchFirstY), initialFirstLocation);
 					float calcRotate = initialViewport.getRotate() + relAngle;
 					rotateToAnimate(calcRotate, multiTouchCenterX, multiTouchCenterY);
-					refreshMap();
+					// rotateToAnimate(...) already triggers a redraw through the renderer’s own invalidation pipeline
+					//refreshMap();
 				} else {
 					changeZoomPosition((float) deltaZoom, relAngle);
 				}


### PR DESCRIPTION
(I am aware that via MAP_REFRESH_MESSAGE we throttle map refresh trigger, but probably we can even save the overhead here?)