### PR TITLE
 Turn-direction-is-not-the-same-as-highlighted-route-#23787 (variant 2)

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
@@ -1467,7 +1467,7 @@ public class RouteResultPreparation {
 		boolean leftOrRightKeep = (rs.keepLeft && !rs.keepRight) || (!rs.keepLeft && rs.keepRight);
 		if (leftOrRightKeep) {
 			setActiveLanesRange(rawLanes, activeBeginIndex, activeEndIndex, activeTurn);
-			int tp = inferSlightTurnFromActiveLanes(rawLanes, rs.keepLeft, rs.keepRight);
+			int tp = inferSlightTurnFromActiveLanes(rawLanes, rs.keepLeft, rs.keepRight, activeTurn);
 			// Checking to see that there is only one unique turn
 			if (tp != 0) {
 				// add extra lanes with same turn
@@ -2027,7 +2027,11 @@ public class RouteResultPreparation {
 	}
 
 	
-	private int inferSlightTurnFromActiveLanes(int[] oLanes, boolean mostLeft, boolean mostRight) {
+	private int inferSlightTurnFromActiveLanes(int[] oLanes, boolean mostLeft, boolean mostRight, int activeTurn) {
+		if (activeTurn == TurnType.C) {
+			return TurnType.C;
+		}
+
 		Integer[] possibleTurns = getPossibleTurns(oLanes, false, false);
 		if (possibleTurns.length == 0) {
 			// No common turns, so can't determine anything.
@@ -2318,12 +2322,13 @@ public class RouteResultPreparation {
 			return pair;
 		}
 
-		findActiveIndexByUniqueDirections(pair, directions, rs, rawLanes);
+		findActiveIndexByUniqueDirections(pair, directions, rs, rawLanes, prevSegm, currentSegm);
 
 		return pair;
 	}
 
-	private void findActiveIndexByUniqueDirections(int[] pair, int[] directions, RoadSplitStructure rs, int[] rawLanes) {
+	private void findActiveIndexByUniqueDirections(int[] pair, int[] directions, RoadSplitStructure rs, int[] rawLanes,
+	                                               RouteSegmentResult prevSegm, RouteSegmentResult currentSegm) {
 		int startDirection = directions[rs.roadsOnLeft];
 		int endDirection = directions[directions.length - rs.roadsOnRight - 1];
 		for (int i = 0; i < rawLanes.length; i++) {
@@ -2345,6 +2350,36 @@ public class RouteResultPreparation {
 				break;
 			}
 		}
+		preferStraightTurnForNearlyStraightRoute(pair, rawLanes, prevSegm, currentSegm);
+	}
+
+	private void preferStraightTurnForNearlyStraightRoute(int[] pair, int[] rawLanes, RouteSegmentResult prevSegm,
+													  RouteSegmentResult currentSegm) {
+		int beginIndex = pair[0];
+		int endIndex = pair[1];
+		int activeTurn = pair[2];
+
+		boolean hasValidRange = beginIndex >= 0 && endIndex >= beginIndex && endIndex < rawLanes.length;
+		boolean hasValidTurns = activeTurn != 0 && !TurnType.isSlightTurn(activeTurn);
+		if (hasValidRange && hasValidTurns) {
+
+			double routeDeviation = MapUtils.degreesDiff(prevSegm.getBearingEnd(), currentSegm.getBearingBegin());
+			boolean isRouteAlmostStraight = Math.abs(routeDeviation) < TURN_SLIGHT_DEGREE;
+			boolean hasRouteStraightLanes = hasTurnTypeInRange(TurnType.C, rawLanes, beginIndex, endIndex);
+
+			if (isRouteAlmostStraight && hasRouteStraightLanes) {
+				pair[2] = TurnType.C;
+			}
+		}
+	}
+
+	private boolean hasTurnTypeInRange(int turnType, int[] lanes, int beginIndex, int endIndex) {
+		for (int i = beginIndex; i <= endIndex; i++) {
+			if (TurnType.hasAnyTurnLane(lanes[i], turnType)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private boolean findActiveIndexByLanes(int[] pair, int[] directions, RoadSplitStructure rs, int[] rawLanes,


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd/issues/23787)
[old pr](https://github.com/osmandapp/OsmAnd/pull/25130)

[testing route](https://osmand.net/map/navigate/?start=48.156773,14.028524&end=48.169177,14.024692&profile=car#16/48.1630/14.0217)

---

Before: has turn left (wrong)

<img width="200"  alt="Screenshot 2026-05-22 at 11 59 58" src="https://github.com/user-attachments/assets/76951654-c7c2-4f7d-937e-174a6628742e" />

---

After: moving forward (correct)

<img width="200"  alt="Screenshot 2026-05-29 at 19 30 45" src="https://github.com/user-attachments/assets/27cd45df-0a8a-4b9b-980c-4e5887d59281" />


---

All tests passed

<img width="1233" height="662" alt="Screenshot 2026-05-29 at 19 33 44" src="https://github.com/user-attachments/assets/d59d45f9-450e-473e-9ebc-32d101ba7874" />


---

[related ios pr](https://github.com/osmandapp/OsmAnd-core-legacy/pull/328)
