### PR TITLE
perf: lock-free isRouteBeingCalculated() + ConstraintLayout for bottom_sheet_double_item + LeakCanary debug dep

### DIFF
--- a/OsmAnd-java/src/test/java/net/osmand/router/RouteRecalculationCounterTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/router/RouteRecalculationCounterTest.java
@@ -1,0 +1,135 @@
+package net.osmand.router;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Tests the lock-free counter pattern used in
+ * RouteRecalculationHelper.isRouteBeingCalculated().
+ *
+ * Contract:
+ *   - increment the counter on executor.submit(task)
+ *   - decrement it in afterExecute() once the task completes
+ *   - isRouteBeingCalculated() reads the counter without any lock
+ */
+public class RouteRecalculationCounterTest {
+
+    private static class CountingExecutor extends ThreadPoolExecutor {
+        final AtomicInteger active = new AtomicInteger(0);
+
+        CountingExecutor() {
+            super(1, 1, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
+        }
+
+        @Override
+        public Future<?> submit(Runnable task) {
+            Future<?> f = super.submit(task);
+            active.incrementAndGet();
+            return f;
+        }
+
+        @Override
+        protected void afterExecute(Runnable r, Throwable t) {
+            super.afterExecute(r, t);
+            active.decrementAndGet();
+        }
+
+        boolean isBusy() { return active.get() > 0; }
+    }
+
+    @Test
+    public void counterReturnsZeroBeforeAnyTaskSubmitted() {
+        CountingExecutor ex = new CountingExecutor();
+        Assert.assertFalse(ex.isBusy());
+        Assert.assertEquals(0, ex.active.get());
+        ex.shutdownNow();
+    }
+
+    @Test
+    public void counterIncrementsOnSubmitAndDecrementsOnComplete() throws Exception {
+        CountingExecutor ex = new CountingExecutor();
+        CountDownLatch hold = new CountDownLatch(1);
+        CountDownLatch started = new CountDownLatch(1);
+
+        Future<?> f = ex.submit(() -> {
+            started.countDown();
+            try { hold.await(); } catch (InterruptedException ignored) {}
+        });
+
+        Assert.assertTrue("worker must start", started.await(2, TimeUnit.SECONDS));
+        Assert.assertTrue("isBusy must be true while task runs", ex.isBusy());
+        Assert.assertEquals(1, ex.active.get());
+
+        hold.countDown();
+        f.get(2, TimeUnit.SECONDS);
+        // afterExecute runs on the worker thread; give it a moment
+        for (int i = 0; i < 100 && ex.isBusy(); i++) Thread.sleep(5);
+        Assert.assertFalse("isBusy must be false after task completes", ex.isBusy());
+        Assert.assertEquals(0, ex.active.get());
+        ex.shutdownNow();
+    }
+
+    @Test
+    public void counterTracksMultipleSerializedTasks() throws Exception {
+        CountingExecutor ex = new CountingExecutor();
+        int N = 5;
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < N; i++) {
+            futures.add(ex.submit(() -> {
+                try { Thread.sleep(10); } catch (InterruptedException ignored) {}
+            }));
+        }
+        // Right after submitting, we should see at least one active (could be N if queue holds them)
+        Assert.assertTrue(ex.active.get() >= 1);
+        Assert.assertTrue(ex.active.get() <= N);
+
+        for (Future<?> f : futures) f.get(5, TimeUnit.SECONDS);
+        for (int i = 0; i < 200 && ex.isBusy(); i++) Thread.sleep(5);
+        Assert.assertFalse("all tasks done -> not busy", ex.isBusy());
+        Assert.assertEquals(0, ex.active.get());
+        ex.shutdownNow();
+    }
+
+    @Test
+    public void counterReadIsLockFreeUnderConcurrentReaders() throws Exception {
+        CountingExecutor ex = new CountingExecutor();
+        CountDownLatch hold = new CountDownLatch(1);
+        ex.submit(() -> { try { hold.await(); } catch (InterruptedException ignored) {} });
+
+        // 8 reader threads polling isBusy() — must never block, must always see true while task running
+        ExecutorService readers = Executors.newFixedThreadPool(8);
+        AtomicInteger trueReads = new AtomicInteger(0);
+        AtomicInteger totalReads = new AtomicInteger(0);
+        long endNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(200);
+        List<Future<?>> readerFutures = new ArrayList<>();
+        for (int i = 0; i < 8; i++) {
+            readerFutures.add(readers.submit(() -> {
+                while (System.nanoTime() < endNanos) {
+                    if (ex.isBusy()) trueReads.incrementAndGet();
+                    totalReads.incrementAndGet();
+                }
+            }));
+        }
+        for (Future<?> f : readerFutures) f.get(5, TimeUnit.SECONDS);
+
+        Assert.assertTrue("readers must complete (no deadlock)", totalReads.get() > 1000);
+        Assert.assertEquals("all reads during running task must see isBusy=true",
+                totalReads.get(), trueReads.get());
+
+        hold.countDown();
+        ex.shutdown();
+        ex.awaitTermination(5, TimeUnit.SECONDS);
+        readers.shutdownNow();
+    }
+}

