### PR TITLE
Fix delayed appearance of symbols when POI enabled

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/layers/core/POITileProvider.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/core/POITileProvider.java
@@ -299,7 +299,7 @@ public class POITileProvider extends interface_MapTiledCollectionProvider {
 
 	@Override
 	public boolean waitForLoading() {
-		return true;
+		return false;
 	}
 
 	private boolean isMapRendererLost() {


### PR DESCRIPTION
Display symbols and don't wait for POI to be loaded