### PR TITLE
Fix legacy locale tag parsing in LocaleHelper

### DIFF
--- a/OsmAnd/src/net/osmand/plus/helpers/LocaleHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/LocaleHelper.java
@@ -220,7 +220,7 @@ public class LocaleHelper {
 		Locale availablePreferredLocale = getAvailablePreferredLocale(localeIds);
 
 		return localeIds.contains(preferredLocaleId)
-				? new Locale(preferredLocaleId)
+				? SupportedLocale.parseLocale(preferredLocaleId)
 				: availablePreferredLocale;
 	}
 


### PR DESCRIPTION
## Summary
Use SupportedLocale.parseLocale for legacy tags such as zh_CN and pt_BR instead of the Locale(String) constructor.

## Audit reference
Static code audit item **I4**.

## Test plan
- [ ] Verify affected behavior on device/emulator
- [ ] Confirm no regression in related feature