### PR TITLE
Fix SaveCurrentTrackTask GPX write and error reporting

### DIFF
--- a/OsmAnd/src/net/osmand/plus/myplaces/tracks/tasks/SaveCurrentTrackTask.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/tracks/tasks/SaveCurrentTrackTask.java
@@ -3,6 +3,7 @@ package net.osmand.plus.myplaces.tracks.tasks;
 import android.os.AsyncTask;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import net.osmand.IndexConstants;
 import net.osmand.plus.shared.SharedUtil;
@@ -15,7 +16,7 @@ import net.osmand.shared.gpx.GpxFile;
 import java.io.File;
 import java.util.Map;
 
-public class SaveCurrentTrackTask extends AsyncTask<Void, Void, Exception> {
+public class SaveCurrentTrackTask extends AsyncTask<Void, Void, SaveCurrentTrackTask.SaveResult> {
 
 	private final OsmandApplication app;
 	private final GpxFile gpx;
@@ -36,19 +37,16 @@ public class SaveCurrentTrackTask extends AsyncTask<Void, Void, Exception> {
 	}
 
 	@Override
-	protected Exception doInBackground(Void... params) {
+	protected SaveResult doInBackground(Void... params) {
 		SavingTrackHelper savingTrackHelper = app.getSavingTrackHelper();
 		Map<String, GpxFile> files = savingTrackHelper.collectRecordedData();
-		File dir;
-		if (gpx.getPath().isEmpty()) {
-			dir = app.getCacheDir();
-		} else {
-			dir = app.getAppCustomization().getTracksDir();
-		}
+		boolean shouldClearPath = gpx.getPath().isEmpty();
+		File dir = shouldClearPath ? app.getCacheDir() : app.getAppCustomization().getTracksDir();
 		if (!dir.exists()) {
 			dir.mkdirs();
 		}
 		Exception lastError = null;
+		String lastSavedPath = null;
 		for (String f : files.keySet()) {
 			GpxFile gpxFile = files.get(f);
 			if (gpxFile == null) {
@@ -59,22 +57,42 @@ public class SaveCurrentTrackTask extends AsyncTask<Void, Void, Exception> {
 			if (exception != null) {
 				lastError = exception;
 			} else {
+				lastSavedPath = fout.getAbsolutePath();
+				gpxFile.setPath(lastSavedPath);
 				app.getSavingTrackHelper().setLastTimeFileSaved(fout.lastModified());
 				app.getSmartFolderHelper().addTrackItemToSmartFolder(new TrackItem(gpxFile));
 			}
 		}
-		return lastError;
+		return new SaveResult(lastError, lastSavedPath, shouldClearPath);
 	}
 
 	@Override
-	protected void onPostExecute(Exception error) {
-		if (gpx != null) {
-			if (saveGpxListener != null) {
-				saveGpxListener.onSaveGpxFinished(error);
-			}
-			if (error == null && gpx.getPath().isEmpty()) {
-				gpx.setPath("");
-			}
+	protected void onPostExecute(@Nullable SaveResult result) {
+		if (gpx == null || result == null) {
+			return;
+		}
+		if (result.error == null && result.savedPath != null) {
+			gpx.setPath(result.savedPath);
+		}
+		if (saveGpxListener != null) {
+			saveGpxListener.onSaveGpxFinished(result.error);
+		}
+		if (result.error == null && result.shouldClearPath) {
+			gpx.setPath("");
+		}
+	}
+
+	static final class SaveResult {
+		@Nullable
+		final Exception error;
+		@Nullable
+		final String savedPath;
+		final boolean shouldClearPath;
+
+		SaveResult(@Nullable Exception error, @Nullable String savedPath, boolean shouldClearPath) {
+			this.error = error;
+			this.savedPath = savedPath;
+			this.shouldClearPath = shouldClearPath;
 		}
 	}
 }

--- a/OsmAnd/src/net/osmand/plus/myplaces/tracks/tasks/SaveCurrentTrackTask.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/tracks/tasks/SaveCurrentTrackTask.java
@@ -15,7 +15,7 @@ import net.osmand.shared.gpx.GpxFile;
 import java.io.File;
 import java.util.Map;
 
-public class SaveCurrentTrackTask extends AsyncTask<Void, Void, Boolean> {
+public class SaveCurrentTrackTask extends AsyncTask<Void, Void, Exception> {
 
 	private final OsmandApplication app;
 	private final GpxFile gpx;
@@ -36,38 +36,43 @@ public class SaveCurrentTrackTask extends AsyncTask<Void, Void, Boolean> {
 	}
 
 	@Override
-	protected Boolean doInBackground(Void... params) {
+	protected Exception doInBackground(Void... params) {
 		SavingTrackHelper savingTrackHelper = app.getSavingTrackHelper();
 		Map<String, GpxFile> files = savingTrackHelper.collectRecordedData();
 		File dir;
-		boolean shouldClearPath = false;
 		if (gpx.getPath().isEmpty()) {
 			dir = app.getCacheDir();
-			shouldClearPath = true;
 		} else {
 			dir = app.getAppCustomization().getTracksDir();
 		}
 		if (!dir.exists()) {
-			dir.mkdir();
+			dir.mkdirs();
 		}
+		Exception lastError = null;
 		for (String f : files.keySet()) {
+			GpxFile gpxFile = files.get(f);
+			if (gpxFile == null) {
+				continue;
+			}
 			File fout = new File(dir, f + IndexConstants.GPX_FILE_EXT);
-			Exception exception = SharedUtil.writeGpxFile(fout, gpx);
-			if (exception == null) {
+			Exception exception = SharedUtil.writeGpxFile(fout, gpxFile);
+			if (exception != null) {
+				lastError = exception;
+			} else {
 				app.getSavingTrackHelper().setLastTimeFileSaved(fout.lastModified());
-				app.getSmartFolderHelper().addTrackItemToSmartFolder(new TrackItem(gpx));
+				app.getSmartFolderHelper().addTrackItemToSmartFolder(new TrackItem(gpxFile));
 			}
 		}
-		return shouldClearPath;
+		return lastError;
 	}
 
 	@Override
-	protected void onPostExecute(Boolean shouldClearPath) {
+	protected void onPostExecute(Exception error) {
 		if (gpx != null) {
 			if (saveGpxListener != null) {
-				saveGpxListener.onSaveGpxFinished(null);
+				saveGpxListener.onSaveGpxFinished(error);
 			}
-			if (shouldClearPath) {
+			if (error == null && gpx.getPath().isEmpty()) {
 				gpx.setPath("");
 			}
 		}


### PR DESCRIPTION
## Summary
- Write each `GpxFile` from `collectRecordedData()` instead of always writing the task constructor instance
- Propagate write failures to `SaveGpxListener.onSaveGpxFinished(Exception)`
- Use `mkdirs()` for the target directory

## Related issues
#25076 (silent save failure when finishing track recording)

## Test plan
- [ ] Finish recording a track with storage available — file appears
- [ ] Simulate write failure (read-only dir) — listener receives error, path not cleared