### PR TITLE
Guard weather download progress when tiles are unknown

### DIFF
--- a/OsmAnd/src/net/osmand/plus/plugins/weather/OfflineForecastHelper.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/weather/OfflineForecastHelper.java
@@ -656,7 +656,10 @@ public class OfflineForecastHelper implements ResetTotalWeatherCacheSizeListener
 
 	public int getProgressDestination(@NonNull String regionId) {
 		List<Long> tileIds = getTileIds(regionId);
-		return tileIds != null ? tileIds.size() * FORECAST_DATES_COUNT : -1;
+		if (tileIds == null || tileIds.isEmpty()) {
+			return 0;
+		}
+		return tileIds.size() * FORECAST_DATES_COUNT;
 	}
 
 	public void onDownloadStarted(@NonNull WorldRegion region, @Nullable IProgress progress) {
@@ -677,6 +680,9 @@ public class OfflineForecastHelper implements ResetTotalWeatherCacheSizeListener
 			return;
 		}
 		int destinationTilesCount = getProgressDestination(regionId);
+		if (destinationTilesCount <= 0) {
+			return;
+		}
 		int downloadedTilesCount = getOfflineForecastProgressInfo(regionId);
 		setOfflineForecastProgressInfo(regionId, ++downloadedTilesCount);
 


### PR DESCRIPTION
## Summary
Avoid `-1` progress destination and division by invalid totals when tile ids are not ready.

## Related issues
#25000 (progress bar jumps to 99% / hangs — partial; size overflow handled separately in #25180)

## Test plan
- [ ] Start offline weather forecast download for a region
- [ ] Progress bar behaves sensibly when tile list is still loading