### PR TITLE
Implement a per-profile setting for notifications

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -3455,6 +3455,8 @@ You need to activate the sensor so OsmAnd can find it.</string>
     <string name="voice_announces_descr">Navigation instructions and announcements</string>
     <string name="voice_announces">Voice prompts</string>
     <string name="screen_alerts">Screen alerts</string>
+    <string name="send_navigation_notifications">Send notifications</string>
+    <string name="send_navigation_notifications_descr">Show navigation turn-by-turn notifications</string>
     <string name="route_parameters_descr">Configure route parameters</string>
     <string name="route_parameters">Route parameters</string>
     <string name="day">Day</string>

--- a/OsmAnd/res/xml/navigation_settings_new.xml
+++ b/OsmAnd/res/xml/navigation_settings_new.xml
@@ -37,6 +37,14 @@
 		app:fragment="net.osmand.plus.settings.fragments.voice.VoiceAnnouncesFragment"
 		tools:icon="@drawable/ic_action_volume_up" />
 
+	<net.osmand.plus.settings.preferences.SwitchPreferenceEx
+		android:key="show_navigation_notifications"
+		android:layout="@layout/preference_with_descr"
+		android:summaryOff="@string/shared_string_off"
+		android:summaryOn="@string/shared_string_on"
+		android:title="@string/send_navigation_notifications"
+		tools:icon="@drawable/ic_action_notification" />
+
 	<Preference
 		android:key="vehicle_parameters"
 		android:layout="@layout/preference_with_descr"

--- a/OsmAnd/src/net/osmand/plus/notifications/NavigationNotification.java
+++ b/OsmAnd/src/net/osmand/plus/notifications/NavigationNotification.java
@@ -131,6 +131,8 @@ public class NavigationNotification extends OsmandNotification {
 		Bitmap turnBitmap = null;
 		ongoing = true;
 		RoutingHelper routingHelper = app.getRoutingHelper();
+		boolean showNotifications = app.getSettings().SHOW_NAVIGATION_NOTIFICATIONS
+				.getModeValue(routingHelper.getAppMode());
 		if (isUsedByService(service)) {
 			color = app.getColor(R.color.osmand_orange);
 
@@ -233,6 +235,10 @@ public class NavigationNotification extends OsmandNotification {
 				.setCategory(NotificationCompat.CATEGORY_NAVIGATION)
 				.setStyle(new BigTextStyle().bigText(notificationText))
 				.setLargeIcon(turnBitmap);
+
+		if (!showNotifications) {
+			return null;
+		}
 
 		NavigationSession carNavigationSession = app.getCarNavigationSession();
 		if (carNavigationSession != null) {

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -1677,6 +1677,8 @@ public class OsmandSettings {
 
 	public final CommonPreference<Boolean> SHOW_ROUTING_ALARMS = new BooleanPreference(this, "show_routing_alarms", true).makeProfile().cache();
 
+	public final CommonPreference<Boolean> SHOW_NAVIGATION_NOTIFICATIONS = new BooleanPreference(this, "show_navigation_notifications", true).makeProfile().cache();
+
 	public final CommonPreference<Boolean> SHOW_TRAFFIC_WARNINGS = new BooleanPreference(this, "show_traffic_warnings", false).makeProfile().cache();
 
 	{

--- a/OsmAnd/src/net/osmand/plus/settings/fragments/NavigationFragment.java
+++ b/OsmAnd/src/net/osmand/plus/settings/fragments/NavigationFragment.java
@@ -90,6 +90,7 @@ public class NavigationFragment extends BaseSettingsFragment implements OnSelect
 		showRoutingAlarms.setIcon(getPersistentPrefIcon(R.drawable.ic_action_alert));
 
 		setupSpeakRoutingAlarmsPref();
+		setupNavigationNotificationsPref();
 		setupVehicleParametersPref();
 		showHideCustomizeRouteLinePref();
 		showTrackGuidancePref();
@@ -116,6 +117,13 @@ public class NavigationFragment extends BaseSettingsFragment implements OnSelect
 		SwitchPreferenceCompat speakRoutingAlarms = findPreference(settings.VOICE_MUTE.getId());
 		speakRoutingAlarms.setIcon(icon);
 		speakRoutingAlarms.setChecked(!settings.VOICE_MUTE.getModeValue(getSelectedAppMode()));
+	}
+
+	private void setupNavigationNotificationsPref() {
+		SwitchPreferenceCompat pref = findPreference(settings.SHOW_NAVIGATION_NOTIFICATIONS.getId());
+		if (pref != null) {
+			pref.setIcon(getPersistentPrefIcon(R.drawable.ic_action_notification));
+		}
 	}
 
 	private void showHideCustomizeRouteLinePref() {


### PR DESCRIPTION
Per default is the setting on for all profiles. If turned off, no notification is sent for route navigation. This avoids sending many notifications in car profiles.

Solves #24180