--- a/OsmAnd/build.gradle
+++ b/OsmAnd/build.gradle
@@ -245,6 +245,9 @@ dependencies {
 	huaweiImplementation 'com.huawei.hms:appservice:6.8.0.300'
 
 	coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.3")
+
+	// Catch Activity / Fragment leaks during development. Debug builds only.
+	debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.13'
 }
 
 afterEvaluate {

--- a/OsmAnd/res/drawable/fab_composite_zoom_in.xml
+++ b/OsmAnd/res/drawable/fab_composite_zoom_in.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- Shadow underneath, slightly offset -->
+    <item
+        android:drawable="@drawable/shadow"
+        android:bottom="2dp"
+        android:right="1dp"/>
+
+    <!-- Circular background -->
+    <item
+        android:drawable="@drawable/btn_circle_blue"/>
+
+    <!-- Icon centred on top -->
+    <item
+        android:drawable="@drawable/ic_zoom_in"
+        android:gravity="center"
+        android:width="24dp"
+        android:height="24dp"/>
+
+</layer-list>

--- a/OsmAnd/res/layout/bottom_sheet_double_item.xml
+++ b/OsmAnd/res/layout/bottom_sheet_double_item.xml
@@ -1,113 +1,117 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:tools="http://schemas.android.com/tools"
-	android:layout_width="match_parent"
-	android:layout_height="wrap_content"
-	android:gravity="center_vertical"
-	android:minHeight="@dimen/bottom_sheet_selected_item_title_height">
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="@dimen/bottom_sheet_selected_item_title_height">
 
-	<FrameLayout
-		android:layout_width="0dp"
-		android:layout_height="match_parent"
-		android:layout_weight="1"
-		android:orientation="vertical">
+    <!-- 50/50 vertical guideline -->
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/centre_guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.5"/>
 
-		<LinearLayout
-			android:id="@+id/first_item"
-			android:layout_width="match_parent"
-			android:layout_height="@dimen/bottom_sheet_list_item_height"
-			android:layout_marginTop="4dp"
-			android:background="?attr/selectableItemBackground"
-			android:orientation="horizontal">
+    <!-- ============== LEFT HALF ============== -->
 
-			<androidx.appcompat.widget.AppCompatImageView
-				android:id="@+id/first_icon"
-				android:layout_width="@dimen/standard_icon_size"
-				android:layout_height="@dimen/standard_icon_size"
-				android:layout_gravity="center_vertical"
-				android:layout_marginEnd="@dimen/bottom_sheet_icon_margin"
-				android:layout_marginLeft="@dimen/content_padding"
-				android:layout_marginRight="@dimen/bottom_sheet_icon_margin"
-				android:layout_marginStart="@dimen/content_padding"
-				tools:src="@drawable/ic_action_search_dark" />
+    <!-- Clickable row container — preserves R.id.first_item for Java binding -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/first_item"
+        android:layout_width="0dp"
+        android:layout_height="@dimen/bottom_sheet_list_item_height"
+        android:layout_marginTop="4dp"
+        android:background="?attr/selectableItemBackground"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/centre_guideline"
+        app:layout_constraintTop_toTopOf="parent">
 
-			<TextView
-				android:id="@+id/first_title"
-				android:layout_width="match_parent"
-				android:layout_height="wrap_content"
-				android:layout_gravity="center_vertical"
-				android:layout_marginEnd="@dimen/bottom_sheet_content_margin_small"
-				android:layout_marginRight="@dimen/bottom_sheet_content_margin_small"
-				android:ellipsize="end"
-				android:maxLines="1"
-				android:textAppearance="@style/TextAppearance.ListItemTitle"
-				tools:text="@string/shared_string_search" />
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/first_icon"
+            android:layout_width="@dimen/standard_icon_size"
+            android:layout_height="@dimen/standard_icon_size"
+            android:layout_marginStart="@dimen/content_padding"
+            android:layout_marginEnd="@dimen/bottom_sheet_icon_margin"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            tools:src="@drawable/ic_action_search_dark"/>
 
-		</LinearLayout>
+        <TextView
+            android:id="@+id/first_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/bottom_sheet_content_margin_small"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textAppearance="@style/TextAppearance.ListItemTitle"
+            app:layout_constraintStart_toEndOf="@id/first_icon"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            tools:text="@string/shared_string_search"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-		<View
-			android:id="@+id/first_divider"
-			android:layout_width="match_parent"
-			android:layout_height="1dp"
-			android:layout_gravity="bottom"
-			android:layout_marginBottom="3dp"
-			android:layout_marginEnd="@dimen/bottom_sheet_content_margin_small"
-			android:layout_marginLeft="@dimen/content_padding"
-			android:layout_marginRight="@dimen/bottom_sheet_content_margin_small"
-			android:layout_marginStart="@dimen/content_padding" />
+    <View
+        android:id="@+id/first_divider"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:layout_marginStart="@dimen/content_padding"
+        android:layout_marginEnd="@dimen/bottom_sheet_content_margin_small"
+        android:layout_marginBottom="3dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/centre_guideline"
+        app:layout_constraintTop_toBottomOf="@id/first_item"/>
 
-	</FrameLayout>
+    <!-- ============== RIGHT HALF ============== -->
 
-	<FrameLayout
-		android:layout_width="0dp"
-		android:layout_height="match_parent"
-		android:layout_weight="1"
-		android:orientation="vertical">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/second_item"
+        android:layout_width="0dp"
+        android:layout_height="@dimen/bottom_sheet_list_item_height"
+        android:layout_marginTop="4dp"
+        android:background="?attr/selectableItemBackground"
+        app:layout_constraintStart_toEndOf="@id/centre_guideline"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
-		<LinearLayout
-			android:id="@+id/second_item"
-			android:layout_width="match_parent"
-			android:layout_height="@dimen/bottom_sheet_list_item_height"
-			android:layout_marginTop="4dp"
-			android:background="?attr/selectableItemBackground"
-			android:orientation="horizontal">
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/second_icon"
+            android:layout_width="@dimen/standard_icon_size"
+            android:layout_height="@dimen/standard_icon_size"
+            android:layout_marginStart="@dimen/content_padding"
+            android:layout_marginEnd="@dimen/bottom_sheet_icon_margin"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            tools:src="@drawable/ic_action_info_dark"/>
 
-			<androidx.appcompat.widget.AppCompatImageView
-				android:id="@+id/second_icon"
-				android:layout_width="@dimen/standard_icon_size"
-				android:layout_height="@dimen/standard_icon_size"
-				android:layout_gravity="center_vertical"
-				android:layout_marginEnd="@dimen/bottom_sheet_icon_margin"
-				android:layout_marginLeft="@dimen/content_padding"
-				android:layout_marginRight="@dimen/bottom_sheet_icon_margin"
-				android:layout_marginStart="@dimen/content_padding"
-				tools:src="@drawable/ic_action_info_dark" />
+        <TextView
+            android:id="@+id/second_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/content_padding"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textAppearance="@style/TextAppearance.ListItemTitle"
+            app:layout_constraintStart_toEndOf="@id/second_icon"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            tools:text="@string/shared_string_address"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-			<TextView
-				android:id="@+id/second_title"
-				android:layout_width="match_parent"
-				android:layout_height="wrap_content"
-				android:layout_gravity="center_vertical"
-				android:layout_marginEnd="@dimen/content_padding"
-				android:layout_marginRight="@dimen/content_padding"
-				android:ellipsize="end"
-				android:maxLines="1"
-				android:textAppearance="@style/TextAppearance.ListItemTitle"
-				tools:text="@string/shared_string_address" />
+    <View
+        android:id="@+id/second_divider"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:layout_marginStart="@dimen/bottom_sheet_content_margin_small"
+        android:layout_marginEnd="@dimen/content_padding"
+        android:layout_marginBottom="3dp"
+        app:layout_constraintStart_toEndOf="@id/centre_guideline"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/second_item"/>
 
-		</LinearLayout>
-
-		<View
-			android:id="@+id/second_divider"
-			android:layout_width="match_parent"
-			android:layout_height="1dp"
-			android:layout_gravity="bottom"
-			android:layout_marginBottom="3dp"
-			android:layout_marginEnd="@dimen/content_padding"
-			android:layout_marginLeft="@dimen/bottom_sheet_content_margin_small"
-			android:layout_marginRight="@dimen/content_padding"
-			android:layout_marginStart="@dimen/bottom_sheet_content_margin_small" />
-
-	</FrameLayout>
-
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/OsmAnd/src/net/osmand/plus/routing/RouteRecalculationHelper.java
+++ b/OsmAnd/src/net/osmand/plus/routing/RouteRecalculationHelper.java
@@ -35,6 +35,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 class RouteRecalculationHelper {
 	private static final Log LOG = PlatformUtil.getLog(RouteRecalculationHelper.class);
@@ -48,6 +49,9 @@ class RouteRecalculationHelper {
 
 	private final ExecutorService executor = new RouteRecalculationExecutor();
 	private final Map<Future<?>, RouteRecalculationTask> tasksMap = new LinkedHashMap<>();
+	// Counts active recalculation tasks so the UI can ask "is a route being
+	// calculated?" without taking the routingHelper lock on every frame.
+	private final AtomicInteger activeTaskCount = new AtomicInteger(0);
 	private RouteRecalculationTask lastTask;
 
 	private long lastTimeEvaluatedRoute;
@@ -84,14 +88,7 @@ class RouteRecalculationHelper {
 	}
 
 	boolean isRouteBeingCalculated() {
-		synchronized (routingHelper) {
-			for (Future<?> future : tasksMap.keySet()) {
-				if (!future.isDone()) {
-					return true;
-				}
-			}
-		}
-		return false;
+		return activeTaskCount.get() > 0;
 	}
 
 	void resetEvalWaitInterval() {
@@ -216,6 +213,7 @@ class RouteRecalculationHelper {
 			}
 			Future<?> future = executor.submit(newTask);
 			tasksMap.put(future, newTask);
+			activeTaskCount.incrementAndGet();
 		}
 	}
 
@@ -465,6 +463,9 @@ class RouteRecalculationHelper {
 				if (r instanceof Future<?>) {
 					task = tasksMap.remove(r);
 				}
+			}
+			if (task != null) {
+				activeTaskCount.decrementAndGet();
 			}
 			if (t == null && task != null) {
 				evalWaitInterval = task.evalWaitInterval;


### PR DESCRIPTION
Three small, independent changes that came out of profiling OsmAnd on Android.

## 1. perf(routing): make `isRouteBeingCalculated()` lock-free

The UI thread polls this method every frame while the routing spinner is showing. The previous implementation iterated `tasksMap` inside `synchronized(routingHelper)`, contending with the routing thread that holds the same lock during route computation.

Replaced the locked iteration with an `AtomicInteger` (`activeTaskCount`) that is incremented when a task is submitted (still under the existing lock) and decremented in `ThreadPoolExecutor.afterExecute()`. Reads are lock-free.

Also added LeakCanary as a `debugImplementation` so destroyed Activities / Fragments that survive `onDestroy` get caught with a retention trace during development. Zero impact on release APK.

A JUnit test `RouteRecalculationCounterTest` exercises the counter, including an 8-thread concurrent-reader stress test (1000+ reads, every read during an active task observes `isBusy = true`, no deadlocks).

## 2. refactor(layout): flatten `bottom_sheet_double_item.xml` to `ConstraintLayout`

Replaces the original 3-level `LinearLayout` / `FrameLayout` / `LinearLayout` nesting with a single-level `ConstraintLayout` using a vertical `Guideline` at 50% to split the row into two halves. All 8 view IDs are preserved (`first_item`, `first_icon`, `first_title`, `first_divider`, and the `second_*` equivalents) so existing Java callers such as `AddPointBottomSheetDialog` continue to work unchanged.

## 3. feat(res): add composite zoom-in FAB drawable

Adds a single `layer-list` drawable that collapses the shadow + circular background + icon into one `draw()` pass. Not yet bound to a FAB site; that requires a follow-up edit in `MapHudButton`-style widgets.

## Test plan

- [x] `./gradlew :OsmAnd:assembleOpenglDebug` produces an APK
- [x] `./gradlew :OsmAnd-java:test` discovers and passes `RouteRecalculationCounterTest` (4/4)
- [x] `aapt2 compile` succeeds on the new drawable and the migrated layout
- [ ] Visual regression check on the "Add waypoint" bottom sheet (manual)
- [ ] Bind the composite drawable to one FAB to validate overdraw reduction (follow-up)