### PR TITLE
Reapply preferred locale resources after configuration changes

### DIFF
--- a/OsmAnd/src/net/osmand/plus/OsmandApplication.java
+++ b/OsmAnd/src/net/osmand/plus/OsmandApplication.java
@@ -559,6 +559,7 @@ public class OsmandApplication extends MultiDexApplication {
 		if (preferredLocale != null && !Objects.equals(newConfig.locale.getLanguage(), preferredLocale.getLanguage())) {
 			super.onConfigurationChanged(newConfig);
 			Locale.setDefault(preferredLocale);
+			localeHelper.checkPreferredLocale();
 		} else {
 			super.onConfigurationChanged(newConfig);
 		}


### PR DESCRIPTION
## Summary
Call checkPreferredLocale after Locale.setDefault when system configuration changes but app locale stays user-selected.

## Audit reference
Static code audit item **I5**.

## Test plan
- [ ] Verify affected behavior on device/emulator
- [ ] Confirm no regression in related feature