### PR TITLE
Add "Dashed line" track appearance option

### DIFF
--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxDataItem.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxDataItem.kt
@@ -98,6 +98,11 @@ class GpxDataItem(
 					GpxParameter.SHOW_ARROWS,
 					if (gpxFile.isShowArrowsSet()) gpxFile.isShowArrows() else null)
 
+			GpxParameter.LINE_DASHED ->
+				setParameter(
+					GpxParameter.LINE_DASHED,
+					if (gpxFile.isLineDashedSet()) gpxFile.isLineDashed() else null)
+
 			GpxParameter.SHOW_START_FINISH -> {
 				setParameter(
 					GpxParameter.SHOW_START_FINISH,

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxDatabase.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxDatabase.kt
@@ -23,7 +23,7 @@ class GpxDatabase {
 	companion object {
 		val log = LoggerFactory.getLogger("GpxDatabase")
 
-		const val DB_VERSION = 36
+		const val DB_VERSION = 37
 		const val DB_NAME = "gpx_database"
 		const val GPX_TABLE_NAME = "gpxTable"
 		const val GPX_DIR_TABLE_NAME = "gpxDirTable"

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxDbUtils.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxDbUtils.kt
@@ -126,6 +126,7 @@ object GpxDbUtils {
 			addIfMissingGpxTableColumn(columnNames, db, SHOW_AS_MARKERS);
 			addIfMissingGpxTableColumn(columnNames, db, JOIN_SEGMENTS);
 			addIfMissingGpxTableColumn(columnNames, db, SHOW_ARROWS);
+			addIfMissingGpxTableColumn(columnNames, db, LINE_DASHED);
 			addIfMissingGpxTableColumn(columnNames, db, SHOW_START_FINISH);
 			addIfMissingGpxTableColumn(columnNames, db, TRACK_VISUALIZATION_TYPE);
 			addIfMissingGpxTableColumn(columnNames, db, TRACK_3D_WALL_COLORING_TYPE);

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxFile.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxFile.kt
@@ -740,6 +740,18 @@ class GpxFile : GpxExtensions {
 		getExtensionsToWrite()["show_arrows"] = showArrows.toString()
 	}
 
+	fun isLineDashedSet(): Boolean {
+		return extensions?.containsKey("line_dashed") ?: false
+	}
+
+	fun isLineDashed(): Boolean {
+		return extensions?.get("line_dashed")?.toBoolean() ?: false
+	}
+
+	fun setLineDashed(lineDashed: Boolean) {
+		getExtensionsToWrite()["line_dashed"] = lineDashed.toString()
+	}
+
 	fun get3DVisualizationType(): String? {
 		return extensions?.get("line_3d_visualization_by_type")
 	}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxParameter.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxParameter.kt
@@ -43,6 +43,7 @@ enum class GpxParameter(
 	SHOW_AS_MARKERS("showAsMarkers", "int", Boolean::class, false, false),
 	JOIN_SEGMENTS("joinSegments", "int", Boolean::class, false, false),
 	SHOW_ARROWS("showArrows", "int", Boolean::class, false, false),
+	LINE_DASHED("lineDashed", "int", Boolean::class, false, false),
 	SHOW_START_FINISH("showStartFinish", "int", Boolean::class, true, false),
 	TRACK_VISUALIZATION_TYPE("track_visualization_type", "TEXT", String::class, "none", false),
 	TRACK_3D_WALL_COLORING_TYPE("track_3d_wall_coloring_type", "TEXT", String::class, "none", false),
@@ -178,7 +179,7 @@ enum class GpxParameter(
 	companion object {
 
 		private val APPEARANCE_PARAMETERS = listOf(
-			COLOR, WIDTH, COLORING_TYPE, SHOW_ARROWS,
+			COLOR, WIDTH, COLORING_TYPE, SHOW_ARROWS, LINE_DASHED,
 			SHOW_START_FINISH, SPLIT_TYPE, SPLIT_INTERVAL,
 			TRACK_3D_LINE_POSITION_TYPE, TRACK_VISUALIZATION_TYPE, TRACK_3D_WALL_COLORING_TYPE, COLOR_PALETTE
 		)

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <resources>
+    <string name="gpx_dashed_line">Dashed line</string>
 <!--
 	README:
 	- The preferred way to help with translations is via https://hosted.weblate.org/engage/osmand/

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -1778,6 +1778,7 @@ public class OsmandSettings {
 			"current_track_route_info_attribute", null);
 	public final CommonPreference<String> CURRENT_TRACK_WIDTH = new StringPreference(this, "current_track_width", "").makeGlobal().makeShared().cache();
 	public final CommonPreference<Boolean> CURRENT_TRACK_SHOW_ARROWS = new BooleanPreference(this, "current_track_show_arrows", false).makeGlobal().makeShared().cache();
+	public final CommonPreference<Boolean> CURRENT_TRACK_LINE_DASHED = new BooleanPreference(this, "current_track_line_dashed", false).makeGlobal().makeShared().cache();
 	public final CommonPreference<Boolean> CURRENT_TRACK_SHOW_START_FINISH = new BooleanPreference(this, "current_track_show_start_finish", true).makeGlobal().makeShared().cache();
 	public final CommonPreference<String> CURRENT_TRACK_3D_VISUALIZATION_TYPE = new StringPreference(this, "currentTrackVisualization3dByType", "none").makeGlobal().makeShared().cache();
 	public final CommonPreference<String> CURRENT_TRACK_3D_WALL_COLORING_TYPE = new StringPreference(this, "currentTrackVisualization3dWallColorType", "none").makeGlobal().makeShared().cache();

--- a/OsmAnd/src/net/osmand/plus/track/TrackDrawInfo.java
+++ b/OsmAnd/src/net/osmand/plus/track/TrackDrawInfo.java
@@ -11,6 +11,7 @@ import static net.osmand.shared.gpx.GpxParameter.COLOR;
 import static net.osmand.shared.gpx.GpxParameter.COLORING_TYPE;
 import static net.osmand.shared.gpx.GpxParameter.ELEVATION_METERS;
 import static net.osmand.shared.gpx.GpxParameter.JOIN_SEGMENTS;
+import static net.osmand.shared.gpx.GpxParameter.LINE_DASHED;
 import static net.osmand.shared.gpx.GpxParameter.SHOW_ARROWS;
 import static net.osmand.shared.gpx.GpxParameter.SHOW_START_FINISH;
 import static net.osmand.shared.gpx.GpxParameter.SPLIT_INTERVAL;
@@ -66,6 +67,7 @@ public class TrackDrawInfo {
 	private static final String TRACK_SPLIT_INTERVAL = "track_split_interval";
 	private static final String TRACK_JOIN_SEGMENTS = "track_join_segments";
 	private static final String TRACK_SHOW_ARROWS = "track_show_arrows";
+	private static final String TRACK_LINE_DASHED = "track_line_dashed";
 	private static final String TRACK_SHOW_START_FINISH = "track_show_start_finish";
 
 	private static final String TRACK_VISUALIZATION_TYPE_KEY = "track_visualization_type";
@@ -86,6 +88,7 @@ public class TrackDrawInfo {
 	private double splitInterval;
 	private boolean joinSegments;
 	private boolean showArrows;
+	private boolean dashedLine;
 	private boolean showStartFinish = true;
 	private Gpx3DVisualizationType trackVisualizationType = Gpx3DVisualizationType.NONE;
 	private Gpx3DWallColorType trackWallColorType = Gpx3DWallColorType.NONE;
@@ -128,6 +131,7 @@ public class TrackDrawInfo {
 		coloringType = settings.CURRENT_TRACK_COLORING_TYPE.get();
 		routeInfoAttribute = settings.CURRENT_TRACK_ROUTE_INFO_ATTRIBUTE.get();
 		showArrows = settings.CURRENT_TRACK_SHOW_ARROWS.get();
+		dashedLine = settings.CURRENT_TRACK_LINE_DASHED.get();
 		showStartFinish = settings.CURRENT_TRACK_SHOW_START_FINISH.get();
 		additionalExaggeration = settings.CURRENT_TRACK_ADDITIONAL_EXAGGERATION.get();
 		elevationMeters = settings.CURRENT_TRACK_ELEVATION_METERS.get();
@@ -155,6 +159,7 @@ public class TrackDrawInfo {
 		splitInterval = helper.requireParameter(item, SPLIT_INTERVAL);
 		joinSegments = helper.requireParameter(item, JOIN_SEGMENTS);
 		showArrows = helper.requireParameter(item, SHOW_ARROWS);
+		dashedLine = helper.requireParameter(item, LINE_DASHED);
 		showStartFinish = helper.isShowStartFinishForTrack(gpxFile, item, null);
 		trackVisualizationType = Gpx3DVisualizationType.get3DVisualizationType(helper.getParameter(item, TRACK_VISUALIZATION_TYPE));
 		trackWallColorType = Gpx3DWallColorType.Companion.get3DWallColorType(helper.getParameter(item, TRACK_3D_WALL_COLORING_TYPE));
@@ -269,6 +274,14 @@ public class TrackDrawInfo {
 		this.showArrows = showArrows;
 	}
 
+	public boolean isDashedLine() {
+		return dashedLine;
+	}
+
+	public void setDashedLine(boolean dashedLine) {
+		this.dashedLine = dashedLine;
+	}
+
 	public Gpx3DVisualizationType getTrackVisualizationType() {
 		return trackVisualizationType;
 	}
@@ -347,6 +360,7 @@ public class TrackDrawInfo {
 			settings.CURRENT_GRADIENT_PALETTE.resetToDefault();
 			settings.CURRENT_TRACK_ROUTE_INFO_ATTRIBUTE.resetToDefault();
 			settings.CURRENT_TRACK_SHOW_ARROWS.resetToDefault();
+			settings.CURRENT_TRACK_LINE_DASHED.resetToDefault();
 			settings.CURRENT_TRACK_SHOW_START_FINISH.resetToDefault();
 			settings.CURRENT_TRACK_3D_VISUALIZATION_TYPE.resetToDefault();
 			initCurrentTrackParams(app);
@@ -354,6 +368,7 @@ public class TrackDrawInfo {
 			color = getDefaultColor(settings, renderer);
 			width = getDefaultWidth(settings, renderer);
 			showArrows = false;
+			dashedLine = false;
 			showStartFinish = true;
 			coloringType = ColoringType.Companion.requireValueOf(TRACK, null);
 			gradientColorName = PaletteConstants.DEFAULT_NAME;
@@ -365,6 +380,7 @@ public class TrackDrawInfo {
 			color = gpxFile.getColor(null);
 			width = gpxFile.getWidth(null);
 			showArrows = gpxFile.isShowArrows();
+			dashedLine = gpxFile.isLineDashed();
 			showStartFinish = gpxFile.isShowStartFinish();
 			splitInterval = gpxFile.getSplitInterval();
 			splitType = GpxSplitType.getSplitTypeByName(gpxFile.getSplitType()).getType();
@@ -388,6 +404,7 @@ public class TrackDrawInfo {
 		splitInterval = bundle.getDouble(TRACK_SPLIT_INTERVAL);
 		joinSegments = bundle.getBoolean(TRACK_JOIN_SEGMENTS);
 		showArrows = bundle.getBoolean(TRACK_SHOW_ARROWS);
+		dashedLine = bundle.getBoolean(TRACK_LINE_DASHED);
 		showStartFinish = bundle.getBoolean(TRACK_SHOW_START_FINISH);
 		trackVisualizationType = AndroidUtils.getSerializable(bundle, TRACK_VISUALIZATION_TYPE_KEY, Gpx3DVisualizationType.class);
 		trackWallColorType = AndroidUtils.getSerializable(bundle, TRACK_WALL_COLOR_TYPE_KEY, Gpx3DWallColorType.class);
@@ -405,6 +422,7 @@ public class TrackDrawInfo {
 		bundle.putDouble(TRACK_SPLIT_INTERVAL, splitInterval);
 		bundle.putBoolean(TRACK_JOIN_SEGMENTS, joinSegments);
 		bundle.putBoolean(TRACK_SHOW_ARROWS, showArrows);
+		bundle.putBoolean(TRACK_LINE_DASHED, dashedLine);
 		bundle.putBoolean(TRACK_SHOW_START_FINISH, showStartFinish);
 		bundle.putInt(TRACK_APPEARANCE_TYPE, appearanceType);
 		bundle.putSerializable(TRACK_VISUALIZATION_TYPE_KEY, trackVisualizationType);

--- a/OsmAnd/src/net/osmand/plus/track/cards/DashedLineCard.java
+++ b/OsmAnd/src/net/osmand/plus/track/cards/DashedLineCard.java
@@ -1,0 +1,32 @@
+package net.osmand.plus.track.cards;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentActivity;
+
+import net.osmand.plus.R;
+import net.osmand.plus.track.TrackDrawInfo;
+
+public class DashedLineCard extends BaseSwitchCard {
+
+	private final TrackDrawInfo trackDrawInfo;
+
+	public DashedLineCard(@NonNull FragmentActivity activity, @NonNull TrackDrawInfo trackDrawInfo) {
+		super(activity);
+		this.trackDrawInfo = trackDrawInfo;
+	}
+
+	@Override
+	int getTitleId() {
+		return R.string.gpx_dashed_line;
+	}
+
+	@Override
+	protected boolean getChecked() {
+		return trackDrawInfo.isDashedLine();
+	}
+
+	@Override
+	protected void setChecked(boolean checked) {
+		trackDrawInfo.setDashedLine(checked);
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/track/fragments/TrackAppearanceFragment.java
+++ b/OsmAnd/src/net/osmand/plus/track/fragments/TrackAppearanceFragment.java
@@ -11,6 +11,7 @@ import static net.osmand.shared.gpx.GpxParameter.COLOR;
 import static net.osmand.shared.gpx.GpxParameter.COLORING_TYPE;
 import static net.osmand.shared.gpx.GpxParameter.COLOR_PALETTE;
 import static net.osmand.shared.gpx.GpxParameter.ELEVATION_METERS;
+import static net.osmand.shared.gpx.GpxParameter.LINE_DASHED;
 import static net.osmand.shared.gpx.GpxParameter.SHOW_ARROWS;
 import static net.osmand.shared.gpx.GpxParameter.SHOW_START_FINISH;
 import static net.osmand.shared.gpx.GpxParameter.SPLIT_INTERVAL;
@@ -63,6 +64,7 @@ import net.osmand.plus.track.GpxSplitType;
 import net.osmand.plus.track.SplitTrackAsyncTask.SplitTrackListener;
 import net.osmand.plus.track.TrackDrawInfo;
 import net.osmand.plus.track.cards.ActionsCard;
+import net.osmand.plus.track.cards.DashedLineCard;
 import net.osmand.plus.track.cards.DirectionArrowsCard;
 import net.osmand.plus.track.cards.ShowStartFinishCard;
 import net.osmand.plus.track.cards.SplitIntervalCard;
@@ -703,6 +705,7 @@ public class TrackAppearanceFragment extends ContextMenuScrollFragment implement
 			settings.CURRENT_TRACK_ROUTE_INFO_ATTRIBUTE.set(trackDrawInfo.getRouteInfoAttribute());
 			settings.CURRENT_TRACK_WIDTH.set(trackDrawInfo.getWidth());
 			settings.CURRENT_TRACK_SHOW_ARROWS.set(trackDrawInfo.isShowArrows());
+			settings.CURRENT_TRACK_LINE_DASHED.set(trackDrawInfo.isDashedLine());
 			settings.CURRENT_TRACK_SHOW_START_FINISH.set(trackDrawInfo.isShowStartFinish());
 			settings.CURRENT_TRACK_3D_VISUALIZATION_TYPE.set(trackDrawInfo.getTrackVisualizationType().getTypeName());
 			settings.CURRENT_TRACK_3D_WALL_COLORING_TYPE.set(trackDrawInfo.getTrackWallColorType().getTypeName());
@@ -714,6 +717,7 @@ public class TrackAppearanceFragment extends ContextMenuScrollFragment implement
 			gpxDataItem.setParameter(COLOR, trackDrawInfo.getColor());
 			gpxDataItem.setParameter(WIDTH, trackDrawInfo.getWidth());
 			gpxDataItem.setParameter(SHOW_ARROWS, trackDrawInfo.isShowArrows());
+			gpxDataItem.setParameter(LINE_DASHED, trackDrawInfo.isDashedLine());
 			gpxDataItem.setParameter(SHOW_START_FINISH, trackDrawInfo.isShowStartFinish());
 			gpxDataItem.setParameter(SPLIT_TYPE, GpxSplitType.getSplitTypeByTypeId(trackDrawInfo.getSplitType()).getType());
 			gpxDataItem.setParameter(SPLIT_INTERVAL, trackDrawInfo.getSplitInterval());
@@ -791,6 +795,7 @@ public class TrackAppearanceFragment extends ContextMenuScrollFragment implement
 				addCard(container, splitIntervalCard);
 			}
 			addCard(container, new DirectionArrowsCard(mapActivity, trackDrawInfo));
+			addCard(container, new DashedLineCard(mapActivity, trackDrawInfo));
 			addCard(container, new ShowStartFinishCard(mapActivity, trackDrawInfo));
 
 			inflate(R.layout.list_item_divider_basic, container, true);

--- a/OsmAnd/src/net/osmand/plus/track/helpers/GpxAppearanceHelper.java
+++ b/OsmAnd/src/net/osmand/plus/track/helpers/GpxAppearanceHelper.java
@@ -98,6 +98,26 @@ public class GpxAppearanceHelper {
 		return gpxFile.isShowArrows();
 	}
 
+	public boolean isLineDashedForTrack(@NonNull GpxFile gpxFile, @Nullable GpxDataItem gpxItem, @Nullable GpxDirItem dirItem) {
+		TrackDrawInfo drawInfo = getTrackDrawInfoForTrack(gpxFile);
+		if (drawInfo != null) {
+			return drawInfo.isDashedLine();
+		} else if (gpxFile.isShowCurrentTrack()) {
+			return settings.CURRENT_TRACK_LINE_DASHED.get();
+		} else if (gpxItem != null) {
+			Boolean dashed = getAppearanceParameter(gpxItem, dirItem, LINE_DASHED);
+			if (dashed != null) {
+				return dashed;
+			}
+		}
+		return gpxFile.isLineDashed();
+	}
+
+	public boolean isLineDashedForTrack(@NonNull GpxFile gpxFile, @Nullable GpxDataItem gpxItem,
+			@Nullable GpxDirItem dirItem, boolean selected) {
+		return selected && isLineDashedForTrack(gpxFile, gpxItem, dirItem);
+	}
+
 	public boolean isShowStartFinishForTrack(@NonNull GpxFile gpxFile, @Nullable GpxDataItem gpxItem, @Nullable GpxDirItem dirItem) {
 		TrackDrawInfo drawInfo = getTrackDrawInfoForTrack(gpxFile);
 		if (drawInfo != null) {

--- a/OsmAnd/src/net/osmand/plus/track/helpers/GpxUiHelper.java
+++ b/OsmAnd/src/net/osmand/plus/track/helpers/GpxUiHelper.java
@@ -763,6 +763,7 @@ public class GpxUiHelper {
 	private static void addAppearanceToGpx(@NonNull OsmandApplication app, @NonNull GpxFile gpxFile, @NonNull GpxDataItem item) {
 		GpxAppearanceHelper helper = new GpxAppearanceHelper(app);
 		gpxFile.setShowArrows(helper.requireParameter(item, SHOW_ARROWS));
+		gpxFile.setLineDashed(helper.requireParameter(item, LINE_DASHED));
 		gpxFile.setShowStartFinish(helper.requireParameter(item, SHOW_START_FINISH));
 		gpxFile.setSplitInterval(helper.requireParameter(item, SPLIT_INTERVAL));
 		gpxFile.setSplitType(GpxSplitType.getSplitTypeByTypeId(helper.requireParameter(item, SPLIT_TYPE)).getTypeName());

--- a/OsmAnd/src/net/osmand/plus/views/Renderable.java
+++ b/OsmAnd/src/net/osmand/plus/views/Renderable.java
@@ -98,6 +98,7 @@ public class Renderable {
 
         protected GpxGeometryWay geometryWay;
         protected boolean drawArrows;
+        protected boolean dashed;
         protected Track3DStyle track3DStyle;
 
         public RenderableSegment(List<WptPt> points, double segmentSize) {
@@ -113,6 +114,12 @@ public class Renderable {
         public boolean setDrawArrows(boolean drawArrows) {
             boolean changed = this.drawArrows != drawArrows;
             this.drawArrows = drawArrows;
+            return changed;
+        }
+
+        public boolean setDashed(boolean dashed) {
+            boolean changed = this.dashed != dashed;
+            this.dashed = dashed;
             return changed;
         }
 

--- a/OsmAnd/src/net/osmand/plus/views/layers/GPXLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/GPXLayer.java
@@ -1399,11 +1399,17 @@ public class GPXLayer extends OsmandMapLayer implements IContextMenuProvider, IM
 					}
 					updated |= renderableSegment.setDrawArrows(showArrows);
 					updated |= renderableSegment.setTrack3DStyle(track3DStyle);
+					boolean dashed = appearanceHelper.isLineDashedForTrack(gpxFile, gpxItem, dirItem, selected);
+					updated |= renderableSegment.setDashed(dashed);
 					if (updated || !hasMapRenderer) {
 						float[] intervals = null;
 						PathEffect pathEffect = paint.getPathEffect();
 						if (pathEffect instanceof OsmandDashPathEffect) {
 							intervals = ((OsmandDashPathEffect) pathEffect).getIntervals();
+						}
+						if (dashed) {
+							float dashStrokeWidth = paint.getStrokeWidth();
+							intervals = new float[] {Math.max(dashStrokeWidth * 2.5f, 1f), Math.max(dashStrokeWidth * 1.6f, 1f)};
 						}
 						boolean recreateSegments = invalidated || boundsChanged;
 						renderableSegment.drawGeometry(canvas, tileBox, correctedQuadRect, paint.getColor(),


### PR DESCRIPTION
### What
Adds a per-track **Dashed line** option to the track *Appearance* editor. When enabled, the track is rendered as a dashed line instead of solid.

### Why
A simple, frequently-wished way to visually distinguish tracks (e.g. planned vs. recorded, variants) without changing colour or width.

### How
Mirrors the existing `SHOW_ARROWS` appearance option end-to-end:
- New `LINE_DASHED` `GpxParameter` (boolean):
  - persisted in the gpx database — `DB_VERSION` 36 → 37; the generic `onUpgrade` column-add migrates both the gpx and gpx-dir tables,
  - written to / read from the GPX file `<extensions>` as `line_dashed` (`GpxFile.isLineDashed()/setLineDashed()`).
- `DashedLineCard` (`BaseSwitchCard`) added to `TrackAppearanceFragment`, next to "Direction arrows". Persisted on save for saved tracks and for the current recording track (`CURRENT_TRACK_LINE_DASHED`).
- `TrackDrawInfo` carries the flag; `GpxAppearanceHelper.isLineDashedForTrack(...)` resolves it (editor → current track → DB → GPX file).
- Rendering reuses the existing dash pipeline: `GPXLayer` supplies a width-proportional dash pattern to `RenderableSegment.drawGeometry(...)`, which already feeds `VectorLineBuilder.setLineDash(...)` for the OpenGL core. A small `Renderable.setDashed()` change-detector (mirroring `setDrawArrows`) makes a toggle rebuild the geometry.

### Notes
- Single colour for now (an alternating second dash colour is a natural follow-up).
- Only the English string is added; translations go through Weblate.
- Built and verified on-device (`androidFull` / `opengl` / `arm64`).
- Provided under the project's licence (MIT, per `PULL_REQUEST.MIT.LICENSE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)