### PR TITLE
Mark NavigationService usage bitmask volatile

### DIFF
--- a/OsmAnd/src/net/osmand/plus/NavigationService.java
+++ b/OsmAnd/src/net/osmand/plus/NavigationService.java
@@ -53,7 +53,7 @@ public class NavigationService extends Service {
 	private OsmandSettings settings;
 	private RoutingHelper routingHelper;
 
-	protected int usedBy;
+	protected volatile int usedBy;
 	private OsmAndLocationProvider locationProvider;
 	private LocationServiceHelper locationServiceHelper;
 	private StateChangedListener<LocationSource> locationSourceListener;

--- a/OsmAnd/src/net/osmand/plus/NavigationService.java
+++ b/OsmAnd/src/net/osmand/plus/NavigationService.java
@@ -33,6 +33,7 @@ import net.osmand.plus.settings.enums.LocationSource;
 import org.apache.commons.logging.Log;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class NavigationService extends Service {
 
@@ -53,7 +54,7 @@ public class NavigationService extends Service {
 	private OsmandSettings settings;
 	private RoutingHelper routingHelper;
 
-	protected volatile int usedBy;
+	private final AtomicInteger usedBy = new AtomicInteger(0);
 	private OsmAndLocationProvider locationProvider;
 	private LocationServiceHelper locationServiceHelper;
 	private StateChangedListener<LocationSource> locationSourceListener;
@@ -69,15 +70,15 @@ public class NavigationService extends Service {
 	}
 
 	public int getUsedBy() {
-		return usedBy;
+		return usedBy.get();
 	}
 
 	public boolean isUsed() {
-		return usedBy != 0;
+		return usedBy.get() != 0;
 	}
 
 	public boolean isUsedBy(int type) {
-		return (usedBy & type) == type;
+		return (usedBy.get() & type) == type;
 	}
 
 	private void onServiceChanged(boolean start) {
@@ -103,18 +104,16 @@ public class NavigationService extends Service {
 	}
 
 	public void addUsageIntent(int usageIntent) {
-		usedBy |= usageIntent;
+		usedBy.updateAndGet(value -> value | usageIntent);
 		onServiceChanged(true);
 	}
 
 	public void stopIfNeeded(@NonNull Context context, int usageIntent) {
 		LOG.info(">>>> NavigationService stopIfNeeded = " + usageIntent);
 		OsmandApplication app = getApp();
-		if ((usedBy & usageIntent) > 0) {
-			usedBy &= ~usageIntent;
-		}
+		usedBy.updateAndGet(value -> (value & usageIntent) > 0 ? value & ~usageIntent : value);
 		onServiceChanged(false);
-		if (usedBy == 0) {
+		if (usedBy.get() == 0) {
 			context.stopService(new Intent(context, NavigationService.class));
 		} else {
 			app.getNotificationHelper().updateTopNotification();
@@ -127,7 +126,7 @@ public class NavigationService extends Service {
 		LOG.info(">>>> NavigationService onStartCommand");
 		int usageIntent = intent != null ? intent.getIntExtra(USAGE_INTENT, 0) : 0;
 		if (isUsed()) {
-			LOG.info(">>>> NavigationService is used by = " + usedBy);
+			LOG.info(">>>> NavigationService is used by = " + usedBy.get());
 			addUsageIntent(usageIntent);
 			return START_REDELIVER_INTENT;
 		}
@@ -135,7 +134,7 @@ public class NavigationService extends Service {
 		OsmandApplication app = getApp();
 		settings = app.getSettings();
 		routingHelper = app.getRoutingHelper();
-		usedBy = usageIntent;
+		usedBy.set(usageIntent);
 
 		locationProvider = app.getLocationProvider();
 		locationServiceHelper = app.createLocationServiceHelper();
@@ -151,8 +150,8 @@ public class NavigationService extends Service {
 				startForeground(notification);
 			} catch (Exception e) {
 				app.setNavigationService(null);
-				LOG.error("Failed to start NavigationService (usedBy=" + usedBy + ")", e);
-				usedBy = 0;
+				LOG.error("Failed to start NavigationService (usedBy=" + usedBy.get() + ")", e);
+				usedBy.set(0);
 				return START_NOT_STICKY;
 			}
 			try {
@@ -161,7 +160,7 @@ public class NavigationService extends Service {
 				LOG.error(e.getMessage(), e);
 			}
 		} else {
-			LOG.error("NavigationService could not be started because the notification is null. usedBy=" + usedBy);
+			LOG.error("NavigationService could not be started because the notification is null. usedBy=" + usedBy.get());
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 				try {
 					startForeground(notificationHelper.buildFallbackNotification());
@@ -198,7 +197,7 @@ public class NavigationService extends Service {
 
 		OsmandApplication app = getApp();
 		app.setNavigationService(null);
-		usedBy = 0;
+		usedBy.set(0);
 		removeLocationUpdates();
 		removeLocationSourceListener();
 


### PR DESCRIPTION
## Summary
- usedBy is updated from binder and service threads; volatile ensures visibility

## Test plan
- [ ] GPX recording + navigation concurrently; service stops only when all usages cleared