### PR TITLE
Treat regional English map locales as English names

### DIFF
--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -1504,7 +1504,8 @@ public class OsmandSettings {
 	public final OsmandPreference<Boolean> MAP_SHOW_LOCAL_NAMES = new BooleanPreference(this, "map_show_local_names", false).makeGlobal().makeShared().cache();
 
 	public boolean usingEnglishNames() {
-		return MAP_PREFERRED_LOCALE.get().equals("en");
+		String locale = MAP_PREFERRED_LOCALE.get();
+		return "en".equals(locale) || locale.startsWith("en_") || locale.startsWith("en-");
 	}
 
 	public static final String BILLING_USER_DONATION_WORLD_PARAMETER = "";


### PR DESCRIPTION
## Summary
Recognize en_GB and en-US when deciding whether map transliteration defaults should use English names.

## Audit reference
Static code audit item **I9**.

## Test plan
- [ ] Verify affected behavior on device/emulator
- [ ] Confirm no regression in related feature