### PR TITLE
Reject empty color strings in Algorithms.parseColor

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/util/Algorithms.java
+++ b/OsmAnd-java/src/main/java/net/osmand/util/Algorithms.java
@@ -629,6 +629,9 @@ public class Algorithms {
 	 * #AARRGGBB
 	 */
 	public static int parseColor(String colorString) throws IllegalArgumentException {
+		if (isEmpty(colorString)) {
+			throw new IllegalArgumentException("Unknown color " + colorString); //$NON-NLS-1$
+		}
 		if (colorString.charAt(0) == '#') {
 			// Use a long to avoid rollovers on #ffXXXXXX
 			if (colorString.length() == 4) {


### PR DESCRIPTION
## Summary
Throw IllegalArgumentException for empty input instead of StringIndexOutOfBoundsException.

## Audit reference
Static code audit item **J3**.

## Test plan
- [ ] Verify affected behavior on device/emulator
- [ ] Confirm no regression in related feature