### PR TITLE
object-filtering-by-suffix-improvement

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/binary/BinaryMapAddressReaderAdapter.java
+++ b/OsmAnd-java/src/main/java/net/osmand/binary/BinaryMapAddressReaderAdapter.java
@@ -764,7 +764,7 @@ public class BinaryMapAddressReaderAdapter {
 							}
 							long slen = codedIS.readRawVarint32();
 							long soldLim = codedIS.pushLimitLong((long) slen);
-							readAddressNameData(req, refs, refsToCities, fp, suffixMask == null ? null : suffixMask.masks);
+							readAddressNameData(req, refs, refsToCities, fp, suffixMask);
 							codedIS.popLimit(soldLim);
 						} else if (stag != 0) {
 							skipUnknownField(st);
@@ -895,14 +895,14 @@ public class BinaryMapAddressReaderAdapter {
 	}
 
 	private void readAddressNameData(SearchRequest<MapObject> req, TIntArrayList[] refs,
-			TIntArrayList[] refsToCities, long fp, TIntArrayList suffixMasks) throws IOException {
+			TIntArrayList[] refsToCities, long fp, QueryToken.SuffixMask suffixMask) throws IOException {
 		TIntArrayList toAdd = null;
 		TIntArrayList toAddCity = null;
 		int shiftindex = 0;
 		int shiftcityindex = 0;
 		boolean add = true; 
-		boolean suffixMatched = suffixMasks == null;
-		int suffixMaskIndex = 0;
+		boolean matched = suffixMask != null && suffixMask.shouldPassThrough();
+		int maskIndex = 0;
 		while (true) {
 			if (req.isCancelled()) {
 				return;
@@ -910,7 +910,7 @@ public class BinaryMapAddressReaderAdapter {
 			int t = codedIS.readTag();
 			int tag = WireFormat.getTagFieldNumber(t);
 			if(tag == 0 || tag == AddressNameIndexDataAtom.SHIFTTOINDEX_FIELD_NUMBER) {
-				if (toAdd != null && add && suffixMatched) {
+				if (toAdd != null && add && matched) {
 					if (shiftindex != 0) {
 						toAdd.add(shiftindex);
 					}
@@ -930,11 +930,10 @@ public class BinaryMapAddressReaderAdapter {
 				break;
 			case AddressNameIndexDataAtom.SUFFIXESBITSET_FIELD_NUMBER:
 				int mask = codedIS.readUInt32();
-				if (!suffixMatched && suffixMasks != null && suffixMaskIndex < suffixMasks.size()
-						&& (suffixMasks.get(suffixMaskIndex) & mask) != 0) {
-					suffixMatched = true;
+				if (!matched && suffixMask != null && suffixMask.isMatched(maskIndex, mask)) {
+					matched = true;
 				}
-				suffixMaskIndex++;
+				maskIndex++;
 				break;
 			case AddressNameIndexDataAtom.SHIFTTOCITYINDEX_FIELD_NUMBER:
 				if (toAddCity != null) {

--- a/OsmAnd-java/src/main/java/net/osmand/binary/BinaryMapPoiReaderAdapter.java
+++ b/OsmAnd-java/src/main/java/net/osmand/binary/BinaryMapPoiReaderAdapter.java
@@ -3,7 +3,6 @@ package net.osmand.binary;
 
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.WireFormat;
-import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.map.hash.TIntLongHashMap;
 import gnu.trove.set.hash.TLongHashSet;
 import net.osmand.*;
@@ -539,7 +538,7 @@ public class BinaryMapPoiReaderAdapter {
 					}
 					int len = codedIS.readRawVarint32();
 					long oldLim = codedIS.pushLimitLong((long) len);
-					readPoiNameIndexDataAtom(offsets, req, region, nameIndexCoordinates, mask == null ? null : mask.masks);
+					readPoiNameIndexDataAtom(offsets, req, region, nameIndexCoordinates, mask);
 					codedIS.popLimit(oldLim);
 					break;
 				default:
@@ -550,12 +549,12 @@ public class BinaryMapPoiReaderAdapter {
 	}
 
 	private void readPoiNameIndexDataAtom(TIntLongHashMap offsets, SearchRequest<Amenity> req, PoiRegion region,
-	                                      List<Integer> nameIndexCoordinates, TIntArrayList suffixMasks) throws IOException {
+	                                      List<Integer> nameIndexCoordinates, QueryToken.SuffixMask suffixMask) throws IOException {
 		int x = 0;
 		int y = 0;
 		int zoom = 15;
 		int shift = Integer.MIN_VALUE;
-		boolean matched = suffixMasks == null;
+		boolean matched = suffixMask != null && suffixMask.shouldPassThrough();
 		int maskIndex = 0;
 		while (true) {
 			int t = codedIS.readTag();
@@ -595,7 +594,7 @@ public class BinaryMapPoiReaderAdapter {
 				break;
 			case OsmandOdb.OsmAndPoiNameIndexDataAtom.SUFFIXESBITSET_FIELD_NUMBER:
 				int mask = codedIS.readUInt32();
-				if (!matched && suffixMasks != null && maskIndex < suffixMasks.size() && (suffixMasks.get(maskIndex) & mask) != 0) {
+				if (!matched && suffixMask != null && suffixMask.isMatched(maskIndex, mask)) {
 					matched = true;
 				}
 				maskIndex++;

--- a/OsmAnd-java/src/main/java/net/osmand/binary/QueryToken.java
+++ b/OsmAnd-java/src/main/java/net/osmand/binary/QueryToken.java
@@ -17,17 +17,20 @@ public class QueryToken {
     class SuffixMask {
         TIntArrayList masks;
         final Prefix prefix;
+        private boolean passThrough;
 
         SuffixMask(Prefix prefix) {
             this.prefix = prefix;
         }
 
         void setDictionary(List<String> suffixDictionary) {
+            passThrough = suffixDictionary == null;
             if (prefix.key() == null || suffixDictionary == null) {
                 return;
             }
             
             if (suffixDictionary.size() == 1 && suffixDictionary.get(0).isEmpty()) {
+                passThrough = query != null && CollatorStringMatcher.cmatches(collator, prefix.key(), query, matcherMode);
                 return;
             }
             if (masks == null) {
@@ -39,6 +42,14 @@ public class QueryToken {
             for (int index = 0; index < suffixDictionary.size(); index++) {
                 addSuffix(index, suffixDictionary.get(index));
             }
+        }
+
+        boolean shouldPassThrough() {
+            return passThrough;
+        }
+        
+        boolean isMatched(int maskIndex, int mask) {
+            return masks != null && maskIndex < masks.size() && (masks.get(maskIndex) & mask) != 0;
         }
 
         private void addSuffix(int index, String suffix) {


### PR DESCRIPTION
improve objects filtering for case when suffixDictionary is non-empty, but query-side suffixMask is empty for the current prefix:
  - it means the prefix block exists and has suffix entries, but none of them can complete the current query token
  - for broad ancestor prefixes like `z`, `zu`, `zum` while searching `zumba`, object loading should be rejected through suffix filtering
  - exception: exact terminal-prefix handling via suffixDictionary.size() == 1 && suffixDictionary.get(0).isEmpty() remains pass-through