### PR TITLE
Use Locale.ROOT for POI name capitalization

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/util/Algorithms.java
+++ b/OsmAnd-java/src/main/java/net/osmand/util/Algorithms.java
@@ -598,7 +598,7 @@ public class Algorithms {
 	public static String capitalizeFirstLetterAndLowercase(String s) {
 		if (s != null && s.length() > 1) {
 			// not very efficient algorithm
-			return Character.toUpperCase(s.charAt(0)) + s.substring(1).toLowerCase();
+			return Character.toUpperCase(s.charAt(0)) + s.substring(1).toLowerCase(Locale.ROOT);
 		} else {
 			return s;
 		}


### PR DESCRIPTION
## Summary
Avoid locale-sensitive lowercasing such as Turkish dotted/dotless I when normalizing place names.

## Audit reference
Static code audit item **J1**.

## Test plan
- [ ] Verify affected behavior on device/emulator
- [ ] Confirm no regression in related feature