### PR TITLE
Fix: Empty row for untagged buildings in Context Menu "Within" list #24233

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/osm/MapPoiTypes.java
+++ b/OsmAnd-java/src/main/java/net/osmand/osm/MapPoiTypes.java
@@ -929,15 +929,22 @@ public class MapPoiTypes {
 	}
 
 	public String getPoiTranslation(String keyName) {
+		return getPoiTranslation(keyName, true);
+	}
+
+	public String getPoiTranslation(String keyName, boolean withDefault) {
 		if (poiTranslator != null) {
 			String translation = poiTranslator.getTranslation(keyName);
 			if (!Algorithms.isEmpty(translation)) {
 				return translation;
 			}
 		}
-		String name = keyName;
-		name = name.replace('_', ' ');
-		return Algorithms.capitalizeFirstLetter(name);
+		if (withDefault) {
+			String name = keyName;
+			name = name.replace('_', ' ');
+			return Algorithms.capitalizeFirstLetter(name);
+		}
+		return null;
 	}
 
 	public boolean isRegisteredType(PoiCategory t) {

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/controllers/RenderedObjectMenuController.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/controllers/RenderedObjectMenuController.java
@@ -18,6 +18,7 @@ import net.osmand.plus.render.RenderingIcons;
 import net.osmand.plus.utils.AndroidUtils;
 import net.osmand.util.Algorithms;
 
+import java.util.Collection;
 import java.util.Map;
 
 public class RenderedObjectMenuController extends MenuController {
@@ -163,7 +164,9 @@ public class RenderedObjectMenuController extends MenuController {
 		}
 
 		if (Algorithms.isEmpty(typeStr) && renderedObject != null && mapPoiTypes != null) {
-			typeStr = searchObjectNameByRawTags(mapPoiTypes, renderedObject.getTags());
+			Amenity amenity = builder != null ? builder.getAmenity() : null;
+			Collection<String> additionalInfoKeys = amenity != null ? amenity.getAdditionalInfoKeys() : null;
+			typeStr = searchObjectNameByRawTags(mapPoiTypes, renderedObject.getTags(), additionalInfoKeys);
 		}
 
 		return typeStr != null ? typeStr : super.getTypeStr();
@@ -171,35 +174,24 @@ public class RenderedObjectMenuController extends MenuController {
 
 	@Nullable
 	private static String searchObjectNameByRawTags(@NonNull MapPoiTypes poiTypes,
-	                                                @NonNull Map<String, String> rawTags) {
+													@NonNull Map<String, String> rawTags,
+													@Nullable Collection<String> additionalInfoKeys) {
 		for (Map.Entry<String, String> entry : rawTags.entrySet()) {
 			String key = entry.getKey();
 			String value = entry.getValue();
 
-			// Skip common metadata and name tags that shouldn't represent the object type
-			if (key.equals("name") || key.startsWith("name:") || key.equals("ele")
-					|| key.equals("height") || key.equals("min_height")
-					|| key.equals("levels") || key.equals("layer")
-					|| key.equals("type") || key.equals("osmwiki")) {
+			if (additionalInfoKeys != null && additionalInfoKeys.contains(key)) {
 				continue;
 			}
 
 			String translation = null;
-
-			// Try to translate the key-value pair first
-			if (!Algorithms.isEmpty(value) && !value.equals("yes")) {
-				translation = poiTypes.getPoiTranslation(key + "_" + value);
-
-				// Ignore auto-generated capitalized fallbacks to prioritize translating just the key
-				String autoFallback = Algorithms.capitalizeFirstLetter((key + "_" + value).replace('_', ' '));
-				if (translation != null && translation.equalsIgnoreCase(autoFallback)) {
-					translation = null;
-				}
+			if (!Algorithms.isEmpty(value)) {
+				String complexKey = key + "_" + value;
+				translation = poiTypes.getPoiTranslation(complexKey, false);
 			}
 
-			// Fallback to translating just the key (e.g., "building")
 			if (Algorithms.isEmpty(translation)) {
-				translation = poiTypes.getPoiTranslation(key);
+				translation = poiTypes.getPoiTranslation(key, false);
 			}
 
 			if (!Algorithms.isEmpty(translation)) {


### PR DESCRIPTION
### Description
Fixes #24233

**Root Cause:**
As noted in the issue discussion, the empty row is caused by a missing translation. The `building` tags was intentionally removed from `poi_types.xml` in one of the previous commits to optimize OBF file sizes and POI search performance. Because it is no longer a registered POI type, `poiTranslator` fails to resolve the `building_yes` or `building` keys, returning an empty string for generic buildings in `RenderedObjectMenuController`.

**Solution:**
Added a targeted fallback in `RenderedObjectMenuController`. If the standard `poiTranslator` fails to find a translation for an object's tags, we explicitly check for the `building` key in the object's additional info and fetch the `poi_building` string directly from Android resources. 

This restores the "Building" label in the UI without reverting the POI index optimization and without bloating the map data.