### PR TITLE
Guard weather cache clearing when resources manager is unavailable

### DIFF
--- a/OsmAnd/src/net/osmand/plus/plugins/weather/OfflineForecastHelper.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/weather/OfflineForecastHelper.java
@@ -371,6 +371,10 @@ public class OfflineForecastHelper implements ResetTotalWeatherCacheSizeListener
 	}
 
 	private void clearOnlineCache() {
+		if (weatherResourcesManager == null) {
+			LOG.error("[Clear] [All online] Can't clear online cache. WeatherResourcesManager isn't available.");
+			return;
+		}
 		clearOnlineCacheInProgress = true;
 		totalCacheSize.reset(false);
 
@@ -394,6 +398,10 @@ public class OfflineForecastHelper implements ResetTotalWeatherCacheSizeListener
 	}
 
 	private void clearOfflineCache(@Nullable List<String> regionIds) {
+		if (weatherResourcesManager == null) {
+			LOG.error("[Clear] [All offline] Can't clear offline cache. WeatherResourcesManager isn't available.");
+			return;
+		}
 		if (Algorithms.isEmpty(regionIds)) {
 			regionIds = getTempForecastsWithDownloadStates(IN_PROGRESS, FINISHED);
 		}
@@ -482,7 +490,11 @@ public class OfflineForecastHelper implements ResetTotalWeatherCacheSizeListener
 		TileIdList qTileIds = NativeUtilities.convertToQListTileIds(tileIds);
 		ZoomLevel zoom = getGeoTileZoom();
 		if (!qTileIds.isEmpty()) {
-			weatherResourcesManager.clearDbCache(qTileIds, new TileIdList(), zoom);
+			if (weatherResourcesManager == null) {
+				LOG.error("[Clear] Can't remove local forecast tiles. WeatherResourcesManager isn't available.");
+			} else {
+				weatherResourcesManager.clearDbCache(qTileIds, new TileIdList(), zoom);
+			}
 		}
 		if (notifyUserOnFinish) {
 			for (String regionId : regionIds) {


### PR DESCRIPTION
## Summary
Skip native cache clearing when WeatherTileResourcesManager is not initialized yet to avoid NPE during startup.

## Audit reference
Static code audit item **W3**.

## Test plan
- [ ] Verify affected behavior on device/emulator
- [ ] Confirm no regression in related feature