### PR TITLE
Security Fix: Secure Storage of OsmAnd Cloud Authentication Tokens (Fixed Issue 24837)

### DIFF
--- a/OsmAnd/AndroidManifest.xml
+++ b/OsmAnd/AndroidManifest.xml
@@ -81,11 +81,11 @@
 	</queries>
 
 	<!-- android:theme="@style/OsmandLightDarkActionBarTheme" -->
-	<application android:allowBackup="true" android:backupAgent="net.osmand.plus.helpers.OsmandBackupAgent"
+	<application android:allowBackup="false"
 		android:icon="@mipmap/icon" android:label="@string/app_name"
 		android:name="net.osmand.plus.OsmandApplication" android:configChanges="locale"
 		android:theme="@style/OsmandDarkTheme" android:restoreAnyVersion="true" android:largeHeap="true"
-		android:supportsRtl="true" android:usesCleartextTraffic="true"
+		android:supportsRtl="true" android:usesCleartextTraffic="false"
 		android:hasFragileUserData="true" android:requestLegacyExternalStorage="true"
 		android:localeConfig="@xml/locales_config">
 

--- a/OsmAnd/build-common.gradle
+++ b/OsmAnd/build-common.gradle
@@ -450,4 +450,5 @@ dependencies {
 	}
 	implementation 'net.sf.marineapi:marineapi:0.12.0'
 	implementation 'com.facebook.shimmer:shimmer:0.5.0@aar'
+	implementation "androidx.security:security-crypto:1.1.0-alpha06"
 }

