### PR TITLE
Attempt navigation foreground service start even from background

### DIFF
--- a/OsmAnd/src/net/osmand/plus/OsmandApplication.java
+++ b/OsmAnd/src/net/osmand/plus/OsmandApplication.java
@@ -1111,15 +1111,17 @@ public class OsmandApplication extends MultiDexApplication {
 		intent.putExtra(NavigationService.USAGE_INTENT, usageIntent);
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 			runInUIThread(() -> {
+				if (!OsmAndLocationProvider.isLocationPermissionAvailable(this)) {
+					LOG.info(">>>> Failed APP startForegroundService = " + usageIntent + " {no location permission}");
+					return;
+				}
 				try {
-					if (isAppInForeground() && OsmAndLocationProvider.isLocationPermissionAvailable(this)) {
-						LOG.info(">>>> APP startForegroundService = " + usageIntent);
-						context.startForegroundService(intent);
-					} else {
-						LOG.info(">>>> Failed APP startForegroundService = " + usageIntent + "{foreground " + isAppInForeground() + ", permissions " + OsmAndLocationProvider.isLocationPermissionAvailable(this));
-					}
-				} catch (IllegalStateException e) {
-					LOG.error("Failed to start foreground service: " + e.getMessage(), e);
+					LOG.info(">>>> APP startForegroundService = " + usageIntent + " {foreground " + isAppInForeground() + "}");
+					context.startForegroundService(intent);
+				} catch (Exception e) {
+					// e.g. ForegroundServiceStartNotAllowedException (Android 12+) when the service
+					// cannot be started from the background; do not fail silently in the log only.
+					LOG.error("Failed to start foreground service (usageIntent=" + usageIntent + "): " + e.getMessage(), e);
 				}
 			});
 		} else {


### PR DESCRIPTION
## Summary
When the app is in the background, `OsmandApplication.startNavigationService` previously only logged a failure and never attempted to start the foreground service, so background-triggered navigation and track recording were silently dropped.

This change attempts `startForegroundService` whenever location permission is available (regardless of foreground state) and catches `ForegroundServiceStartNotAllowedException` (Android 12+) and other exceptions so a genuinely blocked start no longer happens without any attempt.

## Audit reference
Static code audit item **A3**. Likely related user reports: #19845, #10512, #11038, #19521.

## Test plan
- [ ] Start track recording / navigation from a background trigger on Android 8-11 and 12+
- [ ] Verify the service starts when permitted and that a blocked start is logged without crashing