### PR TITLE
Remove duplicate Armenian locale entry from locales_config

### DIFF
--- a/OsmAnd/res/xml/locales_config.xml
+++ b/OsmAnd/res/xml/locales_config.xml
@@ -45,7 +45,6 @@
 	<locale android:name="hr" />
 	<locale android:name="hu" />
 	<locale android:name="hy" />
-	<locale android:name="hy" />
 	<locale android:name="ia" />
 	<locale android:name="in" />
 	<locale android:name="is" />


### PR DESCRIPTION
## Summary
Delete duplicated hy entry from locales_config.xml used for per-app language selection on Android 13+.

## Audit reference
Static code audit item **I3**.

## Test plan
- [ ] Verify affected behavior on device/emulator
- [ ] Confirm no regression in related feature