### PR TITLE
Turn direction is not the same as highlighted route #23787 (variant 1)

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
@@ -1468,6 +1468,13 @@ public class RouteResultPreparation {
 		if (leftOrRightKeep) {
 			setActiveLanesRange(rawLanes, activeBeginIndex, activeEndIndex, activeTurn);
 			int tp = inferSlightTurnFromActiveLanes(rawLanes, rs.keepLeft, rs.keepRight);
+
+			double deviation = MapUtils.degreesDiff(prevSegm.getBearingEnd(), currentSegm.getBearingBegin());
+			boolean forceGoAhead = shouldPreferStraightOverInferredTurn(rawLanes, tp, deviation);
+			if (forceGoAhead) {
+				tp = TurnType.C;
+			}
+
 			// Checking to see that there is only one unique turn
 			if (tp != 0) {
 				// add extra lanes with same turn
@@ -1482,7 +1489,7 @@ public class RouteResultPreparation {
 			}
 			if (tp != t.getValue() && tp != 0) {
 				t = TurnType.valueOf(tp, leftSide);
-			} else {
+			} else if (!forceGoAhead) {
 				//use keepRight and keepLeft turns when attached road doesn't have lanes
 				//or prev segment has more then 1 turn to the active lane
 				if (rs.keepRight && !rs.keepLeft) {
@@ -1499,6 +1506,27 @@ public class RouteResultPreparation {
 		t.setPossibleLeftTurn(possiblyLeftTurn);
 		t.setPossibleRightTurn(possiblyRightTurn);
 		return t;
+	}
+
+	private boolean shouldPreferStraightOverInferredTurn(int[] lanes, int inferredTurn, double deviation) {
+		if (inferredTurn == 0 || inferredTurn == TurnType.C) {
+			return false;
+		}
+		if (TurnType.isSlightTurn(inferredTurn) || TurnType.isKeepDirectionTurn(inferredTurn)) {
+			return false;
+		}
+		if (Math.abs(deviation) >= TURN_SLIGHT_DEGREE) {
+			return false;
+		}
+		return hasActiveLaneWithTurn(lanes, TurnType.C);
+	}
+	private boolean hasActiveLaneWithTurn(int[] lanes, int turnType) {
+		for (int lane : lanes) {
+			if ((lane & 1) == 1 && TurnType.hasAnyTurnLane(lane, turnType)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private void setActiveLanesRange(int[] rawLanes, int activeBeginIndex, int activeEndIndex, int activeTurn) {

--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
@@ -1522,7 +1522,9 @@ public class RouteResultPreparation {
 	}
 	private boolean hasActiveLaneWithTurn(int[] lanes, int turnType) {
 		for (int lane : lanes) {
-			if ((lane & 1) == 1 && TurnType.hasAnyTurnLane(lane, turnType)) {
+			boolean isActiveLane = (lane & 1) == 1;
+			boolean hasRequestedTurn = TurnType.hasAnyTurnLane(lane, turnType);
+			if (isActiveLane && hasRequestedTurn) {
 				return true;
 			}
 		}

--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
@@ -1520,6 +1520,7 @@ public class RouteResultPreparation {
 		}
 		return hasActiveLaneWithTurn(lanes, TurnType.C);
 	}
+	
 	private boolean hasActiveLaneWithTurn(int[] lanes, int turnType) {
 		for (int lane : lanes) {
 			boolean isActiveLane = (lane & 1) == 1;

--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
@@ -54,6 +54,8 @@ public class RouteResultPreparation {
 	
 	protected static final Log LOG = PlatformUtil.getLog(RouteResultPreparation.class);
 	public static final String UNMATCHED_HIGHWAY_TYPE = "unmatched";
+
+	private static final int ACTIVE_LANE_MASK = 1;
 	
 	private static class CombineAreaRoutePoint {
 		int x31;
@@ -1070,7 +1072,7 @@ public class RouteResultPreparation {
 						tt.getLanes()[it] = turn & (~1);
 					}
 				} else {
-					tt.getLanes()[it] = turn | 1;
+					tt.getLanes()[it] = turn | ACTIVE_LANE_MASK;
 				}
 			}
 		}
@@ -1186,7 +1188,7 @@ public class RouteResultPreparation {
 		for (int i = 0; i < active.disabledLanes.length; i++) {
 			if (i >= active.activeStartIndex && i <= active.activeEndIndex && 
 					active.originalLanes[i] % 2 == 1) {
-				active.disabledLanes[i] |= 1;
+				active.disabledLanes[i] |= ACTIVE_LANE_MASK;
 			}
 		}
 		TurnType currentTurn = currentSegment.getTurnType();
@@ -1388,7 +1390,7 @@ public class RouteResultPreparation {
 				for (int k = startIndex; k <= endIndex; k++) {
 					int[] oneActiveLane = {lanesArray[k]};
 					if (hasAllowedLanes(mainTurnType, oneActiveLane, 0, 0)) {
-						lanesArray[k] |= 1;
+						lanesArray[k] |= ACTIVE_LANE_MASK;
 					}
 				}
 				isSet = true;
@@ -1405,7 +1407,7 @@ public class RouteResultPreparation {
 		boolean turnSet = false;
 		for (int i = 0; i < lanesArray.length; i++) {
 			if (TurnType.getPrimaryTurn(lanesArray[i]) == mainTurnType) {
-				lanesArray[i] |= 1;
+				lanesArray[i] |= ACTIVE_LANE_MASK;
 				turnSet = true;
 			}
 		}
@@ -1481,9 +1483,9 @@ public class RouteResultPreparation {
 				for(int i = 0; i < rawLanes.length; i++) {
 					if (TurnType.getSecondaryTurn(rawLanes[i]) == tp) {
 						TurnType.setSecondaryToPrimary(rawLanes, i);
-						rawLanes[i] |= 1;
+						rawLanes[i] |= ACTIVE_LANE_MASK;
 					} else if(TurnType.getPrimaryTurn(rawLanes[i]) == tp) {
-						rawLanes[i] |= 1;
+						rawLanes[i] |= ACTIVE_LANE_MASK;
 					}
 				}
 			}
@@ -1522,7 +1524,9 @@ public class RouteResultPreparation {
 	}
 	private boolean hasActiveLaneWithTurn(int[] lanes, int turnType) {
 		for (int lane : lanes) {
-			if ((lane & 1) == 1 && TurnType.hasAnyTurnLane(lane, turnType)) {
+			boolean isActiveLane = (lane & ACTIVE_LANE_MASK) == ACTIVE_LANE_MASK;
+			boolean hasRequestedTurn = TurnType.hasAnyTurnLane(lane, turnType);
+			if (isActiveLane && hasRequestedTurn) {
 				return true;
 			}
 		}
@@ -1533,7 +1537,7 @@ public class RouteResultPreparation {
 		Set<Integer> possibleTurns = new TreeSet<>();
 		Set<Integer> upossibleTurns = new TreeSet<>();
 		for (int k = activeBeginIndex; k < rawLanes.length && k <= activeEndIndex; k++) {
-			rawLanes[k] |= 1;
+			rawLanes[k] |= ACTIVE_LANE_MASK;
 			upossibleTurns.clear();
 			upossibleTurns.add(TurnType.getPrimaryTurn(rawLanes[k]));
 			if (TurnType.getSecondaryTurn(rawLanes[k]) != 0) {
@@ -1896,7 +1900,7 @@ public class RouteResultPreparation {
 				}
 			}
 		}
-		lanes[0] |= 1;
+		lanes[0] |= ACTIVE_LANE_MASK;
 		return lanes;
 	}
 

--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
@@ -54,8 +54,6 @@ public class RouteResultPreparation {
 	
 	protected static final Log LOG = PlatformUtil.getLog(RouteResultPreparation.class);
 	public static final String UNMATCHED_HIGHWAY_TYPE = "unmatched";
-
-	private static final int ACTIVE_LANE_MASK = 1;
 	
 	private static class CombineAreaRoutePoint {
 		int x31;
@@ -1072,7 +1070,7 @@ public class RouteResultPreparation {
 						tt.getLanes()[it] = turn & (~1);
 					}
 				} else {
-					tt.getLanes()[it] = turn | ACTIVE_LANE_MASK;
+					tt.getLanes()[it] = turn | 1;
 				}
 			}
 		}
@@ -1188,7 +1186,7 @@ public class RouteResultPreparation {
 		for (int i = 0; i < active.disabledLanes.length; i++) {
 			if (i >= active.activeStartIndex && i <= active.activeEndIndex && 
 					active.originalLanes[i] % 2 == 1) {
-				active.disabledLanes[i] |= ACTIVE_LANE_MASK;
+				active.disabledLanes[i] |= 1;
 			}
 		}
 		TurnType currentTurn = currentSegment.getTurnType();
@@ -1390,7 +1388,7 @@ public class RouteResultPreparation {
 				for (int k = startIndex; k <= endIndex; k++) {
 					int[] oneActiveLane = {lanesArray[k]};
 					if (hasAllowedLanes(mainTurnType, oneActiveLane, 0, 0)) {
-						lanesArray[k] |= ACTIVE_LANE_MASK;
+						lanesArray[k] |= 1;
 					}
 				}
 				isSet = true;
@@ -1407,7 +1405,7 @@ public class RouteResultPreparation {
 		boolean turnSet = false;
 		for (int i = 0; i < lanesArray.length; i++) {
 			if (TurnType.getPrimaryTurn(lanesArray[i]) == mainTurnType) {
-				lanesArray[i] |= ACTIVE_LANE_MASK;
+				lanesArray[i] |= 1;
 				turnSet = true;
 			}
 		}
@@ -1483,9 +1481,9 @@ public class RouteResultPreparation {
 				for(int i = 0; i < rawLanes.length; i++) {
 					if (TurnType.getSecondaryTurn(rawLanes[i]) == tp) {
 						TurnType.setSecondaryToPrimary(rawLanes, i);
-						rawLanes[i] |= ACTIVE_LANE_MASK;
+						rawLanes[i] |= 1;
 					} else if(TurnType.getPrimaryTurn(rawLanes[i]) == tp) {
-						rawLanes[i] |= ACTIVE_LANE_MASK;
+						rawLanes[i] |= 1;
 					}
 				}
 			}
@@ -1524,9 +1522,7 @@ public class RouteResultPreparation {
 	}
 	private boolean hasActiveLaneWithTurn(int[] lanes, int turnType) {
 		for (int lane : lanes) {
-			boolean isActiveLane = (lane & ACTIVE_LANE_MASK) == ACTIVE_LANE_MASK;
-			boolean hasRequestedTurn = TurnType.hasAnyTurnLane(lane, turnType);
-			if (isActiveLane && hasRequestedTurn) {
+			if ((lane & 1) == 1 && TurnType.hasAnyTurnLane(lane, turnType)) {
 				return true;
 			}
 		}
@@ -1537,7 +1533,7 @@ public class RouteResultPreparation {
 		Set<Integer> possibleTurns = new TreeSet<>();
 		Set<Integer> upossibleTurns = new TreeSet<>();
 		for (int k = activeBeginIndex; k < rawLanes.length && k <= activeEndIndex; k++) {
-			rawLanes[k] |= ACTIVE_LANE_MASK;
+			rawLanes[k] |= 1;
 			upossibleTurns.clear();
 			upossibleTurns.add(TurnType.getPrimaryTurn(rawLanes[k]));
 			if (TurnType.getSecondaryTurn(rawLanes[k]) != 0) {
@@ -1900,7 +1896,7 @@ public class RouteResultPreparation {
 				}
 			}
 		}
-		lanes[0] |= ACTIVE_LANE_MASK;
+		lanes[0] |= 1;
 		return lanes;
 	}
 


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd/issues/23787)

[testing route](https://osmand.net/map/navigate/?start=48.156773,14.028524&end=48.169177,14.024692&profile=car#16/48.1630/14.0217)

---

Before: has turn left (wrong)

<img width="200"  alt="Screenshot 2026-05-22 at 11 59 58" src="https://github.com/user-attachments/assets/76951654-c7c2-4f7d-937e-174a6628742e" />

---

After: moving forward (correct)

<img width="200"  alt="Screenshot 2026-05-25 at 12 09 26" src="https://github.com/user-attachments/assets/6ede1856-d395-4052-838c-1b3e57c5754b" />

---

All tests passed

<img width="1090" height="611" alt="Screenshot 2026-05-25 at 13 30 33" src="https://github.com/user-attachments/assets/0087db4e-7cec-4af3-a725-2e58e9972385" />


---

[related ios pr](https://github.com/osmandapp/OsmAnd-core-legacy/pull/328)
