### PR TITLE
Cap wiki POI online loading wait at 30 seconds

### DIFF
--- a/OsmAnd/src/net/osmand/plus/poi/PoiUIFilterDataProvider.java
+++ b/OsmAnd/src/net/osmand/plus/poi/PoiUIFilterDataProvider.java
@@ -68,7 +68,7 @@ public class PoiUIFilterDataProvider {
         boolean cancelled = matcher != null && matcher.isCancelled();
         PoiUIFilterResultMatcher<?> uiFilterResultMatcher = matcher != null ? (PoiUIFilterResultMatcher<?>) matcher : null;
         long waitDeadlineMs = System.currentTimeMillis() + WIKI_LOAD_MAX_WAIT_MS;
-        while (explorePlacesProvider.isLoading() && !cancelled && System.currentTimeMillis() < waitDeadlineMs) {
+        while (explorePlacesProvider.isLoadingRect(rect) && !cancelled && System.currentTimeMillis() < waitDeadlineMs) {
             if (uiFilterResultMatcher != null) {
                 uiFilterResultMatcher.defferedResults();
             }

--- a/OsmAnd/src/net/osmand/plus/poi/PoiUIFilterDataProvider.java
+++ b/OsmAnd/src/net/osmand/plus/poi/PoiUIFilterDataProvider.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 public class PoiUIFilterDataProvider {
 
+	private static final long WIKI_LOAD_MAX_WAIT_MS = 30_000;
+
     private final OsmandApplication app;
     private final PoiUIFilter filter;
 
@@ -65,7 +67,8 @@ public class PoiUIFilterDataProvider {
         boolean loading = false;
         boolean cancelled = matcher != null && matcher.isCancelled();
         PoiUIFilterResultMatcher<?> uiFilterResultMatcher = matcher != null ? (PoiUIFilterResultMatcher<?>) matcher : null;
-        while (explorePlacesProvider.isLoading() && !cancelled) {
+        long waitDeadlineMs = System.currentTimeMillis() + WIKI_LOAD_MAX_WAIT_MS;
+        while (explorePlacesProvider.isLoading() && !cancelled && System.currentTimeMillis() < waitDeadlineMs) {
             if (uiFilterResultMatcher != null) {
                 uiFilterResultMatcher.defferedResults();
             }


### PR DESCRIPTION
## Summary
- Avoid infinite wait when ExplorePlacesProvider stays in loading state

## Test plan
- [ ] Wiki POI layer with slow/stuck online load returns within ~30s