### PR TITLE
Custom "Quick Action" slot for Android Auto Action Strip

### DIFF
--- a/OsmAnd/res/layout/configure_buttons_card.xml
+++ b/OsmAnd/res/layout/configure_buttons_card.xml
@@ -12,6 +12,10 @@
 		layout="@layout/configure_screen_list_item" />
 
 	<include
+		android:id="@+id/aauto_custom_button"
+		layout="@layout/configure_screen_list_item" />
+
+	<include
 		android:id="@+id/default_buttons"
 		layout="@layout/configure_screen_list_item" />
 

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -1058,6 +1058,7 @@ You will be able to pair this scanner again at any time.</string>
     <string name="custom_map_button_name_present">Such button already present</string>
     <string name="add_button">Add button</string>
     <string name="custom_buttons">Custom buttons</string>
+    <string name="aauto_cbutton">Android Auto custom button</string>
     <string name="default_buttons">Default buttons</string>
     <string name="sorted_sufolders_toast">Subfolders in “%1$s” are sorted by: “%2$s”</string>
     <string name="sort_subfolders">Sort subfolders</string>

--- a/OsmAnd/src/net/osmand/plus/auto/screens/LandingScreen.kt
+++ b/OsmAnd/src/net/osmand/plus/auto/screens/LandingScreen.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import net.osmand.plus.R
 import net.osmand.plus.auto.NavigationSession
+import net.osmand.util.Algorithms
 
 class LandingScreen(
     carContext: CarContext,
@@ -53,6 +54,25 @@ class LandingScreen(
         }
         val actionStripBuilder = ActionStrip.Builder()
         updateCompass()
+
+        val state = app.mapButtonsHelper.androidAutoButtonState
+        if (state != null && state.isEnabled) {
+            actionStripBuilder.addAction(
+                Action.Builder()
+                    .setIcon(CarIcon.Builder(IconCompat.createWithResource(carContext, R.drawable.ic_quick_action)).build())
+                    .setOnClickListener {
+                        val actions = state.quickActions
+                        if (!Algorithms.isEmpty(actions)) {
+                            val mapActivity = app.osmandMap.mapView.mapActivity
+                            if (mapActivity != null) {
+                                actions[0].execute(mapActivity, null)
+                                invalidate()
+                            }
+                        }
+                    }
+                    .build())
+        }
+
         actionStripBuilder.addAction(settingsAction)
         actionStripBuilder.addAction(createSearchAction())
         val mapActionStripBuilder = ActionStrip.Builder()

--- a/OsmAnd/src/net/osmand/plus/auto/screens/NavigationScreen.java
+++ b/OsmAnd/src/net/osmand/plus/auto/screens/NavigationScreen.java
@@ -31,10 +31,12 @@ import androidx.lifecycle.LifecycleOwner;
 import net.osmand.data.ValueHolder;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.R;
+import net.osmand.plus.activities.MapActivity;
 import net.osmand.plus.auto.NavigationListener;
 import net.osmand.plus.auto.NavigationSession;
 import net.osmand.plus.auto.SurfaceRenderer;
 import net.osmand.plus.auto.SurfaceRenderer.SurfaceRendererCallback;
+import net.osmand.plus.quickaction.QuickAction;
 import net.osmand.plus.routing.IRouteInformationListener;
 import net.osmand.plus.routing.RoutingHelper;
 import net.osmand.plus.settings.backend.OsmandSettings;
@@ -44,6 +46,7 @@ import net.osmand.plus.views.OsmandMap;
 import net.osmand.plus.views.OsmandMapTileView;
 import net.osmand.plus.views.OsmandMapTileView.ElevationListener;
 import net.osmand.plus.views.layers.base.OsmandMapLayer.DrawSettings;
+import net.osmand.plus.views.mapwidgets.configure.buttons.QuickActionButtonState;
 import net.osmand.plus.views.mapwidgets.widgets.AlarmWidget;
 import net.osmand.plus.views.mapwidgets.widgets.SpeedometerWidget;
 import net.osmand.util.Algorithms;
@@ -264,6 +267,25 @@ public final class NavigationScreen extends BaseAndroidAutoScreen implements Sur
 							})
 							.build());
 		}
