### PR TITLE
Make weather offline forecast cache map thread-safe

### DIFF
--- a/OsmAnd/src/net/osmand/plus/plugins/weather/OfflineForecastHelper.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/weather/OfflineForecastHelper.java
@@ -695,8 +695,7 @@ public class OfflineForecastHelper implements ResetTotalWeatherCacheSizeListener
 		if (destinationTilesCount <= 0) {
 			return;
 		}
-		int downloadedTilesCount = getOfflineForecastProgressInfo(regionId);
-		setOfflineForecastProgressInfo(regionId, ++downloadedTilesCount);
+		int downloadedTilesCount = getOrCreateCachedInfo(regionId).incrementDownloadProgress();
 
 		float currentProgress = (float) downloadedTilesCount / destinationTilesCount;
 		if (progress != null) {

--- a/OsmAnd/src/net/osmand/plus/plugins/weather/OfflineForecastHelper.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/weather/OfflineForecastHelper.java
@@ -69,12 +69,12 @@ import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class OfflineForecastHelper implements ResetTotalWeatherCacheSizeListener {
 
@@ -103,7 +103,7 @@ public class OfflineForecastHelper implements ResetTotalWeatherCacheSizeListener
 	public OfflineForecastHelper(@NonNull OsmandApplication app) {
 		this.app = app;
 		settings = app.getSettings();
-		offlineForecastInfo = new HashMap<>();
+		offlineForecastInfo = new ConcurrentHashMap<>();
 		totalCacheSize = new WeatherTotalCacheSize(this);
 	}
 
@@ -880,12 +880,7 @@ public class OfflineForecastHelper implements ResetTotalWeatherCacheSizeListener
 
 	@NonNull
 	private OfflineForecastInfo getOrCreateCachedInfo(@NonNull String regionId) {
-		OfflineForecastInfo info = getCachedInfo(regionId);
-		if (info == null) {
-			info = new OfflineForecastInfo();
-			offlineForecastInfo.put(regionId, info);
-		}
-		return info;
+		return offlineForecastInfo.computeIfAbsent(regionId, key -> new OfflineForecastInfo());
 	}
 
 	private void runAsync(@NonNull Runnable runnable) {

--- a/OsmAnd/src/net/osmand/plus/plugins/weather/containers/OfflineForecastInfo.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/weather/containers/OfflineForecastInfo.java
@@ -3,12 +3,13 @@ package net.osmand.plus.plugins.weather.containers;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class OfflineForecastInfo {
 
-	private final Map<InfoType, Object> infoMap = new HashMap<>();
+	private final ConcurrentHashMap<InfoType, Object> infoMap = new ConcurrentHashMap<>();
+	private final AtomicInteger downloadProgress = new AtomicInteger(0);
 
 	public enum InfoType {
 		LOCAL_SIZE,
@@ -19,14 +20,28 @@ public class OfflineForecastInfo {
 
 	@Nullable
 	public Object get(@NonNull InfoType type) {
+		if (type == InfoType.PROGRESS_DOWNLOAD) {
+			return downloadProgress.get();
+		}
 		return infoMap.get(type);
 	}
 
 	public void put(@NonNull InfoType type, @NonNull Object value) {
-		infoMap.put(type, value);
+		if (type == InfoType.PROGRESS_DOWNLOAD && value instanceof Integer) {
+			downloadProgress.set((Integer) value);
+		} else {
+			infoMap.put(type, value);
+		}
 	}
 
 	public boolean contains(@NonNull InfoType type) {
+		if (type == InfoType.PROGRESS_DOWNLOAD) {
+			return true;
+		}
 		return infoMap.containsKey(type);
+	}
+
+	public int incrementDownloadProgress() {
+		return downloadProgress.incrementAndGet();
 	}
 }


### PR DESCRIPTION
## Summary
`OfflineForecastHelper.offlineForecastInfo` is a plain `HashMap` that is mutated from background `AsyncTask` work (cache size calculation, clearing, removing local forecasts) and also read/written on the UI thread. Concurrent access can throw `ConcurrentModificationException` or lose updates.

Switch it to `ConcurrentHashMap` and use `computeIfAbsent` so the get-or-create path is atomic.

## Audit reference
Static code audit item **W5**.

## Test plan
- [ ] Download/clear/remove offline weather forecasts for several regions while the cache-size calculation runs
- [ ] Confirm no crash and correct cache info