### PR TITLE
Online public transport routing via MOTIS/Transitous

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/data/TransportRoute.java
+++ b/OsmAnd-java/src/main/java/net/osmand/data/TransportRoute.java
@@ -16,6 +16,7 @@ public class TransportRoute extends MapObject {
 	private List<TransportStop> forwardStops = new ArrayList<TransportStop>();
 	private String ref;
 	private String operator;
+	private String url;
 	private String type;
 	private Integer dist = null;
 	private String color;
@@ -35,6 +36,7 @@ public class TransportRoute extends MapObject {
 		this.names = r.names;
 		this.id = r.id;
 		this.operator = r.operator;
+		this.url = r.url;
 		this.ref = r.ref;
 		this.type = r.type;
 		this.color = r.color;
@@ -282,6 +284,14 @@ public class TransportRoute extends MapObject {
 		return operator;
 	}
 	
+	public String getUrl() {
+		return url;
+	}
+
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
 	public void setOperator(String operator) {
 		this.operator = operator;
 	}

--- a/OsmAnd-java/src/main/java/net/osmand/data/TransportStop.java
+++ b/OsmAnd-java/src/main/java/net/osmand/data/TransportStop.java
@@ -23,6 +23,7 @@ public class TransportStop extends MapObject {
 	private List<TransportStopExit> exits;
 	private List<TransportRoute> routes = null;
 	private TransportStopAggregated transportStopAggregated;
+	private String platform;
 
 	public TransportStop() {}
 	
@@ -36,6 +37,14 @@ public class TransportStop extends MapObject {
 
 	public void setRoutes(List<TransportRoute> routes) {
 		this.routes = routes;
+	}
+
+	public String getPlatform() {
+		return platform;
+	}
+
+	public void setPlatform(String platform) {
+		this.platform = platform;
 	}
 	
 	public void addRoute(TransportRoute rt) {

--- a/OsmAnd-java/src/main/java/net/osmand/router/TransportRoutePlanner.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/TransportRoutePlanner.java
@@ -436,7 +436,9 @@ public class TransportRoutePlanner {
 		public int end;
 		public double walkDist ;
 		public int depTime;
-		
+		public long departureTimeMillis = -1;
+		public long arrivalTimeMillis = -1;
+
 		public List<TransportRouteResultSegment> alternatives = new ArrayList<>();
 		
 		public TransportRouteResultSegment() {

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -13,6 +13,8 @@
 	<string name="transit_opt_fewest_changes">Fewest transfers</string>
 	<string name="transit_opt_least_walking">Least walking</string>
 	<string name="transit_wheelchair">Wheelchair accessible</string>
+	<string name="transit_platform">Platform %1$s</string>
+	<string name="transit_platform_track">Platform %1$s, track %2$s</string>
 <!--
 	README:
 	- The preferred way to help with translations is via https://hosted.weblate.org/engage/osmand/

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -7,6 +7,7 @@
 	<string name="transit_depart_at">Depart at…</string>
 	<string name="transit_arrive_by">Arrive by…</string>
 	<string name="transit_arrive_prefix">Arrive %1$s</string>
+	<string name="transit_later_departures">Later departures</string>
 	<string name="transit_optimize">Optimize</string>
 	<string name="transit_opt_best">Best route</string>
 	<string name="transit_opt_fewest_changes">Fewest transfers</string>
@@ -2658,6 +2659,7 @@ You need to activate the sensor so OsmAnd can find it.</string>
     <string name="icon_group_special">Special</string>
     <string name="icon_group_amenity">Amenity</string>
     <string name="ltr_or_rtl_combine_via_dash">%1$s — %2$s</string>
+    <string name="ltr_or_rtl_combine_via_arrow">%1$s → %2$s</string>
     <string name="shared_string_local_maps">Local maps</string>
     <string name="message_graph_will_be_available_after_recalculation">Please wait.\nGraph will be available after route recalculation.</string>
     <string name="shared_string_graph">Graph</string>

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -15,6 +15,7 @@
 	<string name="transit_wheelchair">Wheelchair accessible</string>
 	<string name="transit_platform">Platform %1$s</string>
 	<string name="transit_platform_track">Platform %1$s, track %2$s</string>
+	<string name="transit_buy_ticket">Buy ticket</string>
 <!--
 	README:
 	- The preferred way to help with translations is via https://hosted.weblate.org/engage/osmand/

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <resources>
+	<string name="use_online_public_transport">Online public transport timetables</string>
+	<string name="use_online_public_transport_descr">Route public transport using live online timetables instead of offline OSM schedules. Requires an internet connection.</string>
+	<string name="transit_departure_time">Departure time</string>
+	<string name="transit_leave_now">Leave now</string>
+	<string name="transit_depart_at">Depart at…</string>
+	<string name="transit_arrive_by">Arrive by…</string>
+	<string name="transit_arrive_prefix">Arrive %1$s</string>
+	<string name="transit_optimize">Optimize</string>
+	<string name="transit_opt_best">Best route</string>
+	<string name="transit_opt_fewest_changes">Fewest transfers</string>
+	<string name="transit_opt_least_walking">Least walking</string>
+	<string name="transit_wheelchair">Wheelchair accessible</string>
 <!--
 	README:
 	- The preferred way to help with translations is via https://hosted.weblate.org/engage/osmand/

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/MapRouteInfoMenu.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/MapRouteInfoMenu.java
@@ -130,6 +130,7 @@ public class MapRouteInfoMenu implements IRouteInformationListener, CardListener
 	public static final int DEFAULT_MENU_STATE = 0;
 	private static final int MAX_PEDESTRIAN_ROUTE_DURATION = 30 * 60;
 	private static final double STANDARD_LONG_ROUTE_SEGMENT_DISTANCE = 300_000;
+	private static final long NEXT_DEPARTURE_SEARCH_OFFSET = 60_000;
 
 	public static int directionInfo = -1;
 	public static boolean chooseRoutesVisible;
@@ -594,6 +595,20 @@ public class MapRouteInfoMenu implements IRouteInformationListener, CardListener
 					pedestrianRouteCard.setListener(this);
 					menuCards.add(pedestrianRouteCard);
 				}
+				long latestDeparture = -1;
+				for (TransportRouteResult r : routes) {
+					if (!r.getSegments().isEmpty()) {
+						long dep = r.getSegments().get(0).departureTimeMillis;
+						if (dep > latestDeparture) {
+							latestDeparture = dep;
+						}
+					}
+				}
+				if (latestDeparture > 0) {
+					LaterDeparturesCard laterCard = new LaterDeparturesCard(mapActivity, latestDeparture + NEXT_DEPARTURE_SEARCH_OFFSET);
+					laterCard.setListener(this);
+					menuCards.add(laterCard);
+				}
 				bottomShadowVisible = routes.isEmpty();
 			} else {
 				RouteMenuAppModes mode = app.getRoutingOptionsHelper().getRouteMenuAppMode(routingHelper.getAppMode());
@@ -895,6 +910,10 @@ public class MapRouteInfoMenu implements IRouteInformationListener, CardListener
 				AvoidRoadsBottomSheetDialogFragment.showInstance(mapActivity, null, null, true, null);
 			} else if (card instanceof PedestrianRouteCard) {
 				updateApplicationMode(null, ApplicationMode.PEDESTRIAN);
+			} else if (card instanceof LaterDeparturesCard) {
+				OnlineTransportState.setTimeMillis(((LaterDeparturesCard) card).getLaterTimeMillis());
+				OnlineTransportState.setArriveBy(false);
+				app.getRoutingHelper().onSettingsChanged(true);
 			} else if (card instanceof AttachTrackToRoadsBannerCard) {
 				if (MeasurementToolFragment.showSnapToRoadsDialog(mapActivity, true)) {
 					hide();

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/MapRouteInfoMenu.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/MapRouteInfoMenu.java
@@ -105,6 +105,9 @@ import net.osmand.plus.track.fragments.TrackSelectSegmentBottomSheet;
 import net.osmand.plus.track.fragments.TrackSelectSegmentBottomSheet.OnSegmentSelectedListener;
 import net.osmand.plus.track.helpers.GpxUiHelper;
 import net.osmand.plus.track.helpers.SelectedGpxFile;
+import net.osmand.plus.transport.online.OnlineTransportOptionsBottomSheet;
+import net.osmand.plus.transport.online.OnlineTransportState;
+import net.osmand.plus.transport.online.OnlineTransportTimeBottomSheet;
 import net.osmand.plus.utils.AndroidUtils;
 import net.osmand.plus.utils.ColorUtilities;
 import net.osmand.plus.utils.UiUtilities;
@@ -1146,6 +1149,25 @@ public class MapRouteInfoMenu implements IRouteInformationListener, CardListener
 		optionsContainer.removeAllViews();
 		if (mode == null) {
 			return;
+		}
+		if (routingHelper.isPublicTransportMode() && app.getSettings().USE_ONLINE_PUBLIC_TRANSPORT.get()) {
+			int margin = AndroidUtils.dpToPx(app, 3);
+			LinearLayout timeBtn = createToolbarOptionView(!OnlineTransportState.isNow(),
+					OnlineTransportTimeBottomSheet.getLabel(app), R.drawable.ic_action_time, R.drawable.ic_action_time,
+					v -> OnlineTransportTimeBottomSheet.showInstance(mapActivity.getSupportFragmentManager(), this::updateOptionsButtons));
+			if (timeBtn != null) {
+				LinearLayout.LayoutParams params = getContainerButtonLayoutParams(mapActivity, false);
+				AndroidUtils.setMargins(params, margin, 0, margin, 0);
+				optionsContainer.addView(timeBtn, params);
+			}
+			LinearLayout optBtn = createToolbarOptionView(false, app.getString(R.string.shared_string_options),
+					R.drawable.ic_action_settings, R.drawable.ic_action_settings,
+					v -> OnlineTransportOptionsBottomSheet.showInstance(mapActivity.getSupportFragmentManager(), this::updateOptionsButtons));
+			if (optBtn != null) {
+				LinearLayout.LayoutParams params = getContainerButtonLayoutParams(mapActivity, false);
+				AndroidUtils.setMargins(params, margin, 0, margin, 0);
+				optionsContainer.addView(optBtn, params);
+			}
 		}
 		createRoutingParametersButtons(mapActivity, mode, optionsContainer);
 		int endPadding = mapActivity.getResources().getDimensionPixelSize(R.dimen.action_bar_image_side_margin);

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/RouteDetailsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/RouteDetailsFragment.java
@@ -446,7 +446,12 @@ public class RouteDetailsFragment extends ContextMenuFragment
 		Typeface typeface = FontCache.getMediumFont();
 		String timeText = getStopTimeText(segment.departureTimeMillis, startTime[0]);
 
-		SpannableString secondaryText = new SpannableString(getString(R.string.sit_on_the_stop));
+		String sitText = getString(R.string.sit_on_the_stop);
+		String startPlatform = getPlatformText(startStop);
+		if (startPlatform != null) {
+			sitText = getString(R.string.ltr_or_rtl_combine_via_bold_point, sitText, startPlatform);
+		}
+		SpannableString secondaryText = new SpannableString(sitText);
 		secondaryText.setSpan(new ForegroundColorSpan(getMainFontColor()), 0, secondaryText.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 
 		SpannableString title = new SpannableString(startStop.getName(getPreferredMapLang(), isTransliterateNames()));
@@ -526,7 +531,12 @@ public class RouteDetailsFragment extends ContextMenuFragment
 		startTime[0] += (int) segment.getTravelTime();
 		String textTime = getStopTimeText(segment.arrivalTimeMillis, startTime[0]);
 
-		secondaryText = new SpannableString(getString(R.string.exit_at));
+		String exitText = getString(R.string.exit_at);
+		String endPlatform = getPlatformText(endStop);
+		if (endPlatform != null) {
+			exitText = getString(R.string.ltr_or_rtl_combine_via_bold_point, exitText, endPlatform);
+		}
+		secondaryText = new SpannableString(exitText);
 		secondaryText.setSpan(new CustomTypefaceSpan(typeface), 0, secondaryText.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 		int spaceIndex = secondaryText.toString().indexOf(" ");
 		if (spaceIndex != -1) {
@@ -624,6 +634,19 @@ public class RouteDetailsFragment extends ContextMenuFragment
 			return OsmAndFormatter.getFormattedTimeShort(epochMillis / 1000, false);
 		}
 		return OsmAndFormatter.getFormattedDurationShortMinutes(fallbackDurationSec);
+	}
+
+	@Nullable
+	private String getPlatformText(@NonNull TransportStop stop) {
+		String platform = stop.getPlatform();
+		if (platform == null) {
+			return null;
+		}
+		int slash = platform.indexOf('/');
+		if (slash > 0 && slash < platform.length() - 1) {
+			return getString(R.string.transit_platform_track, platform.substring(0, slash), platform.substring(slash + 1));
+		}
+		return getString(R.string.transit_platform, platform);
 	}
 
 	private void buildStartItem(@NonNull View view, TargetPoint start, int[] startTime,

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/RouteDetailsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/RouteDetailsFragment.java
@@ -444,7 +444,7 @@ public class RouteDetailsFragment extends ContextMenuFragment
 		Drawable icon = getContentIcon(drawableResId);
 
 		Typeface typeface = FontCache.getMediumFont();
-		String timeText = OsmAndFormatter.getFormattedDurationShortMinutes(startTime[0]);
+		String timeText = getStopTimeText(segment.departureTimeMillis, startTime[0]);
 
 		SpannableString secondaryText = new SpannableString(getString(R.string.sit_on_the_stop));
 		secondaryText.setSpan(new ForegroundColorSpan(getMainFontColor()), 0, secondaryText.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
@@ -524,7 +524,7 @@ public class RouteDetailsFragment extends ContextMenuFragment
 		}
 		// fix later for schedule
 		startTime[0] += (int) segment.getTravelTime();
-		String textTime = OsmAndFormatter.getFormattedDurationShortMinutes(startTime[0]);
+		String textTime = getStopTimeText(segment.arrivalTimeMillis, startTime[0]);
 
 		secondaryText = new SpannableString(getString(R.string.exit_at));
 		secondaryText.setSpan(new CustomTypefaceSpan(typeface), 0, secondaryText.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
@@ -619,6 +619,13 @@ public class RouteDetailsFragment extends ContextMenuFragment
 		}
 	}
 
+	private String getStopTimeText(long epochMillis, int fallbackDurationSec) {
+		if (epochMillis > 0) {
+			return OsmAndFormatter.getFormattedTimeShort(epochMillis / 1000, false);
+		}
+		return OsmAndFormatter.getFormattedDurationShortMinutes(fallbackDurationSec);
+	}
+
 	private void buildStartItem(@NonNull View view, TargetPoint start, int[] startTime,
 								TransportRouteResultSegment segment, double walkSpeed) {
 		FrameLayout baseItemView = new FrameLayout(view.getContext());
@@ -637,7 +644,7 @@ public class RouteDetailsFragment extends ContextMenuFragment
 			name = getString(R.string.shared_string_my_location);
 		}
 		Spannable startTitle = new SpannableString(name);
-		String text = OsmAndFormatter.getFormattedDurationShortMinutes(startTime[0]);
+		String text = getStopTimeText(segment.departureTimeMillis, startTime[0]);
 
 		int drawableId = start == null ? R.drawable.ic_action_location_color : R.drawable.list_startpoint;
 		Drawable icon = app.getUIUtilities().getIcon(drawableId);
@@ -760,7 +767,8 @@ public class RouteDetailsFragment extends ContextMenuFragment
 		buildRowDivider(infoContainer, true);
 		addWalkRouteIcon(imagesContainer);
 
-		String timeStr = OsmAndFormatter.getFormattedDurationShortMinutes(startTime[0] + walkTime);
+		long destEpoch = segment.arrivalTimeMillis > 0 ? segment.arrivalTimeMillis + walkTime * 1000L : -1;
+		String timeStr = getStopTimeText(destEpoch, startTime[0] + walkTime);
 		String name = getRoutePointDescription(destination.getLatLon(), destination.getOnlyName());
 		SpannableString title = new SpannableString(name);
 		title.setSpan(new CustomTypefaceSpan(typeface), 0, title.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/RouteDetailsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/RouteDetailsFragment.java
@@ -546,7 +546,7 @@ public class RouteDetailsFragment extends ContextMenuFragment
 		((ViewGroup) view).addView(baseContainer);
 
 		if (nextSegment != null) {
-			double walkDist = (long) getWalkDistance(segment, nextSegment, segment.walkDist);
+			double walkDist = (long) getWalkDistance(segment, nextSegment, nextSegment.walkDist);
 
 			if (walkDist > 0) {
 				int walkTime = (int) getWalkTime(segment, nextSegment, walkDist, walkSpeed);
@@ -644,7 +644,13 @@ public class RouteDetailsFragment extends ContextMenuFragment
 			name = getString(R.string.shared_string_my_location);
 		}
 		Spannable startTitle = new SpannableString(name);
-		String text = getStopTimeText(segment.departureTimeMillis, startTime[0]);
+		double walkDist = (long) getWalkDistance(null, segment, segment.walkDist);
+		int walkTime = (int) getWalkTime(null, segment, walkDist, walkSpeed);
+		if (walkTime < 60) {
+			walkTime = 60;
+		}
+		long startEpoch = segment.departureTimeMillis > 0 ? segment.departureTimeMillis - walkTime * 1000L : -1;
+		String text = getStopTimeText(startEpoch, startTime[0]);
 
 		int drawableId = start == null ? R.drawable.ic_action_location_color : R.drawable.list_startpoint;
 		Drawable icon = app.getUIUtilities().getIcon(drawableId);
@@ -658,11 +664,6 @@ public class RouteDetailsFragment extends ContextMenuFragment
 		addWalkRouteIcon(imagesContainer);
 		buildRowDivider(infoContainer, true);
 
-		double walkDist = (long) getWalkDistance(null, segment, segment.walkDist);
-		int walkTime = (int) getWalkTime(null, segment, walkDist, walkSpeed);
-		if (walkTime < 60) {
-			walkTime = 60;
-		}
 		startTime[0] += walkTime;
 		SpannableStringBuilder title = new SpannableStringBuilder(Algorithms.capitalizeFirstLetter(getString(R.string.shared_string_walk)));
 		title.setSpan(new ForegroundColorSpan(getSecondaryColor()), 0, title.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/RouteDetailsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/RouteDetailsFragment.java
@@ -465,7 +465,7 @@ public class RouteDetailsFragment extends ContextMenuFragment
 			}
 		});
 
-		buildTransportStopRouteRow(stopsContainer, transportStopRoute, new OnClickListener() {
+		buildTransportStopRouteRow(stopsContainer, transportStopRoute, transportRoute.getUrl(), new OnClickListener() {
 			@Override
 			public void onClick(View v) {
 				showRouteSegmentOnMap(segment);
@@ -475,7 +475,7 @@ public class RouteDetailsFragment extends ContextMenuFragment
 		for (TransportRouteResultSegment alt : segment.alternatives) {
 			TransportStopRoute altTransportStopRoute = TransportStopRoute.getTransportStopRoute(alt.route,
 					alt.getTravelStops().get(0));
-			buildTransportStopRouteRow(stopsContainer, altTransportStopRoute, new OnClickListener() {
+			buildTransportStopRouteRow(stopsContainer, altTransportStopRoute, null, new OnClickListener() {
 				@Override
 				public void onClick(View v) {
 					showRouteSegmentOnMap(alt);
@@ -963,7 +963,7 @@ public class RouteDetailsFragment extends ContextMenuFragment
 	}
 
 	public void buildTransportStopRouteRow(@NonNull View view, @NonNull TransportStopRoute transportStopRoute,
-										   OnClickListener onClickListener) {
+										   @Nullable String ticketUrl, OnClickListener onClickListener) {
 		MapActivity mapActivity = getMapActivity();
 		if (mapActivity == null) {
 			return;
@@ -996,6 +996,21 @@ public class RouteDetailsFragment extends ContextMenuFragment
 		AndroidUtils.setMargins(routeBadgeParams, 0, dpToPx(6), 0, dpToPx(8));
 		routeBadge.setLayoutParams(routeBadgeParams);
 		llText.addView(routeBadge);
+
+		if (ticketUrl != null) {
+			ImageView ticketIcon = new ImageView(view.getContext());
+			ticketIcon.setImageDrawable(getContentIcon(R.drawable.ic_action_price_tag));
+			ticketIcon.setContentDescription(getString(R.string.transit_buy_ticket));
+			ticketIcon.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
+			LinearLayout.LayoutParams ticketParams = new LinearLayout.LayoutParams(dpToPx(40), dpToPx(40));
+			ticketParams.gravity = Gravity.CENTER_VERTICAL;
+			AndroidUtils.setMargins(ticketParams, dpToPx(4), 0, dpToPx(4), 0);
+			ticketIcon.setLayoutParams(ticketParams);
+			AndroidUtils.setPadding(ticketIcon, dpToPx(8), dpToPx(8), dpToPx(8), dpToPx(8));
+			ticketIcon.setBackgroundResource(AndroidUtils.resolveAttribute(view.getContext(), android.R.attr.selectableItemBackground));
+			ticketIcon.setOnClickListener(v -> AndroidUtils.openUrl(v.getContext(), ticketUrl, isNightMode()));
+			ll.addView(ticketIcon);
+		}
 
 		if (onClickListener != null) {
 			ll.setOnClickListener(onClickListener);

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/LaterDeparturesCard.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/LaterDeparturesCard.java
@@ -1,0 +1,51 @@
+package net.osmand.plus.routepreparationmenu.cards;
+
+import android.graphics.drawable.Drawable;
+import android.view.View;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+
+import net.osmand.plus.R;
+import net.osmand.plus.activities.MapActivity;
+import net.osmand.plus.utils.AndroidUtils;
+
+public class LaterDeparturesCard extends MapBaseCard {
+
+	private final long laterTimeMillis;
+
+	public LaterDeparturesCard(@NonNull MapActivity mapActivity, long laterTimeMillis) {
+		super(mapActivity);
+		this.laterTimeMillis = laterTimeMillis;
+	}
+
+	public long getLaterTimeMillis() {
+		return laterTimeMillis;
+	}
+
+	@Override
+	public int getCardLayoutId() {
+		return R.layout.route_ped_info;
+	}
+
+	@Override
+	protected void updateContent() {
+		view.findViewById(R.id.title).setVisibility(View.GONE);
+
+		TextView buttonDescr = view.findViewById(R.id.button_descr);
+		buttonDescr.setText(R.string.transit_later_departures);
+
+		FrameLayout button = view.findViewById(R.id.button);
+		button.setOnClickListener(v -> notifyButtonPressed(0));
+		AndroidUtils.setBackground(app, button, nightMode, R.drawable.btn_border_light, R.drawable.btn_border_dark);
+		AndroidUtils.setBackground(app, buttonDescr, nightMode, R.drawable.ripple_light, R.drawable.ripple_dark);
+
+		Drawable icon = app.getUIUtilities().getIcon(R.drawable.ic_action_time, R.color.icon_color_default_light);
+		((ImageView) view.findViewById(R.id.image)).setImageDrawable(icon);
+
+		view.findViewById(R.id.card_divider).setVisibility(View.VISIBLE);
+		view.findViewById(R.id.top_divider).setVisibility(View.GONE);
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/PublicTransportCard.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/PublicTransportCard.java
@@ -237,16 +237,39 @@ public class PublicTransportCard extends MapBaseCard {
 		int walkDistancePT = (int) routeResult.getWalkDist();
 		int walkDistance = walkDistanceReal > 0 ? walkDistanceReal : walkDistancePT;
 		String walkDistanceStr = OsmAndFormatter.getFormattedDistance(walkDistance, app);
-		int travelTime = (int) routeResult.getTravelTime() + walkTime;
+		TransportRouteResultSegment firstSeg = segments.get(0);
+		TransportRouteResultSegment lastSeg = segments.get(segments.size() - 1);
+		double walkSpeed = routeResult.getWalkSpeed();
+		long depEpoch = -1;
+		long arrEpoch = -1;
+		if (firstSeg.departureTimeMillis > 0 && lastSeg.arrivalTimeMillis > 0) {
+			depEpoch = firstSeg.departureTimeMillis - (long) (getWalkTime(firstSeg.walkDist, walkSpeed) * 1000);
+			arrEpoch = lastSeg.arrivalTimeMillis + (long) (getWalkTime(routeResult.getFinishWalkDist(), walkSpeed) * 1000);
+		}
+		int travelTime = depEpoch > 0 && arrEpoch > 0
+				? (int) ((arrEpoch / 60000 - depEpoch / 60000) * 60)
+				: (int) routeResult.getTravelTime() + walkTime;
 		String travelTimeStr = OsmAndFormatter.getFormattedDuration(travelTime, app);
 		int travelDist = (int) routeResult.getTravelDist() + walkDistance;
 		String travelDistStr = OsmAndFormatter.getFormattedDistance(travelDist, app);
 
 		String secondLine = travelTimeStr + ", " + travelDistStr + "  •  " + app.getString(R.string.shared_string_walk) + " " + walkTimeStr + ", " + walkDistanceStr;
 
+		String clockStr = null;
+		if (depEpoch > 0 && arrEpoch > 0) {
+			clockStr = app.getString(R.string.ltr_or_rtl_combine_via_arrow,
+					OsmAndFormatter.getFormattedTimeShort(depEpoch / 1000, false),
+					OsmAndFormatter.getFormattedTimeShort(arrEpoch / 1000, false));
+			secondLine = clockStr + "  •  " + secondLine;
+		}
+
 		SpannableString secondLineDesc = new SpannableString(secondLine);
 
 		int mainFontColor = getMainFontColor();
+		if (clockStr != null) {
+			secondLineDesc.setSpan(new ForegroundColorSpan(mainFontColor), 0, clockStr.length(), 0);
+			secondLineDesc.setSpan(new CustomTypefaceSpan(typeface), 0, clockStr.length(), 0);
+		}
 		int startTravelTime = secondLine.indexOf(travelTimeStr);
 		secondLineDesc.setSpan(new ForegroundColorSpan(mainFontColor), startTravelTime, startTravelTime + travelTimeStr.length(), 0);
 		secondLineDesc.setSpan(new CustomTypefaceSpan(typeface), startTravelTime, startTravelTime + travelTimeStr.length(), 0);

--- a/OsmAnd/src/net/osmand/plus/routing/TransportRoutingHelper.java
+++ b/OsmAnd/src/net/osmand/plus/routing/TransportRoutingHelper.java
@@ -22,6 +22,7 @@ import net.osmand.plus.render.NativeOsmandLibrary;
 import net.osmand.plus.settings.backend.ApplicationMode;
 import net.osmand.plus.settings.backend.OsmandSettings;
 import net.osmand.plus.settings.backend.preferences.CommonPreference;
+import net.osmand.plus.transport.online.OnlineTransportRouteTranslator;
 import net.osmand.router.GeneralRouter;
 import net.osmand.router.GeneralRouter.RoutingParameter;
 import net.osmand.router.NativeTransportRoutingResult;
@@ -527,6 +528,13 @@ public class TransportRoutingHelper {
 			}
 			GeneralRouter prouter = config.getRouter(params.mode.getRoutingProfile());
 			TransportRoutingConfiguration cfg = new TransportRoutingConfiguration(prouter, params.params);
+
+			if (settings.USE_ONLINE_PUBLIC_TRANSPORT.get()) {
+				List<TransportRouteResult> res = OnlineTransportRouteTranslator.buildRoutes(settings, params.params, params.start, params.end, cfg);
+				if (!res.isEmpty()) {
+					return res;
+				}
+			}
 
 			TransportRoutingContext ctx = new TransportRoutingContext(cfg, library, files);
 			ctx.calculationProgress = params.calculationProgress;

--- a/OsmAnd/src/net/osmand/plus/routing/TransportRoutingHelper.java
+++ b/OsmAnd/src/net/osmand/plus/routing/TransportRoutingHelper.java
@@ -133,6 +133,10 @@ public class TransportRoutingHelper {
 		return null;
 	}
 
+	public Map<Pair<TransportRouteResultSegment, TransportRouteResultSegment>, RouteCalculationResult> getWalkingRouteSegments() {
+		return walkingRouteSegments;
+	}
+
 	public int getWalkingTime(@NonNull List<TransportRouteResultSegment> segments) {
 		int res = 0;
 		Map<Pair<TransportRouteResultSegment, TransportRouteResultSegment>, RouteCalculationResult> walkingRouteSegments = this.walkingRouteSegments;
@@ -278,7 +282,7 @@ public class TransportRoutingHelper {
 						updateProgress(params);
 					}
 				} else {
-					if (routes != null && routes.size() > 0) {
+					if (routes != null && routes.size() > 0 && currentRoute < 0) {
 						setCurrentRoute(0);
 					}
 					progressRoute.finish();
@@ -721,6 +725,18 @@ public class TransportRoutingHelper {
 			try {
 				res = calculateRouteImpl(params, lib);
 				if (res != null && !params.calculationProgress.isCancelled) {
+					if (params.ctx.getSettings().USE_ONLINE_PUBLIC_TRANSPORT.get()) {
+						// online transit: show the result immediately, walking legs are routed after and refine the display
+						synchronized (transportRoutingHelper) {
+							transportRoutingHelper.routes = res;
+							transportRoutingHelper.currentRoute = res.isEmpty() ? -1 : 0;
+							transportRoutingHelper.walkingRouteSegments = null;
+							if (params.resultListener != null) {
+								params.resultListener.onRouteCalculated(res);
+							}
+						}
+						transportRoutingHelper.setNewRoute(res);
+					}
 					calculateWalkingRoutes(res);
 				}
 			} catch (Exception e) {

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -99,6 +99,7 @@ import net.osmand.plus.settings.backend.storages.ImpassableRoadsStorage;
 import net.osmand.plus.settings.backend.storages.IntermediatePointsStorage;
 import net.osmand.plus.settings.coordinates.CoordinateFormatSettingsStorage;
 import net.osmand.plus.settings.enums.*;
+import net.osmand.plus.transport.online.OnlineTransportOptimize;
 import net.osmand.plus.utils.AndroidUtils;
 import net.osmand.plus.utils.FileUtils;
 import net.osmand.plus.views.layers.RadiusRulerControlLayer.RadiusRulerMode;
@@ -3344,6 +3345,11 @@ public class OsmandSettings {
 	public final OsmandPreference<Boolean> USE_OSM_LIVE_FOR_ROUTING = new BooleanPreference(this, "enable_osmc_routing", true).makeProfile();
 
 	public final OsmandPreference<Boolean> USE_OSM_LIVE_FOR_PUBLIC_TRANSPORT = new BooleanPreference(this, "enable_osmc_public_transport", false).makeProfile();
+
+	public final OsmandPreference<Boolean> USE_ONLINE_PUBLIC_TRANSPORT = new BooleanPreference(this, "use_online_public_transport", false).makeProfile();
+	public final CommonPreference<OnlineTransportOptimize> ONLINE_TRANSPORT_OPTIMIZE = new EnumStringPreference<>(this, "online_transport_optimize", OnlineTransportOptimize.BEST, OnlineTransportOptimize.values()).makeProfile();
+	public final CommonPreference<Boolean> ONLINE_TRANSPORT_WHEELCHAIR = new BooleanPreference(this, "online_transport_wheelchair", false).makeProfile();
+	public final CommonPreference<String> ONLINE_TRANSPORT_URL = new StringPreference(this, "online_transport_url", "https://api.transitous.org/api/v6/plan").makeProfile();
 
 	public final OsmandPreference<Boolean> VOICE_MUTE = new BooleanPreference(this, "voice_mute", false).makeProfile().cache();
 	public final CommonPreference<TrackApproximationType> DETAILED_TRACK_GUIDANCE = new EnumStringPreference<>(this, "detailed_track_guidance",

--- a/OsmAnd/src/net/osmand/plus/settings/fragments/RouteParametersFragment.java
+++ b/OsmAnd/src/net/osmand/plus/settings/fragments/RouteParametersFragment.java
@@ -169,6 +169,16 @@ public class RouteParametersFragment extends BaseSettingsFragment {
 		getPreferenceScreen().addPreference(timeConditionalRouting);
 	}
 
+	private void setupOnlinePublicTransportPref() {
+		SwitchPreferenceEx onlinePublicTransport = createSwitchPreferenceEx(settings.USE_ONLINE_PUBLIC_TRANSPORT.getId(),
+				R.string.use_online_public_transport, R.layout.preference_with_descr_dialog_and_switch);
+		onlinePublicTransport.setDescription(getString(R.string.use_online_public_transport_descr));
+		onlinePublicTransport.setSummaryOn(R.string.shared_string_enabled);
+		onlinePublicTransport.setSummaryOff(R.string.shared_string_disabled);
+		onlinePublicTransport.setIconSpaceReserved(true);
+		getPreferenceScreen().addPreference(onlinePublicTransport);
+	}
+
 	private void setupOsmLiveForPublicTransportPref() {
 		SwitchPreferenceEx useOsmLiveForPublicTransport = createSwitchPreferenceEx(settings.USE_OSM_LIVE_FOR_PUBLIC_TRANSPORT.getId(),
 				R.string.use_live_public_transport, R.layout.preference_with_descr_dialog_and_switch);
@@ -204,6 +214,10 @@ public class RouteParametersFragment extends BaseSettingsFragment {
 	private void setupRoutingPrefs() {
 		PreferenceScreen screen = getPreferenceScreen();
 		ApplicationMode am = getSelectedAppMode();
+
+		if (am.isDerivedRoutingFrom(ApplicationMode.PUBLIC_TRANSPORT)) {
+			setupOnlinePublicTransportPref();
+		}
 
 		SwitchPreferenceEx fastRoute = createSwitchPreferenceEx(app.getSettings().FAST_ROUTE_MODE.getId(), R.string.fast_route_mode, R.layout.preference_with_descr_dialog_and_switch);
 		fastRoute.setIcon(getRoutingPrefIcon(app.getSettings().FAST_ROUTE_MODE.getId()));

--- a/OsmAnd/src/net/osmand/plus/transport/TransportStopRoute.java
+++ b/OsmAnd/src/net/osmand/plus/transport/TransportStopRoute.java
@@ -10,6 +10,7 @@ import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.R;
 import net.osmand.render.RenderingRuleSearchRequest;
 import net.osmand.render.RenderingRulesStorage;
+import net.osmand.util.Algorithms;
 
 import java.util.HashMap;
 import java.util.List;
@@ -83,6 +84,14 @@ public class TransportStopRoute {
 		if (cachedColor == 0 || cachedNight != nightMode) {
 			cachedColor = ctx.getColor(R.color.transport_route_line);
 			cachedNight = nightMode;
+			String directColor = route != null ? route.getColor() : null;
+			if (directColor != null && directColor.startsWith("#")) {
+				try {
+					cachedColor = Algorithms.parseColor(directColor);
+					return cachedColor;
+				} catch (IllegalArgumentException ignored) {
+				}
+			}
 			if (type != null) {
 				RenderingRulesStorage rrs = ctx.getRendererRegistry().getCurrentSelectedRenderer();
 				RenderingRuleSearchRequest req = new RenderingRuleSearchRequest(rrs);

--- a/OsmAnd/src/net/osmand/plus/transport/online/OnlineTransportOptimize.java
+++ b/OsmAnd/src/net/osmand/plus/transport/online/OnlineTransportOptimize.java
@@ -1,0 +1,7 @@
+package net.osmand.plus.transport.online;
+
+public enum OnlineTransportOptimize {
+	BEST,
+	FEWEST_TRANSFERS,
+	LEAST_WALKING
+}

--- a/OsmAnd/src/net/osmand/plus/transport/online/OnlineTransportOptionsBottomSheet.java
+++ b/OsmAnd/src/net/osmand/plus/transport/online/OnlineTransportOptionsBottomSheet.java
@@ -1,0 +1,121 @@
+package net.osmand.plus.transport.online;
+
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.FragmentManager;
+
+import net.osmand.plus.R;
+import net.osmand.plus.base.MenuBottomSheetDialogFragment;
+import net.osmand.plus.base.bottomsheetmenu.BottomSheetItemWithCompoundButton;
+import net.osmand.plus.base.bottomsheetmenu.simpleitems.DividerItem;
+import net.osmand.plus.base.bottomsheetmenu.simpleitems.TitleItem;
+import net.osmand.plus.settings.backend.ApplicationMode;
+import net.osmand.plus.settings.backend.OsmandSettings;
+import net.osmand.plus.utils.AndroidUtils;
+import net.osmand.plus.utils.ColorUtilities;
+import net.osmand.plus.utils.UiUtilities;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OnlineTransportOptionsBottomSheet extends MenuBottomSheetDialogFragment {
+
+	public static final String TAG = OnlineTransportOptionsBottomSheet.class.getSimpleName();
+
+	private Runnable onApplied;
+
+	private OnlineTransportOptimize optimize;
+	private boolean wheelchair;
+	private final List<BottomSheetItemWithCompoundButton> optimizeItems = new ArrayList<>();
+
+	@Override
+	public void createMenuItems(Bundle savedInstanceState) {
+		Context ctx = getContext();
+		if (ctx == null) {
+			return;
+		}
+		OsmandSettings settings = app.getSettings();
+		optimize = settings.ONLINE_TRANSPORT_OPTIMIZE.get();
+		wheelchair = settings.ONLINE_TRANSPORT_WHEELCHAIR.get();
+		optimizeItems.clear();
+
+		ctx = UiUtilities.getThemedContext(ctx, nightMode);
+		ApplicationMode appMode = settings.APPLICATION_MODE.get();
+		ColorStateList tint = AndroidUtils.createCheckedColorIntStateList(
+				ColorUtilities.getDefaultIconColor(ctx, nightMode), appMode.getProfileColor(nightMode));
+
+		items.add(new TitleItem(getString(R.string.transit_optimize)));
+		items.add(createRadio(OnlineTransportOptimize.BEST, R.string.transit_opt_best, tint));
+		items.add(createRadio(OnlineTransportOptimize.FEWEST_TRANSFERS, R.string.transit_opt_fewest_changes, tint));
+		items.add(createRadio(OnlineTransportOptimize.LEAST_WALKING, R.string.transit_opt_least_walking, tint));
+
+		items.add(new DividerItem(ctx));
+		items.add(createWheelchairSwitch());
+	}
+
+	@NonNull
+	private BottomSheetItemWithCompoundButton createRadio(@NonNull OnlineTransportOptimize opt, int titleId, @NonNull ColorStateList tint) {
+		BottomSheetItemWithCompoundButton item = (BottomSheetItemWithCompoundButton) new BottomSheetItemWithCompoundButton.Builder()
+				.setChecked(optimize == opt)
+				.setButtonTintList(tint)
+				.setTitle(getString(titleId))
+				.setTag(opt)
+				.setLayoutId(R.layout.bottom_sheet_item_with_long_descr_and_left_radio_btn)
+				.setOnClickListener(v -> selectOptimize(opt))
+				.create();
+		optimizeItems.add(item);
+		return item;
+	}
+
+	private void selectOptimize(@NonNull OnlineTransportOptimize opt) {
+		optimize = opt;
+		for (BottomSheetItemWithCompoundButton item : optimizeItems) {
+			item.setChecked(item.getTag() == opt);
+		}
+	}
+
+	@NonNull
+	private BottomSheetItemWithCompoundButton createWheelchairSwitch() {
+		BottomSheetItemWithCompoundButton[] ref = new BottomSheetItemWithCompoundButton[1];
+		ref[0] = (BottomSheetItemWithCompoundButton) new BottomSheetItemWithCompoundButton.Builder()
+				.setChecked(wheelchair)
+				.setTitle(getString(R.string.transit_wheelchair))
+				.setLayoutId(R.layout.bottom_sheet_item_with_switch_no_icon)
+				.setOnClickListener(v -> {
+					wheelchair = !wheelchair;
+					ref[0].setChecked(wheelchair);
+				})
+				.create();
+		return ref[0];
+	}
+
+	@Override
+	protected int getRightBottomButtonTextId() {
+		return R.string.shared_string_apply;
+	}
+
+	@Override
+	protected void onRightBottomButtonClick() {
+		OsmandSettings settings = app.getSettings();
+		ApplicationMode appMode = settings.APPLICATION_MODE.get();
+		settings.ONLINE_TRANSPORT_OPTIMIZE.setModeValue(appMode, optimize);
+		settings.ONLINE_TRANSPORT_WHEELCHAIR.setModeValue(appMode, wheelchair);
+		app.getRoutingHelper().onSettingsChanged(true);
+		if (onApplied != null) {
+			onApplied.run();
+		}
+		dismiss();
+	}
+
+	public static void showInstance(@NonNull FragmentManager manager, @Nullable Runnable onApplied) {
+		if (AndroidUtils.isFragmentCanBeAdded(manager, TAG)) {
+			OnlineTransportOptionsBottomSheet fragment = new OnlineTransportOptionsBottomSheet();
+			fragment.onApplied = onApplied;
+			fragment.show(manager, TAG);
+		}
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/transport/online/OnlineTransportRouteTranslator.java
+++ b/OsmAnd/src/net/osmand/plus/transport/online/OnlineTransportRouteTranslator.java
@@ -152,6 +152,14 @@ public class OnlineTransportRouteTranslator {
 			route.setRef(leg.optString("routeShortName", ""));
 			route.setType(osmandType(mode));
 			route.setName(leg.optString("headsign", ""));
+			route.setOperator(leg.optString("agencyName", ""));
+			String ticketUrl = leg.optString("routeUrl", "");
+			if (ticketUrl.isEmpty()) {
+				ticketUrl = leg.optString("agencyUrl", "");
+			}
+			if (!ticketUrl.isEmpty()) {
+				route.setUrl(ticketUrl);
+			}
 			String color = leg.optString("routeColor", "");
 			if (!color.isEmpty()) {
 				route.setColor("#" + color);

--- a/OsmAnd/src/net/osmand/plus/transport/online/OnlineTransportRouteTranslator.java
+++ b/OsmAnd/src/net/osmand/plus/transport/online/OnlineTransportRouteTranslator.java
@@ -192,6 +192,10 @@ public class OnlineTransportRouteTranslator {
 		stop.setId(ID_SEQ.getAndIncrement());
 		stop.setLocation(lat, lon);
 		stop.setName(place.optString("name", ""));
+		String track = place.optString("track", "");
+		if (!track.isEmpty()) {
+			stop.setPlatform(track);
+		}
 		stops.add(stop);
 	}
 

--- a/OsmAnd/src/net/osmand/plus/transport/online/OnlineTransportRouteTranslator.java
+++ b/OsmAnd/src/net/osmand/plus/transport/online/OnlineTransportRouteTranslator.java
@@ -1,0 +1,325 @@
+package net.osmand.plus.transport.online;
+
+import net.osmand.PlatformUtil;
+import net.osmand.data.LatLon;
+import net.osmand.data.TransportRoute;
+import net.osmand.data.TransportStop;
+import net.osmand.osm.edit.Node;
+import net.osmand.osm.edit.Way;
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.settings.backend.OsmandSettings;
+import net.osmand.router.TransportRoutePlanner.TransportRouteResultSegment;
+import net.osmand.router.TransportRouteResult;
+import net.osmand.router.TransportRoutingConfiguration;
+import net.osmand.util.GeoPolylineParserUtil;
+import net.osmand.util.MapUtils;
+
+import org.apache.commons.logging.Log;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class OnlineTransportRouteTranslator {
+
+	private static final Log LOG = PlatformUtil.getLog(OnlineTransportRouteTranslator.class);
+	private static final List<String> ALL_MODES = Arrays.asList("HIGHSPEED_RAIL", "LONG_DISTANCE", "NIGHT_RAIL",
+			"REGIONAL_RAIL", "SUBURBAN", "SUBWAY", "TRAM", "BUS", "COACH", "FERRY", "FUNICULAR", "AERIAL_LIFT");
+	private static final AtomicLong ID_SEQ = new AtomicLong(1);
+
+	private OnlineTransportRouteTranslator() {
+	}
+
+	public static List<TransportRouteResult> buildRoutes(OsmandSettings settings, Map<String, String> routeParams,
+			LatLon from, LatLon to, TransportRoutingConfiguration cfg) {
+		OsmandApplication app = settings.getContext();
+		String body;
+		try {
+			body = app.getOnlineRoutingHelper().makeRequest(buildUrl(settings, routeParams, from, to));
+		} catch (Exception e) {
+			LOG.error("Online transit request failed", e);
+			return Collections.emptyList();
+		}
+		try {
+			JSONArray itineraries = new JSONObject(body).optJSONArray("itineraries");
+			if (itineraries == null) {
+				return Collections.emptyList();
+			}
+			List<JSONObject> list = new ArrayList<>(itineraries.length());
+			for (int i = 0; i < itineraries.length(); i++) {
+				JSONObject itinerary = itineraries.optJSONObject(i);
+				if (itinerary != null) {
+					list.add(itinerary);
+				}
+			}
+			Comparator<JSONObject> comparator = optimizeComparator(settings.ONLINE_TRANSPORT_OPTIMIZE.get());
+			if (comparator != null) {
+				Collections.sort(list, comparator);
+			}
+			List<TransportRouteResult> results = new ArrayList<>(list.size());
+			for (JSONObject itinerary : list) {
+				TransportRouteResult result = toRouteResult(itinerary, cfg);
+				if (result != null) {
+					results.add(result);
+				}
+			}
+			return results;
+		} catch (Exception e) {
+			LOG.error("Online transit response parse failed", e);
+			return Collections.emptyList();
+		}
+	}
+
+	private static String buildUrl(OsmandSettings settings, Map<String, String> routeParams, LatLon from, LatLon to) {
+		StringBuilder sb = new StringBuilder(settings.ONLINE_TRANSPORT_URL.get());
+		sb.append("?fromPlace=").append(from.getLatitude()).append(',').append(from.getLongitude());
+		sb.append("&toPlace=").append(to.getLatitude()).append(',').append(to.getLongitude());
+		if (!OnlineTransportState.isNow()) {
+			sb.append("&time=").append(Instant.ofEpochMilli(OnlineTransportState.getTimeMillis()));
+		}
+		if (OnlineTransportState.isArriveBy()) {
+			sb.append("&arriveBy=true");
+		}
+		if (settings.ONLINE_TRANSPORT_WHEELCHAIR.get()) {
+			sb.append("&pedestrianProfile=WHEELCHAIR");
+		}
+		sb.append("&transitModes=").append(transitModes(routeParams));
+		Integer maxTransfers = maxTransfers(routeParams);
+		if (maxTransfers != null) {
+			sb.append("&maxTransfers=").append(maxTransfers);
+		}
+		return sb.toString();
+	}
+
+	// MOTIS counts first/last-mile transit legs as transfers, so allow two beyond the profile's change limit.
+	private static Integer maxTransfers(Map<String, String> routeParams) {
+		String value = routeParams.get("max_num_changes");
+		if (value == null) {
+			return null;
+		}
+		try {
+			return (int) Double.parseDouble(value) + 2;
+		} catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+	private static TransportRouteResult toRouteResult(JSONObject itinerary, TransportRoutingConfiguration cfg) {
+		JSONArray legs = itinerary.optJSONArray("legs");
+		if (legs == null) {
+			return null;
+		}
+		TransportRouteResult result = new TransportRouteResult(cfg);
+		boolean anyLeg = false;
+		double pendingWalkDist = 0;
+		for (int i = 0; i < legs.length(); i++) {
+			JSONObject leg = legs.optJSONObject(i);
+			if (leg == null) {
+				continue;
+			}
+			String mode = leg.optString("mode");
+			if (!isTransit(mode)) {
+				if ("WALK".equals(mode)) {
+					pendingWalkDist += leg.optDouble("distance", 0);
+				}
+				continue;
+			}
+			List<TransportStop> stops = new ArrayList<>();
+			addStop(stops, leg.optJSONObject("from"));
+			JSONArray intermediate = leg.optJSONArray("intermediateStops");
+			if (intermediate != null) {
+				for (int j = 0; j < intermediate.length(); j++) {
+					addStop(stops, intermediate.optJSONObject(j));
+				}
+			}
+			addStop(stops, leg.optJSONObject("to"));
+			if (stops.size() < 2) {
+				return null;
+			}
+
+			TransportRoute route = new TransportRoute();
+			route.setId(ID_SEQ.getAndIncrement());
+			route.setRef(leg.optString("routeShortName", ""));
+			route.setType(osmandType(mode));
+			route.setName(leg.optString("headsign", ""));
+			String color = leg.optString("routeColor", "");
+			if (!color.isEmpty()) {
+				route.setColor("#" + color);
+			}
+			route.setForwardStops(stops);
+			addGeometry(route, leg.optJSONObject("legGeometry"));
+
+			TransportRouteResultSegment segment = new TransportRouteResultSegment();
+			segment.route = route;
+			segment.start = 0;
+			segment.end = stops.size() - 1;
+			segment.walkDist = pendingWalkDist;
+			pendingWalkDist = 0;
+			long departure = epochMillis(leg.optString("startTime"));
+			long arrival = epochMillis(leg.optString("endTime"));
+			segment.departureTimeMillis = departure;
+			segment.arrivalTimeMillis = arrival;
+			segment.travelTime = departure > 0 && arrival > 0 ? (arrival - departure) / 1000.0 : 0;
+			result.addSegment(segment);
+			anyLeg = true;
+		}
+		if (anyLeg) {
+			result.setFinishWalkDist(pendingWalkDist);
+		}
+		return anyLeg ? result : null;
+	}
+
+	private static void addStop(List<TransportStop> stops, JSONObject place) {
+		if (place == null) {
+			return;
+		}
+		double lat = place.optDouble("lat", Double.NaN);
+		double lon = place.optDouble("lon", Double.NaN);
+		if (Double.isNaN(lat) || Double.isNaN(lon)) {
+			return;
+		}
+		TransportStop stop = new TransportStop();
+		stop.setId(ID_SEQ.getAndIncrement());
+		stop.setLocation(lat, lon);
+		stop.setName(place.optString("name", ""));
+		stops.add(stop);
+	}
+
+	private static void addGeometry(TransportRoute route, JSONObject legGeometry) {
+		String points = legGeometry != null ? legGeometry.optString("points") : null;
+		if (points == null || points.isEmpty()) {
+			return;
+		}
+		List<LatLon> decoded = GeoPolylineParserUtil.parse(points, GeoPolylineParserUtil.PRECISION_6);
+		if (decoded == null || decoded.isEmpty()) {
+			return;
+		}
+		Way way = new Way(ID_SEQ.getAndIncrement());
+		LatLon prev = null;
+		for (int i = 0; i < decoded.size(); i++) {
+			LatLon point = decoded.get(i);
+			// bound node count on long-distance legs: keep the endpoints and points at least 20 m apart
+			if (prev == null || i == decoded.size() - 1 || MapUtils.getDistance(prev, point) >= 20) {
+				way.addNode(new Node(point.getLatitude(), point.getLongitude(), ID_SEQ.getAndIncrement()));
+				prev = point;
+			}
+		}
+		route.setForwardWays(Collections.singletonList(way));
+	}
+
+	private static Comparator<JSONObject> optimizeComparator(OnlineTransportOptimize optimize) {
+		switch (optimize) {
+			case FEWEST_TRANSFERS:
+				return Comparator.comparingInt((JSONObject o) -> o.optInt("transfers", 0))
+						.thenComparingDouble(o -> o.optDouble("duration", 0));
+			case LEAST_WALKING:
+				return Comparator.comparingDouble(OnlineTransportRouteTranslator::walkDistance)
+						.thenComparingDouble(o -> o.optDouble("duration", 0));
+			default:
+				// keep the order the server returns, which is earliest departure first
+				return null;
+		}
+	}
+
+	private static double walkDistance(JSONObject itinerary) {
+		JSONArray legs = itinerary.optJSONArray("legs");
+		if (legs == null) {
+			return 0;
+		}
+		double distance = 0;
+		for (int i = 0; i < legs.length(); i++) {
+			JSONObject leg = legs.optJSONObject(i);
+			if (leg != null && "WALK".equals(leg.optString("mode"))) {
+				distance += leg.optDouble("distance", 0);
+			}
+		}
+		return distance;
+	}
+
+	private static String transitModes(Map<String, String> routeParams) {
+		Set<String> modes = new LinkedHashSet<>(ALL_MODES);
+		if (isAvoided(routeParams, "avoid_train")) {
+			modes.removeAll(Arrays.asList("HIGHSPEED_RAIL", "LONG_DISTANCE", "NIGHT_RAIL", "REGIONAL_RAIL", "SUBURBAN"));
+		}
+		if (isAvoided(routeParams, "avoid_subway")) {
+			modes.remove("SUBWAY");
+		}
+		if (isAvoided(routeParams, "avoid_tram")) {
+			modes.remove("TRAM");
+		}
+		if (isAvoided(routeParams, "avoid_bus")) {
+			modes.removeAll(Arrays.asList("BUS", "COACH"));
+		}
+		if (isAvoided(routeParams, "avoid_ferry")) {
+			modes.remove("FERRY");
+		}
+		return String.join(",", modes);
+	}
+
+	private static boolean isAvoided(Map<String, String> routeParams, String id) {
+		return "true".equals(routeParams.get(id));
+	}
+
+	private static boolean isTransit(String mode) {
+		switch (mode) {
+			case "WALK":
+			case "BIKE":
+			case "CAR":
+			case "CAR_PARKING":
+			case "CAR_DROPOFF":
+			case "RENTAL":
+			case "ODM":
+			case "RIDE_SHARING":
+			case "FLEX":
+			case "":
+				return false;
+			default:
+				return true;
+		}
+	}
+
+	private static String osmandType(String mode) {
+		switch (mode) {
+			case "SUBWAY":
+				return "subway";
+			case "TRAM":
+				return "tram";
+			case "FERRY":
+				return "ferry";
+			case "FUNICULAR":
+			case "AERIAL_LIFT":
+				return "funicular";
+			case "RAIL":
+			case "HIGHSPEED_RAIL":
+			case "LONG_DISTANCE":
+			case "NIGHT_RAIL":
+			case "REGIONAL_FAST_RAIL":
+			case "REGIONAL_RAIL":
+			case "SUBURBAN":
+				return "train";
+			default:
+				return "bus";
+		}
+	}
+
+	private static long epochMillis(String iso) {
+		if (iso == null || iso.isEmpty()) {
+			return -1;
+		}
+		try {
+			return OffsetDateTime.parse(iso).toInstant().toEpochMilli();
+		} catch (Exception e) {
+			return -1;
+		}
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/transport/online/OnlineTransportState.java
+++ b/OsmAnd/src/net/osmand/plus/transport/online/OnlineTransportState.java
@@ -1,0 +1,35 @@
+package net.osmand.plus.transport.online;
+
+public class OnlineTransportState {
+
+	private static volatile long timeMillis = 0;
+	private static volatile boolean arriveBy = false;
+
+	private OnlineTransportState() {
+	}
+
+	public static long getTimeMillis() {
+		return timeMillis;
+	}
+
+	public static void setTimeMillis(long value) {
+		timeMillis = value;
+	}
+
+	public static boolean isArriveBy() {
+		return arriveBy;
+	}
+
+	public static void setArriveBy(boolean value) {
+		arriveBy = value;
+	}
+
+	public static boolean isNow() {
+		return timeMillis <= 0;
+	}
+
+	public static void reset() {
+		timeMillis = 0;
+		arriveBy = false;
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/transport/online/OnlineTransportTimeBottomSheet.java
+++ b/OsmAnd/src/net/osmand/plus/transport/online/OnlineTransportTimeBottomSheet.java
@@ -1,0 +1,134 @@
+package net.osmand.plus.transport.online;
+
+import android.app.DatePickerDialog;
+import android.app.TimePickerDialog;
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.os.Bundle;
+import android.text.format.DateFormat;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.R;
+import net.osmand.plus.base.MenuBottomSheetDialogFragment;
+import net.osmand.plus.base.bottomsheetmenu.BottomSheetItemWithCompoundButton;
+import net.osmand.plus.base.bottomsheetmenu.simpleitems.TitleItem;
+import net.osmand.plus.utils.AndroidUtils;
+import net.osmand.plus.utils.ColorUtilities;
+import net.osmand.plus.utils.OsmAndFormatter;
+import net.osmand.plus.utils.UiUtilities;
+
+import java.util.Calendar;
+
+public class OnlineTransportTimeBottomSheet extends MenuBottomSheetDialogFragment {
+
+	public static final String TAG = OnlineTransportTimeBottomSheet.class.getSimpleName();
+
+	private Runnable onApplied;
+
+	@NonNull
+	public static String getLabel(@NonNull OsmandApplication app) {
+		if (OnlineTransportState.isNow()) {
+			return app.getString(R.string.transit_leave_now);
+		}
+		String time = OsmAndFormatter.getFormattedTimeShort(OnlineTransportState.getTimeMillis() / 1000, false);
+		return OnlineTransportState.isArriveBy() ? app.getString(R.string.transit_arrive_prefix, time) : time;
+	}
+
+	@Override
+	public void createMenuItems(Bundle savedInstanceState) {
+		Context ctx = getContext();
+		if (ctx == null) {
+			return;
+		}
+		ctx = UiUtilities.getThemedContext(ctx, nightMode);
+		ColorStateList tint = AndroidUtils.createCheckedColorIntStateList(
+				ColorUtilities.getDefaultIconColor(ctx, nightMode),
+				app.getSettings().APPLICATION_MODE.get().getProfileColor(nightMode));
+
+		boolean now = OnlineTransportState.isNow();
+		boolean arriveBy = OnlineTransportState.isArriveBy();
+		String picked = now ? null : formatDateTime(ctx, OnlineTransportState.getTimeMillis());
+
+		items.add(new TitleItem(getString(R.string.transit_departure_time)));
+		items.add(new BottomSheetItemWithCompoundButton.Builder()
+				.setChecked(now)
+				.setButtonTintList(tint)
+				.setTitle(getString(R.string.transit_leave_now))
+				.setLayoutId(R.layout.bottom_sheet_item_with_long_descr_and_left_radio_btn)
+				.setOnClickListener(v -> {
+					OnlineTransportState.reset();
+					apply();
+				})
+				.create());
+		items.add(new BottomSheetItemWithCompoundButton.Builder()
+				.setChecked(!now && !arriveBy)
+				.setButtonTintList(tint)
+				.setDescription(!now && !arriveBy ? picked : null)
+				.setTitle(getString(R.string.transit_depart_at))
+				.setLayoutId(R.layout.bottom_sheet_item_with_long_descr_and_left_radio_btn)
+				.setOnClickListener(v -> pickDateTime(false))
+				.create());
+		items.add(new BottomSheetItemWithCompoundButton.Builder()
+				.setChecked(!now && arriveBy)
+				.setButtonTintList(tint)
+				.setDescription(!now && arriveBy ? picked : null)
+				.setTitle(getString(R.string.transit_arrive_by))
+				.setLayoutId(R.layout.bottom_sheet_item_with_long_descr_and_left_radio_btn)
+				.setOnClickListener(v -> pickDateTime(true))
+				.create());
+	}
+
+	private void pickDateTime(boolean arriveBy) {
+		FragmentActivity activity = getActivity();
+		if (activity == null) {
+			return;
+		}
+		Calendar cal = Calendar.getInstance();
+		if (!OnlineTransportState.isNow()) {
+			cal.setTimeInMillis(OnlineTransportState.getTimeMillis());
+		}
+		new DatePickerDialog(activity, (dateView, year, month, day) -> {
+			Calendar picked = Calendar.getInstance();
+			if (!OnlineTransportState.isNow()) {
+				picked.setTimeInMillis(OnlineTransportState.getTimeMillis());
+			}
+			picked.set(Calendar.YEAR, year);
+			picked.set(Calendar.MONTH, month);
+			picked.set(Calendar.DAY_OF_MONTH, day);
+			new TimePickerDialog(activity, (timeView, hour, minute) -> {
+				picked.set(Calendar.HOUR_OF_DAY, hour);
+				picked.set(Calendar.MINUTE, minute);
+				picked.set(Calendar.SECOND, 0);
+				OnlineTransportState.setTimeMillis(picked.getTimeInMillis());
+				OnlineTransportState.setArriveBy(arriveBy);
+				apply();
+			}, picked.get(Calendar.HOUR_OF_DAY), picked.get(Calendar.MINUTE), DateFormat.is24HourFormat(activity)).show();
+		}, cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), cal.get(Calendar.DAY_OF_MONTH)).show();
+	}
+
+	private void apply() {
+		app.getRoutingHelper().onSettingsChanged(true);
+		if (onApplied != null) {
+			onApplied.run();
+		}
+		dismiss();
+	}
+
+	@NonNull
+	private static String formatDateTime(@NonNull Context ctx, long millis) {
+		return DateFormat.getDateFormat(ctx).format(millis) + " " + DateFormat.getTimeFormat(ctx).format(millis);
+	}
+
+	public static void showInstance(@NonNull FragmentManager manager, @Nullable Runnable onApplied) {
+		if (AndroidUtils.isFragmentCanBeAdded(manager, TAG)) {
+			OnlineTransportTimeBottomSheet fragment = new OnlineTransportTimeBottomSheet();
+			fragment.onApplied = onApplied;
+			fragment.show(manager, TAG);
+		}
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/views/layers/RouteLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/RouteLayer.java
@@ -69,6 +69,7 @@ public class RouteLayer extends BaseRouteLayer implements IContextMenuProvider {
 	private PublicTransportGeometryWayContext publicTransportWayContext;
 	private RouteGeometryWay routeGeometry;
 	private PublicTransportGeometryWay publicTransportRouteGeometry;
+	private Object lastWalkingRouteSegments;
 
 	private final ColoringTypeAvailabilityCache coloringAvailabilityCache;
 
@@ -474,8 +475,13 @@ public class RouteLayer extends BaseRouteLayer implements IContextMenuProvider {
 				}
 			}
 			List<TransportRouteResult> routes = transportHelper.getRoutes();
-			TransportRouteResult route = routes != null && routes.size() > currentRoute ? routes.get(currentRoute) : null;
+			TransportRouteResult route = routes != null && currentRoute >= 0 && currentRoute < routes.size() ? routes.get(currentRoute) : null;
 			routeGeometry.clearRoute();
+			Object walkingRouteSegments = transportHelper.getWalkingRouteSegments();
+			if (walkingRouteSegments != lastWalkingRouteSegments) {
+				lastWalkingRouteSegments = walkingRouteSegments;
+				publicTransportRouteGeometry.clearRoute();
+			}
 			boolean routeUpdated = publicTransportRouteGeometry.updateRoute(tileBox, route);
 			boolean draw = routeUpdated || renderState.shouldRebuildTransportRoute
 					|| !publicTransportRouteGeometry.hasMapRenderer() || mapActivityInvalidated || mapRendererChanged;


### PR DESCRIPTION
Closes #23121.

Native public-transport routing has no schedule data, so journeys render from `00:00` with no real
times. This adds real-time routing from open online timetables: the existing PT route UI now shows
actual departure and arrival times, alternatives, official line colours, and real leg geometry.

The backend is MOTIS through the public [Transitous](https://transitous.org) instance: Apache-2.0,
keyless, self-hostable, no vendored library, no new dependency. It hooks in at **a single point** in
`TransportRoutingHelper.calculateRouteImpl`, maps each itinerary onto the native
`TransportRouteResult`, and falls through to the native engine on an empty result, so everything
downstream is unchanged. One per-profile switch, `USE_ONLINE_PUBLIC_TRANSPORT`, turns it off.

One call for maintainers: the switch defaults on and the endpoint is the hardcoded volunteer
Transitous instance, which asks to be contacted before large-scale traffic. A wide rollout probably
wants the endpoint made configurable (the way `net.osmand.plus.onlinerouting` ships the OSRM demo
server) or the default flipped. One-line change either way.
