### PR TITLE
Fix widget copying for separate layouts

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/WidgetsSettingsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/WidgetsSettingsHelper.java
@@ -86,7 +86,7 @@ public class WidgetsSettingsHelper {
 
 	public void copyConfigureScreenSettings(@NonNull ApplicationMode fromAppMode) {
 		for (WidgetsPanel panel : WidgetsPanel.values()) {
-			copyWidgetsForPanel(fromAppMode, null, panel);
+			copyWidgetsForPanel(fromAppMode, getLayoutModeForProfileCopy(layoutMode), panel);
 		}
 		copyPrefFromAppMode(settings.getPanelsLayoutMode(mapActivity, layoutMode), fromAppMode);
 		copyPrefFromAppMode(settings.getTransparentMapThemePreference(layoutMode), fromAppMode);
@@ -100,6 +100,11 @@ public class WidgetsSettingsHelper {
 		copyPrefFromAppMode(mapButtonsHelper.getDefaultOpacityPref(), fromAppMode);
 		copyPrefFromAppMode(mapButtonsHelper.getDefaultCornerRadiusPref(), fromAppMode);
 		mapButtonsHelper.copyButtonStatesFromMode(appMode, fromAppMode, mapButtonsHelper.getAllButtonsStates());
+	}
+
+	@Nullable
+	static ScreenLayoutMode getLayoutModeForProfileCopy(@Nullable ScreenLayoutMode layoutMode) {
+		return layoutMode;
 	}
 
 	public void copyWidgetsForPanel(@NonNull ApplicationMode fromAppMode,

--- a/OsmAnd/test/java/net/osmand/plus/views/mapwidgets/configure/WidgetsSettingsHelperTest.java
+++ b/OsmAnd/test/java/net/osmand/plus/views/mapwidgets/configure/WidgetsSettingsHelperTest.java
@@ -1,0 +1,30 @@
+package net.osmand.plus.views.mapwidgets.configure;
+
+import net.osmand.plus.settings.enums.ScreenLayoutMode;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class WidgetsSettingsHelperTest {
+
+	@Test
+	public void testGetLayoutModeForProfileCopy_keepsPortraitSeparateLayout() {
+		assertEquals(
+				ScreenLayoutMode.PORTRAIT,
+				WidgetsSettingsHelper.getLayoutModeForProfileCopy(ScreenLayoutMode.PORTRAIT));
+	}
+
+	@Test
+	public void testGetLayoutModeForProfileCopy_keepsLandscapeSeparateLayout() {
+		assertEquals(
+				ScreenLayoutMode.LANDSCAPE,
+				WidgetsSettingsHelper.getLayoutModeForProfileCopy(ScreenLayoutMode.LANDSCAPE));
+	}
+
+	@Test
+	public void testGetLayoutModeForProfileCopy_keepsSharedLayout() {
+		assertNull(WidgetsSettingsHelper.getLayoutModeForProfileCopy(null));
+	}
+}


### PR DESCRIPTION
## Summary
- fix Configure screen profile copy to preserve the active separate layout mode
- ensure left/right panel widgets are copied from portrait/landscape layout settings instead of shared layout settings
- add regression tests for portrait, landscape, and shared layout copy mode resolution

## Testing
- `git diff --check`
- Android compile was not rerun because current master is blocked by unrelated `EpsgCoordinateTransformer.kt` / `net.osmand.core.jni.CoordinateTransformer` resolution issue.