### PR TITLE
Enable BackupHelper debug logging only in development builds

### DIFF
--- a/OsmAnd/src/net/osmand/plus/OsmandApplication.java
+++ b/OsmAnd/src/net/osmand/plus/OsmandApplication.java
@@ -297,7 +297,7 @@ public class OsmandApplication extends MultiDexApplication {
 		}
 
 		SearchUICore.setDebugMode(PluginsHelper.isDevelopment());
-		BackupHelper.DEBUG = true;//PluginsHelper.isDevelopment();
+		BackupHelper.DEBUG = PluginsHelper.isDevelopment();
 	}
 
 	public boolean isPlusVersionInApp() {


### PR DESCRIPTION
## Summary
Restore PluginsHelper.isDevelopment() guard for BackupHelper.DEBUG.

## Audit reference
Static code audit item **A5**.

## Test plan
- [ ] Verify affected behavior on device/emulator
- [ ] Confirm no regression in related feature