### PR TITLE
Fix IntHolder identity fast-path in GeneralRouter

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/GeneralRouter.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/GeneralRouter.java
@@ -631,7 +631,7 @@ public class GeneralRouter implements VehicleRouter {
 
 		@Override
 		public boolean equals(Object other) {
-			if (array == other) {
+			if (this == other) {
 				return true;
 			}
 			if (!(other instanceof IntHolder)) {


### PR DESCRIPTION
## Summary
Compare IntHolder instances with reference equality instead of comparing the int array field to Object.

## Audit reference
Static code audit item **R3**.

## Test plan
- [ ] Verify affected behavior on device/emulator
- [ ] Confirm no regression in related feature