### PR TITLE
Use Locale.ROOT for travel and saved POI category keys

### DIFF
--- a/OsmAnd/src/net/osmand/plus/poi/PoiFilterDbHelper.java
+++ b/OsmAnd/src/net/osmand/plus/poi/PoiFilterDbHelper.java
@@ -20,6 +20,7 @@ import org.json.JSONObject;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -274,7 +275,7 @@ public class PoiFilterDbHelper {
 						map.put(filterId, new LinkedHashMap<>());
 					}
 					Map<PoiCategory, LinkedHashSet<String>> m = map.get(filterId);
-					PoiCategory a = poiTypes.getPoiCategoryByName(query.getString(1).toLowerCase(), false);
+					PoiCategory a = poiTypes.getPoiCategoryByName(query.getString(1).toLowerCase(Locale.ROOT), false);
 					String subCategory = query.getString(2);
 					if (subCategory == null) {
 						m.put(a, null);

--- a/OsmAnd/src/net/osmand/plus/render/TravelRendererHelper.java
+++ b/OsmAnd/src/net/osmand/plus/render/TravelRendererHelper.java
@@ -39,6 +39,7 @@ import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -261,7 +262,7 @@ public class TravelRendererHelper implements RendererEventListener {
 				for (String category : categories) {
 					CommonPreference<Boolean> prop = getRoutePointCategoryProperty(category);
 					if (prop.get()) {
-						selectedCategories.add(category.replace('_', ':').toLowerCase());
+						selectedCategories.add(category.replace('_', ':').toLowerCase(Locale.ROOT));
 					}
 				}
 				routeArticlePointsFilter.setFilterByName(TextUtils.join(" ", selectedCategories));


### PR DESCRIPTION
## Summary
- `Locale.ROOT` in `TravelRendererHelper` and `PoiFilterDbHelper` for category keys

## Test plan
- [ ] Travel map style category selection persists after restart
- [ ] Saved POI filters load on Turkish locale device

Related to #25157
