### PR TITLE
External Sensors: fix insets for several bottom sheets

### DIFF
--- a/OsmAnd/res/layout/forget_obd_device_dialog.xml
+++ b/OsmAnd/res/layout/forget_obd_device_dialog.xml
@@ -4,8 +4,7 @@
 	xmlns:tools="http://schemas.android.com/tools"
 	android:layout_width="match_parent"
 	android:layout_height="wrap_content"
-	android:layout_gravity="bottom"
-	android:background="?attr/bottom_menu_view_bg">
+	android:layout_gravity="bottom">
 
 	<LinearLayout
 		android:layout_width="match_parent"
@@ -19,6 +18,7 @@
 			android:layout_marginTop="@dimen/content_padding"
 			android:layout_weight="1"
 			android:paddingEnd="@dimen/content_padding"
+			android:paddingStart="0dp"
 			android:text="@string/obd_device_forget_sensor"
 			android:textColor="?android:textColorPrimary"
 			android:textSize="@dimen/dialog_header_text_size" />
@@ -30,6 +30,7 @@
 			android:layout_marginStart="@dimen/content_padding"
 			android:layout_marginTop="@dimen/content_padding"
 			android:paddingEnd="@dimen/content_padding_half"
+			android:paddingStart="0dp"
 			android:text="@string/obd_device_forget_sensor_description"
 			android:textColor="?android:textColorSecondary"
 			android:textSize="@dimen/default_list_text_size" />

--- a/OsmAnd/src/net/osmand/plus/plugins/externalsensors/dialogs/ForgetDeviceBaseDialog.kt
+++ b/OsmAnd/src/net/osmand/plus/plugins/externalsensors/dialogs/ForgetDeviceBaseDialog.kt
@@ -1,18 +1,18 @@
 package net.osmand.plus.plugins.externalsensors.dialogs
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import net.osmand.plus.R
-import net.osmand.plus.base.BottomSheetDialogFragment
+import net.osmand.plus.base.MenuBottomSheetDialogFragment
+import net.osmand.plus.base.bottomsheetmenu.BaseBottomSheetItem
 import net.osmand.plus.utils.AndroidUtils
 import net.osmand.plus.utils.ColorUtilities
 
 
-abstract class ForgetDeviceBaseDialog : BottomSheetDialogFragment() {
+abstract class ForgetDeviceBaseDialog : MenuBottomSheetDialogFragment() {
+
 	open val layoutId = R.layout.forget_obd_device_dialog
 
 	companion object {
@@ -31,14 +31,8 @@ abstract class ForgetDeviceBaseDialog : BottomSheetDialogFragment() {
 
 	abstract fun onForgetSensorConfirmed()
 
-	override fun onCreateView(
-		inflater: LayoutInflater,
-		container: ViewGroup?,
-		savedInstanceState: Bundle?
-	): View {
-
-		updateNightMode()
-		val view: View = inflate(layoutId, container, false)
+	override fun createMenuItems(savedInstanceState: Bundle?) {
+		val view: View = inflate(layoutId)
 
 		val forgetButton = view.findViewById<View>(R.id.forget_btn)
 		val forgetButtonText = forgetButton.findViewById<TextView>(R.id.button_text)
@@ -69,6 +63,7 @@ abstract class ForgetDeviceBaseDialog : BottomSheetDialogFragment() {
 			R.drawable.dlg_btn_secondary_light,
 			R.drawable.dlg_btn_secondary_dark
 		)
+
 		val forgetBtnTextColor =
 			if (nightMode) R.color.color_osm_edit_delete else R.color.color_osm_edit_delete
 
@@ -90,6 +85,10 @@ abstract class ForgetDeviceBaseDialog : BottomSheetDialogFragment() {
 			R.drawable.dlg_btn_secondary_dark
 		)
 		cancelButtonText.setTextColor(ColorUtilities.getButtonSecondaryTextColor(app, nightMode))
-		return view
+		items.add(BaseBottomSheetItem.Builder().setCustomView(view).create())
+	}
+
+	override fun hideButtonsContainer(): Boolean {
+		return true
 	}
 }

--- a/OsmAnd/src/net/osmand/plus/plugins/externalsensors/dialogs/PairNewDeviceBottomSheet.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/externalsensors/dialogs/PairNewDeviceBottomSheet.java
@@ -6,8 +6,7 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.FragmentManager;
 
 import net.osmand.plus.R;
-import net.osmand.plus.activities.MapActivity;
-import net.osmand.plus.base.BottomSheetBehaviourDialogFragment;
+import net.osmand.plus.base.MenuBottomSheetDialogFragment;
 import net.osmand.plus.base.bottomsheetmenu.BaseBottomSheetItem;
 import net.osmand.plus.base.bottomsheetmenu.BottomSheetItemButton;
 import net.osmand.plus.base.bottomsheetmenu.BottomSheetItemWithDescription;
@@ -17,10 +16,9 @@ import net.osmand.plus.base.bottomsheetmenu.simpleitems.TitleItem;
 import net.osmand.plus.utils.AndroidUtils;
 import net.osmand.plus.widgets.dialogbutton.DialogButtonType;
 
-public class PairNewDeviceBottomSheet extends BottomSheetBehaviourDialogFragment {
+public class PairNewDeviceBottomSheet extends MenuBottomSheetDialogFragment {
 
 	public static final String TAG = PairNewDeviceBottomSheet.class.getSimpleName();
-	public static final int BOTTOM_SHEET_HEIGHT_DP = 427;
 
 	@Override
 	public void createMenuItems(Bundle savedInstanceState) {
@@ -74,21 +72,6 @@ public class PairNewDeviceBottomSheet extends BottomSheetBehaviourDialogFragment
 		items.add(cancelItem);
 		int padding = getDimensionPixelSize(R.dimen.content_padding_small);
 		items.add(new DividerSpaceItem(getContext(), padding));
-	}
-
-	@Override
-	protected int getPeekHeight() {
-		return dpToPx(BOTTOM_SHEET_HEIGHT_DP);
-	}
-
-	protected void hideBottomSheet() {
-		MapActivity mapActivity = (MapActivity) getActivity();
-		if (mapActivity != null) {
-			FragmentManager manager = mapActivity.getSupportFragmentManager();
-			manager.beginTransaction()
-					.hide(this)
-					.commitAllowingStateLoss();
-		}
 	}
 
 	protected boolean hideButtonsContainer() {


### PR DESCRIPTION
Migrate external sensors bottom sheets to use MenuBottomSheetDialogFragment that already implements appropriate insets processing