### PR TITLE
Fix NavigationService NPE on null intent in onStartCommand

### DIFF
--- a/OsmAnd/src/net/osmand/plus/NavigationService.java
+++ b/OsmAnd/src/net/osmand/plus/NavigationService.java
@@ -125,16 +125,17 @@ public class NavigationService extends Service {
 	@Override
 	public int onStartCommand(Intent intent, int flags, int startId) {
 		LOG.info(">>>> NavigationService onStartCommand");
+		int usageIntent = intent != null ? intent.getIntExtra(USAGE_INTENT, 0) : 0;
 		if (isUsed()) {
 			LOG.info(">>>> NavigationService is used by = " + usedBy);
-			addUsageIntent(intent.getIntExtra(USAGE_INTENT, 0));
+			addUsageIntent(usageIntent);
 			return START_REDELIVER_INTENT;
 		}
 
 		OsmandApplication app = getApp();
 		settings = app.getSettings();
 		routingHelper = app.getRoutingHelper();
-		usedBy = intent.getIntExtra(USAGE_INTENT, 0);
+		usedBy = usageIntent;
 
 		locationProvider = app.getLocationProvider();
 		locationServiceHelper = app.createLocationServiceHelper();


### PR DESCRIPTION
## Summary
Handle null `intent` when Android redelivers the service with START_REDELIVER_INTENT.

## Audit reference
Static code audit item **A2**.

## Test plan
- [ ] Verify affected behavior on device/emulator
- [ ] Confirm no regression in related feature