### PR TITLE
Fix display position handling in plan route

### DIFF
--- a/OsmAnd/src/net/osmand/plus/helpers/MapDisplayPositionManager.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/MapDisplayPositionManager.java
@@ -73,7 +73,15 @@ public class MapDisplayPositionManager implements ViewportListener {
 
 	@NonNull
 	public MapPosition getNavigationMapPosition() {
-		return getPositionFromPreferences();
+		DisplayPositionData positionData = getPositionFromProviders();
+		MapPosition providerPosition = positionData != null ? positionData.position : null;
+		return resolveNavigationMapPosition(providerPosition, getPositionFromPreferences());
+	}
+
+	@NonNull
+	static MapPosition resolveNavigationMapPosition(@Nullable MapPosition providerPosition,
+	                                                @NonNull MapPosition preferencePosition) {
+		return providerPosition != null ? providerPosition : preferencePosition;
 	}
 
 	@Nullable

--- a/OsmAnd/src/net/osmand/plus/quickaction/actions/DisplayPositionAction.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/actions/DisplayPositionAction.java
@@ -17,6 +17,7 @@ import net.osmand.plus.R;
 import net.osmand.plus.activities.MapActivity;
 import net.osmand.plus.quickaction.QuickAction;
 import net.osmand.plus.quickaction.QuickActionType;
+import net.osmand.plus.settings.backend.OsmandSettings;
 import net.osmand.plus.settings.backend.preferences.CommonPreference;
 import net.osmand.plus.utils.UiUtilities;
 
@@ -44,9 +45,14 @@ public class DisplayPositionAction extends QuickAction {
 	@Override
 	public void execute(@NonNull MapActivity mapActivity, @Nullable Bundle params) {
 		CommonPreference<Integer> pref = getPreference(mapActivity);
-		int currentState = pref.get();
-		pref.set((currentState == 2) ? 0 : currentState + 1);
+		pref.set(getNextPlacement(pref.get()));
 		mapActivity.updateLayers();
+	}
+
+	public static int getNextPlacement(int currentPlacement) {
+		return currentPlacement == OsmandSettings.POSITION_PLACEMENT_BOTTOM
+				? OsmandSettings.POSITION_PLACEMENT_AUTOMATIC
+				: currentPlacement + 1;
 	}
 
 	private CommonPreference<Integer> getPreference(@NonNull Context ctx) {

--- a/OsmAnd/test/java/net/osmand/plus/helpers/MapDisplayPositionManagerTest.java
+++ b/OsmAnd/test/java/net/osmand/plus/helpers/MapDisplayPositionManagerTest.java
@@ -1,0 +1,24 @@
+package net.osmand.plus.helpers;
+
+import net.osmand.plus.settings.enums.MapPosition;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MapDisplayPositionManagerTest {
+
+	@Test
+	public void testNavigationMapPosition_usesPlanRouteProviderOverBottomPreference() {
+		assertEquals(
+				MapPosition.MIDDLE_TOP,
+				MapDisplayPositionManager.resolveNavigationMapPosition(MapPosition.MIDDLE_TOP, MapPosition.BOTTOM));
+	}
+
+	@Test
+	public void testNavigationMapPosition_fallsBackToPreferenceWithoutProvider() {
+		assertEquals(
+				MapPosition.BOTTOM,
+				MapDisplayPositionManager.resolveNavigationMapPosition(null, MapPosition.BOTTOM));
+	}
+}

--- a/OsmAnd/test/java/net/osmand/plus/quickaction/actions/DisplayPositionActionTest.java
+++ b/OsmAnd/test/java/net/osmand/plus/quickaction/actions/DisplayPositionActionTest.java
@@ -1,0 +1,23 @@
+package net.osmand.plus.quickaction.actions;
+
+import net.osmand.plus.settings.backend.OsmandSettings;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DisplayPositionActionTest {
+
+	@Test
+	public void testGetNextPlacement_cyclesThroughDisplayPositionStates() {
+		assertEquals(
+				OsmandSettings.POSITION_PLACEMENT_CENTER,
+				DisplayPositionAction.getNextPlacement(OsmandSettings.POSITION_PLACEMENT_AUTOMATIC));
+		assertEquals(
+				OsmandSettings.POSITION_PLACEMENT_BOTTOM,
+				DisplayPositionAction.getNextPlacement(OsmandSettings.POSITION_PLACEMENT_CENTER));
+		assertEquals(
+				OsmandSettings.POSITION_PLACEMENT_AUTOMATIC,
+				DisplayPositionAction.getNextPlacement(OsmandSettings.POSITION_PLACEMENT_BOTTOM));
+	}
+}


### PR DESCRIPTION
## Summary
- make navigation map position respect active display position providers
- keep Plan a Route centered correctly when Display position preference is set to Bottom
- extract Display position state transition logic for testability
- add regression tests for provider override and Display position status cycling

## Testing
- Attempted:
  `JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.15/libexec/openjdk.jdk/Contents/Home ./gradlew :OsmAnd:compileGplayFreeLegacyArm64DebugAndroidTestJavaWithJavac -x :OsmAnd-java:test -Dorg.gradle.jvmargs=-Xmx6g -Dorg.gradle.vfs.watch=false`
- Blocked by unrelated master/OsmAndCore issue:
  `EpsgCoordinateTransformer.kt` cannot resolve `net.osmand.core.jni.CoordinateTransformer`.