+
+		QuickActionButtonState state = getApp().getMapButtonsHelper().getAndroidAutoButtonState();
+		if (state != null && state.isEnabled()) {
+			actionStripBuilder.addAction(
+					new Action.Builder()
+							.setIcon(new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_quick_action)).build())
+							.setOnClickListener(() -> {
+								List<QuickAction> actions = state.getQuickActions();
+								if (!Algorithms.isEmpty(actions)) {
+									MapActivity mapActivity = getApp().getOsmandMap().getMapView().getMapActivity();
+									if (mapActivity != null) {
+										actions.get(0).execute(mapActivity, null);
+										invalidate();
+									}
+								}
+							})
+							.build());
+		}
+
 		actionStripBuilder.addAction(settingsAction);
 		if (navigating) {
 			actionStripBuilder.addAction(

--- a/OsmAnd/src/net/osmand/plus/plugins/weather/actions/ShowHideAirPressureLayerAction.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/weather/actions/ShowHideAirPressureLayerAction.java
@@ -14,7 +14,8 @@ public class ShowHideAirPressureLayerAction extends BaseWeatherQuickAction {
 			.nameActionRes(R.string.quick_action_verb_show_hide)
 			.nameRes(R.string.pressure_layer)
 			.iconRes(R.drawable.ic_action_air_pressure).nonEditable()
-			.category(QuickActionType.CONFIGURE_MAP);
+			.category(QuickActionType.CONFIGURE_MAP)
+			.allowedInAndroidAuto(true);
 
 	public ShowHideAirPressureLayerAction() {
 		super(TYPE);

--- a/OsmAnd/src/net/osmand/plus/plugins/weather/actions/ShowHideCloudLayerAction.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/weather/actions/ShowHideCloudLayerAction.java
@@ -14,7 +14,8 @@ public class ShowHideCloudLayerAction extends BaseWeatherQuickAction {
 			.nameActionRes(R.string.quick_action_verb_show_hide)
 			.nameRes(R.string.cloud_layer)
 			.iconRes(R.drawable.ic_action_clouds).nonEditable()
-			.category(QuickActionType.CONFIGURE_MAP);
+			.category(QuickActionType.CONFIGURE_MAP)
+			.allowedInAndroidAuto(true);
 
 	public ShowHideCloudLayerAction() {
 		super(TYPE);

--- a/OsmAnd/src/net/osmand/plus/plugins/weather/actions/ShowHidePrecipitationLayerAction.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/weather/actions/ShowHidePrecipitationLayerAction.java
@@ -14,7 +14,8 @@ public class ShowHidePrecipitationLayerAction extends BaseWeatherQuickAction {
 			.nameActionRes(R.string.quick_action_verb_show_hide)
 			.nameRes(R.string.precipitation_layer)
 			.iconRes(R.drawable.ic_action_precipitation).nonEditable()
-			.category(QuickActionType.CONFIGURE_MAP);
+			.category(QuickActionType.CONFIGURE_MAP)
+			.allowedInAndroidAuto(true);
 
 	public ShowHidePrecipitationLayerAction() {
 		super(TYPE);

--- a/OsmAnd/src/net/osmand/plus/plugins/weather/actions/ShowHideTemperatureLayerAction.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/weather/actions/ShowHideTemperatureLayerAction.java
@@ -14,7 +14,8 @@ public class ShowHideTemperatureLayerAction extends BaseWeatherQuickAction {
 			.nameActionRes(R.string.quick_action_verb_show_hide)
 			.nameRes(R.string.temperature_layer)
 			.iconRes(R.drawable.ic_action_thermometer).nonEditable()
-			.category(QuickActionType.CONFIGURE_MAP);
+			.category(QuickActionType.CONFIGURE_MAP)
+			.allowedInAndroidAuto(true);
 
 	public ShowHideTemperatureLayerAction() {
 		super(TYPE);

--- a/OsmAnd/src/net/osmand/plus/plugins/weather/actions/ShowHideWeatherLayersAction.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/weather/actions/ShowHideWeatherLayersAction.java
@@ -26,7 +26,8 @@ public class ShowHideWeatherLayersAction extends QuickAction {
 			.nameActionRes(R.string.quick_action_verb_show_hide)
 			.nameRes(R.string.weather_layers)
 			.iconRes(R.drawable.ic_action_umbrella).nonEditable()
-			.category(QuickActionType.CONFIGURE_MAP);
+			.category(QuickActionType.CONFIGURE_MAP)
+			.allowedInAndroidAuto(true);
 
 	public ShowHideWeatherLayersAction() {
 		super(TYPE);

--- a/OsmAnd/src/net/osmand/plus/plugins/weather/actions/ShowHideWindAnimationAction.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/weather/actions/ShowHideWindAnimationAction.java
@@ -14,7 +14,8 @@ public class ShowHideWindAnimationAction extends BaseWeatherQuickAction {
 			.nameActionRes(R.string.quick_action_verb_show_hide)
 			.nameRes(R.string.wind_animation_layer)
 			.iconRes(R.drawable.ic_action_wind).nonEditable()
-			.category(QuickActionType.CONFIGURE_MAP);
+			.category(QuickActionType.CONFIGURE_MAP)
+			.allowedInAndroidAuto(true);
 
 	public ShowHideWindAnimationAction() {
 		super(TYPE);

--- a/OsmAnd/src/net/osmand/plus/plugins/weather/actions/ShowHideWindLayerAction.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/weather/actions/ShowHideWindLayerAction.java
@@ -14,7 +14,8 @@ public class ShowHideWindLayerAction extends BaseWeatherQuickAction {
 			.nameActionRes(R.string.quick_action_verb_show_hide)
 			.nameRes(R.string.wind_layer)
 			.iconRes(R.drawable.ic_action_wind).nonEditable()
-			.category(QuickActionType.CONFIGURE_MAP);
+			.category(QuickActionType.CONFIGURE_MAP)
+			.allowedInAndroidAuto(true);
 
 	public ShowHideWindLayerAction() {
 		super(TYPE);

--- a/OsmAnd/src/net/osmand/plus/quickaction/MapButtonsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/MapButtonsHelper.java
@@ -514,8 +514,12 @@ public class MapButtonsHelper {
 				set.add(action.getActionType().getId());
 			}
 		}
+		boolean androidAutoOnly = buttonState != null && Algorithms.stringsEqual(buttonState.getId(), ANDROID_AUTO_BUTTON_ID);
 		for (QuickActionType type : enabledTypes) {
 			if (type.getCategory() == filter.getCategory()) {
+				if (androidAutoOnly && !type.isAllowedInAndroidAuto()) {
+					continue;
+				}
 				if (!type.isActionEditable()) {
 					boolean instanceInList = set.contains(type.getId());
 					if (!instanceInList) {

--- a/OsmAnd/src/net/osmand/plus/quickaction/MapButtonsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/MapButtonsHelper.java
@@ -39,6 +39,7 @@ import java.util.*;
 public class MapButtonsHelper {
 
 	public final static String KEY_EVENT_KEY = "key_event";
+	public static final String ANDROID_AUTO_BUTTON_ID = "android_auto_custom_button";
 
 	public interface QuickActionUpdatesListener {
 
@@ -120,6 +121,7 @@ public class MapButtonsHelper {
 	private ConfigureMapButtonState configureMapButtonState;
 	private DrawerMenuButtonState drawerMenuButtonState;
 	private CompassButtonState compassButtonState;
+	private QuickActionButtonState androidAutoButtonState;
 	private List<QuickActionButtonState> quickActionStates = new ArrayList<>();
 
 	private List<QuickActionType> enabledTypes = new ArrayList<>();
@@ -149,6 +151,8 @@ public class MapButtonsHelper {
 		quickSearchButtonState = new QuickSearchButtonState(app);
 		zoomInButtonState = new ZoomInButtonState(app);
 		zoomOutButtonState = new ZoomOutButtonState(app);
+		androidAutoButtonState = new QuickActionButtonState(app, ANDROID_AUTO_BUTTON_ID);
+		androidAutoButtonState.parseQuickActions(gson);
 	}
 
 	public void addUpdatesListener(@NonNull QuickActionUpdatesListener listener) {
@@ -217,6 +221,11 @@ public class MapButtonsHelper {
 	@NonNull
 	public List<QuickActionButtonState> getQuickActionButtonsStates() {
 		return quickActionStates;
+	}
+
+	@Nullable
+	public QuickActionButtonState getAndroidAutoButtonState() {
+		return androidAutoButtonState;
 	}
 
 	@NonNull
@@ -437,6 +446,9 @@ public class MapButtonsHelper {
 
 	public void updateActiveActions() {
 		quickActionStates = createButtonsStates();
+		if (androidAutoButtonState != null) {
+			androidAutoButtonState.parseQuickActions(gson);
+		}
 	}
 
 	@NonNull
@@ -582,6 +594,9 @@ public class MapButtonsHelper {
 
 	@Nullable
 	public QuickActionButtonState getActionButtonStateById(@NonNull String id) {
+		if (Algorithms.stringsEqual(id, ANDROID_AUTO_BUTTON_ID)) {
+			return androidAutoButtonState;
+		}
 		for (QuickActionButtonState buttonState : quickActionStates) {
 			if (Algorithms.stringsEqual(buttonState.getId(), id)) {
 				return buttonState;
@@ -603,6 +618,9 @@ public class MapButtonsHelper {
 	@Nullable
 	public QuickActionButtonState getButtonStateByAction(@NonNull QuickAction action) {
 		long id = action.getId();
+		if (androidAutoButtonState != null && androidAutoButtonState.getQuickAction(id) != null) {
+			return androidAutoButtonState;
+		}
 		for (QuickActionButtonState buttonState : quickActionStates) {
 			if (buttonState.getQuickAction(id) != null) {
 				return buttonState;

--- a/OsmAnd/src/net/osmand/plus/quickaction/QuickActionListFragment.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/QuickActionListFragment.java
@@ -303,7 +303,13 @@ public class QuickActionListFragment extends BaseFullScreenFragment implements Q
 
 		LayoutInflater inflater = UiUtilities.getInflater(toolbar.getContext(), nightMode);
 		createDeleteActionsButton(inflater, container);
-		createOptionsButton(inflater, container);
+		if (!isAndroidAuto()) {
+			createOptionsButton(inflater, container);
+		}
+	}
+
+	private boolean isAndroidAuto() {
+		return buttonState != null && Algorithms.stringsEqual(buttonState.getId(), MapButtonsHelper.ANDROID_AUTO_BUTTON_ID);
 	}
 
 	private void createDeleteActionsButton(@NonNull LayoutInflater inflater, @NonNull ViewGroup container) {

--- a/OsmAnd/src/net/osmand/plus/quickaction/QuickActionType.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/QuickActionType.java
@@ -32,6 +32,7 @@ public class QuickActionType {
 	private int iconRes;
 	private Class<? extends QuickAction> cl;
 	private int category;
+	private boolean allowedInAndroidAuto;
 
 	public QuickActionType(int id, String stringId) {
 		this.id = id;
@@ -72,6 +73,11 @@ public class QuickActionType {
 
 	public QuickActionType forceUseExtendedName() {
 		forceUseExtendedName = true;
+		return this;
+	}
+
+	public QuickActionType allowedInAndroidAuto(boolean allowed) {
+		this.allowedInAndroidAuto = allowed;
 		return this;
 	}
 
@@ -131,6 +137,10 @@ public class QuickActionType {
 
 	public int getCategory() {
 		return category;
+	}
+
+	public boolean isAllowedInAndroidAuto() {
+		return allowedInAndroidAuto;
 	}
 
 	@NonNull

--- a/OsmAnd/src/net/osmand/plus/quickaction/ShowHideCoordinatesGridAction.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/ShowHideCoordinatesGridAction.java
@@ -24,7 +24,8 @@ public class ShowHideCoordinatesGridAction extends QuickAction {
 			.nameRes(R.string.layer_coordinates_grid)
 			.iconRes(R.drawable.ic_action_world_globe)
 			.nonEditable()
-			.category(QuickActionType.CONFIGURE_MAP);
+			.category(QuickActionType.CONFIGURE_MAP)
+			.allowedInAndroidAuto(true);
 
 	private transient CoordinatesGridSettings gridSettings;
 

--- a/OsmAnd/src/net/osmand/plus/quickaction/actions/DayNightModeAction.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/actions/DayNightModeAction.java
@@ -25,7 +25,8 @@ public class DayNightModeAction extends QuickAction {
 	public static final QuickActionType TYPE = new QuickActionType(DAY_NIGHT_MODE_ACTION_ID,
 			"daynight.switch", DayNightModeAction.class).
 			nameRes(R.string.map_mode).iconRes(R.drawable.ic_action_map_day).nonEditable().
-			category(QuickActionType.CONFIGURE_MAP).nameActionRes(R.string.shared_string_change);
+			category(QuickActionType.CONFIGURE_MAP).nameActionRes(R.string.shared_string_change)
+			.allowedInAndroidAuto(true);
 
 	public DayNightModeAction() {super(TYPE);}
 

--- a/OsmAnd/src/net/osmand/plus/quickaction/actions/NavAutoZoomMapAction.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/actions/NavAutoZoomMapAction.java
@@ -24,7 +24,8 @@ public class NavAutoZoomMapAction extends QuickAction {
 			"nav.autozoom", NavAutoZoomMapAction.class).
 			nameRes(R.string.quick_action_auto_zoom).iconRes(R.drawable.ic_action_search_dark).nonEditable().
 			category(QuickActionType.NAVIGATION)
-			.nameActionRes(R.string.quick_action_verb_turn_on_off);
+			.nameActionRes(R.string.quick_action_verb_turn_on_off)
+			.allowedInAndroidAuto(true);
 
 
 	public NavAutoZoomMapAction() {

--- a/OsmAnd/src/net/osmand/plus/quickaction/actions/NavRemoveNextDestination.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/actions/NavRemoveNextDestination.java
@@ -27,7 +27,8 @@ public class NavRemoveNextDestination extends QuickAction {
 			.iconRes(R.drawable.ic_action_navigation_skip_destination)
 			.nonEditable()
 			.category(QuickActionType.NAVIGATION)
-			.nameActionRes(R.string.shared_string_remove);
+			.nameActionRes(R.string.shared_string_remove)
+			.allowedInAndroidAuto(true);
 
 	public NavRemoveNextDestination() {
 		super(TYPE);

--- a/OsmAnd/src/net/osmand/plus/quickaction/actions/NavResumePauseAction.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/actions/NavResumePauseAction.java
@@ -26,7 +26,8 @@ public class NavResumePauseAction extends QuickAction {
 	public static final QuickActionType TYPE = new QuickActionType(NAV_RESUME_PAUSE_ACTION_ID,
 			"nav.resumepause", NavResumePauseAction.class)
 			.nameRes(R.string.shared_string_navigation).iconRes(R.drawable.ic_play_dark).nonEditable()
-			.category(QuickActionType.NAVIGATION).nameActionRes(R.string.quick_action_verb_pause_resume);
+			.category(QuickActionType.NAVIGATION).nameActionRes(R.string.quick_action_verb_pause_resume)
+			.allowedInAndroidAuto(true);
 
 
 	public NavResumePauseAction() {

--- a/OsmAnd/src/net/osmand/plus/quickaction/actions/NavStartStopAction.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/actions/NavStartStopAction.java
@@ -28,7 +28,8 @@ public class NavStartStopAction extends QuickAction {
 			"nav.startstop", NavStartStopAction.class)
 			.nameRes(R.string.shared_string_navigation).iconRes(R.drawable.ic_action_start_navigation).nonEditable()
 			.category(QuickActionType.NAVIGATION)
-			.nameActionRes(R.string.quick_action_verb_start_stop);
+			.nameActionRes(R.string.quick_action_verb_start_stop)
+			.allowedInAndroidAuto(true);
 
 	public NavStartStopAction() {
 		super(TYPE);

--- a/OsmAnd/src/net/osmand/plus/quickaction/actions/NavVoiceAction.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/actions/NavVoiceAction.java
@@ -22,7 +22,8 @@ public class NavVoiceAction extends QuickAction {
 			"nav.voice", NavVoiceAction.class).
 			nameRes(R.string.voices).iconRes(R.drawable.ic_action_volume_up).nonEditable().
 			category(QuickActionType.NAVIGATION)
-			.nameActionRes(R.string.quick_action_verb_turn_on_off);
+			.nameActionRes(R.string.quick_action_verb_turn_on_off)
+			.allowedInAndroidAuto(true);
 
 	public NavVoiceAction() {
 		super(TYPE);

--- a/OsmAnd/src/net/osmand/plus/quickaction/actions/ShowHideFavoritesAction.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/actions/ShowHideFavoritesAction.java
@@ -24,7 +24,8 @@ public class ShowHideFavoritesAction extends QuickAction {
 			.nameActionRes(R.string.quick_action_verb_show_hide)
 			.nameRes(R.string.shared_string_favorites)
 			.iconRes(R.drawable.ic_action_favorite).nonEditable()
-			.category(QuickActionType.CONFIGURE_MAP);
+			.category(QuickActionType.CONFIGURE_MAP)
+			.allowedInAndroidAuto(true);
 
 	public ShowHideFavoritesAction() {
 		super(TYPE);

--- a/OsmAnd/src/net/osmand/plus/quickaction/actions/ShowHideGpxTracksAction.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/actions/ShowHideGpxTracksAction.java
@@ -24,7 +24,8 @@ public class ShowHideGpxTracksAction extends QuickAction {
 			"gpx.showhide", ShowHideGpxTracksAction.class)
 			.nameActionRes(R.string.quick_action_verb_show_hide)
 			.nameRes(R.string.show_gpx).iconRes(R.drawable.ic_action_polygom_dark).nonEditable()
-			.category(QuickActionType.CONFIGURE_MAP);
+			.category(QuickActionType.CONFIGURE_MAP)
+			.allowedInAndroidAuto(true);
 
 	public ShowHideGpxTracksAction() {
 		super(TYPE);

--- a/OsmAnd/src/net/osmand/plus/quickaction/actions/ShowHidePoiAction.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/actions/ShowHidePoiAction.java
@@ -51,7 +51,8 @@ public class ShowHidePoiAction extends QuickAction {
 			.nameActionRes(R.string.quick_action_verb_show_hide)
 			.nameRes(defaultActionNameId)
 			.iconRes(R.drawable.ic_action_info_dark)
-			.category(QuickActionType.CONFIGURE_MAP);
+			.category(QuickActionType.CONFIGURE_MAP)
+			.allowedInAndroidAuto(true);
 
 	public static final String KEY_FILTERS = "filters";
 

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/buttons/AndroidAutoMapButtonFragment.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/buttons/AndroidAutoMapButtonFragment.java
@@ -1,0 +1,82 @@
+package net.osmand.plus.views.mapwidgets.configure.buttons;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+import net.osmand.plus.R;
+import net.osmand.plus.activities.MapActivity;
+import net.osmand.plus.helpers.AndroidUiHelper;
+import net.osmand.plus.quickaction.MapButtonsHelper;
+import net.osmand.plus.quickaction.QuickActionListFragment;
+import net.osmand.plus.settings.backend.ApplicationMode;
+import net.osmand.plus.utils.AndroidUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AndroidAutoMapButtonFragment extends BaseMapButtonsFragment {
+
+	public static final String TAG = AndroidAutoMapButtonFragment.class.getSimpleName();
+
+	private MapButtonsHelper mapButtonsHelper;
+
+	@Override
+	public void onCreate(@Nullable Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		mapButtonsHelper = app.getMapButtonsHelper();
+	}
+
+	@Override
+	protected void setupToolbar(@NonNull View view) {
+		super.setupToolbar(view);
+		TextView title = toolbar.findViewById(R.id.toolbar_title);
+		title.setText(R.string.aauto_cbutton);
+
+		// Disable add button for now
+		View actionButton = toolbar.findViewById(R.id.action_button);
+		AndroidUiHelper.updateVisibility(actionButton, false);
+	}
+
+	@NonNull
+	@Override
+	protected List<MapButtonState> getAdapterItems() {
+		List<MapButtonState> items = new ArrayList<>();
+		// Get Android Auto specific button state
+		QuickActionButtonState state = mapButtonsHelper.getAndroidAutoButtonState();
+		if (state != null) {
+			items.add(state);
+		}
+		return items;
+	}
+
+	@Override
+	public void onItemClick(@NonNull MapButtonState buttonState) {
+		FragmentActivity activity = getActivity();
+		if (activity != null && buttonState instanceof QuickActionButtonState) {
+			QuickActionListFragment.showInstance(activity, (QuickActionButtonState) buttonState);
+		}
+	}
+
+	@Override
+	public void copyAppModePrefs(@NonNull ApplicationMode appMode) {
+		// Android Auto settings are typically global or handled differently
+	}
+
+	public static void showInstance(@NonNull FragmentManager manager, @Nullable Fragment target) {
+		if (AndroidUtils.isFragmentCanBeAdded(manager, TAG)) {
+			AndroidAutoMapButtonFragment fragment = new AndroidAutoMapButtonFragment();
+			fragment.setTargetFragment(target, 0);
+			manager.beginTransaction()
+					.add(R.id.fragmentContainer, fragment, TAG)
+					.addToBackStack(TAG)
+					.commitAllowingStateLoss();
+		}
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/buttons/QuickActionButtonState.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/buttons/QuickActionButtonState.java
@@ -17,6 +17,7 @@ import com.google.gson.reflect.TypeToken;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.R;
 import net.osmand.plus.quickaction.ButtonAppearanceParams;
+import net.osmand.plus.quickaction.MapButtonsHelper;
 import net.osmand.plus.quickaction.QuickAction;
 import net.osmand.plus.quickaction.actions.ChangeMapOrientationAction;
 import net.osmand.plus.settings.backend.preferences.CommonPreference;
@@ -47,9 +48,17 @@ public class QuickActionButtonState extends MapButtonState {
 	public QuickActionButtonState(@NonNull OsmandApplication app, @NonNull String id) {
 		super(app, id);
 		this.visibilityPref = addPreference(settings.registerBooleanPreference(id + "_state", false)).makeProfile();
-		this.namePref = addPreference(settings.registerStringPreference(id + "_name", null)).makeGlobal().storeLastModifiedTime();
-		this.quickActionsPref = addPreference(settings.registerStringPreference(id + "_list", null)).makeGlobal().storeLastModifiedTime();
-		this.quickActionLayer = app.getOsmandMap().getMapLayers().getMapQuickActionLayer();
+		boolean isAndroidAuto = Algorithms.stringsEqual(id, MapButtonsHelper.ANDROID_AUTO_BUTTON_ID);
+		CommonPreference<String> namePref = settings.registerStringPreference(id + "_name", null);
+		if (isAndroidAuto) {
+			this.namePref = addPreference(settings.registerStringPreference(id + "_name", null)).makeProfile().storeLastModifiedTime();
+			this.quickActionsPref = addPreference(settings.registerStringPreference(id + "_list", null)).makeProfile().storeLastModifiedTime();
+			this.quickActionLayer = app.getOsmandMap().getMapLayers().getMapQuickActionLayer();
+		} else {
+			this.namePref = addPreference(settings.registerStringPreference(id + "_name", null)).makeGlobal().storeLastModifiedTime();
+			this.quickActionsPref = addPreference(settings.registerStringPreference(id + "_list", null)).makeGlobal().storeLastModifiedTime();
+			this.quickActionLayer = app.getOsmandMap().getMapLayers().getMapQuickActionLayer();
+		}
 	}
 
 	@Override

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/dialogs/ConfigureScreenFragment.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/dialogs/ConfigureScreenFragment.java
@@ -27,6 +27,7 @@ import net.osmand.plus.profiles.SelectAppModesBottomSheetDialogFragment;
 import net.osmand.plus.profiles.SelectAppModesBottomSheetDialogFragment.AppModeChangedListener;
 import net.osmand.plus.profiles.SelectCopyAppModeBottomSheet;
 import net.osmand.plus.profiles.SelectCopyAppModeBottomSheet.CopyAppModePrefsListener;
+import net.osmand.plus.quickaction.QuickActionListFragment;
 import net.osmand.plus.routepreparationmenu.cards.BaseCard;
 import net.osmand.plus.routepreparationmenu.cards.BaseCard.CardListener;
 import net.osmand.plus.settings.backend.ApplicationMode;
@@ -40,8 +41,10 @@ import net.osmand.plus.utils.InsetTargetsCollection;
 import net.osmand.plus.utils.InsetsUtils;
 import net.osmand.plus.views.layers.MapInfoLayer;
 import net.osmand.plus.views.mapwidgets.configure.WidgetsSettingsHelper;
+import net.osmand.plus.views.mapwidgets.configure.buttons.AndroidAutoMapButtonFragment;
 import net.osmand.plus.views.mapwidgets.configure.buttons.CustomMapButtonsFragment;
 import net.osmand.plus.views.mapwidgets.configure.buttons.DefaultMapButtonsFragment;
+import net.osmand.plus.views.mapwidgets.configure.buttons.QuickActionButtonState;
 import net.osmand.plus.views.mapwidgets.configure.dialogs.cards.ConfigureActionsCard;
 import net.osmand.plus.views.mapwidgets.configure.dialogs.cards.ConfigureButtonsCard;
 import net.osmand.plus.views.mapwidgets.configure.dialogs.cards.MapScreenLayoutCard;
@@ -322,6 +325,11 @@ public class ConfigureScreenFragment extends BaseFullScreenFragment implements C
 		} else if (card instanceof ConfigureButtonsCard) {
 			if (buttonIndex == ConfigureButtonsCard.CUSTOM_MAP_BUTTONS_INDEX) {
 				CustomMapButtonsFragment.showInstance(manager, ConfigureScreenFragment.this);
+			} else if (buttonIndex == ConfigureButtonsCard.AAUTO_CUSTOM_MAP_BUTTON_INDEX) {
+				QuickActionButtonState state = app.getMapButtonsHelper().getAndroidAutoButtonState();
+				if (state != null) {
+					QuickActionListFragment.showInstance(mapActivity, state);
+				}
 			} else if (buttonIndex == ConfigureButtonsCard.DEFAULT_MAP_BUTTONS_INDEX) {
 				DefaultMapButtonsFragment.showInstance(manager, ConfigureScreenFragment.this);
 			}

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/dialogs/cards/ConfigureButtonsCard.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/dialogs/cards/ConfigureButtonsCard.java
@@ -28,7 +28,8 @@ import java.util.List;
 public class ConfigureButtonsCard extends MapBaseCard {
 
 	public static final int CUSTOM_MAP_BUTTONS_INDEX = 0;
-	public static final int DEFAULT_MAP_BUTTONS_INDEX = 1;
+	public static final int AAUTO_CUSTOM_MAP_BUTTON_INDEX = 1;
+	public static final int DEFAULT_MAP_BUTTONS_INDEX = 2;
 
 	private final MapButtonsHelper mapButtonsHelper;
 
@@ -48,6 +49,7 @@ public class ConfigureButtonsCard extends MapBaseCard {
 		title.setText(R.string.shared_string_buttons);
 
 		setupCustomWidgetsButton();
+		setupAAutoCustomWidgetButton();
 		setupDefaultWidgetsButton();
 
 		AndroidUiHelper.updateVisibility(view.findViewById(R.id.description), false);
@@ -70,6 +72,18 @@ public class ConfigureButtonsCard extends MapBaseCard {
 		button.setOnClickListener(v -> notifyButtonPressed(CUSTOM_MAP_BUTTONS_INDEX));
 
 		AndroidUiHelper.updateVisibility(count, true);
+		AndroidUiHelper.updateVisibility(view.findViewById(R.id.short_divider), true);
+	}
+
+	private void setupAAutoCustomWidgetButton() {
+		String title = getString(R.string.aauto_cbutton);
+		View button = view.findViewById(R.id.aauto_custom_button);
+
+		QuickActionButtonState state = mapButtonsHelper.getAndroidAutoButtonState();
+		boolean enabled = state != null && state.isEnabled();
+
+		setupButton(button, title, null, R.drawable.ic_action_android_auto, enabled, nightMode);
+		button.setOnClickListener(v -> notifyButtonPressed(AAUTO_CUSTOM_MAP_BUTTON_INDEX));
 		AndroidUiHelper.updateVisibility(view.findViewById(R.id.short_divider), true);
 	}
 


### PR DESCRIPTION
Add a configurable "Custom Action" slot to the Android Auto Action Strip (the template-defined button cluster) as described in issue #24515 