### PR TITLE
Introduce testReverseGeocoding() in testSearch()

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/search/SearchUICore.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/SearchUICore.java
@@ -1231,6 +1231,29 @@ public class SearchUICore {
 		return json;
 	}
 
+	public static String formatSearchResultForTest(boolean simpleTest, SearchResult r, SearchPhrase phrase) {
+		if (simpleTest) {
+			return r.toString().trim();
+		}
+		double dist = 0;
+		if (r.location != null) {
+			dist = MapUtils.getDistance(r.location, phrase.getLastTokenLocation());
+		}
+		String subType = "";
+		if (r.objectType == ObjectType.POI) {
+			Amenity am = (Amenity) r.object;
+			String subtype = am.getSubType();
+			if ("town".equals(subtype) || "city".equals(subtype)) {
+				subType = " (" + subtype + ")";
+			}
+		}
+		return String.format(Locale.US, "%s [[%d, %s, %.3f, %.2f km]]", r.toString(),
+				r.getFoundWordCount(), r.objectType.toString() + subType,
+				r.getUnknownPhraseMatchWeight(),
+				dist / 1000
+		);
+	}
+
 	private enum ResultCompareStep {
 		TOP_VISIBLE,
 		FOUND_WORD_COUNT, // more is better (top)

--- a/OsmAnd-java/src/test/java/net/osmand/search/SearchUICoreTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/search/SearchUICoreTest.java
@@ -4,7 +4,6 @@ import net.osmand.ResultMatcher;
 import net.osmand.binary.BinaryMapIndexReader;
 import net.osmand.binary.GeocodingUtilities;
 import net.osmand.binary.GeocodingUtilities.GeocodingResult;
-import net.osmand.data.Amenity;
 import net.osmand.data.Building;
 import net.osmand.data.Street;
 import net.osmand.osm.AbstractPoiType;
@@ -14,7 +13,6 @@ import net.osmand.search.SearchUICore.SearchResultCollection;
 import net.osmand.search.SearchUICore.SearchResultMatcher;
 import net.osmand.search.core.*;
 import net.osmand.util.Algorithms;
-import net.osmand.util.MapUtils;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -305,30 +303,11 @@ public class SearchUICoreTest {
 		}
 	}
 
