### PR TITLE
Fix layout mode not passed when copying configure screen settings

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/WidgetsSettingsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/WidgetsSettingsHelper.java
@@ -86,7 +86,7 @@ public class WidgetsSettingsHelper {
 
 	public void copyConfigureScreenSettings(@NonNull ApplicationMode fromAppMode) {
 		for (WidgetsPanel panel : WidgetsPanel.values()) {
-			copyWidgetsForPanel(fromAppMode, null, panel);
+			copyWidgetsForPanel(fromAppMode, layoutMode, panel);
 		}
 		copyPrefFromAppMode(settings.getPanelsLayoutMode(mapActivity, layoutMode), fromAppMode);
 		copyPrefFromAppMode(settings.getTransparentMapThemePreference(layoutMode), fromAppMode);


### PR DESCRIPTION
## Fix
Fixed `copyConfigureScreenSettings` passing `null` instead of 
`layoutMode` when calling `copyWidgetsForPanel`. This caused widgets 
to always be copied from the default layout regardless of the active 
screen layout mode, which would produce incorrect results when 
"Separate layout for landscape" is enabled.