### PR TITLE
Fix WeatherBand setBandUnitAuto switch fall-through

### DIFF
--- a/OsmAnd/src/net/osmand/plus/plugins/weather/WeatherBand.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/weather/WeatherBand.java
@@ -258,18 +258,12 @@ public class WeatherBand {
 	public void setBandUnitAuto(boolean unitAuto) {
 		WeatherSettings settings = getWeatherSettings();
 		switch (bandIndex) {
-			case WEATHER_BAND_CLOUD:
-				settings.weatherCloudUnitAuto.set(unitAuto);
-			case WEATHER_BAND_TEMPERATURE:
-				settings.weatherTempUnitAuto.set(unitAuto);
-			case WEATHER_BAND_PRESSURE:
-				settings.weatherPressureUnitAuto.set(unitAuto);
-			case WEATHER_BAND_WIND_SPEED:
-				settings.weatherWindUnitAuto.set(unitAuto);
-			case WEATHER_BAND_PRECIPITATION:
-				settings.weatherPrecipUnitAuto.set(unitAuto);
-			case WEATHER_BAND_WIND_ANIMATION:
-				settings.weatherWindAnimationUnitAuto.set(unitAuto);
+			case WEATHER_BAND_CLOUD -> settings.weatherCloudUnitAuto.set(unitAuto);
+			case WEATHER_BAND_TEMPERATURE -> settings.weatherTempUnitAuto.set(unitAuto);
+			case WEATHER_BAND_PRESSURE -> settings.weatherPressureUnitAuto.set(unitAuto);
+			case WEATHER_BAND_WIND_SPEED -> settings.weatherWindUnitAuto.set(unitAuto);
+			case WEATHER_BAND_PRECIPITATION -> settings.weatherPrecipUnitAuto.set(unitAuto);
+			case WEATHER_BAND_WIND_ANIMATION -> settings.weatherWindAnimationUnitAuto.set(unitAuto);
 		}
 	}
 


### PR DESCRIPTION
## Summary
Use arrow switch syntax so toggling auto-units for one weather band does not overwrite auto-unit flags for all other bands.

## Audit reference
Static code audit item **W1**.

## Test plan
- [ ] Verify affected behavior on device/emulator
- [ ] Confirm no regression in related feature