### PR TITLE
Reschedule live update alarms on startup without downloading

### DIFF
--- a/OsmAnd/src/net/osmand/plus/AppInitializer.java
+++ b/OsmAnd/src/net/osmand/plus/AppInitializer.java
@@ -590,19 +590,15 @@ public class AppInitializer implements IProgress {
 					continue;
 				}
 				UpdateFrequency updateFrequency = updateFrequencies[updateFrequencyOrd];
-				long lastCheck = preferenceLastSuccessfulUpdateCheck(fileName, settings).get();
-
-				if (System.currentTimeMillis() - lastCheck > updateFrequency.intervalMillis * 2) {
-					runLiveUpdate(app, fileName, false, null);
-					PendingIntent alarmIntent = getPendingIntent(app, fileName);
-					int timeOfDayOrd = preferenceTimeOfDayToUpdate(fileName, settings).get();
-					TimeOfDay[] timeOfDayValues = TimeOfDay.values();
-					if (timeOfDayOrd < 0 || timeOfDayOrd >= timeOfDayValues.length) {
-						continue;
-					}
-					TimeOfDay timeOfDayToUpdate = timeOfDayValues[timeOfDayOrd];
-					setAlarmForPendingIntent(alarmIntent, manager, updateFrequency, timeOfDayToUpdate);
+				PendingIntent alarmIntent = getPendingIntent(app, fileName);
+				int timeOfDayOrd = preferenceTimeOfDayToUpdate(fileName, settings).get();
+				TimeOfDay[] timeOfDayValues = TimeOfDay.values();
+				if (timeOfDayOrd < 0 || timeOfDayOrd >= timeOfDayValues.length) {
+					continue;
 				}
+				TimeOfDay timeOfDayToUpdate = timeOfDayValues[timeOfDayOrd];
+				// Reschedule only; downloads run via LiveUpdatesAlarmReceiver, not on cold start (#25148).
+				setAlarmForPendingIntent(alarmIntent, manager, updateFrequency, timeOfDayToUpdate);
 			}
 		}
 		notifyEvent(LIVE_UPDATES_ALERTS_CHECKED);


### PR DESCRIPTION
## Summary
- `checkLiveUpdatesAlerts` only reschedules alarms for enabled maps
- Removes `runLiveUpdate` on cold start entirely

## Test plan
- [ ] Restart app with live updates on: no immediate download
- [ ] Alarms still fire and update runs at scheduled time
- [ ] Manual update from Live Updates screen works

Fixes #25148. Supersedes #25202 (alarms now always rescheduled on startup).
