### PR TITLE
Use Locale.ROOT for OSM tag matching in PoiUIFilter

### DIFF
--- a/OsmAnd/src/net/osmand/plus/poi/PoiUIFilter.java
+++ b/OsmAnd/src/net/osmand/plus/poi/PoiUIFilter.java
@@ -48,6 +48,7 @@ import org.apache.commons.logging.Log;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -161,7 +162,7 @@ public class PoiUIFilter implements Comparable<PoiUIFilter>, CustomSearchPoiFilt
 		isStandardFilter = false;
 		poiTypes = app.getPoiTypes();
 		if (filterId == null) {
-			filterId = USER_PREFIX + name.replace(' ', '_').toLowerCase();
+			filterId = USER_PREFIX + name.replace(' ', '_').toLowerCase(Locale.ROOT);
 		}
 		this.filterId = filterId;
 		this.name = name;
@@ -486,11 +487,11 @@ public class PoiUIFilter implements Comparable<PoiUIFilter>, CustomSearchPoiFilt
 					allTime = true;
 				} else if (getNameTokenOpen().equalsIgnoreCase(s)) {
 					open = true;
-				} else if (poiAdditionals.containsKey(s.toLowerCase())) {
+				} else if (poiAdditionals.containsKey(s.toLowerCase(Locale.ROOT))) {
 					if (poiAdditionalsFilter == null) {
 						poiAdditionalsFilter = new ArrayList<>();
 					}
-					PoiType pt = poiAdditionals.get(s.toLowerCase());
+					PoiType pt = poiAdditionals.get(s.toLowerCase(Locale.ROOT));
 					if (pt != null) {
 						poiAdditionalsFilter.add(pt);
 					}
@@ -554,7 +555,7 @@ public class PoiUIFilter implements Comparable<PoiUIFilter>, CustomSearchPoiFilt
 
 		StringBuilder nameFilter = new StringBuilder();
 		for (String filter : unknownFilters) {
-			String formattedFilter = filter.replace(':', '_').toLowerCase();
+			String formattedFilter = filter.replace(':', '_').toLowerCase(Locale.ROOT);
 			if (amenity.getAdditionalInfo(formattedFilter) == null) {
 				nameFilter.append(filter).append(" ");
 			}
@@ -651,9 +652,9 @@ public class PoiUIFilter implements Comparable<PoiUIFilter>, CustomSearchPoiFilt
 		}
 
 		String[] items = filterValue.split(";");
-		String val = filter.getOsmValue().trim().toLowerCase();
+		String val = filter.getOsmValue().trim().toLowerCase(Locale.ROOT);
 		for (String item : items) {
-			if (item.trim().toLowerCase().equals(val)) {
+			if (item.trim().toLowerCase(Locale.ROOT).equals(val)) {
 				return true;
 			}
 		}
@@ -662,11 +663,11 @@ public class PoiUIFilter implements Comparable<PoiUIFilter>, CustomSearchPoiFilt
 	}
 
 	public String getNameToken24H() {
-		return app.getString(R.string.shared_string_is_open_24_7).replace(' ', '_').toLowerCase();
+		return app.getString(R.string.shared_string_is_open_24_7).replace(' ', '_').toLowerCase(Locale.ROOT);
 	}
 
 	public String getNameTokenOpen() {
-		return app.getString(R.string.shared_string_is_open).replace(' ', '_').toLowerCase();
+		return app.getString(R.string.shared_string_is_open).replace(' ', '_').toLowerCase(Locale.ROOT);
 	}
 
 	@Override
@@ -830,7 +831,7 @@ public class PoiUIFilter implements Comparable<PoiUIFilter>, CustomSearchPoiFilt
 	private void fillPoiAdditionals(@NonNull AbstractPoiType pt, boolean allFromCategory) {
 		for (PoiType add : pt.getPoiAdditionals()) {
 			poiAdditionals.put(add.getKeyName().replace('_', ':').replace(' ', ':'), add);
-			poiAdditionals.put(add.getTranslation().replace(' ', ':').toLowerCase(), add);
+			poiAdditionals.put(add.getTranslation().replace(' ', ':').toLowerCase(Locale.ROOT), add);
 		}
 		if (pt instanceof PoiCategory && allFromCategory) {
 			for (PoiFilter pf : ((PoiCategory) pt).getPoiFilters()) {
@@ -892,7 +893,7 @@ public class PoiUIFilter implements Comparable<PoiUIFilter>, CustomSearchPoiFilt
 	private void addOtherPoiAdditionals() {
 		for (PoiType add : poiTypes.getOtherMapCategory().getPoiAdditionalsCategorized()) {
 			poiAdditionals.put(add.getKeyName().replace('_', ':').replace(' ', ':'), add);
-			poiAdditionals.put(add.getTranslation().replace(' ', ':').toLowerCase(), add);
+			poiAdditionals.put(add.getTranslation().replace(' ', ':').toLowerCase(Locale.ROOT), add);
 		}
 	}
 
@@ -970,7 +971,7 @@ public class PoiUIFilter implements Comparable<PoiUIFilter>, CustomSearchPoiFilt
 		if (filterId.startsWith(STD_PREFIX)) {
 			iconName = standardIconId;
 		} else if (filterId.startsWith(USER_PREFIX)) {
-			iconName = filterId.substring(USER_PREFIX.length()).toLowerCase();
+			iconName = filterId.substring(USER_PREFIX.length()).toLowerCase(Locale.ROOT);
 		}
 		if (RenderingIcons.containsBigIcon(iconName)) {
 			return iconName;


### PR DESCRIPTION
## Summary
- `Locale.ROOT` for OSM tag / filter key normalization in `PoiUIFilter`

## Test plan
- [ ] Custom POI filters work on Turkish locale device
- [ ] Opening hours / additional filters match correctly

Related to #25157, complements #25206
