### PR TITLE
Catch corrupt map data errors during nearby amenity search

### DIFF
--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/SearchAmenitiesTask.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/SearchAmenitiesTask.java
@@ -5,6 +5,7 @@ import android.os.AsyncTask;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import net.osmand.PlatformUtil;
 import net.osmand.ResultMatcher;
 import net.osmand.data.Amenity;
 import net.osmand.data.LatLon;
@@ -13,10 +14,14 @@ import net.osmand.plus.poi.PoiUIFilter;
 import net.osmand.plus.views.AmenityObjectsMerger;
 import net.osmand.util.MapUtils;
 
+import org.apache.commons.logging.Log;
+
 import java.util.Collections;
 import java.util.List;
 
 public class SearchAmenitiesTask extends AsyncTask<Void, Void, List<Amenity>> {
+
+	private static final Log LOG = PlatformUtil.getLog(SearchAmenitiesTask.class);
 
 	public static final int NEARBY_MAX_POI_COUNT = 10;
 	private static final int NEARBY_POI_MIN_RADIUS = 250;
@@ -68,17 +73,22 @@ public class SearchAmenitiesTask extends AsyncTask<Void, Void, List<Amenity>> {
 
 	@NonNull
 	private List<Amenity> collectAmenities(@NonNull QuadRect rect) {
-		return filter.searchAmenities(rect.top, rect.left, rect.bottom, rect.right, -1, new ResultMatcher<>() {
-			@Override
-			public boolean publish(Amenity amenity) {
-				return true;
-			}
+		try {
+			return filter.searchAmenities(rect.top, rect.left, rect.bottom, rect.right, -1, new ResultMatcher<>() {
+				@Override
+				public boolean publish(Amenity amenity) {
+					return true;
+				}
 
-			@Override
-			public boolean isCancelled() {
-				return SearchAmenitiesTask.this.isCancelled();
-			}
-		}, true);
+				@Override
+				public boolean isCancelled() {
+					return SearchAmenitiesTask.this.isCancelled();
+				}
+			}, true);
+		} catch (RuntimeException e) {
+			LOG.error("Failed to search nearby amenities", e);
+			return Collections.emptyList();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
## Summary
- Catch `RuntimeException` from `searchAmenities` (e.g. corrupt address index / protobuf)
- Return empty nearby POI list instead of crashing UI thread work

## Test plan
- [ ] Open context menu on GPX waypoint with bad map data: no freeze
- [ ] Nearby POI row empty or partial, menu stays responsive

Fixes #25137 (partial; complements MenuBuilder onHide cancel in #25197)
