### PR TITLE
Fix AstroArticle equals/hashCode contract for mobileHtml

### DIFF
--- a/OsmAnd/src/net/osmand/plus/plugins/astronomy/AstroArticle.kt
+++ b/OsmAnd/src/net/osmand/plus/plugins/astronomy/AstroArticle.kt
@@ -63,7 +63,7 @@ data class AstroArticle(
         if (summaryJson != other.summaryJson) return false
         if (mobileHtml != null) {
             if (other.mobileHtml == null) return false
-            if (mobileHtml.size != other.mobileHtml.size) return false
+            if (!mobileHtml.contentEquals(other.mobileHtml)) return false
         } else if (other.mobileHtml != null) return false
 
         return true


### PR DESCRIPTION
## Summary
Compare gzip-compressed article bytes with contentEquals so equals and hashCode stay consistent in Set/Map.

## Audit reference
Static code audit item **S1**.

## Test plan
- [ ] Verify affected behavior on device/emulator
- [ ] Confirm no regression in related feature