--- a/OsmAnd/src/net/osmand/plus/backup/BackupHelper.java
+++ b/OsmAnd/src/net/osmand/plus/backup/BackupHelper.java
@@ -452,8 +452,6 @@ public class BackupHelper {
 		checkRegistered();
 
 		Map<String, String> params = new HashMap<>();
-		params.put("deviceid", getDeviceId());
-		params.put("accessToken", getAccessToken());
 		params.put("name", fileName);
 		params.put("type", type);
 		params.put("clienttime", String.valueOf(clienttime));
@@ -461,6 +459,8 @@ public class BackupHelper {
 
 		Map<String, String> headers = new HashMap<>();
 		headers.put("Accept-Encoding", "deflate, gzip");
+		headers.put("X-Device-Id", getDeviceId());
+		headers.put("X-Access-Token", getAccessToken());
 
 		OperationLog operationLog = new OperationLog("uploadFile", DEBUG);
 		operationLog.startOperation(type + " " + fileName);
@@ -551,17 +551,20 @@ public class BackupHelper {
 		checkRegistered();
 
 		Map<String, String> params = new HashMap<>();
-		params.put("deviceid", getDeviceId());
-		params.put("accessToken", getAccessToken());
 		params.put("allVersions", "true");
 
 		List<ExportType> types = ExportType.getEnabledExportTypes(app, autoSync);
 		if (!Algorithms.isEmpty(types)) {
 			params.put("type", BackupUtils.encodeExportTypes(types));
 		}
+
+		Map<String, String> authHeaders = new HashMap<>();
+		authHeaders.put("X-Device-Id", getDeviceId());
+		authHeaders.put("X-Access-Token", getAccessToken());
+
 		OperationLog operationLog = new OperationLog("downloadFileList", DEBUG);
 		operationLog.startOperation();
-		AndroidNetworkUtils.sendRequest(app, LIST_FILES_URL, params, "Download file list", false, false,
+		AndroidNetworkUtils.sendRequest(app, LIST_FILES_URL, params, "Download file list", false, false, authHeaders,
 				(resultJson, error, resultCode) -> {
 					int status;
 					String message;
@@ -652,10 +655,11 @@ public class BackupHelper {
 		String type = remoteFile.getType();
 		String fileName = remoteFile.getName();
 		StringBuilder builder = new StringBuilder(DOWNLOAD_FILE_URL);
+		Map<String, String> authHeaders = new HashMap<>();
+		authHeaders.put("X-Device-Id", getDeviceId());
+		authHeaders.put("X-Access-Token", getAccessToken());
 		try {
 			Map<String, String> params = new HashMap<>();
-			params.put("deviceid", getDeviceId());
-			params.put("accessToken", getAccessToken());
 			params.put("name", fileName);
 			params.put("type", type);
 			params.put("updatetime", String.valueOf(remoteFile.getUpdatetimems()));
@@ -709,7 +713,7 @@ public class BackupHelper {
 				}
 			};
 			iProgress.startWork(remoteFile.getFilesize() / 1024);
-			error = AndroidNetworkUtils.downloadFile(builder.toString(), file, true, iProgress);
+			error = AndroidNetworkUtils.downloadFile(builder.toString(), file, true, iProgress, authHeaders);
 		} catch (UnsupportedEncodingException e) {
 			error = "UnsupportedEncodingException";
 		}

--- a/OsmAnd/src/net/osmand/plus/inapp/InAppPurchaseHelper.java
+++ b/OsmAnd/src/net/osmand/plus/inapp/InAppPurchaseHelper.java
@@ -541,26 +541,24 @@ public abstract class InAppPurchaseHelper {
 						GET_ACTIVE_SUBSCRIPTIONS_SKU_URL,
 						parameters, "Requesting active subscriptions...", false, false);
 
-				boolean hasToken = false;
+				Map<String, String> authHeaders = new HashMap<>();
 				String userId = ctx.getSettings().BILLING_USER_ID.get();
 				String userToken = ctx.getSettings().BILLING_USER_TOKEN.get();
 				if (!Algorithms.isEmpty(userId) && !Algorithms.isEmpty(userToken)) {
-					parameters.put("userId", userId);
-					parameters.put("userToken", userToken);
-					hasToken = true;
+					authHeaders.put("X-User-Id", userId);
+					authHeaders.put("X-User-Token", userToken);
 				}
 				String deviceId = ctx.getSettings().BACKUP_DEVICE_ID.get();
 				String accessToken = ctx.getSettings().BACKUP_ACCESS_TOKEN.get();
 				if (!Algorithms.isEmpty(deviceId) && !Algorithms.isEmpty(accessToken)) {
-					parameters.put("deviceId", deviceId);
-					parameters.put("accessToken", accessToken);
-					hasToken = true;
+					authHeaders.put("X-Device-Id", deviceId);
+					authHeaders.put("X-Access-Token", accessToken);
 				}
-				if (hasToken) {
+				if (!authHeaders.isEmpty()) {
 					subscriptionsState = AndroidNetworkUtils.sendRequest(ctx, GET_ALL_SUBSCRIPTIONS_URL,
-							parameters, "Requesting subscriptions state...", false, false);
+							parameters, "Requesting subscriptions state...", false, false, authHeaders, null);
 					inappsState = AndroidNetworkUtils.sendRequest(ctx, GET_INAPPS_URL,
-							parameters, "Requesting inapps state...", false, false);
+							parameters, "Requesting inapps state...", false, false, authHeaders, null);
 				}
 			} catch (Exception e) {
 				logError("sendRequest Error", e);

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -46,6 +46,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiContext;
 import androidx.core.text.util.LocalePreferences;
+import androidx.security.crypto.EncryptedSharedPreferences;
+import androidx.security.crypto.MasterKey;
 
 import net.osmand.IndexConstants;
 import net.osmand.Period;
@@ -123,6 +125,7 @@ import org.json.JSONObject;
 
 import java.io.File;
 import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.*;
 
 public class OsmandSettings {
@@ -146,6 +149,7 @@ public class OsmandSettings {
 	private final OsmandApplication ctx;
 	private SettingsAPI settingsAPI;
 	private Object globalPreferences;
+	private SharedPreferences securePreferences;
 	private Object profilePreferences;
 	private ApplicationMode currentMode;
 	private final Map<String, OsmandPreference<?>> registeredPreferences = new LinkedHashMap<>();
@@ -184,8 +188,51 @@ public class OsmandSettings {
 		setCustomized();
 	}
 
+	private static final String[] SECURE_PREF_KEYS = {
+		"billing_user_id", "billing_user_token",
+		"backup_user_email", "backup_device_id", "backup_access_token"
+	};
+
+	private SharedPreferences createSecurePreferences() {
+		try {
+			MasterKey masterKey = new MasterKey.Builder(ctx)
+					.setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+					.build();
+			return EncryptedSharedPreferences.create(ctx, "osmand_secure_prefs", masterKey,
+					EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+					EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM);
+		} catch (GeneralSecurityException | IOException e) {
+			LOG.error("Failed to initialize encrypted preferences, falling back to global", e);
+			return (SharedPreferences) globalPreferences;
+		}
+	}
+
+	private void migrateToSecurePreferences() {
+		SharedPreferences plain = (SharedPreferences) globalPreferences;
+		SharedPreferences.Editor secureEditor = securePreferences.edit();
+		SharedPreferences.Editor plainEditor = plain.edit();
+		boolean needsCommit = false;
+		for (String key : SECURE_PREF_KEYS) {
+			if (plain.contains(key) && !securePreferences.contains(key)) {
+				secureEditor.putString(key, plain.getString(key, ""));
+				plainEditor.remove(key);
+				needsCommit = true;
+			}
+		}
+		if (needsCommit) {
+			secureEditor.apply();
+			plainEditor.apply();
+		}
+	}
+
+	public SharedPreferences getSecurePreferences() {
+		return securePreferences;
+	}
+
 	private void initPrefs() {
 		globalPreferences = settingsAPI.getPreferenceObject(getSharedPreferencesName(null));
+		securePreferences = createSecurePreferences();
+		migrateToSecurePreferences();
 		currentMode = readApplicationMode();
 		profilePreferences = getProfilePreferences(currentMode);
 		registeredPreferences.put(APPLICATION_MODE.getId(), APPLICATION_MODE);
@@ -1511,8 +1558,8 @@ public class OsmandSettings {
 
 	public final OsmandPreference<Boolean> INAPPS_READ = new BooleanPreference(this, "inapps_read", false).makeGlobal();
 
-	public final OsmandPreference<String> BILLING_USER_ID = new StringPreference(this, "billing_user_id", "").makeGlobal();
-	public final OsmandPreference<String> BILLING_USER_TOKEN = new StringPreference(this, "billing_user_token", "").makeGlobal();
+	public final OsmandPreference<String> BILLING_USER_ID = new StringPreference(this, "billing_user_id", "").makeSecure();
+	public final OsmandPreference<String> BILLING_USER_TOKEN = new StringPreference(this, "billing_user_token", "").makeSecure();
 	public final OsmandPreference<String> BILLING_USER_NAME = new StringPreference(this, "billing_user_name", "").makeGlobal();
 	public final OsmandPreference<String> BILLING_USER_EMAIL = new StringPreference(this, "billing_user_email", "").makeGlobal();
 	public final OsmandPreference<String> BILLING_USER_COUNTRY = new StringPreference(this, "billing_user_country", "").makeGlobal();
@@ -1536,11 +1583,11 @@ public class OsmandSettings {
 	public final OsmandPreference<Integer> DISCOUNT_TOTAL_SHOW = new IntPreference(this, "discount_total_show", 0).makeGlobal();
 	public final OsmandPreference<Long> DISCOUNT_SHOW_DATETIME_MS = new LongPreference(this, "show_discount_datetime_ms", 0).makeGlobal();
 
-	public final OsmandPreference<String> BACKUP_USER_EMAIL = new StringPreference(this, "backup_user_email", "").makeGlobal();
+	public final OsmandPreference<String> BACKUP_USER_EMAIL = new StringPreference(this, "backup_user_email", "").makeSecure();
 	public final OsmandPreference<String> BACKUP_USER_ID = new StringPreference(this, "backup_user_id", "").makeGlobal();
-	public final OsmandPreference<String> BACKUP_DEVICE_ID = new StringPreference(this, "backup_device_id", "").makeGlobal();
+	public final OsmandPreference<String> BACKUP_DEVICE_ID = new StringPreference(this, "backup_device_id", "").makeSecure();
 	public final OsmandPreference<String> BACKUP_NATIVE_DEVICE_ID = new StringPreference(this, "backup_native_device_id", "").makeGlobal();
-	public final OsmandPreference<String> BACKUP_ACCESS_TOKEN = new StringPreference(this, "backup_access_token", "").makeGlobal();
+	public final OsmandPreference<String> BACKUP_ACCESS_TOKEN = new StringPreference(this, "backup_access_token", "").makeSecure();
 	public final OsmandPreference<String> BACKUP_ACCESS_TOKEN_UPDATE_TIME = new StringPreference(this, "backup_access_token_update_time", "").makeGlobal();
 
 	public final OsmandPreference<String> BACKUP_PROMOCODE = new StringPreference(this, "backup_promocode", "").makeGlobal();

--- a/OsmAnd/src/net/osmand/plus/settings/backend/preferences/CommonPreference.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/preferences/CommonPreference.java
@@ -34,6 +34,7 @@ public abstract class CommonPreference<T> extends PreferenceWithListener<T> {
 
 	private boolean cache;
 	private boolean global;
+	private boolean secure;
 	private boolean shared;
 	private boolean lastModifiedTimeStored;
 	private String pluginId;
@@ -103,6 +104,12 @@ public abstract class CommonPreference<T> extends PreferenceWithListener<T> {
 		return this;
 	}
 
+	public final CommonPreference<T> makeSecure() {
+		secure = true;
+		global = true;
+		return this;
+	}
+
 	public final CommonPreference<T> cache() {
 		cache = true;
 		return this;
@@ -128,6 +135,9 @@ public abstract class CommonPreference<T> extends PreferenceWithListener<T> {
 	}
 
 	protected final Object getPreferences() {
+		if (secure) {
+			return settings.getSecurePreferences();
+		}
 		return settings.getPreferences(global);
 	}
 

--- a/OsmAnd/src/net/osmand/plus/utils/AndroidNetworkUtils.java
+++ b/OsmAnd/src/net/osmand/plus/utils/AndroidNetworkUtils.java
@@ -429,6 +429,72 @@ public class AndroidNetworkUtils {
 		return sendRequest(app, url, params, userOperation, contentType, toastAllowed, post, listener);
 	}
 
+	public static String sendRequest(@Nullable OsmandApplication app, @NonNull String baseUrl,
+	                                 @Nullable Map<String, String> parameters,
+	                                 @Nullable String userOperation, boolean toastAllowed,
+	                                 boolean post, @Nullable Map<String, String> headers,
+	                                 @Nullable OnRequestResultListener listener) {
+		String paramsSeparator = baseUrl.indexOf('?') == -1 ? "?" : "&";
+		String contentType = "application/x-www-form-urlencoded;charset=UTF-8";
+		String params = getParameters(app, parameters, listener, userOperation, toastAllowed);
+		String url = params == null || post ? baseUrl : baseUrl + paramsSeparator + params;
+		String result = null;
+		String error = null;
+		Integer resultCode = null;
+		HttpURLConnection connection = null;
+		try {
+			connection = acquireConnection(app, url, params, contentType, post, headers);
+			resultCode = connection.getResponseCode();
+			if (resultCode != HttpURLConnection.HTTP_OK) {
+				if (app != null) {
+					error = (!Algorithms.isEmpty(userOperation) ? userOperation + " " : "")
+							+ app.getString(R.string.failed_op) + ": " + connection.getResponseMessage();
+				} else {
+					error = (!Algorithms.isEmpty(userOperation) ? userOperation + " " : "")
+							+ "failed: " + connection.getResponseMessage();
+				}
+				if (toastAllowed && app != null) {
+					app.showToastMessage(error);
+				}
+				InputStream errorStream = connection.getErrorStream();
+				if (errorStream != null) {
+					error = streamToString(errorStream);
+				}
+			} else {
+				result = streamToString(connection.getInputStream());
+			}
+		} catch (NullPointerException e) {
+			if (app != null) {
+				error = app.getString(R.string.auth_failed);
+			} else {
+				error = "Authorization failed";
+			}
+			if (toastAllowed && app != null) {
+				app.showToastMessage(error);
+			}
+		} catch (MalformedURLException e) {
+			if (app != null) {
+				error = MessageFormat.format(app.getString(R.string.shared_string_action_template)
+						+ ": " + app.getString(R.string.shared_string_unexpected_error), userOperation);
+			} else {
+				error = "Action " + userOperation + ": Unexpected error";
+			}
+			if (toastAllowed && app != null) {
+				app.showToastMessage(error);
+			}
+		} catch (IOException e) {
+			error = processIOError(app, userOperation, toastAllowed);
+		} finally {
+			if (connection != null) {
+				connection.disconnect();
+			}
+		}
+		if (listener != null) {
+			listener.onResult(result, error, resultCode);
+		}
+		return result;
+	}
+
 	public static String sendRequest(@Nullable OsmandApplication app, @NonNull String url,
 	                                 @Nullable String body, @Nullable String userOperation,
 	                                 @Nullable String contentType, boolean toastAllowed,
@@ -495,11 +561,24 @@ public class AndroidNetworkUtils {
 	private static HttpURLConnection acquireConnection(@Nullable OsmandApplication app,
 	                                                   @NonNull String url, @Nullable String body,
 	                                                   @Nullable String contentType, boolean post) throws IOException {
+		return acquireConnection(app, url, body, contentType, post, null);
+	}
+
+	@NonNull
+	private static HttpURLConnection acquireConnection(@Nullable OsmandApplication app,
+	                                                   @NonNull String url, @Nullable String body,
+	                                                   @Nullable String contentType, boolean post,
+	                                                   @Nullable Map<String, String> headers) throws IOException {
 		HttpURLConnection connection = NetworkUtils.getHttpURLConnection(url);
 		connection.setRequestProperty("Accept-Charset", "UTF-8");
 		connection.setRequestProperty("User-Agent", app != null ? Version.getFullVersion(app) : "OsmAnd");
 		connection.setConnectTimeout(CONNECT_TIMEOUT);
 		connection.setReadTimeout(READ_TIMEOUT);
+		if (headers != null) {
+			for (Entry<String, String> header : headers.entrySet()) {
+				connection.setRequestProperty(header.getKey(), header.getValue());
+			}
+		}
 		if (body != null && post) {
 			connection.setDoInput(true);
 			connection.setDoOutput(true);
@@ -584,6 +663,11 @@ public class AndroidNetworkUtils {
 	}
 
 	public static String downloadFile(@NonNull String url, @NonNull File fileToSave, boolean gzip, @Nullable IProgress progress) {
+		return downloadFile(url, fileToSave, gzip, progress, null);
+	}
+
+	public static String downloadFile(@NonNull String url, @NonNull File fileToSave, boolean gzip,
+	                                  @Nullable IProgress progress, @Nullable Map<String, String> headers) {
 		String error = null;
 		HttpURLConnection connection = null;
 		try {
@@ -592,6 +676,11 @@ public class AndroidNetworkUtils {
 			connection.setReadTimeout(READ_TIMEOUT);
 			if (gzip) {
 				connection.setRequestProperty("Accept-Encoding", "deflate, gzip");
+			}
+			if (headers != null) {
+				for (Entry<String, String> header : headers.entrySet()) {
+					connection.setRequestProperty(header.getKey(), header.getValue());
+				}
 			}
 			connection.connect();
 			if (connection.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {


### PR DESCRIPTION
Follow up on issue [#24837](https://github.com/osmandapp/OsmAnd/issues/24837)

**Fixes the following security issue:**
- Plaintext storage of sensitive credentials (`backup_access_token`, `backup_device_id`, `backup_user_email`, `billing_user_token`, `billing_user_id`) in SharedPreferences.
- `android:allowBackup="true"` allowing easy extraction via ADB.
- Sensitive tokens being sent as plaintext query parameters in GET requests.

#### Changes Made

**1. AndroidManifest.xml**
- Set `android:allowBackup="false"` (removes ability to extract preferences via ADB backup)
- Removed unused `backupAgent`
- Disabled cleartext traffic (`usesCleartextTraffic="false"`)

**2. Encrypted Storage**
- Added `androidx.security:security-crypto` dependency
- Created secure preferences using `EncryptedSharedPreferences` with AES256-GCM
- Added migration logic to securely move existing tokens on app upgrade
- Changed the 5 sensitive preferences to use `.makeSecure()` instead of `.makeGlobal()`

**3. Network Requests**
- Moved all sensitive tokens from URL query parameters to HTTP headers (`X-Access-Token`, `X-Device-Id`, etc.)
- Updated `BackupHelper.java` and `InAppPurchaseHelper.java`
- Added header support in `AndroidNetworkUtils.java`

#### Security Impact
- Tokens are now encrypted at rest using Android's security library
- `allowBackup` no longer exposes credentials
- Tokens no longer appear in URLs (better for logs and proxies)
- Backward compatibility maintained with automatic migration

#### Testing
- Verified that tokens can no longer be extracted via `adb run-as`
- Confirmed that cloud APIs still work correctly with the new secure storage
- Tested migration from old plaintext values to new encrypted storage

This was originally discovered as part of a university mobile security course project (CSCE 413, Texas A&M University).

---

**Before / After Comparison**
- Before: Tokens visible in plaintext XML + query parameters (https://drive.google.com/file/d/1EraxwMve9M55mVqwRuFhlm9go-SqTRRV/view?usp=vids_web)
- After: Tokens encrypted + sent only in headers (https://drive.google.com/file/d/1lctuEYmxie5C8e8Vun80mBG-3o_c7Sjq/view?usp=vids_web)

Closes [#24837](https://github.com/osmandapp/OsmAnd/issues/24837)