### PR TITLE
Cancel context menu async work when switching map objects

### DIFF
--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/MenuBuilder.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/MenuBuilder.java
@@ -407,6 +407,8 @@ public class MenuBuilder {
 
 	void onHide() {
 		hidden = true;
+		stopLoadingImagesTask();
+		stopSearchAmenitiesTasks();
 	}
 
 	void onClose() {

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/MenuController.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/MenuController.java
@@ -811,6 +811,9 @@ public abstract class MenuController extends BaseMenuController implements Colla
 	}
 
 	public void onAcquireNewController(PointDescription pointDescription, Object object) {
+		if (builder != null) {
+			builder.onHide();
+		}
 	}
 
 	public boolean isMapDownloaded() {


### PR DESCRIPTION
## Summary
- Cancel amenity search and image loads in `MenuBuilder.onHide`
- Call `onHide` from `MenuController.onAcquireNewController` when switching context menu target

## Test plan
- [ ] Open POI menu, tap another object quickly: no UI freeze
- [ ] Nearby POI / wiki rows do not keep loading in background

Fixes #25137 (with #25197, #25205)
