### PR TITLE
Fix offline forecast update size integer overflow

### DIFF
--- a/OsmAnd/src/net/osmand/plus/plugins/weather/OfflineForecastHelper.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/weather/OfflineForecastHelper.java
@@ -304,8 +304,8 @@ public class OfflineForecastHelper implements ResetTotalWeatherCacheSizeListener
 		});
 	}
 
-	private int calculateApproxUpdatesSize(@NonNull List<Long> tileIds) {
-		return tileIds.size() * FORECAST_DATES_COUNT * TILE_SIZE;
+	private long calculateApproxUpdatesSize(@NonNull List<Long> tileIds) {
+		return (long) tileIds.size() * FORECAST_DATES_COUNT * TILE_SIZE;
 	}
 
 	public void calculateTotalCacheSizeAsync(boolean forceCalculation) {


### PR DESCRIPTION
## Summary
Calculate approximate update cache size in long to avoid overflow for large weather regions.

## Audit reference
Static code audit item **W2**.

## Test plan
- [ ] Verify affected behavior on device/emulator
- [ ] Confirm no regression in related feature