### PR TITLE
Fix bbox search

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/search/core/SearchPhrase.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/core/SearchPhrase.java
@@ -386,17 +386,13 @@ public class SearchPhrase {
 	}
 
 	public static QuadRect calculateBbox(int radiusMeters, LatLon l) {
-		double lat = Math.max(Math.abs(l.getLatitude()) - 4, 30.0);
-		float coeff = (float) (radiusMeters / MapUtils.getTileDistanceWidth(lat, SearchRequest.ZOOM_TO_SEARCH_POI));
-		double tx = MapUtils.getTileNumberX(SearchRequest.ZOOM_TO_SEARCH_POI, l.getLongitude());
-		double ty = MapUtils.getTileNumberY(SearchRequest.ZOOM_TO_SEARCH_POI, l.getLatitude());
-		double topLeftX = Math.max(0, tx - coeff);
-		double topLeftY = Math.max(0, ty - coeff);
-		int max = (1 << SearchRequest.ZOOM_TO_SEARCH_POI)  - 1;
-		double bottomRightX = Math.min(max, tx + coeff);
-		double bottomRightY = Math.min(max, ty + coeff);
-		double pw = MapUtils.getPowZoom(31 - SearchRequest.ZOOM_TO_SEARCH_POI);
-		return new QuadRect(topLeftX * pw, topLeftY * pw, bottomRightX * pw, bottomRightY * pw);
+		LatLon northWest = MapUtils.rhumbDestinationPoint(l.getLatitude(), l.getLongitude(), radiusMeters, 315);
+		LatLon southEast = MapUtils.rhumbDestinationPoint(l.getLatitude(), l.getLongitude(), radiusMeters, 135);
+		int top = MapUtils.get31TileNumberY(northWest.getLatitude());
+		int left = MapUtils.get31TileNumberX(northWest.getLongitude());
+		int bottom = MapUtils.get31TileNumberY(southEast.getLatitude());
+		int right = MapUtils.get31TileNumberX(southEast.getLongitude());
+		return new QuadRect(left, top, right, bottom);
 	}
 	
 	


### PR DESCRIPTION
To issue https://github.com/osmandapp/OsmAnd/issues/23857

By default was [latitude 30.0](https://github.com/osmandapp/OsmAnd/blob/2255c72e54fbc8b5f6eca40230cebe5dd29cbe0a/OsmAnd-java/src/main/java/net/osmand/util/MapUtils.java#L364)

Example 1. From task 
Purple line ~6.4 km
Green square - wrong bbox (current)
Red circle - 10km radius
Yellow square - if use ``Math.max(Math.abs(l.getLatitude()), 30.0);`` 
**Blue square - result bbox** ``Math.max(Math.abs(l.getLatitude()) - 4, 30.0);``
<img width="717" height="719" alt="Знімок екрана 2026-02-20 о 18 05 04" src="https://github.com/user-attachments/assets/5040a0e7-2a4a-4be2-90e0-e66778be81f1" />

Example 2. (From test poi_biergarten.json)
Yellow square - current
Red circle - 10km radius
**Blue square - result bbox** ``Math.max(Math.abs(l.getLatitude()) - 4, 30.0);``
Green square - if use ``Math.max(Math.abs(l.getLatitude()), 30.0);`` (fail in test, change order of 1 item)
Purple dot and circle - ``"Biergarten Villa Else [[1, POI, 1.000, 13.84 km]]"`` from test
<img width="715" height="721" alt="Знімок екрана 2026-02-20 о 18 03 57" src="https://github.com/user-attachments/assets/d099dacd-4f15-4e41-9e28-74c36fd7af66" />
