### PR TITLE
empty-suffix-dictionary-fix

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/binary/BinaryMapAddressReaderAdapter.java
+++ b/OsmAnd-java/src/main/java/net/osmand/binary/BinaryMapAddressReaderAdapter.java
@@ -751,6 +751,9 @@ public class BinaryMapAddressReaderAdapter {
 								suffixDictionary = new ArrayList<>();
 							}
 							String encodedSuffix = codedIS.readString();
+							if (SearchAlgorithms.EMPTY_SUFFIX_DICTIONARY_SENTINEL.equals(encodedSuffix)) {
+								continue;
+							}
 							String previousSuffix = suffixDictionary.isEmpty() ? null : suffixDictionary.get(suffixDictionary.size() - 1);
 							String decodedSuffix = SearchAlgorithms.nameIndexDecodeDictionarySuffix(previousSuffix, encodedSuffix);
 							suffixDictionary.add(decodedSuffix);

--- a/OsmAnd-java/src/main/java/net/osmand/binary/BinaryMapPoiReaderAdapter.java
+++ b/OsmAnd-java/src/main/java/net/osmand/binary/BinaryMapPoiReaderAdapter.java
@@ -525,6 +525,9 @@ public class BinaryMapPoiReaderAdapter {
 					if (suffixDictionary == null) {
 						suffixDictionary = new ArrayList<>();
 					}
+					if (EMPTY_SUFFIX_DICTIONARY_SENTINEL.equals(encodedSuffix)) {
+						break;
+					}
 					String prevSuffix = suffixDictionary.isEmpty() ? null : suffixDictionary.get(suffixDictionary.size() - 1);
 					String entry = nameIndexDecodeDictionarySuffix(prevSuffix, encodedSuffix);
 					suffixDictionary.add(entry);

--- a/OsmAnd-java/src/main/java/net/osmand/binary/QueryToken.java
+++ b/OsmAnd-java/src/main/java/net/osmand/binary/QueryToken.java
@@ -27,12 +27,11 @@ public class QueryToken {
                 return;
             }
             
+            if (suffixDictionary.size() == 1 && suffixDictionary.get(0).isEmpty()) {
+                return;
+            }
             if (masks == null) {
                 masks = new TIntArrayList();
-            }
-            if (suffixDictionary.size() == 1 && suffixDictionary.get(0).isEmpty()) {
-                masks.add(1);
-                return;
             }
             if (query == null) {
                 return;

--- a/OsmAnd-java/src/main/java/net/osmand/binary/QueryToken.java
+++ b/OsmAnd-java/src/main/java/net/osmand/binary/QueryToken.java
@@ -30,6 +30,10 @@ public class QueryToken {
             if (masks == null) {
                 masks = new TIntArrayList();
             }
+            if (suffixDictionary.size() == 1 && suffixDictionary.get(0).isEmpty()) {
+                masks.add(1);
+                return;
+            }
             if (query == null) {
                 return;
             }

--- a/OsmAnd-java/src/main/java/net/osmand/util/SearchAlgorithms.java
+++ b/OsmAnd-java/src/main/java/net/osmand/util/SearchAlgorithms.java
@@ -247,7 +247,7 @@ public class SearchAlgorithms {
 
     private static final int MARKER_LCP_LENGTH = SUFFIX_DICT_MARKER_MAX - SUFFIX_DICT_MARKER_BASE;
     public record SuffixEntry(String resolvedSuffix, String encodedSuffix) {}
-    public static final String EMPTY_POI_SUFFIX_DICTIONARY_SENTINEL = "";
+    public static final String EMPTY_SUFFIX_DICTIONARY_SENTINEL = "\uE100";
     
     public static class SuffixDictionary<T> {
         public final List<SuffixEntry> dictionaryEntries = new ArrayList<>();


### PR DESCRIPTION
fix empty suffix dictionary for short prefixes.

Resulting behavior:
State 1. suffixDictionary == null for old version OBF to skip suffix filtering and allow all offsets.
State 2. suffixDictionary.isEmpty(). Prefix is normal and dictionary is present but no suffixes, no objects pass suffix filtering.
State 3. suffixDictionary.size() == 1 and suffixDictionary.get(0).isEmpty(). For short prefix use singleton dictionary [""] for normal filtering to allow loading of all offsets in that matched block.
State 4. !suffixDictionary.isEmpty(). Non-empty dictionary with normal entries, standard suffix-bitset filtering.
