### PR TITLE
Add Hebrew (he) BCP-47 tag to locales_config

### DIFF
--- a/OsmAnd/res/xml/locales_config.xml
+++ b/OsmAnd/res/xml/locales_config.xml
@@ -51,6 +51,7 @@
 	<locale android:name="is" />
 	<locale android:name="it" />
 	<locale android:name="iw" />
+	<locale android:name="he" />
 	<locale android:name="ja" />
 	<locale android:name="ka" />
 	<locale android:name="kn" />


### PR DESCRIPTION
## Summary
- Add BCP-47 `he` to `locales_config.xml` (legacy `iw` retained)

## Test plan
- [ ] Hebrew selectable in Android per-app languages on API 33+

Complements #25204 (I6)
