### PR TITLE
Fix #25011 – Copy widgets panel from another profile

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/CenterWidgetInfo.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/CenterWidgetInfo.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
+import net.osmand.plus.settings.backend.ApplicationMode;
 import net.osmand.plus.settings.backend.OsmandSettings;
 import net.osmand.plus.settings.enums.ScreenLayoutMode;
 import net.osmand.plus.views.mapwidgets.widgets.MapWidget;
@@ -29,19 +30,20 @@ public class CenterWidgetInfo extends MapWidgetInfo {
 
 	@NonNull
 	@Override
-	public WidgetsPanel getUpdatedPanel(ScreenLayoutMode layoutMode) {
+	public WidgetsPanel getUpdatedPanel(@NonNull ApplicationMode appMode,
+	                                    @Nullable ScreenLayoutMode layoutMode) {
 		OsmandSettings settings = widget.getMyApplication().getSettings();
 		WidgetType widgetType = getWidgetType();
 		if (widgetType != null) {
-			if (widgetType.defaultPanel == BOTTOM && TOP.contains(key, settings, layoutMode)) {
+			if (widgetType.defaultPanel == BOTTOM && TOP.contains(key, settings, appMode, layoutMode)) {
 				widgetPanel = TOP;
-			} else if (widgetType.defaultPanel == TOP && BOTTOM.contains(key, settings, layoutMode)) {
+			} else if (widgetType.defaultPanel == TOP && BOTTOM.contains(key, settings, appMode, layoutMode)) {
 				widgetPanel = BOTTOM;
 			} else {
 				widgetPanel = widgetType.defaultPanel;
 			}
 		} else {
-			widgetPanel = TOP.contains(key, settings, layoutMode) ? TOP : BOTTOM;
+			widgetPanel = TOP.contains(key, settings, appMode, layoutMode) ? TOP : BOTTOM;
 		}
 		return widgetPanel;
 	}

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/ComplexWidgetInfo.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/ComplexWidgetInfo.java
@@ -5,6 +5,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
+import net.osmand.plus.settings.backend.ApplicationMode;
 import net.osmand.plus.settings.backend.OsmandSettings;
 import net.osmand.plus.settings.enums.ScreenLayoutMode;
 import net.osmand.plus.views.mapwidgets.widgetinterfaces.IComplexWidget;
@@ -43,13 +44,14 @@ public class ComplexWidgetInfo extends MapWidgetInfo {
 
 	@NonNull
 	@Override
-	public WidgetsPanel getUpdatedPanel(ScreenLayoutMode layoutMode) {
+	public WidgetsPanel getUpdatedPanel(@NonNull ApplicationMode appMode,
+	                                    @Nullable ScreenLayoutMode layoutMode) {
 		OsmandSettings settings = widget.getMyApplication().getSettings();
 		WidgetType widgetType = getWidgetType();
 		if (widgetType != null) {
-			return widgetType.getPanel(key, settings, layoutMode);
+			return widgetType.getPanel(key, appMode, layoutMode, settings);
 		} else {
-			WidgetType.findWidgetPanel(key, settings, null, layoutMode);
+			WidgetType.findWidgetPanel(key, settings, appMode, layoutMode);
 		}
 		return widgetPanel;
 	}

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/MapWidgetInfo.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/MapWidgetInfo.java
@@ -163,7 +163,8 @@ public abstract class MapWidgetInfo implements Comparable<MapWidgetInfo> {
 	}
 
 	@NonNull
-	public abstract WidgetsPanel getUpdatedPanel(ScreenLayoutMode layoutMode);
+	public abstract WidgetsPanel getUpdatedPanel(@NonNull ApplicationMode appMode,
+	                                             @Nullable ScreenLayoutMode layoutMode);
 
 	public boolean isEnabledForAppMode(@NonNull ApplicationMode appMode, @Nullable ScreenLayoutMode layoutMode) {
 		return isEnabledForAppMode(appMode, getWidgetsVisibility(getApp(), appMode, layoutMode));

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/MapWidgetRegistry.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/MapWidgetRegistry.java
@@ -150,7 +150,7 @@ public class MapWidgetRegistry {
 	private void reorderWidgets(@NonNull List<MapWidgetInfo> widgetInfos, @Nullable ScreenLayoutMode layoutMode) {
 		Map<WidgetsPanel, Set<MapWidgetInfo>> newAllWidgets = new HashMap<>();
 		for (MapWidgetInfo widgetInfo : widgetInfos) {
-			WidgetsPanel panel = widgetInfo.getUpdatedPanel(layoutMode);
+			WidgetsPanel panel = widgetInfo.getUpdatedPanel(settings.getApplicationMode(), layoutMode);
 			widgetInfo.pageIndex = panel.getWidgetPage(widgetInfo.key, settings, layoutMode);
 			widgetInfo.priority = panel.getWidgetOrder(widgetInfo.key, settings, layoutMode);
 
@@ -324,7 +324,7 @@ public class MapWidgetRegistry {
 				boolean passEnabled = !enabledMode || widget.isEnabledForAppMode(appMode, widgetsVisibility);
 				boolean passAvailable = !availableMode || WidgetsAvailabilityHelper.isWidgetAvailable(app, widget.key, appMode);
 				boolean defaultAvailable = !defaultMode || !widget.isCustomWidget();
-				boolean passMatchedPanels = !matchingPanelsMode || panels.contains(widget.getUpdatedPanel(layoutMode));
+				boolean passMatchedPanels = !matchingPanelsMode || panels.contains(widget.getUpdatedPanel(appMode, layoutMode));
 				boolean passTypeAllowed = widgetType.isAllowed();
 				boolean passPanelAllowed = widgetType.isPanelsAllowed(panels);
 

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/SideWidgetInfo.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/SideWidgetInfo.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
+import net.osmand.plus.settings.backend.ApplicationMode;
 import net.osmand.plus.settings.backend.OsmandSettings;
 import net.osmand.plus.settings.enums.ScreenLayoutMode;
 import net.osmand.plus.views.mapwidgets.widgets.TextInfoWidget;
@@ -34,19 +35,20 @@ public class SideWidgetInfo extends MapWidgetInfo {
 
 	@NonNull
 	@Override
-	public WidgetsPanel getUpdatedPanel(ScreenLayoutMode layoutMode) {
+	public WidgetsPanel getUpdatedPanel(@NonNull ApplicationMode appMode,
+	                                    @Nullable ScreenLayoutMode layoutMode) {
 		OsmandSettings settings = widget.getMyApplication().getSettings();
 		WidgetType widgetType = getWidgetType();
 		if (widgetType != null) {
-			if (widgetType.defaultPanel == LEFT && RIGHT.contains(key, settings, layoutMode)) {
+			if (widgetType.defaultPanel == LEFT && RIGHT.contains(key, settings, appMode, layoutMode)) {
 				widgetPanel = RIGHT;
-			} else if (widgetType.defaultPanel == RIGHT && LEFT.contains(key, settings, layoutMode)) {
+			} else if (widgetType.defaultPanel == RIGHT && LEFT.contains(key, settings, appMode, layoutMode)) {
 				widgetPanel = LEFT;
 			} else {
 				widgetPanel = widgetType.defaultPanel;
 			}
 		} else {
-			widgetPanel = LEFT.contains(key, settings, layoutMode) ? LEFT : RIGHT;
+			widgetPanel = LEFT.contains(key, settings, appMode, layoutMode) ? LEFT : RIGHT;
 		}
 
 		return widgetPanel;

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/SimpleWidgetInfo.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/SimpleWidgetInfo.java
@@ -5,6 +5,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
+import net.osmand.plus.settings.backend.ApplicationMode;
 import net.osmand.plus.settings.backend.OsmandSettings;
 import net.osmand.plus.settings.enums.ScreenLayoutMode;
 import net.osmand.plus.views.mapwidgets.widgets.SimpleWidget;
@@ -39,13 +40,14 @@ public class SimpleWidgetInfo extends MapWidgetInfo {
 
 	@NonNull
 	@Override
-	public WidgetsPanel getUpdatedPanel(ScreenLayoutMode layoutMode) {
+	public WidgetsPanel getUpdatedPanel(@NonNull ApplicationMode appMode,
+	                                    @Nullable ScreenLayoutMode layoutMode) {
 		OsmandSettings settings = widget.getMyApplication().getSettings();
 		WidgetType widgetType = getWidgetType();
 		if (widgetType != null) {
-			return widgetType.getPanel(key, settings, layoutMode);
+			return widgetType.getPanel(key, appMode, layoutMode, settings);
 		} else {
-			WidgetType.findWidgetPanel(key, settings, null, layoutMode);
+			WidgetType.findWidgetPanel(key, settings, appMode, layoutMode);
 		}
 		return widgetPanel;
 	}

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/WidgetsPanel.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/WidgetsPanel.java
@@ -195,10 +195,6 @@ public enum WidgetsPanel {
 		return orderPreference.setModeValue(appMode, stringBuilder.toString());
 	}
 
-	public boolean contains(@NonNull String widgetId, @NonNull OsmandSettings settings, @Nullable ScreenLayoutMode layoutMode) {
-		return contains(widgetId, settings, settings.getApplicationMode(), layoutMode);
-	}
-
 	public boolean contains(@NonNull String widgetId, @NonNull OsmandSettings settings,
 			@NonNull ApplicationMode appMode, @Nullable ScreenLayoutMode layoutMode) {
 		return getWidgetOrder(appMode,layoutMode, widgetId, settings) != DEFAULT_ORDER;

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/WidgetsSettingsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/WidgetsSettingsHelper.java
@@ -102,7 +102,9 @@ public class WidgetsSettingsHelper {
 		mapButtonsHelper.copyButtonStatesFromMode(appMode, fromAppMode, mapButtonsHelper.getAllButtonsStates());
 	}
 
-	public void copyWidgetsForPanel(@NonNull ApplicationMode fromAppMode, @Nullable ScreenLayoutMode fromLayoutMode, @NonNull WidgetsPanel panel) {
+	public void copyWidgetsForPanel(@NonNull ApplicationMode fromAppMode,
+	                                @Nullable ScreenLayoutMode fromLayoutMode,
+	                                @NonNull WidgetsPanel panel) {
 		int filter = ENABLED_MODE | AVAILABLE_MODE | MATCHING_PANELS_MODE;
 		List<WidgetsPanel> panels = Collections.singletonList(panel);
 		Set<MapWidgetInfo> widgetInfosToCopy = widgetRegistry.getWidgetsForPanel(mapActivity, fromAppMode, fromLayoutMode, filter, panels);


### PR DESCRIPTION
`getUpdatedPanel()` was called without an explicit `ApplicationMode`, causing it to fall back to `settings.getApplicationMode()` (the currently active profile) instead of the profile being copied from.

This meant that `MATCHING_PANELS_MODE` filtering checked widget panel membership against the wrong profile, causing widgets to be incorrectly filtered out or assigned to wrong panels during copy.

**Fix:** Added `ApplicationMode` parameter to `getUpdatedPanel()` across all `MapWidgetInfo` subclasses and updated all call sites to pass the correct app mode. Also removed the `contains()` overload without explicit `ApplicationMode` to prevent recurrence.