### PR TITLE
Fix duplicate widgets not being copied when copying profile panel settings

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/WidgetsSettingsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/WidgetsSettingsHelper.java
@@ -86,7 +86,7 @@ public class WidgetsSettingsHelper {
 
 	public void copyConfigureScreenSettings(@NonNull ApplicationMode fromAppMode) {
 		for (WidgetsPanel panel : WidgetsPanel.values()) {
-			copyWidgetsForPanel(fromAppMode, null, panel); // todo check may be we should use layout mode too
+			copyWidgetsForPanel(fromAppMode, null, panel);
 		}
 		copyPrefFromAppMode(settings.getPanelsLayoutMode(mapActivity, layoutMode), fromAppMode);
 		copyPrefFromAppMode(settings.getTransparentMapThemePreference(layoutMode), fromAppMode);

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/WidgetsSettingsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/WidgetsSettingsHelper.java
@@ -86,7 +86,7 @@ public class WidgetsSettingsHelper {
 
 	public void copyConfigureScreenSettings(@NonNull ApplicationMode fromAppMode) {
 		for (WidgetsPanel panel : WidgetsPanel.values()) {
-			copyWidgetsForPanel(fromAppMode, null, panel);
+			copyWidgetsForPanel(fromAppMode, null, panel); // todo check may be we should use layout mode too
 		}
 		copyPrefFromAppMode(settings.getPanelsLayoutMode(mapActivity, layoutMode), fromAppMode);
 		copyPrefFromAppMode(settings.getTransparentMapThemePreference(layoutMode), fromAppMode);
@@ -120,18 +120,23 @@ public class WidgetsSettingsHelper {
 			}
 
 			WidgetType widgetTypeToCopy = widgetInfoToCopy.widget.getWidgetType();
-			boolean duplicateNotPossible = widgetTypeToCopy == null;
 			String defaultWidgetId = WidgetType.getDefaultWidgetId(widgetInfoToCopy.key);
 			MapWidgetInfo defaultWidgetInfo = getWidgetInfoById(defaultWidgetId, defaultWidgetInfos);
 
 			if (defaultWidgetInfo != null) {
-				String widgetIdToAdd;
+				String widgetIdToAdd = null;
+				boolean duplicateNotPossible = widgetTypeToCopy == null;
 				boolean disabled = !defaultWidgetInfo.isEnabledForAppMode(appMode, widgetsVisibility);
 				boolean inAnotherPanel = defaultWidgetInfo.getWidgetPanel() != panel;
-				if (duplicateNotPossible || (disabled && !inAnotherPanel)) {
+				boolean defaultAlreadyUsed = newPagedOrder.stream()
+						.anyMatch(page -> page.contains(defaultWidgetInfo.key));
+
+				boolean canReuseDefault = (duplicateNotPossible || (disabled && !inAnotherPanel)) && !defaultAlreadyUsed;
+
+				if (canReuseDefault) {
 					widgetRegistry.enableDisableWidgetForMode(appMode, defaultWidgetInfo, true, layoutMode, false);
 					widgetIdToAdd = defaultWidgetInfo.key;
-				} else {
+				} else if (widgetTypeToCopy != null) {
 					MapWidgetInfo duplicateWidgetInfo = createDuplicateWidgetInfo(widgetTypeToCopy, panel);
 					widgetIdToAdd = duplicateWidgetInfo != null ? duplicateWidgetInfo.key : null;
 				}
@@ -140,7 +145,7 @@ public class WidgetsSettingsHelper {
 					String customId = !widgetIdToAdd.equals(defaultWidgetInfo.key) ? widgetIdToAdd : null;
 					widgetInfoToCopy.widget.copySettingsFromMode(fromAppMode, appMode, customId);
 
-					if (previousPage != widgetInfoToCopy.pageIndex || newPagedOrder.size() == 0) {
+					if (previousPage != widgetInfoToCopy.pageIndex || newPagedOrder.isEmpty()) {
 						previousPage = widgetInfoToCopy.pageIndex;
 						newPagedOrder.add(new ArrayList<>());
 					}


### PR DESCRIPTION
## Problem
When copying widgets from one profile to another, duplicate widgets 
(e.g. "Current time", "Speed limit", "Next turn (small)") were not 
fully copied if the same widget appeared more than once across pages. 
Only the first occurrence was copied; all subsequent ones were silently 
skipped.

## Root Cause
In `copyWidgetsForPanel`, when copying a widget whose default panel 
matches the target panel, the code attempted to reuse the default 
widget slot (via `defaultWidgetInfo.key`) instead of creating a 
duplicate. This is correct for the first occurrence, but for every 
subsequent occurrence of the same widget the same key was assigned 
again — resulting in multiple widgets sharing one ID in `newPagedOrder`.
On save/display, only one of them was actually rendered.

Specifically, this affected widgets where `disabled && !inAnotherPanel` 
was true — meaning the widget belongs to the target panel by default 
but wasn't yet enabled there. The code correctly enabled it on the 
first occurrence, but had no mechanism to detect that the slot was 
already taken on subsequent ones.

## Fix
Added `defaultAlreadyUsed` check to detect when the default widget 
slot has already been taken in the current copy session. If so, fall 
through to `createDuplicateWidgetInfo` instead of reusing the same key.

The condition is extracted into a named boolean `canReuseDefault` 
for readability.