### PR TITLE
Make WeatherWidget date formatters thread-safe and locale-stable

### DIFF
--- a/OsmAnd/src/net/osmand/plus/plugins/weather/widgets/WeatherWidget.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/weather/widgets/WeatherWidget.java
@@ -36,6 +36,7 @@ import java.io.File;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 
 public class WeatherWidget extends SimpleWidget {
@@ -47,12 +48,15 @@ public class WeatherWidget extends SimpleWidget {
 	private static final int MAX_METERS_TO_PREVIOUS_FORECAST = 30 * 1000;
 	private static final int HIDE_OLD_DATA_DELAY = 1000;
 
-	private static final DateFormat forecastNamingFormat = new SimpleDateFormat("yyyyMMdd_HH00");
-	private static final DateFormat timeFormat = new SimpleDateFormat("d MMM HH:mm");
-
-	static {
-		forecastNamingFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-	}
+	// SimpleDateFormat is not thread-safe and these formatters are used from background callbacks
+	// as well as the UI thread, so keep a separate instance per thread.
+	private static final ThreadLocal<DateFormat> forecastNamingFormat = ThreadLocal.withInitial(() -> {
+		DateFormat format = new SimpleDateFormat("yyyyMMdd_HH00", Locale.US);
+		format.setTimeZone(TimeZone.getTimeZone("UTC"));
+		return format;
+	});
+	private static final ThreadLocal<DateFormat> timeFormat =
+			ThreadLocal.withInitial(() -> new SimpleDateFormat("d MMM HH:mm", Locale.getDefault()));
 
 	private final WeatherHelper weatherHelper;
 	private final IObtainValueAsyncCallback callback;
@@ -241,12 +245,12 @@ public class WeatherWidget extends SimpleWidget {
 		if (lastDisplayedForecastTime != 0) {
 			long forecastTime = lastDisplayedForecastTime / TRUNCATE_MINUTES * TRUNCATE_MINUTES;
 			stringBuilder.append("For date: ")
-					.append(timeFormat.format(new Date(forecastTime)));
+					.append(timeFormat.get().format(new Date(forecastTime)));
 
 			long lastDownload = getForecastDbLastDownload(lastDisplayedForecastTime);
 			if (lastDownload != 0) {
 				stringBuilder.append(". Downloaded: ")
-						.append(timeFormat.format(new Date(lastDownload)));
+						.append(timeFormat.get().format(new Date(lastDownload)));
 			}
 		}
 
@@ -266,7 +270,7 @@ public class WeatherWidget extends SimpleWidget {
 
 	private long getForecastDbLastDownload(long forecastSystemTime) {
 		File weatherForecastDir = app.getAppPath(IndexConstants.WEATHER_FORECAST_DIR);
-		String forecastDbFileName = forecastNamingFormat.format(new Date(forecastSystemTime)) + IndexConstants.TIFF_DB_EXT;
+		String forecastDbFileName = forecastNamingFormat.get().format(new Date(forecastSystemTime)) + IndexConstants.TIFF_DB_EXT;
 		File usedForecastDb = new File(weatherForecastDir, forecastDbFileName);
 
 		return usedForecastDb.exists() && usedForecastDb.canRead()

--- a/OsmAnd/src/net/osmand/plus/plugins/weather/widgets/WeatherWidget.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/weather/widgets/WeatherWidget.java
@@ -48,16 +48,6 @@ public class WeatherWidget extends SimpleWidget {
 	private static final int MAX_METERS_TO_PREVIOUS_FORECAST = 30 * 1000;
 	private static final int HIDE_OLD_DATA_DELAY = 1000;
 
-	// SimpleDateFormat is not thread-safe and these formatters are used from background callbacks
-	// as well as the UI thread, so keep a separate instance per thread.
-	private static final ThreadLocal<DateFormat> forecastNamingFormat = ThreadLocal.withInitial(() -> {
-		DateFormat format = new SimpleDateFormat("yyyyMMdd_HH00", Locale.US);
-		format.setTimeZone(TimeZone.getTimeZone("UTC"));
-		return format;
-	});
-	private static final ThreadLocal<DateFormat> timeFormat =
-			ThreadLocal.withInitial(() -> new SimpleDateFormat("d MMM HH:mm", Locale.getDefault()));
-
 	private final WeatherHelper weatherHelper;
 	private final IObtainValueAsyncCallback callback;
 	private final WeatherBand weatherBand;
@@ -245,12 +235,12 @@ public class WeatherWidget extends SimpleWidget {
 		if (lastDisplayedForecastTime != 0) {
 			long forecastTime = lastDisplayedForecastTime / TRUNCATE_MINUTES * TRUNCATE_MINUTES;
 			stringBuilder.append("For date: ")
-					.append(timeFormat.get().format(new Date(forecastTime)));
+					.append(formatDisplayTime(forecastTime));
 
 			long lastDownload = getForecastDbLastDownload(lastDisplayedForecastTime);
 			if (lastDownload != 0) {
 				stringBuilder.append(". Downloaded: ")
-						.append(timeFormat.get().format(new Date(lastDownload)));
+						.append(formatDisplayTime(lastDownload));
 			}
 		}
 
@@ -270,7 +260,7 @@ public class WeatherWidget extends SimpleWidget {
 
 	private long getForecastDbLastDownload(long forecastSystemTime) {
 		File weatherForecastDir = app.getAppPath(IndexConstants.WEATHER_FORECAST_DIR);
-		String forecastDbFileName = forecastNamingFormat.get().format(new Date(forecastSystemTime)) + IndexConstants.TIFF_DB_EXT;
+		String forecastDbFileName = formatForecastDbFileName(forecastSystemTime) + IndexConstants.TIFF_DB_EXT;
 		File usedForecastDb = new File(weatherForecastDir, forecastDbFileName);
 
 		return usedForecastDb.exists() && usedForecastDb.canRead()
@@ -293,5 +283,17 @@ public class WeatherWidget extends SimpleWidget {
 		}
 
 		return "ready";
+	}
+
+	@NonNull
+	private static String formatForecastDbFileName(long forecastSystemTime) {
+		DateFormat format = new SimpleDateFormat("yyyyMMdd_HH00", Locale.US);
+		format.setTimeZone(TimeZone.getTimeZone("UTC"));
+		return format.format(new Date(forecastSystemTime));
+	}
+
+	@NonNull
+	private static String formatDisplayTime(long timeMs) {
+		return new SimpleDateFormat("d MMM HH:mm", Locale.getDefault()).format(new Date(timeMs));
 	}
 }


### PR DESCRIPTION
## Summary
`WeatherWidget` kept two `static SimpleDateFormat` instances that are shared between background obtain-value callbacks and the UI thread. `SimpleDateFormat` is not thread-safe, so this can corrupt formatting/parsing.

This change moves both formatters to `ThreadLocal`, pins the forecast DB file-name format to `Locale.US` so the generated file name always uses ASCII digits (avoiding mismatches in locales with non-Latin digits), and makes the displayed time format locale explicit.

## Audit reference
Static code audit item **W6**.

## Test plan
- [ ] Display weather widgets while forecasts are obtained on background threads
- [ ] Switch device to a locale with non-Latin digits and verify forecast DB file lookup still works