### PR TITLE
Use default routing speed when segment priority zeroes speed

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/BinaryRoutePlanner.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/BinaryRoutePlanner.java
@@ -469,8 +469,8 @@ public class BinaryRoutePlanner {
 		int y = segment.road.getPoint31YTile(segment.getSegmentEnd());
 		float priority = router.defineSpeedPriority(segment.road, segment.isPositive());
 		float speed = (router.defineRoutingSpeed(segment.road, segment.isPositive()) * priority);
-		if (speed == 0) {
-			speed = router.getDefaultSpeed() * priority;
+		if (speed <= 0) {
+			speed = router.getDefaultSpeed();
 		}
 		// speed can not exceed max default speed according to A*
 		if (speed > router.getMaxSpeed()) {


### PR DESCRIPTION
## Summary
Avoid ineffective fallback that multiplied default speed by zero priority in A* segment time estimation.

## Audit reference
Static code audit item **R2**.

## Test plan
- [ ] Verify affected behavior on device/emulator
- [ ] Confirm no regression in related feature