### PR TITLE
Defer live map updates on app startup to scheduled alarms

### DIFF
--- a/OsmAnd/src/net/osmand/plus/AppInitializer.java
+++ b/OsmAnd/src/net/osmand/plus/AppInitializer.java
@@ -593,7 +593,7 @@ public class AppInitializer implements IProgress {
 				long lastCheck = preferenceLastSuccessfulUpdateCheck(fileName, settings).get();
 
 				if (System.currentTimeMillis() - lastCheck > updateFrequency.intervalMillis * 2) {
-					runLiveUpdate(app, fileName, false, null);
+					// Do not download on cold start; LiveUpdatesAlarmReceiver runs updates (#25148).
 					PendingIntent alarmIntent = getPendingIntent(app, fileName);
 					int timeOfDayOrd = preferenceTimeOfDayToUpdate(fileName, settings).get();
 					TimeOfDay[] timeOfDayValues = TimeOfDay.values();


### PR DESCRIPTION
## Summary
- Stop calling `runLiveUpdate` from `AppInitializer.checkLiveUpdatesAlerts` on cold start
- Overdue maps only reschedule alarms; downloads run via `LiveUpdatesAlarmReceiver`

## Test plan
- [ ] Enable live updates for a map, restart app: no immediate download dialog/work
- [ ] Alarm still fires at scheduled time and update runs
- [ ] Manual "Update now" in Live Updates still works

Fixes #25148
