### PR TITLE
Fix inverted StarView min/max zoom range

### DIFF
--- a/OsmAnd/src/net/osmand/plus/plugins/astronomy/views/StarView.kt
+++ b/OsmAnd/src/net/osmand/plus/plugins/astronomy/views/StarView.kt
@@ -720,9 +720,9 @@ class StarView @JvmOverloads constructor(
 		}
 	}
 
-	fun getMinZoom() = if (is2DMode) 200.0 else 150.0
+	fun getMinZoom(): Double = 150.0
 
-	fun getMaxZoom() = 150.0
+	fun getMaxZoom(): Double = if (is2DMode) 200.0 else 150.0
 
 	fun zoomIn() {
 		updateViewAngle(viewAngle / 1.5)


### PR DESCRIPTION
## Summary
Correct `getMinZoom`/`getMaxZoom` so max is not less than min (2D mode max 200, min 150).

## Test plan
- [ ] Astronomy star map: verify zoom in/out still works in 2D and 3D modes