### PR TITLE
Fix NavigationService usage bitmask clearing

### DIFF
--- a/OsmAnd/src/net/osmand/plus/NavigationService.java
+++ b/OsmAnd/src/net/osmand/plus/NavigationService.java
@@ -111,7 +111,7 @@ public class NavigationService extends Service {
 		LOG.info(">>>> NavigationService stopIfNeeded = " + usageIntent);
 		OsmandApplication app = getApp();
 		if ((usedBy & usageIntent) > 0) {
-			usedBy -= usageIntent;
+			usedBy &= ~usageIntent;
 		}
 		onServiceChanged(false);
 		if (usedBy == 0) {


### PR DESCRIPTION
## Summary
Clear `usedBy` with `&= ~usageIntent` instead of subtraction to avoid corrupting the bitmask when navigation and GPX recording overlap or when stop is called twice.

## Audit reference
Static code audit item **A1**.

## Test plan
- [ ] Verify affected behavior on device/emulator
- [ ] Confirm no regression in related feature