### PR TITLE
Optimize serialization and favorites saving

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/ProgressOutputStream.java
+++ b/OsmAnd-java/src/main/java/net/osmand/ProgressOutputStream.java
@@ -45,4 +45,9 @@ public class ProgressOutputStream extends OutputStream {
 		this.out.write(b);
 		submitProgress(1);
 	}
+
+	@Override
+	public void flush() throws IOException {
+		out.flush();
+	}
 }

--- a/OsmAnd-java/src/main/java/net/osmand/gpx/GPXUtilities.java
+++ b/OsmAnd-java/src/main/java/net/osmand/gpx/GPXUtilities.java
@@ -27,6 +27,7 @@ import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlSerializer;
 
 import java.io.BufferedInputStream;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -993,7 +994,8 @@ public class GPXUtilities {
 			if (fout.getParentFile() != null) {
 				fout.getParentFile().mkdirs();
 			}
-			output = new OutputStreamWriter(new FileOutputStream(fout), "UTF-8"); //$NON-NLS-1$
+			output = new BufferedWriter(
+					new OutputStreamWriter(new FileOutputStream(fout), "UTF-8"), 32 * 1024); //$NON-NLS-1$
 			if (Algorithms.isEmpty(file.path)) {
 				file.path = fout.getAbsolutePath();
 			}

--- a/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/io/SinkOutputStream.kt
+++ b/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/io/SinkOutputStream.kt
@@ -2,12 +2,18 @@ package net.osmand.shared.io
 
 import okio.BufferedSink
 import okio.IOException
-import okio.Okio
 import okio.Sink
 import okio.buffer
 import java.io.OutputStream
 
-class SinkOutputStream(sink: Sink) : OutputStream() {
+/**
+ * [OutputStream] over an okio [Sink].
+ *
+ * With [closeSink] = false, [close] only flushes — for caller-owned sinks that must
+ * stay open (e.g. AtomicFile streams closed by finishWrite()).
+ */
+class SinkOutputStream(sink: Sink, private val closeSink: Boolean = true) : OutputStream() {
+
 	private val bufferedSink: BufferedSink = sink.buffer()
 
 	@Throws(IOException::class)
@@ -25,8 +31,19 @@ class SinkOutputStream(sink: Sink) : OutputStream() {
 		bufferedSink.flush()
 	}
 
+	/**
+	 * Closes the underlying sink, or — when [closeSink] is false — only flushes it.
+	 *
+	 * The flush-only mode deliberately deviates from the [OutputStream.close] contract:
+	 * all buffered bytes are pushed through, but the sink stays open and the caller
+	 * remains responsible for closing it.
+	 */
 	@Throws(IOException::class)
 	override fun close() {
-		bufferedSink.close()
+		if (closeSink) {
+			bufferedSink.close()
+		} else {
+			flush()
+		}
 	}
 }

--- a/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/io/SinkStringWriter.kt
+++ b/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/io/SinkStringWriter.kt
@@ -3,9 +3,9 @@ package net.osmand.shared.io
 import okio.IOException
 import okio.Sink
 import okio.buffer
-import java.io.StringWriter
+import java.io.Writer
 
-class SinkStringWriter(sink: Sink) : StringWriter() {
+class SinkStringWriter(sink: Sink) : Writer() {
 
 	private val bufferedSink = sink.buffer()
 
@@ -27,7 +27,7 @@ class SinkStringWriter(sink: Sink) : StringWriter() {
 
 	@Throws(IOException::class)
 	override fun write(str: String, off: Int, len: Int) {
-		bufferedSink.writeUtf8(str.substring(off, off + len))
+		bufferedSink.writeUtf8(str, off, off + len)
 	}
 
 	@Throws(IOException::class)
@@ -35,7 +35,5 @@ class SinkStringWriter(sink: Sink) : StringWriter() {
 		bufferedSink.flush()
 	}
 
-	override fun toString(): String {
-		return bufferedSink.toString()
-	}
+	override fun close() = flush()
 }

--- a/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/xml/XmlSerializer.kt
+++ b/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/xml/XmlSerializer.kt
@@ -4,14 +4,19 @@ import net.osmand.shared.io.KFile
 import net.osmand.shared.io.SinkStringWriter
 import okio.IOException
 import okio.Sink
+import java.io.BufferedWriter
 import java.io.File
 import java.io.OutputStreamWriter
-import java.io.StringWriter
+import java.io.Writer
 
 actual class XmlSerializer actual constructor() {
+	private companion object {
+		const val BUFFER_SIZE = 32 * 1024
+	}
+
 	private val serializer = org.kxml2.io.KXmlSerializer()
-	private var outputStream: OutputStreamWriter? = null
-	private var stringWriter: StringWriter? = null
+	private var outputStream: Writer? = null
+	private var stringWriter: Writer? = null
 
 	@Throws(IllegalArgumentException::class, IllegalStateException::class)
 	actual fun setFeature(name: String, state: Boolean) = serializer.setFeature(name, state)
@@ -32,14 +37,14 @@ actual class XmlSerializer actual constructor() {
 		val fout = File(file.absolutePath())
 		fout.parentFile?.mkdirs()
 
-		outputStream = OutputStreamWriter(fout.outputStream(), "UTF-8")
+		outputStream = BufferedWriter(OutputStreamWriter(fout.outputStream(), Charsets.UTF_8), BUFFER_SIZE)
 		serializer.setOutput(outputStream)
 	}
 
 	@Throws(IOException::class, IllegalArgumentException::class, IllegalStateException::class)
 	actual fun setOutput(output: Sink) {
 		stringWriter?.close()
-		stringWriter = SinkStringWriter(output)
+		stringWriter = BufferedWriter(SinkStringWriter(output), BUFFER_SIZE)
 		serializer.setOutput(stringWriter)
 	}
 

--- a/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/xml/XmlSerializer.kt
+++ b/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/xml/XmlSerializer.kt
@@ -1,7 +1,7 @@
 package net.osmand.shared.xml
 
 import net.osmand.shared.io.KFile
-import net.osmand.shared.io.SinkStringWriter
+import net.osmand.shared.io.SinkOutputStream
 import okio.IOException
 import okio.Sink
 import java.io.BufferedWriter
@@ -44,7 +44,7 @@ actual class XmlSerializer actual constructor() {
 	@Throws(IOException::class, IllegalArgumentException::class, IllegalStateException::class)
 	actual fun setOutput(output: Sink) {
 		stringWriter?.close()
-		stringWriter = BufferedWriter(SinkStringWriter(output), BUFFER_SIZE)
+		stringWriter = BufferedWriter(OutputStreamWriter(SinkOutputStream(output, false), Charsets.UTF_8), BUFFER_SIZE)
 		serializer.setOutput(stringWriter)
 	}
 

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/IndexConstants.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/IndexConstants.kt
@@ -62,6 +62,8 @@ object IndexConstants {
 
 	const val OBJ_FILE_EXT = ".obj"
 
+	const val TMP_FILE_EXT = ".tmp"
+
 	const val POI_TABLE = "poi"
 
 	const val INDEX_DOWNLOAD_DOMAIN = "download.osmand.net"

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxUtilities.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxUtilities.kt
@@ -487,7 +487,7 @@ object GpxUtilities {
 			if (file != null) {
 				serializer.setOutput(file)
 			} else if (stream != null) {
-				serializer.setOutput(stream.buffer())
+				serializer.setOutput(stream)
 			} else {
 				throw KException("Output file or stream is not defined")
 			}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/helper/ImportGpx.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/helper/ImportGpx.kt
@@ -42,10 +42,9 @@ object ImportGpx {
 	@Throws(IOException::class)
 	fun loadGPXFileFromKml(kml: Source): Pair<GpxFile, Long> {
 		return try {
-			val res = convertKmlToGpxString(kml)
-			val byteStr = res.encodeToByteArray()
-			val gpxStream: Source = Buffer().write(byteStr)
-			Pair(loadGpxFile(gpxStream), byteStr.size.toLong())
+			val gpxBuffer = convertKmlToGpxBuffer(kml)
+			val fileSize = gpxBuffer.size
+			Pair(loadGpxFile(gpxBuffer), fileSize)
 		} catch (e: Exception) {
 			errorImport("KML to GPX transform error: ${e.message}")
 		}
@@ -58,13 +57,13 @@ object ImportGpx {
 		return Pair(gpxFile, 0)
 	}
 
-	private fun convertKmlToGpxString(kml: Source): String {
+	private fun convertKmlToGpxBuffer(kml: Source): Buffer {
 		val writer = Buffer()
 		val serializer = startGpxDocument(writer)
 		val documentName = parseKmlStreaming(kml, serializer, writer, flushEvery = Int.MAX_VALUE)
 		writeMetadata(serializer, documentName)
 		endGpxDocument(serializer)
-		return writer.readUtf8()
+		return writer
 	}
 
 	fun convertKmlToGpxStream(

--- a/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/io/SinkOutputStream.kt
+++ b/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/io/SinkOutputStream.kt
@@ -2,12 +2,18 @@ package net.osmand.shared.io
 
 import okio.BufferedSink
 import okio.IOException
-import okio.Okio
 import okio.Sink
 import okio.buffer
 import java.io.OutputStream
 
-class SinkOutputStream(sink: Sink) : OutputStream() {
+/**
+ * [OutputStream] over an okio [Sink].
+ *
+ * With [closeSink] = false, [close] only flushes — for caller-owned sinks that must
+ * stay open (e.g. AtomicFile streams closed by finishWrite()).
+ */
+class SinkOutputStream(sink: Sink, private val closeSink: Boolean = true) : OutputStream() {
+
 	private val bufferedSink: BufferedSink = sink.buffer()
 
 	@Throws(IOException::class)
@@ -25,8 +31,19 @@ class SinkOutputStream(sink: Sink) : OutputStream() {
 		bufferedSink.flush()
 	}
 
+	/**
+	 * Closes the underlying sink, or — when [closeSink] is false — only flushes it.
+	 *
+	 * The flush-only mode deliberately deviates from the [OutputStream.close] contract:
+	 * all buffered bytes are pushed through, but the sink stays open and the caller
+	 * remains responsible for closing it.
+	 */
 	@Throws(IOException::class)
 	override fun close() {
-		bufferedSink.close()
+		if (closeSink) {
+			bufferedSink.close()
+		} else {
+			flush()
+		}
 	}
 }

--- a/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/io/SinkStringWriter.kt
+++ b/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/io/SinkStringWriter.kt
@@ -4,9 +4,9 @@ import okio.BufferedSink
 import okio.IOException
 import okio.Sink
 import okio.buffer
-import java.io.StringWriter
+import java.io.Writer
 
-class SinkStringWriter(sink: Sink) : StringWriter() {
+class SinkStringWriter(sink: Sink) : Writer() {
 
 	private val bufferedSink: BufferedSink = sink.buffer()
 
@@ -29,7 +29,7 @@ class SinkStringWriter(sink: Sink) : StringWriter() {
 
 	@Throws(IOException::class)
 	override fun write(str: String, off: Int, len: Int) {
-		bufferedSink.writeUtf8(str.substring(off, off + len))
+		bufferedSink.writeUtf8(str, off, off + len)
 	}
 
 	@Throws(IOException::class)
@@ -39,6 +39,6 @@ class SinkStringWriter(sink: Sink) : StringWriter() {
 
 	@Throws(IOException::class)
 	override fun close() {
-		bufferedSink.close()
+		flush()
 	}
 }

--- a/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/xml/XmlSerializer.kt
+++ b/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/xml/XmlSerializer.kt
@@ -4,14 +4,19 @@ import net.osmand.shared.io.KFile
 import net.osmand.shared.io.SinkStringWriter
 import okio.IOException
 import okio.Sink
+import java.io.BufferedWriter
 import java.io.File
 import java.io.OutputStreamWriter
-import java.io.StringWriter
+import java.io.Writer
 
 actual class XmlSerializer actual constructor() {
+	private companion object {
+		const val BUFFER_SIZE = 32 * 1024
+	}
+
 	private val serializer = org.kxml2.io.KXmlSerializer()
-	private var outputStream: OutputStreamWriter? = null
-	private var stringWriter: StringWriter? = null
+	private var outputStream: Writer? = null
+	private var stringWriter: Writer? = null
 
 	@Throws(IllegalArgumentException::class, IllegalStateException::class)
 	actual fun setFeature(name: String, state: Boolean) = serializer.setFeature(name, state)
@@ -32,14 +37,14 @@ actual class XmlSerializer actual constructor() {
 		val fout = File(file.absolutePath())
 		fout.parentFile?.mkdirs()
 
-		outputStream = OutputStreamWriter(fout.outputStream(), "UTF-8")
+		outputStream = BufferedWriter(OutputStreamWriter(fout.outputStream(), Charsets.UTF_8), BUFFER_SIZE)
 		serializer.setOutput(outputStream)
 	}
 
 	@Throws(IOException::class, IllegalArgumentException::class, IllegalStateException::class)
 	actual fun setOutput(output: Sink) {
 		stringWriter?.close()
-		stringWriter = SinkStringWriter(output)
+		stringWriter = BufferedWriter(SinkStringWriter(output), BUFFER_SIZE)
 		serializer.setOutput(stringWriter)
 	}
 

--- a/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/xml/XmlSerializer.kt
+++ b/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/xml/XmlSerializer.kt
@@ -1,7 +1,7 @@
 package net.osmand.shared.xml
 
 import net.osmand.shared.io.KFile
-import net.osmand.shared.io.SinkStringWriter
+import net.osmand.shared.io.SinkOutputStream
 import okio.IOException
 import okio.Sink
 import java.io.BufferedWriter
@@ -44,7 +44,7 @@ actual class XmlSerializer actual constructor() {
 	@Throws(IOException::class, IllegalArgumentException::class, IllegalStateException::class)
 	actual fun setOutput(output: Sink) {
 		stringWriter?.close()
-		stringWriter = BufferedWriter(SinkStringWriter(output), BUFFER_SIZE)
+		stringWriter = BufferedWriter(OutputStreamWriter(SinkOutputStream(output, false), Charsets.UTF_8), BUFFER_SIZE)
 		serializer.setOutput(stringWriter)
 	}
 

--- a/OsmAnd/src/net/osmand/plus/backup/AutoBackupHelper.java
+++ b/OsmAnd/src/net/osmand/plus/backup/AutoBackupHelper.java
@@ -140,8 +140,10 @@ public class AutoBackupHelper implements OnPrepareBackupListener {
 			case FAVORITES: {
 				app.getFavoritesHelper().addListener(new FavoritesListener() {
 					@Override
-					public void onSavingFavoritesFinished() {
-						requestAutoBackup();
+					public void onSavingFavoritesFinished(boolean success) {
+						if (success) {
+							requestAutoBackup();
+						}
 					}
 				});
 			}

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavoriteDeletionsJournal.kt
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavoriteDeletionsJournal.kt
@@ -60,13 +60,8 @@ object FavoriteDeletionsJournal {
 		points: Collection<FavouritePoint>?,
 		groups: Collection<FavoriteGroup>?
 	) {
-		val lines = buildList {
-			points?.forEach { add(serializePoint(it.key)) }
-			groups?.forEach { add(serializeGroup(it.name)) }
-		}
-
-		if (lines.isNotEmpty()) {
-			appendPendingDeletionLines(app, lines)
+		if (!points.isNullOrEmpty() || !groups.isNullOrEmpty()) {
+			appendPendingDeletionLines(app, points, groups)
 		}
 	}
 
@@ -87,19 +82,11 @@ object FavoriteDeletionsJournal {
 					}
 				} catch (e: IOException) {
 					log.error("Failed to read favorite deletions journal", e)
-					return ReadResult(
-						deletions = deletions,
-						state = null,
-						readFailed = true
-					)
+					return ReadResult(deletions, null, readFailed = true)
 				}
 			}
 
-			return ReadResult(
-				deletions = deletions,
-				state = getState(file),
-				readFailed = false
-			)
+			return ReadResult(deletions, getState(file), readFailed = false)
 		}
 	}
 
@@ -121,15 +108,19 @@ object FavoriteDeletionsJournal {
 		}
 	}
 
-	private fun appendPendingDeletionLines(app: OsmandApplication, lines: Collection<String>) {
+	private fun appendPendingDeletionLines(app: OsmandApplication, points: Collection<FavouritePoint>?, groups: Collection<FavoriteGroup>?) {
 		synchronized(lock) {
 			val file = getFile(app)
 
 			try {
 				FileOutputStream(file, true).use { fos ->
 					BufferedWriter(OutputStreamWriter(fos, Charsets.UTF_8), 8192).use { writer ->
-						for (line in lines) {
-							writer.write(line)
+						points?.forEach {
+							writer.write(serializePoint(it.key))
+							writer.newLine()
+						}
+						groups?.forEach {
+							writer.write(serializeGroup(it.name))
 							writer.newLine()
 						}
 						writer.flush()
@@ -161,19 +152,7 @@ object FavoriteDeletionsJournal {
 		}
 	}
 
-	private fun getState(file: File): JournalState {
-		return if (file.exists()) {
-			JournalState(
-				length = file.length(),
-				timestamp = file.lastModified()
-			)
-		} else {
-			JournalState(
-				length = 0L,
-				timestamp = 0L
-			)
-		}
-	}
+	private fun getState(file: File): JournalState = if (file.exists()) JournalState(file.length(), file.lastModified()) else JournalState(0L, 0L)
 
 	data class ReadResult(
 		val deletions: FavoritePendingDeletions,

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavoriteDeletionsJournal.kt
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavoriteDeletionsJournal.kt
@@ -1,0 +1,179 @@
+package net.osmand.plus.myplaces.favorites
+
+import net.osmand.PlatformUtil
+import net.osmand.data.FavouritePoint
+import net.osmand.plus.OsmandApplication
+import net.osmand.plus.myplaces.favorites.FavouritesFileHelper.FAV_FILE_PREFIX
+import net.osmand.shared.IndexConstants.TMP_FILE_EXT
+import java.io.BufferedWriter
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.OutputStreamWriter
+
+object FavoriteDeletionsJournal {
+
+	private val log = PlatformUtil.getLog(FavoriteDeletionsJournal::class.java)
+
+	private const val PENDING_DELETIONS_SUFFIX = "_deletions"
+	private const val PREFIX_POINT = "point:"
+	private const val PREFIX_GROUP = "group:"
+
+	private val lock = Any()
+
+	private fun getFile(app: OsmandApplication): File {
+		return app.getFileStreamPath(FAV_FILE_PREFIX + PENDING_DELETIONS_SUFFIX + TMP_FILE_EXT)
+	}
+
+	@JvmStatic
+	fun addPoint(
+		app: OsmandApplication,
+		point: FavouritePoint?
+	) {
+		if (point != null) {
+			addAll(app, listOf(point), null)
+		}
+	}
+
+	@JvmStatic
+	fun addGroup(
+		app: OsmandApplication,
+		group: FavoriteGroup?
+	) {
+		if (group != null) {
+			addAll(app, null, listOf(group))
+		}
+	}
+
+	@JvmStatic
+	fun addAll(
+		app: OsmandApplication,
+		points: Collection<FavouritePoint>?,
+		groups: Collection<FavoriteGroup>?
+	) {
+		val lines = buildList {
+			points?.forEach { add(serializePoint(it.key)) }
+			groups?.forEach { add(serializeGroup(it.name)) }
+		}
+
+		if (lines.isNotEmpty()) {
+			appendPendingDeletionLines(app, lines)
+		}
+	}
+
+	@JvmStatic
+	fun read(app: OsmandApplication): ReadResult {
+		synchronized(lock) {
+			val file = getFile(app)
+			val deletions = FavoritePendingDeletions()
+
+			if (file.exists()) {
+				try {
+					file.bufferedReader(Charsets.UTF_8, 8192).useLines { lines ->
+						lines.forEach { line ->
+							if (line.isNotEmpty()) {
+								deserializeLine(line, deletions)
+							}
+						}
+					}
+				} catch (e: IOException) {
+					log.error("Failed to read favorite deletions journal", e)
+					return ReadResult(
+						deletions = deletions,
+						state = null,
+						readFailed = true
+					)
+				}
+			}
+
+			return ReadResult(
+				deletions = deletions,
+				state = getState(file),
+				readFailed = false
+			)
+		}
+	}
+
+	@JvmStatic
+	fun clearIfUnchanged(app: OsmandApplication, expectedState: JournalState): Boolean {
+		synchronized(lock) {
+			val file = getFile(app)
+			val currentState = getState(file)
+
+			if (currentState != expectedState) {
+				return false
+			}
+
+			if (file.exists() && !file.delete()) {
+				log.warn("Failed to clear favorite deletions journal: ${file.absolutePath}")
+				return false
+			}
+			return true
+		}
+	}
+
+	private fun appendPendingDeletionLines(app: OsmandApplication, lines: Collection<String>) {
+		synchronized(lock) {
+			val file = getFile(app)
+
+			try {
+				FileOutputStream(file, true).use { fos ->
+					BufferedWriter(OutputStreamWriter(fos, Charsets.UTF_8), 8192).use { writer ->
+						for (line in lines) {
+							writer.write(line)
+							writer.newLine()
+						}
+						writer.flush()
+					}
+				}
+			} catch (e: IOException) {
+				log.error("appendPendingDeletionLines failed", e)
+			}
+		}
+	}
+
+	private fun serializePoint(pointKey: String): String {
+		return "$PREFIX_POINT$pointKey"
+	}
+
+	private fun serializeGroup(groupName: String): String {
+		return "$PREFIX_GROUP$groupName"
+	}
+
+	private fun deserializeLine(line: String, deletions: FavoritePendingDeletions) {
+		when {
+			line.startsWith(PREFIX_POINT) -> {
+				deletions.addPoint(line.removePrefix(PREFIX_POINT))
+			}
+
+			line.startsWith(PREFIX_GROUP) -> {
+				deletions.addGroup(line.removePrefix(PREFIX_GROUP))
+			}
+		}
+	}
+
+	private fun getState(file: File): JournalState {
+		return if (file.exists()) {
+			JournalState(
+				length = file.length(),
+				timestamp = file.lastModified()
+			)
+		} else {
+			JournalState(
+				length = 0L,
+				timestamp = 0L
+			)
+		}
+	}
+
+	data class ReadResult(
+		val deletions: FavoritePendingDeletions,
+		val state: JournalState?,
+		val readFailed: Boolean
+	)
+
+	data class JournalState(
+		val length: Long,
+		val timestamp: Long
+	)
+}

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavoriteDeletionsJournal.kt
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavoriteDeletionsJournal.kt
@@ -11,6 +11,15 @@ import java.io.FileOutputStream
 import java.io.IOException
 import java.io.OutputStreamWriter
 
+/**
+ * Lightweight journal for favorite deletions.
+ *
+ * Favorites are saved asynchronously, so the app may be killed before deleted items are
+ * removed from all GPX files. This journal stores pending point/group deletions and applies
+ * them on the next load, preventing deleted favorites from being restored from stale files.
+ *
+ * The journal is cleared only after a successful full save if it was not changed meanwhile.
+ */
 object FavoriteDeletionsJournal {
 
 	private val log = PlatformUtil.getLog(FavoriteDeletionsJournal::class.java)

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavoritePendingDeletions.kt
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavoritePendingDeletions.kt
@@ -15,8 +15,6 @@ class FavoritePendingDeletions {
 	}
 
 	fun addGroup(groupName: String) {
-		if (groupName.isNotEmpty()) {
-			groupNames.add(groupName)
-		}
+		groupNames.add(groupName)
 	}
 }

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavoritePendingDeletions.kt
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavoritePendingDeletions.kt
@@ -1,0 +1,22 @@
+package net.osmand.plus.myplaces.favorites
+
+class FavoritePendingDeletions {
+
+	val pointKeys: MutableSet<String> = HashSet()
+	val groupNames: MutableSet<String> = HashSet()
+
+	val isEmpty: Boolean
+		get() = pointKeys.isEmpty() && groupNames.isEmpty()
+
+	fun addPoint(pointKey: String) {
+		if (pointKey.isNotEmpty()) {
+			pointKeys.add(pointKey)
+		}
+	}
+
+	fun addGroup(groupName: String) {
+		if (groupName.isNotEmpty()) {
+			groupNames.add(groupName)
+		}
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavoritesListener.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavoritesListener.java
@@ -12,6 +12,6 @@ public interface FavoritesListener {
 	default void onFavoriteDataUpdated(@NonNull FavouritePoint point) {
 	}
 
-	default void onSavingFavoritesFinished() {
+	default void onSavingFavoritesFinished(boolean success) {
 	}
 }

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesFileHelper.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesFileHelper.java
@@ -180,7 +180,7 @@ public class FavouritesFileHelper {
 
 	private void startSave(@NonNull SaveBatch batch) {
 		SaveFavoritesTask task = new SaveFavoritesTask(app, this,
-				batch.groups, batch.saveAllGroups,
+				batch.getGroups(), batch.getSaveAllGroups(),
 				(success, journalState) -> onSaveFinished(batch, success, journalState));
 		OsmAndTaskManager.executeTask(task, singleThreadExecutor);
 	}
@@ -195,14 +195,14 @@ public class FavouritesFileHelper {
 				saveRunning = false;
 			}
 		}
-		if (success && completedBatch.saveAllGroups && journalState != null) {
+		if (success && completedBatch.getSaveAllGroups() && journalState != null) {
 			FavoriteDeletionsJournal.clearIfUnchanged(app, journalState);
 		}
-		for (CountDownLatch waiter : completedBatch.waiters) {
+		for (CountDownLatch waiter : completedBatch.getWaiters()) {
 			waiter.countDown();
 		}
 		if (success) {
-			for (FavoritesListener listener : completedBatch.listeners) {
+			for (FavoritesListener listener : completedBatch.getListeners()) {
 				app.runInUIThread(listener::onSavingFavoritesFinished);
 			}
 		}
@@ -399,59 +399,5 @@ public class FavouritesFileHelper {
 			return fileName.replaceAll(XML_COLON, ":");
 		}
 		return fileName;
-	}
-
-	private static class SaveBatch {
-		@NonNull
-		private List<FavoriteGroup> groups;
-		private boolean saveAllGroups;
-		@NonNull
-		private final List<FavoritesListener> listeners = new ArrayList<>();
-		@NonNull
-		private final List<CountDownLatch> waiters = new ArrayList<>();
-
-		SaveBatch(@NonNull List<FavoriteGroup> groups, boolean saveAllGroups,
-				@Nullable FavoritesListener listener, @Nullable CountDownLatch waiter) {
-			this.groups = new ArrayList<>(groups);
-			this.saveAllGroups = saveAllGroups;
-			addRequest(listener, waiter);
-		}
-
-		void merge(@NonNull List<FavoriteGroup> groups, boolean saveAllGroups,
-				@Nullable FavoritesListener listener, @Nullable CountDownLatch waiter) {
-			if (saveAllGroups) {
-				this.groups = new ArrayList<>(groups);
-				this.saveAllGroups = true;
-			} else {
-				mergeGroups(this.groups, groups);
-			}
-			addRequest(listener, waiter);
-		}
-
-		private void addRequest(@Nullable FavoritesListener listener, @Nullable CountDownLatch waiter) {
-			if (listener != null) {
-				listeners.add(listener);
-			}
-			if (waiter != null) {
-				waiters.add(waiter);
-			}
-		}
-
-		private static void mergeGroups(@NonNull List<FavoriteGroup> destination,
-				@NonNull List<FavoriteGroup> source) {
-			for (FavoriteGroup sourceGroup : source) {
-				boolean replaced = false;
-				for (int i = 0; i < destination.size(); i++) {
-					if (Algorithms.stringsEqual(destination.get(i).getName(), sourceGroup.getName())) {
-						destination.set(i, sourceGroup);
-						replaced = true;
-						break;
-					}
-				}
-				if (!replaced) {
-					destination.add(sourceGroup);
-				}
-			}
-		}
 	}
 }

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesFileHelper.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesFileHelper.java
@@ -150,10 +150,10 @@ public class FavouritesFileHelper {
 	}
 
 	public void saveFavoritesIntoFileSync(@NonNull List<FavoriteGroup> groups, boolean saveAllGroups, @Nullable FavoritesListener listener) {
-		CountDownLatch completion = new CountDownLatch(1);
-		enqueueSave(groups, saveAllGroups, listener, completion);
+		CountDownLatch waiter = new CountDownLatch(1);
+		enqueueSave(groups, saveAllGroups, listener, waiter);
 		try {
-			completion.await();
+			waiter.await();
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 			log.error(e.getMessage(), e);
@@ -161,16 +161,16 @@ public class FavouritesFileHelper {
 	}
 
 	private void enqueueSave(@NonNull List<FavoriteGroup> groups, boolean saveAllGroups,
-			@Nullable FavoritesListener listener, @Nullable CountDownLatch completion) {
+			@Nullable FavoritesListener listener, @Nullable CountDownLatch waiter) {
 		SaveBatch batchToStart = null;
 		synchronized (saveLock) {
 			if (!saveRunning) {
 				saveRunning = true;
-				batchToStart = new SaveBatch(groups, saveAllGroups, listener, completion);
+				batchToStart = new SaveBatch(groups, saveAllGroups, listener, waiter);
 			} else if (pendingSave == null) {
-				pendingSave = new SaveBatch(groups, saveAllGroups, listener, completion);
+				pendingSave = new SaveBatch(groups, saveAllGroups, listener, waiter);
 			} else {
-				pendingSave.merge(groups, saveAllGroups, listener, completion);
+				pendingSave.merge(groups, saveAllGroups, listener, waiter);
 			}
 		}
 		if (batchToStart != null) {
@@ -179,7 +179,7 @@ public class FavouritesFileHelper {
 	}
 
 	private void startSave(@NonNull SaveBatch batch) {
-		SaveFavoritesTask task = SaveFavoritesTask.createCoordinated(
+		SaveFavoritesTask task = new SaveFavoritesTask(
 				this, batch.groups, batch.saveAllGroups,
 				success -> onSaveFinished(batch, success));
 		OsmAndTaskManager.executeTask(task, singleThreadExecutor);
@@ -194,8 +194,8 @@ public class FavouritesFileHelper {
 				saveRunning = false;
 			}
 		}
-		for (CountDownLatch completion : completedBatch.completions) {
-			completion.countDown();
+		for (CountDownLatch waiter : completedBatch.waiters) {
+			waiter.countDown();
 		}
 		if (success) {
 			for (FavoritesListener listener : completedBatch.listeners) {
@@ -404,32 +404,32 @@ public class FavouritesFileHelper {
 		@NonNull
 		private final List<FavoritesListener> listeners = new ArrayList<>();
 		@NonNull
-		private final List<CountDownLatch> completions = new ArrayList<>();
+		private final List<CountDownLatch> waiters = new ArrayList<>();
 
 		SaveBatch(@NonNull List<FavoriteGroup> groups, boolean saveAllGroups,
-				@Nullable FavoritesListener listener, @Nullable CountDownLatch completion) {
+				@Nullable FavoritesListener listener, @Nullable CountDownLatch waiter) {
 			this.groups = new ArrayList<>(groups);
 			this.saveAllGroups = saveAllGroups;
-			addCompletion(listener, completion);
+			addRequest(listener, waiter);
 		}
 
 		void merge(@NonNull List<FavoriteGroup> groups, boolean saveAllGroups,
-				@Nullable FavoritesListener listener, @Nullable CountDownLatch completion) {
+				@Nullable FavoritesListener listener, @Nullable CountDownLatch waiter) {
 			if (saveAllGroups) {
 				this.groups = new ArrayList<>(groups);
 				this.saveAllGroups = true;
 			} else {
 				mergeGroups(this.groups, groups);
 			}
-			addCompletion(listener, completion);
+			addRequest(listener, waiter);
 		}
 
-		private void addCompletion(@Nullable FavoritesListener listener, @Nullable CountDownLatch completion) {
+		private void addRequest(@Nullable FavoritesListener listener, @Nullable CountDownLatch waiter) {
 			if (listener != null) {
 				listeners.add(listener);
 			}
-			if (completion != null) {
-				completions.add(completion);
+			if (waiter != null) {
+				waiters.add(waiter);
 			}
 		}
 

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesFileHelper.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesFileHelper.java
@@ -179,13 +179,14 @@ public class FavouritesFileHelper {
 	}
 
 	private void startSave(@NonNull SaveBatch batch) {
-		SaveFavoritesTask task = new SaveFavoritesTask(
-				this, batch.groups, batch.saveAllGroups,
-				success -> onSaveFinished(batch, success));
+		SaveFavoritesTask task = new SaveFavoritesTask(app, this,
+				batch.groups, batch.saveAllGroups,
+				(success, journalState) -> onSaveFinished(batch, success, journalState));
 		OsmAndTaskManager.executeTask(task, singleThreadExecutor);
 	}
 
-	private void onSaveFinished(@NonNull SaveBatch completedBatch, boolean success) {
+	private void onSaveFinished(@NonNull SaveBatch completedBatch, boolean success,
+	                            @Nullable FavoriteDeletionsJournal.JournalState journalState) {
 		SaveBatch batchToStart;
 		synchronized (saveLock) {
 			batchToStart = pendingSave;
@@ -193,6 +194,9 @@ public class FavouritesFileHelper {
 			if (batchToStart == null) {
 				saveRunning = false;
 			}
+		}
+		if (success && completedBatch.saveAllGroups && journalState != null) {
+			FavoriteDeletionsJournal.clearIfUnchanged(app, journalState);
 		}
 		for (CountDownLatch waiter : completedBatch.waiters) {
 			waiter.countDown();

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesFileHelper.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesFileHelper.java
@@ -6,6 +6,8 @@ import static net.osmand.IndexConstants.GPX_FILE_EXT;
 import static net.osmand.IndexConstants.ZIP_EXT;
 import static net.osmand.shared.gpx.GpxFile.XML_COLON;
 
+import android.util.AtomicFile;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -24,8 +26,12 @@ import net.osmand.util.Algorithms;
 import org.apache.commons.logging.Log;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -48,6 +54,11 @@ public class FavouritesFileHelper {
 
 	private final OsmandApplication app;
 	private final ExecutorService singleThreadExecutor = Executors.newSingleThreadExecutor();
+	private final Object saveLock = new Object();
+
+	private boolean saveRunning;
+	@Nullable
+	private SaveBatch pendingSave;
 
 	protected FavouritesFileHelper(@NonNull OsmandApplication app) {
 		this.app = app;
@@ -84,6 +95,7 @@ public class FavouritesFileHelper {
 	public Map<String, FavoriteGroup> loadInternalGroups() {
 		Map<String, FavoriteGroup> groups = new LinkedHashMap<>();
 		File file = getInternalFile();
+		recoverAtomicFile(file);
 		if (file.exists()) {
 			loadFileGroups(file, groups, false);
 		}
@@ -134,16 +146,64 @@ public class FavouritesFileHelper {
 	}
 
 	public void saveFavoritesIntoFile(@NonNull List<FavoriteGroup> groups, boolean saveAllGroups, @Nullable FavoritesListener listener) {
-		SaveFavoritesTask task = new SaveFavoritesTask(this, groups, saveAllGroups, listener);
-		OsmAndTaskManager.executeTask(task, singleThreadExecutor);
+		enqueueSave(groups, saveAllGroups, listener, null);
 	}
 
 	public void saveFavoritesIntoFileSync(@NonNull List<FavoriteGroup> groups, boolean saveAllGroups, @Nullable FavoritesListener listener) {
-		SaveFavoritesTask task = new SaveFavoritesTask(this, groups, saveAllGroups, listener);
+		CountDownLatch completion = new CountDownLatch(1);
+		enqueueSave(groups, saveAllGroups, listener, completion);
 		try {
-			OsmAndTaskManager.executeTask(task, singleThreadExecutor).get();
-		} catch (ExecutionException | InterruptedException e) {
-			log.error(e);
+			completion.await();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			log.error(e.getMessage(), e);
+		}
+	}
+
+	private void enqueueSave(@NonNull List<FavoriteGroup> groups, boolean saveAllGroups,
+			@Nullable FavoritesListener listener, @Nullable CountDownLatch completion) {
+		SaveBatch batchToStart = null;
+		synchronized (saveLock) {
+			if (!saveRunning) {
+				saveRunning = true;
+				batchToStart = new SaveBatch(groups, saveAllGroups, listener, completion);
+			} else if (pendingSave == null) {
+				pendingSave = new SaveBatch(groups, saveAllGroups, listener, completion);
+			} else {
+				pendingSave.merge(groups, saveAllGroups, listener, completion);
+			}
+		}
+		if (batchToStart != null) {
+			startSave(batchToStart);
+		}
+	}
+
+	private void startSave(@NonNull SaveBatch batch) {
+		SaveFavoritesTask task = SaveFavoritesTask.createCoordinated(
+				this, batch.groups, batch.saveAllGroups,
+				success -> onSaveFinished(batch, success));
+		OsmAndTaskManager.executeTask(task, singleThreadExecutor);
+	}
+
+	private void onSaveFinished(@NonNull SaveBatch completedBatch, boolean success) {
+		SaveBatch batchToStart;
+		synchronized (saveLock) {
+			batchToStart = pendingSave;
+			pendingSave = null;
+			if (batchToStart == null) {
+				saveRunning = false;
+			}
+		}
+		for (CountDownLatch completion : completedBatch.completions) {
+			completion.countDown();
+		}
+		if (success) {
+			for (FavoritesListener listener : completedBatch.listeners) {
+				app.runInUIThread(listener::onSavingFavoritesFinished);
+			}
+		}
+		if (batchToStart != null) {
+			startSave(batchToStart);
 		}
 	}
 
@@ -175,10 +235,31 @@ public class FavouritesFileHelper {
 		if (!dir.exists() || !dir.isDirectory()) {
 			return null;
 		}
-		return dir.listFiles((d, name) ->
-				name.startsWith(FAV_FILE_PREFIX + FAV_GROUP_NAME_SEPARATOR)
-						|| name.equals(FAV_FILE_PREFIX + GPX_FILE_EXT)
-						|| name.equals(LEGACY_FAV_FILE_PREFIX + GPX_FILE_EXT));
+		File[] remnants = dir.listFiles((d, name) -> name.endsWith(".new") || name.endsWith(".bak"));
+		if (!Algorithms.isEmpty(remnants)) {
+			for (File remnant : remnants) {
+				String baseName = remnant.getName().substring(0, remnant.getName().length() - 4);
+				if (isFavoritesFileName(baseName)) {
+					recoverAtomicFile(new File(dir, baseName));
+				}
+			}
+		}
+		return dir.listFiles((d, name) -> isFavoritesFileName(name));
+	}
+
+	private static boolean isFavoritesFileName(@NonNull String name) {
+		return (name.startsWith(FAV_FILE_PREFIX + FAV_GROUP_NAME_SEPARATOR)
+				&& name.endsWith(GPX_FILE_EXT))
+				|| name.equals(FAV_FILE_PREFIX + GPX_FILE_EXT)
+				|| name.equals(LEGACY_FAV_FILE_PREFIX + GPX_FILE_EXT);
+	}
+
+	private static void recoverAtomicFile(@NonNull File file) {
+		try (FileInputStream ignored = new AtomicFile(file).openRead()) {
+			// Opening recovers a previous valid base file and removes stale temporary data.
+		} catch (IOException ignored) {
+			// No committed base file exists yet.
+		}
 	}
 
 	@NonNull
@@ -194,6 +275,31 @@ public class FavouritesFileHelper {
 	public Exception saveFile(@NonNull List<FavoriteGroup> favoriteGroups, @NonNull File file) {
 		GpxFile gpx = asGpxFile(favoriteGroups);
 		return SharedUtil.writeGpxFile(file, gpx);
+	}
+
+	@Nullable
+	protected Exception saveFileAtomic(@NonNull List<FavoriteGroup> favoriteGroups, @NonNull File file) {
+		File parent = file.getParentFile();
+		if (parent != null && !parent.exists()) {
+			parent.mkdirs();
+		}
+		GpxFile gpx = asGpxFile(favoriteGroups);
+		AtomicFile atomicFile = new AtomicFile(file);
+		FileOutputStream output = null;
+		try {
+			output = atomicFile.startWrite();
+			Exception error = SharedUtil.writeGpx(output, gpx, null);
+			if (error != null) {
+				throw error;
+			}
+			atomicFile.finishWrite(output);
+			return null;
+		} catch (Exception e) {
+			if (output != null) {
+				atomicFile.failWrite(output);
+			}
+			return e;
+		}
 	}
 
 	@NonNull
@@ -289,5 +395,59 @@ public class FavouritesFileHelper {
 			return fileName.replaceAll(XML_COLON, ":");
 		}
 		return fileName;
+	}
+
+	private static class SaveBatch {
+		@NonNull
+		private List<FavoriteGroup> groups;
+		private boolean saveAllGroups;
+		@NonNull
+		private final List<FavoritesListener> listeners = new ArrayList<>();
+		@NonNull
+		private final List<CountDownLatch> completions = new ArrayList<>();
+
+		SaveBatch(@NonNull List<FavoriteGroup> groups, boolean saveAllGroups,
+				@Nullable FavoritesListener listener, @Nullable CountDownLatch completion) {
+			this.groups = new ArrayList<>(groups);
+			this.saveAllGroups = saveAllGroups;
+			addCompletion(listener, completion);
+		}
+
+		void merge(@NonNull List<FavoriteGroup> groups, boolean saveAllGroups,
+				@Nullable FavoritesListener listener, @Nullable CountDownLatch completion) {
+			if (saveAllGroups) {
+				this.groups = new ArrayList<>(groups);
+				this.saveAllGroups = true;
+			} else {
+				mergeGroups(this.groups, groups);
+			}
+			addCompletion(listener, completion);
+		}
+
+		private void addCompletion(@Nullable FavoritesListener listener, @Nullable CountDownLatch completion) {
+			if (listener != null) {
+				listeners.add(listener);
+			}
+			if (completion != null) {
+				completions.add(completion);
+			}
+		}
+
+		private static void mergeGroups(@NonNull List<FavoriteGroup> destination,
+				@NonNull List<FavoriteGroup> source) {
+			for (FavoriteGroup sourceGroup : source) {
+				boolean replaced = false;
+				for (int i = 0; i < destination.size(); i++) {
+					if (Algorithms.stringsEqual(destination.get(i).getName(), sourceGroup.getName())) {
+						destination.set(i, sourceGroup);
+						replaced = true;
+						break;
+					}
+				}
+				if (!replaced) {
+					destination.add(sourceGroup);
+				}
+			}
+		}
 	}
 }

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesFileHelper.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesFileHelper.java
@@ -179,10 +179,14 @@ public class FavouritesFileHelper {
 	}
 
 	private void startSave(@NonNull SaveBatch batch) {
-		SaveFavoritesTask task = new SaveFavoritesTask(app, this,
-				batch.getGroups(), batch.getSaveAllGroups(),
-				(success, journalState) -> onSaveFinished(batch, success, journalState));
-		OsmAndTaskManager.executeTask(task, singleThreadExecutor);
+		try {
+			SaveFavoritesTask task = new SaveFavoritesTask(app, this, batch.getGroups(), batch.getSaveAllGroups(),
+					(success, journalState) -> onSaveFinished(batch, success, journalState));
+			OsmAndTaskManager.executeTask(task, singleThreadExecutor);
+		} catch (RuntimeException e) {
+			log.error("Failed to start favorites save", e);
+			onSaveFinished(batch, false, null);
+		}
 	}
 
 	private void onSaveFinished(@NonNull SaveBatch completedBatch, boolean success,
@@ -201,10 +205,8 @@ public class FavouritesFileHelper {
 		for (CountDownLatch waiter : completedBatch.getWaiters()) {
 			waiter.countDown();
 		}
-		if (success) {
-			for (FavoritesListener listener : completedBatch.getListeners()) {
-				app.runInUIThread(listener::onSavingFavoritesFinished);
-			}
+		for (FavoritesListener listener : completedBatch.getListeners()) {
+			app.runInUIThread(() -> listener.onSavingFavoritesFinished(success));
 		}
 		if (batchToStart != null) {
 			startSave(batchToStart);

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesHelper.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesHelper.java
@@ -72,6 +72,12 @@ public class FavouritesHelper {
 
 	private List<FavoritesListener> listeners = new ArrayList<>();
 	private final Map<FavouritePoint, AddressLookupRequest> addressRequestMap = new ConcurrentHashMap<>();
+	private final FavoritesListener saveFavoritesListener = new FavoritesListener() {
+		@Override
+		public void onSavingFavoritesFinished() {
+			notifySavingFavoritesFinished(null);
+		}
+	};
 
 	private boolean favoritesLoaded;
 	private long lastModifiedTime;
@@ -791,7 +797,7 @@ public class FavouritesHelper {
 
 	private void saveFavoriteGroups(@NonNull List<FavoriteGroup> groups, boolean saveAllGroups, boolean async, @Nullable FavoritesListener listener) {
 		updateLastModifiedTime();
-		FavoritesListener saveListener = new FavoritesListener() {
+		FavoritesListener saveListener = listener == null ? saveFavoritesListener : new FavoritesListener() {
 			@Override
 			public void onSavingFavoritesFinished() {
 				notifySavingFavoritesFinished(listener);

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesHelper.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesHelper.java
@@ -26,6 +26,7 @@ import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.R;
 import net.osmand.plus.mapmarkers.MapMarkersGroup;
 import net.osmand.plus.mapmarkers.MapMarkersHelper;
+import net.osmand.plus.myplaces.favorites.FavoriteDeletionsJournal.ReadResult;
 import net.osmand.plus.myplaces.favorites.add.AddFavoriteOptions;
 import net.osmand.plus.myplaces.favorites.add.AddFavoriteResult;
 import net.osmand.plus.myplaces.favorites.dialogs.FavoriteSortModesHelper;
@@ -46,9 +47,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -256,8 +259,16 @@ public class FavouritesHelper {
 	}
 
 	public void loadFavorites() {
+		ReadResult journalRead = FavoriteDeletionsJournal.read(app);
+		FavoritePendingDeletions pendingDeletions = journalRead.getDeletions();
+
 		Map<String, FavoriteGroup> groups = fileHelper.loadInternalGroups();
 		Map<String, FavoriteGroup> extGroups = fileHelper.loadExternalGroups();
+
+		if (!pendingDeletions.isEmpty()) {
+			applyPendingDeletions(groups, pendingDeletions);
+			applyPendingDeletions(extGroups, pendingDeletions);
+		}
 
 		boolean changed = merge(extGroups, groups);
 
@@ -271,7 +282,8 @@ public class FavouritesHelper {
 		File legacyExternalFile = fileHelper.getLegacyExternalFile();
 		// Force save favorites to file if internals are different from externals
 		// or no favorites created yet or legacy favourites.gpx present
-		if (changed || !fileHelper.getExternalDir().exists() || legacyExternalFile.exists()) {
+		if (changed || !fileHelper.getExternalDir().exists()
+				|| legacyExternalFile.exists() || !pendingDeletions.isEmpty()) {
 			saveCurrentPointsIntoFile(false);
 			// Delete legacy favourites.gpx if exists
 			if (legacyExternalFile.exists()) {
@@ -282,6 +294,22 @@ public class FavouritesHelper {
 		}
 		favoritesLoaded = true;
 		notifyListeners();
+	}
+
+	private void applyPendingDeletions(@NonNull Map<String, FavoriteGroup> groups,
+	                                   @NonNull FavoritePendingDeletions pendingDeletions) {
+		Set<String> pendingGroupDeletions = pendingDeletions.getGroupNames();
+		Set<String> pendingPointDeletions = pendingDeletions.getPointKeys();
+
+		Iterator<Entry<String, FavoriteGroup>> it = groups.entrySet().iterator();
+		while (it.hasNext()) {
+			Map.Entry<String, FavoriteGroup> entry = it.next();
+			if (pendingGroupDeletions.contains(entry.getKey())) {
+				it.remove();
+			} else {
+				entry.getValue().getPoints().removeIf(point -> pendingPointDeletions.contains(point.getKey()));
+			}
+		}
 	}
 
 	public long getLastModifiedTime() {
@@ -422,6 +450,9 @@ public class FavouritesHelper {
 	}
 
 	public void delete(@Nullable Set<FavoriteGroup> groupsToDelete, @Nullable Set<FavouritePoint> favoritesSelected) {
+		if (!Algorithms.isEmpty(favoritesSelected) || !Algorithms.isEmpty(groupsToDelete)) {
+			FavoriteDeletionsJournal.addAll(app, favoritesSelected, groupsToDelete);
+		}
 		if (!Algorithms.isEmpty(favoritesSelected)) {
 			Set<FavoriteGroup> groupsToSync = new HashSet<>();
 			for (FavouritePoint point : favoritesSelected) {
@@ -465,6 +496,8 @@ public class FavouritesHelper {
 
 	public boolean deleteFavourite(FavouritePoint p, boolean saveImmediately) {
 		if (p != null) {
+			FavoriteDeletionsJournal.addPoint(app, p);
+
 			FavoriteGroup group = flatGroups.get(p.getCategory());
 			if (group != null) {
 				group.getPoints().remove(p);
@@ -775,6 +808,7 @@ public class FavouritesHelper {
 		List<FavoriteGroup> tmpFavoriteGroups = new ArrayList<>(favoriteGroups);
 		boolean remove = tmpFavoriteGroups.remove(group);
 		if (remove) {
+			FavoriteDeletionsJournal.addGroup(app, group);
 			favoriteGroups = tmpFavoriteGroups;
 			Map<String, FavoriteGroup> tmpFlatGroups = new LinkedHashMap<>(flatGroups);
 			tmpFlatGroups.remove(group.getName());
@@ -801,6 +835,7 @@ public class FavouritesHelper {
 		List<FavoriteGroup> tmpFavoriteGroups = new ArrayList<>(favoriteGroups);
 		Map<String, FavoriteGroup> tmpFlatGroups = new LinkedHashMap<>(flatGroups);
 		for (FavoriteGroup group : groupsToDelete) {
+			FavoriteDeletionsJournal.addGroup(app, group);
 			tmpFavoriteGroups.remove(group);
 			tmpFlatGroups.remove(group.getName());
 			removeFavouritePoints(group.getPoints());

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesHelper.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesHelper.java
@@ -74,8 +74,8 @@ public class FavouritesHelper {
 	private final Map<FavouritePoint, AddressLookupRequest> addressRequestMap = new ConcurrentHashMap<>();
 	private final FavoritesListener saveFavoritesListener = new FavoritesListener() {
 		@Override
-		public void onSavingFavoritesFinished() {
-			notifySavingFavoritesFinished(null);
+		public void onSavingFavoritesFinished(boolean success) {
+			notifySavingFavoritesFinished(null, success);
 		}
 	};
 
@@ -799,8 +799,8 @@ public class FavouritesHelper {
 		updateLastModifiedTime();
 		FavoritesListener saveListener = listener == null ? saveFavoritesListener : new FavoritesListener() {
 			@Override
-			public void onSavingFavoritesFinished() {
-				notifySavingFavoritesFinished(listener);
+			public void onSavingFavoritesFinished(boolean success) {
+				notifySavingFavoritesFinished(listener, success);
 			}
 		};
 		if (async) {
@@ -1271,13 +1271,15 @@ public class FavouritesHelper {
 		}
 	}
 
-	private void notifySavingFavoritesFinished(@Nullable FavoritesListener saveListener) {
-		invalidateFavoriteFolderCache();
+	private void notifySavingFavoritesFinished(@Nullable FavoritesListener saveListener, boolean success) {
+		if (success) {
+			invalidateFavoriteFolderCache();
+		}
 		for (FavoritesListener listener : listeners) {
-			listener.onSavingFavoritesFinished();
+			listener.onSavingFavoritesFinished(success);
 		}
 		if (saveListener != null) {
-			saveListener.onSavingFavoritesFinished();
+			saveListener.onSavingFavoritesFinished(success);
 		}
 	}
 

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/SaveBatch.kt
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/SaveBatch.kt
@@ -1,6 +1,7 @@
 package net.osmand.plus.myplaces.favorites
 
 import net.osmand.util.Algorithms
+import java.util.LinkedHashSet
 import java.util.concurrent.CountDownLatch
 
 class SaveBatch(
@@ -13,7 +14,7 @@ class SaveBatch(
 	var groups: MutableList<FavoriteGroup> = ArrayList(groups)
 		private set
 
-	val listeners: MutableList<FavoritesListener> = ArrayList()
+	val listeners: MutableSet<FavoritesListener> = LinkedHashSet()
 	val waiters: MutableList<CountDownLatch> = ArrayList()
 
 	init {
@@ -45,7 +46,6 @@ class SaveBatch(
 	}
 
 	private companion object {
-
 		fun mergeGroups(destination: MutableList<FavoriteGroup>, source: List<FavoriteGroup>) {
 			for (sourceGroup in source) {
 				var replaced = false

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/SaveBatch.kt
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/SaveBatch.kt
@@ -45,20 +45,13 @@ class SaveBatch(
 		}
 	}
 
-	private companion object {
-		fun mergeGroups(destination: MutableList<FavoriteGroup>, source: List<FavoriteGroup>) {
-			for (sourceGroup in source) {
-				var replaced = false
-				for (i in destination.indices) {
-					if (Algorithms.stringsEqual(destination[i].name, sourceGroup.name)) {
-						destination[i] = sourceGroup
-						replaced = true
-						break
-					}
-				}
-				if (!replaced) {
-					destination.add(sourceGroup)
-				}
+	private fun mergeGroups(destination: MutableList<FavoriteGroup>, source: List<FavoriteGroup>) {
+		for (sourceGroup in source) {
+			val index = destination.indexOfFirst { Algorithms.stringsEqual(it.name, sourceGroup.name) }
+			if (index == -1) {
+				destination.add(sourceGroup)
+			} else {
+				destination[index] = sourceGroup
 			}
 		}
 	}

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/SaveBatch.kt
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/SaveBatch.kt
@@ -1,0 +1,65 @@
+package net.osmand.plus.myplaces.favorites
+
+import net.osmand.util.Algorithms
+import java.util.concurrent.CountDownLatch
+
+class SaveBatch(
+	groups: List<FavoriteGroup>,
+	var saveAllGroups: Boolean,
+	listener: FavoritesListener?,
+	waiter: CountDownLatch?
+) {
+
+	var groups: MutableList<FavoriteGroup> = ArrayList(groups)
+		private set
+
+	val listeners: MutableList<FavoritesListener> = ArrayList()
+	val waiters: MutableList<CountDownLatch> = ArrayList()
+
+	init {
+		addRequest(listener, waiter)
+	}
+
+	fun merge(
+		groups: List<FavoriteGroup>,
+		saveAllGroups: Boolean,
+		listener: FavoritesListener?,
+		waiter: CountDownLatch?
+	) {
+		if (saveAllGroups) {
+			this.groups = ArrayList(groups)
+			this.saveAllGroups = true
+		} else {
+			mergeGroups(this.groups, groups)
+		}
+		addRequest(listener, waiter)
+	}
+
+	private fun addRequest(listener: FavoritesListener?, waiter: CountDownLatch?) {
+		if (listener != null) {
+			listeners.add(listener)
+		}
+		if (waiter != null) {
+			waiters.add(waiter)
+		}
+	}
+
+	private companion object {
+
+		fun mergeGroups(destination: MutableList<FavoriteGroup>, source: List<FavoriteGroup>) {
+			for (sourceGroup in source) {
+				var replaced = false
+				for (i in destination.indices) {
+					if (Algorithms.stringsEqual(destination[i].name, sourceGroup.name)) {
+						destination[i] = sourceGroup
+						replaced = true
+						break
+					}
+				}
+				if (!replaced) {
+					destination.add(sourceGroup)
+				}
+			}
+		}
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/SaveFavoritesTask.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/SaveFavoritesTask.java
@@ -24,6 +24,7 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,7 +78,7 @@ final class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 				log.error("Favorite deletions journal could not be read. Favorites save will continue, but journal will not be cleared.");
 			}
 
-			Set<String> deletedPointKeys = journalRead.getDeletions().getPointKeys();
+			Set<String> deletedPointKeys = collectStalePointKeys(groups, journalRead.getDeletions().getPointKeys());
 
 			boolean success = saveExternalFiles(groups, deletedPointKeys);
 			if (!success) {
@@ -97,6 +98,38 @@ final class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 			log.error(e.getMessage(), e);
 			return false;
 		}
+	}
+
+	@NonNull
+	private Set<String> collectStalePointKeys(@NonNull List<FavoriteGroup> groups, @NonNull Set<String> journalDeletedKeys) {
+		Set<String> staleKeys = new HashSet<>(journalDeletedKeys);
+		File internalFile = helper.getInternalFile();
+		if (!internalFile.exists()) {
+			return staleKeys;
+		}
+
+		GpxFile gpxFile = SharedUtil.loadGpxFile(internalFile);
+		if (gpxFile.getError() != null) {
+			return staleKeys;
+		}
+
+		Map<String, FavoriteGroup> previousGroups = new LinkedHashMap<>();
+		helper.collectFavoriteGroups(gpxFile, previousGroups);
+
+		Set<String> currentKeys = new HashSet<>();
+		for (FavoriteGroup group : groups) {
+			for (FavouritePoint point : group.getPoints()) {
+				currentKeys.add(point.getKey());
+			}
+		}
+		for (FavoriteGroup group : previousGroups.values()) {
+			for (FavouritePoint point : group.getPoints()) {
+				if (!currentKeys.contains(point.getKey())) {
+					staleKeys.add(point.getKey());
+				}
+			}
+		}
+		return staleKeys;
 	}
 
 	private boolean saveSelectedGroupsOnly(@NonNull List<FavoriteGroup> groupsToSave) {
@@ -131,15 +164,11 @@ final class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 	                                  @NonNull Set<String> deleted) {
 		Map<String, FavoriteGroup> fileGroups = new LinkedHashMap<>();
 		loadGPXFiles(fileGroups);
-		if (!saveLocalGroups(localGroups, fileGroups, deleted)) {
-			return false;
-		}
-		cleanupOrphanedGroupFiles(localGroups, fileGroups);
-		return true;
+		return saveLocalGroups(localGroups, fileGroups, deleted) && cleanupOrphanedGroupFiles(localGroups, fileGroups);
 	}
 
-	private void cleanupOrphanedGroupFiles(@NonNull List<FavoriteGroup> localGroups,
-	                                       @NonNull Map<String, FavoriteGroup> fileGroups) {
+	private boolean cleanupOrphanedGroupFiles(@NonNull List<FavoriteGroup> localGroups,
+	                                          @NonNull Map<String, FavoriteGroup> fileGroups) {
 		for (FavoriteGroup fileGroup : fileGroups.values()) {
 			// Search corresponding group in memory
 			boolean hasLocalGroup = false;
@@ -151,9 +180,14 @@ final class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 			}
 			// Delete external group file if it does not exist in local groups
 			if (!hasLocalGroup) {
-				helper.getExternalFile(fileGroup).delete();
+				File file = helper.getExternalFile(fileGroup);
+				if (file.exists() && !file.delete()) {
+					log.warn("Failed to delete orphaned favorites file: " + file.getAbsolutePath());
+					return false;
+				}
 			}
 		}
+		return true;
 	}
 
 	private boolean saveLocalGroups(@NonNull List<FavoriteGroup> localGroups,

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/SaveFavoritesTask.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/SaveFavoritesTask.java
@@ -1,14 +1,15 @@
 package net.osmand.plus.myplaces.favorites;
 
 import static net.osmand.IndexConstants.ZIP_EXT;
-import static net.osmand.plus.myplaces.favorites.FavouritesHelper.getPointsFromGroups;
 
 import android.os.AsyncTask;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import net.osmand.PlatformUtil;
 import net.osmand.data.FavouritePoint;
+import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.shared.SharedUtil;
 import net.osmand.shared.gpx.GpxFile;
 import net.osmand.util.Algorithms;
@@ -34,17 +35,21 @@ final class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 
 	private static final Log log = PlatformUtil.getLog(SaveFavoritesTask.class);
 
+	private final OsmandApplication app;
 	private final FavouritesFileHelper helper;
 	private final List<FavoriteGroup> groups;
 	private final CompletionListener completionListener;
+	@Nullable
+	private FavoriteDeletionsJournal.JournalState journalState;
 	private final boolean saveAllGroups;
 
-	SaveFavoritesTask(@NonNull FavouritesFileHelper helper,
-			@NonNull List<FavoriteGroup> groups, boolean saveAllGroups,
-			@NonNull CompletionListener completionListener) {
-		this.saveAllGroups = saveAllGroups;
+	SaveFavoritesTask(@NonNull OsmandApplication app, @NonNull FavouritesFileHelper helper,
+	                  @NonNull List<FavoriteGroup> groups, boolean saveAllGroups,
+	                  @NonNull CompletionListener completionListener) {
+		this.app = app;
 		this.helper = helper;
 		this.groups = groups;
+		this.saveAllGroups = saveAllGroups;
 		this.completionListener = completionListener;
 	}
 
@@ -59,47 +64,34 @@ final class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 			log.error(e.getMessage(), e);
 			success = false;
 		}
-		completionListener.onSaveFinished(success);
+		completionListener.onSaveFinished(success, journalState);
 		return null;
 	}
 
 	private boolean saveAllGroups(@NonNull List<FavoriteGroup> groups) {
 		try {
-			Map<String, FavoriteGroup> deletedGroups = new LinkedHashMap<>();
-			Map<String, FavouritePoint> deletedPoints = new LinkedHashMap<>();
+			FavoriteDeletionsJournal.ReadResult journalRead = FavoriteDeletionsJournal.read(app);
+			journalState = journalRead.getState();
+
+			if (journalRead.getReadFailed()) {
+				log.error("Favorite deletions journal could not be read. Favorites save will continue, but journal will not be cleared.");
+			}
+
+			Set<String> deletedPointKeys = journalRead.getDeletions().getPointKeys();
+
+			boolean success = saveExternalFiles(groups, deletedPointKeys);
+			if (!success) {
+				return false;
+			}
 
 			File internalFile = helper.getInternalFile();
-			GpxFile gpxFile = SharedUtil.loadGpxFile(internalFile);
-			if (gpxFile.getError() == null) {
-				helper.collectFavoriteGroups(gpxFile, deletedGroups);
-			}
-			// Get all points from internal file to filter later
-			for (FavoriteGroup group : deletedGroups.values()) {
-				for (FavouritePoint point : group.getPoints()) {
-					deletedPoints.put(point.getKey(), point);
-				}
-			}
-			// Hold only deleted points in map
-			for (FavouritePoint point : getPointsFromGroups(groups)) {
-				deletedPoints.remove(point.getKey());
-			}
-			// Hold only deleted groups in map
-			for (FavoriteGroup group : groups) {
-				deletedGroups.remove(group.getName());
-			}
-			// Save groups to internal file
 			Exception internalError = helper.saveFileAtomic(groups, internalFile);
 			if (internalError != null) {
 				log.error(internalError.getMessage(), internalError);
 				return false;
 			}
-			// Save groups to external files
-			if (!saveExternalFiles(groups, deletedPoints.keySet())) {
-				return false;
-			}
-			// Save groups to backup file
-			// backup(groups, getBackupFile()); // creates new, but does not zip
-			backup(helper.getBackupFile(), internalFile); // simply backs up internal file, hence internal name is reflected in gpx <name> metadata
+
+			backup(helper.getBackupFile(), internalFile);
 			return true;
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
@@ -136,7 +128,7 @@ final class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 	}
 
 	private boolean saveExternalFiles(@NonNull List<FavoriteGroup> localGroups,
-			@NonNull Set<String> deleted) {
+	                                  @NonNull Set<String> deleted) {
 		Map<String, FavoriteGroup> fileGroups = new LinkedHashMap<>();
 		loadGPXFiles(fileGroups);
 		if (!saveLocalGroups(localGroups, fileGroups, deleted)) {
@@ -147,7 +139,7 @@ final class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 	}
 
 	private void cleanupOrphanedGroupFiles(@NonNull List<FavoriteGroup> localGroups,
-			@NonNull Map<String, FavoriteGroup> fileGroups) {
+	                                       @NonNull Map<String, FavoriteGroup> fileGroups) {
 		for (FavoriteGroup fileGroup : fileGroups.values()) {
 			// Search corresponding group in memory
 			boolean hasLocalGroup = false;
@@ -232,6 +224,7 @@ final class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 	}
 
 	interface CompletionListener {
-		void onSaveFinished(boolean success);
+		void onSaveFinished(boolean success,
+		                    @Nullable FavoriteDeletionsJournal.JournalState journalState);
 	}
 }

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/SaveFavoritesTask.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/SaveFavoritesTask.java
@@ -6,7 +6,6 @@ import static net.osmand.plus.myplaces.favorites.FavouritesHelper.getPointsFromG
 import android.os.AsyncTask;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import net.osmand.PlatformUtil;
 import net.osmand.data.FavouritePoint;
@@ -31,42 +30,22 @@ import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-public class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
+final class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 
 	private static final Log log = PlatformUtil.getLog(SaveFavoritesTask.class);
 
 	private final FavouritesFileHelper helper;
 	private final List<FavoriteGroup> groups;
-	@Nullable
-	private final FavoritesListener listener;
-	@Nullable
 	private final CompletionListener completionListener;
 	private final boolean saveAllGroups;
 
-	public SaveFavoritesTask(@NonNull FavouritesFileHelper helper,
-			@NonNull List<FavoriteGroup> groups, boolean saveAllGroups,
-			@Nullable FavoritesListener listener) {
-		this.saveAllGroups = saveAllGroups;
-		this.helper = helper;
-		this.groups = groups;
-		this.listener = listener;
-		this.completionListener = null;
-	}
-
-	private SaveFavoritesTask(@NonNull FavouritesFileHelper helper,
+	SaveFavoritesTask(@NonNull FavouritesFileHelper helper,
 			@NonNull List<FavoriteGroup> groups, boolean saveAllGroups,
 			@NonNull CompletionListener completionListener) {
 		this.saveAllGroups = saveAllGroups;
 		this.helper = helper;
 		this.groups = groups;
-		this.listener = null;
 		this.completionListener = completionListener;
-	}
-
-	static SaveFavoritesTask createCoordinated(@NonNull FavouritesFileHelper helper,
-			@NonNull List<FavoriteGroup> groups, boolean saveAllGroups,
-			@NonNull CompletionListener completionListener) {
-		return new SaveFavoritesTask(helper, groups, saveAllGroups, completionListener);
 	}
 
 	@Override
@@ -80,9 +59,7 @@ public class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 			log.error(e.getMessage(), e);
 			success = false;
 		}
-		if (completionListener != null) {
-			completionListener.onSaveFinished(success);
-		}
+		completionListener.onSaveFinished(success);
 		return null;
 	}
 
@@ -256,12 +233,5 @@ public class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 
 	interface CompletionListener {
 		void onSaveFinished(boolean success);
-	}
-
-	@Override
-	protected void onPostExecute(Void result) {
-		if (listener != null) {
-			listener.onSavingFavoritesFinished();
-		}
 	}
 }

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/SaveFavoritesTask.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/SaveFavoritesTask.java
@@ -37,7 +37,10 @@ public class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 
 	private final FavouritesFileHelper helper;
 	private final List<FavoriteGroup> groups;
+	@Nullable
 	private final FavoritesListener listener;
+	@Nullable
+	private final CompletionListener completionListener;
 	private final boolean saveAllGroups;
 
 	public SaveFavoritesTask(@NonNull FavouritesFileHelper helper,
@@ -47,19 +50,43 @@ public class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 		this.helper = helper;
 		this.groups = groups;
 		this.listener = listener;
+		this.completionListener = null;
+	}
+
+	private SaveFavoritesTask(@NonNull FavouritesFileHelper helper,
+			@NonNull List<FavoriteGroup> groups, boolean saveAllGroups,
+			@NonNull CompletionListener completionListener) {
+		this.saveAllGroups = saveAllGroups;
+		this.helper = helper;
+		this.groups = groups;
+		this.listener = null;
+		this.completionListener = completionListener;
+	}
+
+	static SaveFavoritesTask createCoordinated(@NonNull FavouritesFileHelper helper,
+			@NonNull List<FavoriteGroup> groups, boolean saveAllGroups,
+			@NonNull CompletionListener completionListener) {
+		return new SaveFavoritesTask(helper, groups, saveAllGroups, completionListener);
 	}
 
 	@Override
 	protected Void doInBackground(Void... params) {
-		if (saveAllGroups) {
-			saveAllGroups(groups);
-		} else {
-			saveSelectedGroupsOnly(groups);
+		boolean success;
+		try {
+			success = saveAllGroups
+					? saveAllGroups(groups)
+					: saveSelectedGroupsOnly(groups);
+		} catch (Exception e) {
+			log.error(e.getMessage(), e);
+			success = false;
+		}
+		if (completionListener != null) {
+			completionListener.onSaveFinished(success);
 		}
 		return null;
 	}
 
-	private void saveAllGroups(@NonNull List<FavoriteGroup> groups) {
+	private boolean saveAllGroups(@NonNull List<FavoriteGroup> groups) {
 		try {
 			Map<String, FavoriteGroup> deletedGroups = new LinkedHashMap<>();
 			Map<String, FavouritePoint> deletedPoints = new LinkedHashMap<>();
@@ -84,26 +111,38 @@ public class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 				deletedGroups.remove(group.getName());
 			}
 			// Save groups to internal file
-			helper.saveFile(groups, internalFile);
+			Exception internalError = helper.saveFileAtomic(groups, internalFile);
+			if (internalError != null) {
+				log.error(internalError.getMessage(), internalError);
+				return false;
+			}
 			// Save groups to external files
-			saveExternalFiles(groups, deletedPoints.keySet());
+			if (!saveExternalFiles(groups, deletedPoints.keySet())) {
+				return false;
+			}
 			// Save groups to backup file
 			// backup(groups, getBackupFile()); // creates new, but does not zip
 			backup(helper.getBackupFile(), internalFile); // simply backs up internal file, hence internal name is reflected in gpx <name> metadata
+			return true;
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
+			return false;
 		}
 	}
 
-	private void saveSelectedGroupsOnly(@NonNull List<FavoriteGroup> groupsToSave) {
+	private boolean saveSelectedGroupsOnly(@NonNull List<FavoriteGroup> groupsToSave) {
 		try {
 			// No need to touch internal file or backup
 			// Changes will be picked up during next loadFavorites()
 			for (FavoriteGroup group : groupsToSave) {
-				saveFavoriteGroup(group);
+				if (!saveFavoriteGroup(group)) {
+					return false;
+				}
 			}
+			return true;
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
+			return false;
 		}
 	}
 
@@ -119,12 +158,15 @@ public class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 		}
 	}
 
-	private void saveExternalFiles(@NonNull List<FavoriteGroup> localGroups,
+	private boolean saveExternalFiles(@NonNull List<FavoriteGroup> localGroups,
 			@NonNull Set<String> deleted) {
 		Map<String, FavoriteGroup> fileGroups = new LinkedHashMap<>();
 		loadGPXFiles(fileGroups);
+		if (!saveLocalGroups(localGroups, fileGroups, deleted)) {
+			return false;
+		}
 		cleanupOrphanedGroupFiles(localGroups, fileGroups);
-		saveLocalGroups(localGroups, fileGroups, deleted);
+		return true;
 	}
 
 	private void cleanupOrphanedGroupFiles(@NonNull List<FavoriteGroup> localGroups,
@@ -145,7 +187,7 @@ public class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 		}
 	}
 
-	private void saveLocalGroups(@NonNull List<FavoriteGroup> localGroups,
+	private boolean saveLocalGroups(@NonNull List<FavoriteGroup> localGroups,
 			@NonNull Map<String, FavoriteGroup> fileGroups, @NonNull Set<String> deleted) {
 		for (FavoriteGroup localGroup : localGroups) {
 			FavoriteGroup fileGroup = fileGroups.get(localGroup.getName());
@@ -168,20 +210,25 @@ public class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 			localGroup.getPoints().addAll(all.values());
 			// Save file if group changed
 			if (!localGroup.equals(fileGroup)) {
-				saveFavoriteGroup(localGroup);
+				if (!saveFavoriteGroup(localGroup)) {
+					return false;
+				}
 			}
 		}
+		return true;
 	}
 
-	private void saveFavoriteGroup(@NonNull FavoriteGroup group) {
+	private boolean saveFavoriteGroup(@NonNull FavoriteGroup group) {
 		File externalFile = helper.getExternalFile(group);
-		Exception exception = helper.saveFile(Collections.singletonList(group), externalFile);
+		Exception exception = helper.saveFileAtomic(Collections.singletonList(group), externalFile);
 		if (exception != null) {
-			log.error(exception);
+			log.error(exception.getMessage(), exception);
+			return false;
 		} else if (externalFile.exists()) {
 			group.setSize(externalFile.length());
 			group.setTimeModified(externalFile.lastModified());
 		}
+		return true;
 	}
 
 	private void backup(@NonNull File backupFile, @NonNull File externalFile) {
@@ -205,6 +252,10 @@ public class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 			Algorithms.closeStream(fis);
 		}
 		helper.clearOldBackups();
+	}
+
+	interface CompletionListener {
+		void onSaveFinished(boolean success);
 	}
 
 	@Override

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/dialogs/FavoriteFolderFragment.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/dialogs/FavoriteFolderFragment.java
@@ -485,7 +485,7 @@ public class FavoriteFolderFragment extends BaseFavoriteListFragment
 	}
 
 	@Override
-	public void onSavingFavoritesFinished() {
+	public void onSavingFavoritesFinished(boolean success) {
 		updateContent();
 	}
 

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/dialogs/SearchFavoriteFragment.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/dialogs/SearchFavoriteFragment.java
@@ -676,7 +676,7 @@ public class SearchFavoriteFragment extends BaseFullScreenDialogFragment impleme
 	}
 
 	@Override
-	public void onSavingFavoritesFinished() {
+	public void onSavingFavoritesFinished(boolean success) {
 		updateContent();
 	}
 

--- a/OsmAnd/src/net/osmand/plus/settings/backend/backup/OsmandSettingsItemWriter.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/backup/OsmandSettingsItemWriter.java
@@ -7,12 +7,10 @@ import net.osmand.IProgress;
 import net.osmand.plus.settings.backend.preferences.OsmandPreference;
 import net.osmand.plus.settings.backend.OsmandSettings;
 import net.osmand.plus.settings.backend.backup.items.OsmandSettingsItem;
-import net.osmand.util.Algorithms;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -48,17 +46,9 @@ public abstract class OsmandSettingsItemWriter<T extends OsmandSettingsItem> ext
 			}
 		}
 		try {
-			int bytesDivisor = 1024;
-			byte[] bytes = json.toString(2).getBytes("UTF-8");
-			if (progress != null) {
-				progress.startWork(bytes.length / bytesDivisor);
-			}
-			Algorithms.streamCopy(new ByteArrayInputStream(bytes), outputStream, progress, bytesDivisor);
+			SettingsHelper.writeJson(json, outputStream, progress);
 		} catch (JSONException e) {
 			SettingsHelper.LOG.error("Failed to write json to stream", e);
-		}
-		if (progress != null) {
-			progress.finishTask();
 		}
 	}
 }

--- a/OsmAnd/src/net/osmand/plus/settings/backend/backup/SettingsExporter.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/backup/SettingsExporter.java
@@ -44,7 +44,7 @@ public class SettingsExporter extends Exporter {
 		try {
 			ZipEntry entry = new ZipEntry("items.json");
 			zos.putNextEntry(entry);
-			zos.write(json.toString(2).getBytes("UTF-8"));
+			SettingsHelper.writeJson(json, zos, null);
 			zos.closeEntry();
 			if (exportItemsFiles) {
 				writeItemFiles(zos);

--- a/OsmAnd/src/net/osmand/plus/settings/backend/backup/SettingsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/backup/SettingsHelper.java
@@ -125,14 +125,14 @@ public abstract class SettingsHelper {
 	public static void writeJson(@NonNull JSONObject json, @NonNull OutputStream outputStream,
 	                             @Nullable IProgress progress) throws IOException, JSONException {
 		String jsonString = json.toString(2);
+		OutputStream targetStream = outputStream;
 		if (progress != null) {
 			long work = Utf8.size(jsonString) / BUFFER;
 			progress.startWork((int) Math.min(work, Integer.MAX_VALUE));
+			targetStream = new ProgressOutputStream(outputStream, progress, BUFFER);
 		}
 		try {
-			OutputStream progressStream = new ProgressOutputStream(outputStream, progress, BUFFER);
-			Writer writer = new BufferedWriter(
-					new OutputStreamWriter(progressStream, StandardCharsets.UTF_8), JSON_BUFFER_SIZE);
+			Writer writer = new BufferedWriter(new OutputStreamWriter(targetStream, StandardCharsets.UTF_8), JSON_BUFFER_SIZE);
 			writer.write(jsonString);
 			writer.flush();
 		} finally {

--- a/OsmAnd/src/net/osmand/plus/settings/backend/backup/SettingsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/backup/SettingsHelper.java
@@ -6,7 +6,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import net.osmand.IndexConstants;
+import net.osmand.IProgress;
 import net.osmand.PlatformUtil;
+import net.osmand.ProgressOutputStream;
 import net.osmand.map.ITileSource;
 import net.osmand.map.TileSourceManager.TileSourceTemplate;
 import net.osmand.plus.OsmandApplication;
@@ -32,8 +34,16 @@ import net.osmand.shared.gpx.GpxDirItem;
 import net.osmand.util.Algorithms;
 
 import org.apache.commons.logging.Log;
+import org.json.JSONException;
+import org.json.JSONObject;
 
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -41,6 +51,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import okio.Utf8;
 
 public abstract class SettingsHelper {
 
@@ -53,6 +65,7 @@ public abstract class SettingsHelper {
 	public static final String SETTINGS_VERSION_KEY = "settings_version";
 
 	public static final int BUFFER = 1024;
+	private static final int JSON_BUFFER_SIZE = 32 * 1024;
 
 	public static final Log LOG = PlatformUtil.getLog(SettingsHelper.class);
 
@@ -107,6 +120,26 @@ public abstract class SettingsHelper {
 
 	public OsmandApplication getApp() {
 		return app;
+	}
+
+	public static void writeJson(@NonNull JSONObject json, @NonNull OutputStream outputStream,
+	                             @Nullable IProgress progress) throws IOException, JSONException {
+		String jsonString = json.toString(2);
+		if (progress != null) {
+			long work = Utf8.size(jsonString) / BUFFER;
+			progress.startWork((int) Math.min(work, Integer.MAX_VALUE));
+		}
+		try {
+			OutputStream progressStream = new ProgressOutputStream(outputStream, progress, BUFFER);
+			Writer writer = new BufferedWriter(
+					new OutputStreamWriter(progressStream, StandardCharsets.UTF_8), JSON_BUFFER_SIZE);
+			writer.write(jsonString);
+			writer.flush();
+		} finally {
+			if (progress != null) {
+				progress.finishTask();
+			}
+		}
 	}
 
 	public List<SettingsItem> getFilteredSettingsItems(List<ExportType> acceptedTypes,

--- a/OsmAnd/src/net/osmand/plus/settings/backend/backup/items/SettingsItem.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/backup/items/SettingsItem.java
@@ -255,18 +255,10 @@ public abstract class SettingsItem {
 			public void writeToStream(@NonNull OutputStream outputStream, @Nullable IProgress progress) throws IOException {
 				JSONObject json = writeItemsToJson(new JSONObject());
 				try {
-					int bytesDivisor = 1024;
-					byte[] bytes = json.toString(2).getBytes("UTF-8");
-					if (progress != null) {
-						progress.startWork(bytes.length / bytesDivisor);
-					}
-					Algorithms.streamCopy(new ByteArrayInputStream(bytes), outputStream, progress, bytesDivisor);
+					SettingsHelper.writeJson(json, outputStream, progress);
 				} catch (JSONException e) {
 					warnings.add(app.getString(R.string.settings_item_write_error, String.valueOf(getType())));
 					SettingsHelper.LOG.error("Failed to write json to stream", e);
-				}
-				if (progress != null) {
-					progress.finishTask();
 				}
 			}
 		};

--- a/OsmAnd/src/net/osmand/plus/settings/mediastorage/task/MoveMediaFilesTask.java
+++ b/OsmAnd/src/net/osmand/plus/settings/mediastorage/task/MoveMediaFilesTask.java
@@ -371,9 +371,13 @@ public class MoveMediaFilesTask extends AsyncTask<Void, Object, Map<String, Pair
 		}
 		app.getFavoritesHelper().saveCurrentPointsIntoFile(true, new FavoritesListener() {
 			@Override
-			public void onSavingFavoritesFinished() {
-				// Only delete the originals once favorites are written with the new links.
-				deleteMovedSources(callback);
+			public void onSavingFavoritesFinished(boolean success) {
+				if (success) {
+					// Only delete the originals once favorites are written with the new links.
+					deleteMovedSources(callback);
+				} else {
+					callback.processResult(false);
+				}
 			}
 		});
 	}


### PR DESCRIPTION
## 1. XML/GPX serialization buffering

In OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/xml/XmlSerializer.kt:12, both output paths now use a `BufferedWriter` with a 32K-character buffer:

```text
KXmlSerializer
    → BufferedWriter (32K characters)
        → UTF-8 writer / Okio Sink
```

Previously, KXml could send many tiny writes—sometimes individual characters—to the UTF-8 encoder. Now they accumulate and are encoded/written in approximately 32K-character chunks.

Memory cost is approximately:

- 32K Java/Kotlin characters × 2 bytes = 64 KB.
- Plus small Writer and Okio buffers.
- No complete GPX document is accumulated.

Ownership remains:

- File output is flushed and closed by `XmlSerializer`.
- Caller-provided `Sink` is flushed but not closed.

`SinkStringWriter` now extends `Writer` directly and uses Okio’s ranged `writeUtf8(str, start, end)`, eliminating `substring()` allocations.

The same 32K buffering was added to legacy JVM/server `GPXUtilities.writeGpxFile()`.

## 2. KML conversion

Previously, KML conversion created several complete representations:

```text
KML → GPX Okio Buffer → String → UTF-8 ByteArray → second Buffer → parser
```

Now OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/helper/ImportGpx.kt:43 does:

```text
KML → one GPX Okio Buffer → parser
```

The buffer size is recorded before parsing because parsing consumes the buffer.

This removes:

- Complete GPX `String`.
- Complete UTF-8 `ByteArray`.
- Second GPX `Buffer`.

One complete generated GPX buffer still exists because it becomes the parser input.

## 3. Settings JSON export

Previously:

```java
json.toString(2).getBytes("UTF-8")
```

This held both:

- The complete JSON `String`.
- A second complete UTF-8 `byte[]`.

Now OsmAnd/src/net/osmand/plus/settings/backend/backup/SettingsHelper.java:125 writes the JSON string through:

```text
JSONObject
    → formatted String
        → BufferedWriter (32K characters)
            → destination stream
```

`JSONObject` and the formatted `String` still exist. Only the additional full UTF-8 byte-array copy was removed.

When progress is needed:

- `Utf8.size()` calculates byte length without allocating a byte array.
- `ProgressOutputStream` counts bytes actually written.
- `flush()` now reaches the underlying stream.
- The caller’s ZIP/network stream is not closed.

## 4. Favorites coalescing

The coordinator state is in OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesFileHelper.java:55:

```java
boolean saveRunning;
SaveBatch pendingSave;
```

All save requests enter `enqueueSave()`.

### First request

When nothing is running:

1. `saveRunning` becomes `true`.
2. A `SaveBatch` is created.
3. `SaveFavoritesTask` starts on the existing single-thread executor.

### Requests arriving while saving

Only one `pendingSave` is retained:

- First additional request creates it.
- Further requests merge into it.
- No additional `SaveFavoritesTask` objects enter the executor queue.

For ten rapid operations:

```text
Request 1 → running save
Requests 2–10 → one merged pending SaveBatch
Request 1 finishes → one follow-up save
```

Changes arriving during the follow-up save can create one new pending batch, so the invariant remains one running save plus one pending save.

## 5. What `SaveBatch` contains

`SaveBatch` is defined at OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesFileHelper.java:400.

It contains:

- A shallow `List<FavoriteGroup>`.
- `saveAllGroups`.
- Listeners waiting for that save.
- `CountDownLatch` objects for synchronous callers.

It does not copy points or GPX data:

```java
this.groups = new ArrayList<>(groups);
```

This copies only group references.

Merge behavior:

- A newer full-save request replaces the pending group list.
- A selected-group request replaces/adds those groups by name.
- Once a batch becomes a full save, it remains a full save.
- Listeners and synchronous completions are appended in request order.

Its RAM usage is therefore small, although listeners grow with the number of coalesced requests. There are no repeated 10 MB GPX snapshots.

The temporary `GpxFile` created by `asGpxFile()` still exists during actual serialization. That behavior already existed and was not redesigned.

## 6. Synchronous saves

`saveFavoritesIntoFileSync()` creates a `CountDownLatch`, submits through the same coordinator, then waits.

Therefore a synchronous request:

- Does not bypass the bounded queue.
- Can become part of the pending batch.
- Returns after its physical save attempt finishes.

The latch is released after both success and failure to prevent the caller from waiting forever.

## 7. Save task execution

For a full save, OsmAnd/src/net/osmand/plus/myplaces/favorites/SaveFavoritesTask.java:89 performs:

1. Load the previous internal GPX to identify deleted points/groups.
2. Atomically save the internal GPX.
3. Merge/save external group files atomically.
4. Delete orphan group files only after replacement writes succeed.
5. Create the ZIP backup from the committed internal file.

Selected-group saves only write their external group GPX files.

Backup failure remains best-effort: it is logged but does not invalidate successfully committed GPX files.

## 8. AtomicFile operation

`saveFileAtomic()` is at OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesFileHelper.java:281.

Its flow is:

```text
Previous GPX remains available
        ↓
AtomicFile.startWrite()
        ↓
Serialize GPX into temporary/new storage
        ↓
Success?
 ├─ yes → finishWrite(): flush/sync and commit replacement
 └─ no  → failWrite(): discard failed write and restore previous GPX
```

It is used for:

- Internal Favorites GPX.
- Every managed external group GPX.

AtomicFile mainly consumes temporary disk space, potentially close to one additional GPX file. It does not hold another complete GPX in RAM.

## 9. Atomic recovery

Android can leave `.new` or `.bak` files if the process dies.

Before loading internal Favorites, `AtomicFile.openRead()` is called. It restores the previous committed base file and removes stale temporary state.

External Favorites discovery also:

1. Finds `.new` and `.bak` remnants.
2. Derives their base GPX filename.
3. Runs AtomicFile recovery.
4. Returns only actual `.gpx` files to the GPX loader.

Temporary files therefore cannot accidentally be parsed as normal Favorites files.

## 10. Completion behavior

After a coordinated task finishes:

- Synchronous latches are released.
- On success, listeners are posted to the UI thread in request order.
- The pending batch, if present, starts.
- Otherwise `saveRunning` becomes `false`.

One current limitation: if a save fails, its listeners are not transferred to a later pending batch. A later batch may successfully contain the same changes, but those earlier listeners will not fire. Strict “listener completes when any covering save commits” semantics would require correcting this.

## Guarantees and limitations

Guaranteed:

- The save-task queue cannot grow without bound.
- Rapid edits normally result in one current rewrite and one follow-up rewrite.
- Interrupted writes preserve the previous committed GPX.
- Temporary AtomicFile remnants are recovered.
- Serialization uses small fixed buffers rather than document-sized buffers.

Not guaranteed:

- The newest in-flight edit survives process death.
- Internal and external GPX files commit as one transaction.
- Automatic retry when a save fails with no pending request.
- Protection if both the committed file and filesystem-level backup are physically corrupted.
- Zero GPX model allocation during serialization.

This remains the deliberately minimal solution: faster serialization, bounded saves, and valid previous files—without a journal, database, or duplicate persistent Favorites model.