### PR TITLE
Add Indonesian (id) to locales_config for SupportedLocale sync

### DIFF
--- a/OsmAnd/res/xml/locales_config.xml
+++ b/OsmAnd/res/xml/locales_config.xml
@@ -48,6 +48,7 @@
 	<locale android:name="hy" />
 	<locale android:name="ia" />
 	<locale android:name="in" />
+	<locale android:name="id" />
 	<locale android:name="is" />
 	<locale android:name="it" />
 	<locale android:name="iw" />

--- a/OsmAnd/src/net/osmand/plus/helpers/SupportedLocale.kt
+++ b/OsmAnd/src/net/osmand/plus/helpers/SupportedLocale.kt
@@ -90,6 +90,7 @@ enum class SupportedLocale(
 	// @formatter:on
 
 	companion object {
+		// Keep modernTag values in sync with OsmAnd/res/xml/locales_config.xml (Android 13+ per-app locales).
 
 		@JvmStatic
 		fun fromTag(tag: String?): SupportedLocale? {


### PR DESCRIPTION
## Summary
- Add BCP-47 `id` to `locales_config.xml` (UI uses `id`, legacy `in` kept)
- Document sync requirement in `SupportedLocale`

## Test plan
- [ ] Indonesian appears in Android per-app language list on API 33+
