### PR TITLE
Fix #24336: "To" value ignores second edit and UI crashes in track filters

### DIFF
--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/filters/BaseTrackFilter.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/filters/BaseTrackFilter.kt
@@ -9,7 +9,8 @@ import net.osmand.shared.gpx.TrackItem
 sealed class BaseTrackFilter(
 	@Serializable
 	@SerialName("filterType") val trackFilterType: TrackFilterType,
-	@Transient var filterChangedListener: FilterChangedListener? = null) {
+	@Transient var filterChangedListener: FilterChangedListener? = null
+) {
 
 	abstract fun isEnabled(): Boolean
 

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/filters/TextTrackFilter.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/filters/TextTrackFilter.kt
@@ -14,9 +14,8 @@ class TextTrackFilter
 
 	constructor(
 		trackFilterType: TrackFilterType,
-		filterChangedListener: FilterChangedListener?) : super(
-		trackFilterType,
-		filterChangedListener)
+		filterChangedListener: FilterChangedListener?
+	) : super(trackFilterType, filterChangedListener)
 
 	@Serializable
 	var value = ""

--- a/OsmAnd/src/net/osmand/plus/myplaces/tracks/filters/viewholders/FilterRangeViewHolder.kt
+++ b/OsmAnd/src/net/osmand/plus/myplaces/tracks/filters/viewholders/FilterRangeViewHolder.kt
@@ -1,6 +1,5 @@
 package net.osmand.plus.myplaces.tracks.filters.viewholders
 
-//import net.osmand.plus.myplaces.tracks.filters.MeasureUnitType
 import android.text.Editable
 import android.view.View
 import android.widget.ImageView
@@ -26,6 +25,7 @@ import java.text.DecimalFormatSymbols
 import java.util.Locale
 import kotlin.math.ceil
 import kotlin.math.floor
+import kotlin.math.roundToInt
 
 open class FilterRangeViewHolder(
 	itemView: View,
@@ -113,8 +113,7 @@ open class FilterRangeViewHolder(
 				if (!Algorithms.isEmpty(newText) && Algorithms.isInt(newText.toString())) {
 					val newValue = newText.toString().toInt()
 					if (getDisplayValueFrom(filter) != newValue
-						&& filter.valueTo is Number
-						&& newValue < (filter.valueTo as Number).toInt()
+						&& newValue < getDisplayValueTo(filter)
 						&& !isSliderDragging
 						&& !isBinding) {
 						filter.setValueFrom(newValue.toString())
@@ -130,8 +129,7 @@ open class FilterRangeViewHolder(
 				if (!Algorithms.isEmpty(newText) && Algorithms.isInt(newText.toString())) {
 					val newValue = newText.toString().toInt()
 					if (getDisplayValueTo(filter) != newValue
-						&& filter.valueFrom is Number
-						&& newValue > (filter.valueFrom as Number).toInt()
+						&& newValue > getDisplayValueFrom(filter)
 						&& !isSliderDragging
 						&& !isBinding) {
 						filter.setValueTo(newValue.toString())
@@ -181,7 +179,9 @@ open class FilterRangeViewHolder(
 		if (maxValue > minValue) {
 			slider.valueTo = maxValue.toFloat()
 			slider.valueFrom = minValue.toFloat()
-			slider.setValues(valueFrom.toFloat(), valueTo.toFloat())
+			val safeValueFrom = maxOf(minValue.toFloat(), minOf(valueFrom.toFloat(), maxValue.toFloat()))
+			val safeValueTo = maxOf(safeValueFrom, minOf(valueTo.toFloat(), maxValue.toFloat()))
+			slider.setValues(safeValueFrom, safeValueTo)
 		} else {
 			expanded = false
 			updateExpandState()
@@ -214,18 +214,18 @@ open class FilterRangeViewHolder(
 	open fun getDisplayMinValue(filter: RangeTrackFilter<*>): Int {
 		val formattedValue =
 			getFormattedValue(filter.trackFilterType.measureUnitType, filter.ceilMinValue())
-		return formattedValue.valueSrc.toInt()
+		return floor(formattedValue.valueSrc).toInt()
 	}
 
 	open fun getDisplayValueFrom(filter: RangeTrackFilter<*>): Int {
 		val formattedValue =
 			getFormattedValue(filter.trackFilterType.measureUnitType, filter.valueFrom.toString())
-		return formattedValue.valueSrc.toInt()
+		return formattedValue.valueSrc.roundToInt()
 	}
 
 	open fun getDisplayValueTo(filter: RangeTrackFilter<*>): Int {
 		val formattedValue = getFormattedValue(filter.trackFilterType.measureUnitType, filter.ceilValueTo())
-		return formattedValue.valueSrc.toInt()
+		return formattedValue.valueSrc.roundToInt()
 	}
 
 	fun getFormattedValue(measureUnitType: MeasureUnitType, value: String): FormattedValue {


### PR DESCRIPTION
- Fixed a race condition and background initialization spam in `TracksSearchFilter` by moving `fillFiltersWithValues` out of the loop and introducing an `isInitializing` flag to suppress premature UI updates.
- Prevented `IllegalStateException` in `MaterialSlider` by implementing safe value clamping (`safeValueFrom`/`safeValueTo`) in `FilterRangeViewHolder` to ensure values stay strictly within rails.
- Fixed the issue where the "To" input field ignored user edits by comparing formatted display units instead of raw base values in `TextWatcher`.
- Resolved value jumping and precision loss (e.g., in Average Speed) by removing destructive `floor`/`ceil` roundings from `RangeTrackFilter` and applying `roundToInt()` only at the UI display level.
- Implemented a smart merge in `RangeTrackFilter.initWithValue` to safely combine actual database limits with saved filter limits, ensuring rails dynamically expand when users input custom values.