### PR TITLE
Protect RouteSegmentResult against broken osmand:types

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteSegmentResult.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteSegmentResult.java
@@ -119,7 +119,13 @@ public class RouteSegmentResult implements StringExternalizable<RouteDataBundle>
 		}
 		if (object.nameIds != null) {
 			for (int nameId : object.nameIds) {
+				if (nameId >= region.quickGetEncodingRulesSize()) {
+					continue;
+				}
 				String name = object.names.get(nameId);
+				if (name == null) {
+					continue;
+				}
 				String tag = region.quickGetEncodingRule(nameId).getTag();
 				RouteTypeRule r = new RouteTypeRule(tag, name);
 				if (!rules.containsKey(r)) {
@@ -134,6 +140,9 @@ public class RouteSegmentResult implements StringExternalizable<RouteDataBundle>
 				int[] types = object.pointNameTypes[i];
 				if (types != null) {
 					for (int type : types) {
+						if (type >= region.quickGetEncodingRulesSize()) {
+							continue;
+						}
 						RouteTypeRule r = region.quickGetEncodingRule(type);
 						if (!rules.containsKey(r)) {
 							rules.put(r, rules.size());
@@ -147,6 +156,9 @@ public class RouteSegmentResult implements StringExternalizable<RouteDataBundle>
 	private void collectRules(Map<RouteTypeRule, Integer> rules, int[] types) {
 		RouteRegion region = object.region;
 		for (int type : types) {
+			if (type >= region.quickGetEncodingRulesSize()) {
+				continue;
+			}
 			RouteTypeRule rule = region.quickGetEncodingRule(type);
 			String tag = rule.getTag();
 			if (tag.equals("osmand_ele_start") || tag.equals("osmand_ele_end")
@@ -167,6 +179,9 @@ public class RouteSegmentResult implements StringExternalizable<RouteDataBundle>
 		List<Integer> arr = new ArrayList<>();
 		for (int i = 0; i < types.length; i++) {
 			int type = types[i];
+			if (type >= object.region.quickGetEncodingRulesSize()) {
+				continue;
+			}
 			RouteTypeRule rule = object.region.quickGetEncodingRule(type);
 			Integer ruleId = rules.get(rule);
 			if (ruleId != null) {
@@ -201,7 +216,13 @@ public class RouteSegmentResult implements StringExternalizable<RouteDataBundle>
 		int[] res = new int[nameIds.length];
 		for (int i = 0; i < nameIds.length; i++) {
 			int nameId = nameIds[i];
+			if (nameId >= object.region.quickGetEncodingRulesSize()) {
+				continue;
+			}
 			String name = object.names.get(nameId);
+			if (name == null) {
+				continue;
+			}
 			String tag = object.region.quickGetEncodingRule(nameId).getTag();
 			RouteTypeRule rule = new RouteTypeRule(tag, name);
 			Integer ruleId = rules.get(rule);
@@ -224,6 +245,9 @@ public class RouteSegmentResult implements StringExternalizable<RouteDataBundle>
 				int[] arr = new int[types.length];
 				for (int k = 0; k < types.length; k++) {
 					int type = types[k];
+					if (type >= object.region.quickGetEncodingRulesSize()) {
+						continue;
+					}
 					String tag = object.region.quickGetEncodingRule(type).getTag();
 					String name = pointNames[i][k];
 					RouteTypeRule rule = new RouteTypeRule(tag, name);
@@ -274,6 +298,9 @@ public class RouteSegmentResult implements StringExternalizable<RouteDataBundle>
 					pointNameTypes[i] = new int[namesIds.length];
 					for (int k = 0; k < namesIds.length; k++) {
 						int id = namesIds[k];
+						if (id >= object.region.quickGetEncodingRulesSize()) {
+							continue;
+						}
 						RouteTypeRule r = object.region.quickGetEncodingRule(id);
 						if (r != null) {
 							pointNames[i][k] = r.getValue();


### PR DESCRIPTION
Current Issue (iOS / Android crash): https://github.com/osmandapp/OsmAnd-iOS/issues/5206
Previous similar Issue: https://github.com/osmandapp/OsmAnd/issues/19514
With previous fix: https://github.com/osmandapp/OsmAnd/commit/798242f63518d98e6df15bbc440861e08f0fbce5

Fixes crash

```
12:21:49.099  E  FATAL EXCEPTION: AsyncTask #23
Process: net.osmand.plus, PID: 3528
java.lang.RuntimeException: An error occurred while executing doInBackground()
	at android.os.AsyncTask$4.done(AsyncTask.java:415)
	at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:383)
	at java.util.concurrent.FutureTask.setException(FutureTask.java:252)
	at java.util.concurrent.FutureTask.run(FutureTask.java:271)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
	at java.lang.Thread.run(Thread.java:923)
Caused by: java.lang.IndexOutOfBoundsException: Index: 19, Size: 19
	at java.util.ArrayList.get(ArrayList.java:437)
	at net.osmand.binary.BinaryMapRouteReaderAdapter$RouteRegion.quickGetEncodingRule(BinaryMapRouteReaderAdapter.java:382)
	at net.osmand.router.RouteSegmentResult.collectRules(RouteSegmentResult.java:150)
	at net.osmand.router.RouteSegmentResult.collectTypes(RouteSegmentResult.java:91)
	at net.osmand.router.RouteExporter.generateRouteSegment(RouteExporter.java:76)
	at net.osmand.plus.measurementtool.MeasurementEditingContext.getRouteSegment(MeasurementEditingContext.java:1249)
	at net.osmand.plus.measurementtool.MeasurementEditingContext.getRouteSegments(MeasurementEditingContext.java:1273)
	at net.osmand.plus.measurementtool.MeasurementEditingContext.exportGpx(MeasurementEditingContext.java:1210)
```