### PR TITLE
Fix crash during rendering release

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/layers/core/AidlTileProvider.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/core/AidlTileProvider.java
@@ -74,6 +74,7 @@ public class AidlTileProvider extends interface_MapTiledCollectionProvider {
 		this.smallIconBg = aidlMapLayer.getSmallIconBg();
 		this.offset = new PointI(0, 0);
 		this.bigIconOffset = new PointI(0, (int) yOffset);
+		this.swigTakeOwnership();
 	}
 
 	public void drawSymbols(@NonNull MapRendererView mapRenderer) {

--- a/OsmAnd/src/net/osmand/plus/views/layers/core/AudioNotesTileProvider.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/core/AudioNotesTileProvider.java
@@ -50,6 +50,7 @@ public class AudioNotesTileProvider extends interface_MapTiledCollectionProvider
         textStyle = new TextRasterizer.Style();
         this.density = density;
         this.offset = new PointI(0, 0);
+        this.swigTakeOwnership();
     }
 
     public void drawSymbols(@NonNull MapRendererView mapRenderer) {

--- a/OsmAnd/src/net/osmand/plus/views/layers/core/FavoritesTileProvider.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/core/FavoritesTileProvider.java
@@ -45,6 +45,7 @@ public class FavoritesTileProvider extends interface_MapTiledCollectionProvider 
 		this.textStyle = textStyle;
 		this.density = density;
 		this.offset = new PointI(0, 0);
+		this.swigTakeOwnership();
 	}
 
 	public void drawSymbols(@NonNull MapRendererView mapRenderer) {

--- a/OsmAnd/src/net/osmand/plus/views/layers/core/LocationPointsTileProvider.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/core/LocationPointsTileProvider.java
@@ -39,6 +39,7 @@ public class LocationPointsTileProvider extends interface_MapTiledCollectionProv
       }
       skPointBitmap = pointBitmap;
       this.offset = new PointI(0, 0);
+      this.swigTakeOwnership();
    }
 
    public void drawPoints(@NonNull MapRendererView mapRenderer) {

--- a/OsmAnd/src/net/osmand/plus/views/layers/core/OsmBugsTileProvider.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/core/OsmBugsTileProvider.java
@@ -130,6 +130,7 @@ public class OsmBugsTileProvider extends interface_MapTiledCollectionProvider {
 		this.showClosed = showClosed;
 		this.minZoom = minZoom;
 		this.offset = new PointI(0, -BACKGROUND_TYPE.getOffsetY(context, textScale));
+		this.swigTakeOwnership();
 	}
 
 	public void drawSymbols(@NonNull MapRendererView mapRenderer) {

--- a/OsmAnd/src/net/osmand/plus/views/layers/core/POITileProvider.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/core/POITileProvider.java
@@ -141,6 +141,7 @@ public class POITileProvider extends interface_MapTiledCollectionProvider {
 		this.textScale = textScale;
 		this.density = density;
 		this.offset = new PointI(0, 0);
+		this.swigTakeOwnership();
 	}
 
 	public void drawSymbols(@NonNull MapRendererView mapRenderer) {

--- a/OsmAnd/src/net/osmand/plus/views/layers/core/TilePointsProvider.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/core/TilePointsProvider.java
@@ -106,6 +106,7 @@ public class TilePointsProvider<T extends TilePointsProvider.ICollectionPoint> e
 		this.minZoom = minZoom;
 		this.maxZoom = maxZoom;
 		this.offset = new PointI(0, 0);
+		this.swigTakeOwnership();
 	}
 
 	public void drawSymbols(@NonNull MapRendererView mapRenderer) {

--- a/OsmAnd/src/net/osmand/plus/views/layers/core/TransportStopsTileProvider.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/core/TransportStopsTileProvider.java
@@ -61,6 +61,7 @@ public class TransportStopsTileProvider extends interface_MapTiledCollectionProv
 		this.textStyle = new TextRasterizer.Style();
 		this.textScale = textScale;
 		offset = new PointI(0, 0);
+		this.swigTakeOwnership();
 	}
 
 	public void drawSymbols(@NonNull MapRendererView mapRenderer) {

--- a/OsmAnd/src/net/osmand/plus/views/layers/core/WptPtTileProvider.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/core/WptPtTileProvider.java
@@ -46,6 +46,7 @@ public class WptPtTileProvider extends interface_MapTiledCollectionProvider {
       this.textStyle = textStyle != null ? textStyle : new TextRasterizer.Style();
       this.density = density;
       offset = new PointI(0,0);
+      this.swigTakeOwnership();
    }
 
    public void drawSymbols(@NonNull MapRendererView mapRenderer) {


### PR DESCRIPTION
Hold Java provider objects in memory while rendering is still active.