-	private String formatResult(boolean simpleTest, SearchResult r, SearchPhrase phrase) {
-		if (simpleTest) {
-			return r.toString().trim();
-		}
-		double dist = 0;
-		if (r.location != null) {
-			dist = MapUtils.getDistance(r.location, phrase.getLastTokenLocation());
-		}
-		String subType = "";
-		if (r.objectType == ObjectType.POI) {
-			Amenity am = (Amenity) r.object;
-			String subtype = am.getSubType();
-			if ("town".equals(subtype) || "city".equals(subtype)) {
-				subType = " (" + subtype + ")";
-			}
-		}
-		return String.format(Locale.US, "%s [[%d, %s, %.3f, %.2f km]]", r.toString(),
-				r.getFoundWordCount(), r.objectType.toString() + subType,
-				r.getUnknownPhraseMatchWeight(), //r.getSearchDistance(phrase.getSettings().getOriginalLocation())
-				dist / 1000
-				);
+	public static String formatResult(boolean simpleTest, SearchResult r, SearchPhrase phrase) {
+		return SearchUICore.formatSearchResultForTest(simpleTest, r, phrase);
 	}
 	
-	private String formatResultMultiSearch(SearchResult r, SearchPhrase phrase) {
+	public static String formatResultMultiSearch(SearchResult r, SearchPhrase phrase) {
 		String format = formatResult(false, r, phrase);
 		String reg = r.file == null ? "-" : r.file.getFile().getName();
 		return String.format(Locale.US, "%s [%s]", format, reg);

--- a/OsmAnd-java/src/test/java/net/osmand/search/SearchUICoreTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/search/SearchUICoreTest.java
@@ -2,9 +2,14 @@ package net.osmand.search;
 
 import net.osmand.ResultMatcher;
 import net.osmand.binary.BinaryMapIndexReader;
+import net.osmand.binary.GeocodingUtilities;
+import net.osmand.binary.GeocodingUtilities.GeocodingResult;
 import net.osmand.data.Amenity;
+import net.osmand.data.Building;
+import net.osmand.data.Street;
 import net.osmand.osm.AbstractPoiType;
 import net.osmand.osm.MapPoiTypes;
+import net.osmand.router.RoutingContext;
 import net.osmand.search.SearchUICore.SearchResultCollection;
 import net.osmand.search.SearchUICore.SearchResultMatcher;
 import net.osmand.search.core.*;
@@ -36,7 +41,10 @@ public class SearchUICoreTest {
 
 	private static final String SEARCH_RESOURCES_PATH = "src/test/resources/search/";
 	private static boolean TEST_EXTRA_RESULTS = true;
-	
+
+	private RoutingContext geoCtx = null;
+	private final GeocodingUtilities geoUtils = new GeocodingUtilities();
+
 	private final File testFile;
 
     public SearchUICoreTest(String name, File file) {
@@ -104,7 +112,6 @@ public class SearchUICoreTest {
 			}
 		}
 		JSONObject settingsJson = sourceJson.getJSONObject("settings");
-		BinaryMapIndexReader reader = null;
 		boolean useData = settingsJson.optBoolean("useData", true);
 		JSONArray filesJson = sourceJson.optJSONArray("files");
 		List<BinaryMapIndexReader> readers = new ArrayList<>();
@@ -207,6 +214,8 @@ public class SearchUICoreTest {
 					expected = expected.substring(0, expected.indexOf('[')).trim();
 				}
 				// String present = result.toString();
+				boolean testGeocoding = expected.startsWith("@");
+				expected = expected.replaceFirst("^@", "");
 				String present = res == null ? ("#MISSING " + (i + 1)) : formatResult(simpleTest, res, phrase);
 				if (!Algorithms.stringsEqual(expected, present)) {
 					System.out.printf("Phrase: %s%n", phrase);
@@ -225,12 +234,38 @@ public class SearchUICoreTest {
 					}
 				}
 				Assert.assertEquals(expected, present);
+				if (testGeocoding) {
+					testReverseGeocoding(res, readers.get(0));
+				}
 			}
 		}
 
 		obfFile.delete();
 	}
-	
+
+	private void testReverseGeocoding(SearchResult searchResult, BinaryMapIndexReader reader) throws IOException {
+		Assert.assertNotNull(searchResult);
+		Assert.assertNotNull(searchResult.location);
+		if (geoCtx == null) {
+			geoCtx = GeocodingUtilities.buildDefaultContextForPOI(reader);
+		}
+
+		List<GeocodingResult> geoResult = geoUtils.reverseGeocodingSearch(
+				geoCtx, searchResult.location.getLatitude(), searchResult.location.getLongitude(), false);
+
+		geoResult = geoUtils.sortGeocodingResults(Collections.singletonList(reader), geoResult);
+
+		Assert.assertFalse(geoResult.isEmpty());
+
+		if (searchResult.object instanceof Building b1 && searchResult.relatedObject instanceof Street s1) {
+			Assert.assertEquals(s1, geoResult.get(0).street);
+			Assert.assertEquals(b1, geoResult.get(0).building);
+			Assert.assertEquals(s1.getCity(), geoResult.get(0).city);
+		} else {
+			Assert.fail("Unsupported searchResult object / relatedObject");
+		}
+	}
+
 	private void unzipObf(File obfGzFile, File obfFile) throws IOException {
 		GZIPInputStream gzin = new GZIPInputStream(new FileInputStream(obfGzFile));
 		FileOutputStream fous = new FileOutputStream(obfFile);


### PR DESCRIPTION
https://github.com/osmandapp/OsmAnd/issues/23547

Example:

```
{
    "phrases": [
        "2627 NC-42 East city Clayton",
        "2621 NC-42 Hwy East city Clayton"
    ],
    "settings": {
        "sortByName": false,
        "emptyQueryAllowed": false,
        "totalLimit": -1,
        "regionLang": "en",
        "radiusLevel": 1,
        "transliterateIfMissing": false,
        "lon": "-78.39242",
        "lat": "35.64865"
    },
    "results": [
      [ "@2627, NC-42 East, Clayton [[4, HOUSE, 1.817, 0.02 km]]"],
      [ "@2621, NC-42 Hwy East, Clayton [[5, HOUSE, 1.817, 0.07 km]]"]
    ]
}
```