### PR TITLE
Live traffic overlay and traffic-aware routing via TomTom

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <resources>
+	<string name="traffic_plugin_name">Traffic</string>
+	<string name="traffic_plugin_description">Shows live road traffic from TomTom as a coloured overlay and factors it into car routing. Requires a personal TomTom API key and an internet connection.</string>
+	<string name="traffic_show_overlay">Show traffic overlay</string>
+	<string name="traffic_routing">Traffic-aware routing</string>
+	<string name="traffic_routing_description">Route the car profile with TomTom live traffic. Sets up the routing engine automatically from your API key.</string>
+	<string name="traffic_api_key">TomTom API key</string>
+	<string name="traffic_api_key_description">Personal TomTom API key, used for the traffic overlay tiles and traffic-aware routing.</string>
+	<string name="traffic_auto_reroute">Re-route for traffic</string>
+	<string name="traffic_auto_reroute_description">While navigating, periodically recalculate the route to avoid newly reported jams.</string>
 <!--
 	README:
 	- The preferred way to help with translations is via https://hosted.weblate.org/engage/osmand/

--- a/OsmAnd/res/xml/traffic_settings.xml
+++ b/OsmAnd/res/xml/traffic_settings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:title="@string/traffic_plugin_name">
+
+    <net.osmand.plus.settings.preferences.SwitchPreferenceEx
+        android:key="traffic_overlay_enabled"
+        android:layout="@layout/preference_with_descr_dialog_and_switch"
+        android:summaryOff="@string/shared_string_disabled"
+        android:summaryOn="@string/shared_string_enabled"
+        android:title="@string/traffic_show_overlay" />
+
+    <net.osmand.plus.settings.preferences.SwitchPreferenceEx
+        android:key="traffic_routing"
+        android:layout="@layout/preference_with_descr_dialog_and_switch"
+        android:summaryOff="@string/shared_string_disabled"
+        android:summaryOn="@string/shared_string_enabled"
+        android:title="@string/traffic_routing" />
+
+    <net.osmand.plus.settings.preferences.SwitchPreferenceEx
+        android:key="traffic_auto_reroute"
+        android:layout="@layout/preference_with_descr_dialog_and_switch"
+        android:summaryOff="@string/shared_string_disabled"
+        android:summaryOn="@string/shared_string_enabled"
+        android:title="@string/traffic_auto_reroute" />
+
+    <net.osmand.plus.settings.preferences.EditTextPreferenceEx
+        android:key="tomtom_api_key"
+        android:layout="@layout/preference_with_descr"
+        android:title="@string/traffic_api_key"
+        tools:summary="@string/traffic_api_key_description" />
+</PreferenceScreen>

--- a/OsmAnd/src/net/osmand/plus/onlinerouting/engine/EngineType.java
+++ b/OsmAnd/src/net/osmand/plus/onlinerouting/engine/EngineType.java
@@ -9,6 +9,7 @@ public class EngineType {
 	public static final OnlineRoutingEngine GRAPHHOPPER_TYPE = new GraphhopperEngine(null);
 	public static final OnlineRoutingEngine OSRM_TYPE = new OsrmEngine(null);
 	public static final OnlineRoutingEngine ORS_TYPE = new OrsEngine(null);
+	public static final OnlineRoutingEngine TOMTOM_TYPE = new TomTomEngine(null);
 	public static final OnlineRoutingEngine GPX_TYPE = new GpxEngine(null);
 
 	private static OnlineRoutingEngine[] enginesTypes;
@@ -19,6 +20,7 @@ public class EngineType {
 					GRAPHHOPPER_TYPE,
 					OSRM_TYPE,
 					ORS_TYPE,
+					TOMTOM_TYPE,
 					GPX_TYPE
 			};
 		}

--- a/OsmAnd/src/net/osmand/plus/onlinerouting/engine/TomTomEngine.java
+++ b/OsmAnd/src/net/osmand/plus/onlinerouting/engine/TomTomEngine.java
@@ -1,0 +1,215 @@
+package net.osmand.plus.onlinerouting.engine;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import net.osmand.Location;
+import net.osmand.data.LatLon;
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.R;
+import net.osmand.plus.onlinerouting.EngineParameter;
+import net.osmand.plus.onlinerouting.VehicleType;
+import net.osmand.plus.routing.RouteCalculationResult;
+import net.osmand.plus.routing.RouteDirectionInfo;
+import net.osmand.router.RouteCalculationProgress;
+import net.osmand.router.TurnType;
+import net.osmand.shared.gpx.GpxFile;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static net.osmand.plus.onlinerouting.engine.EngineType.TOMTOM_TYPE;
+import static net.osmand.util.Algorithms.isEmpty;
+
+public class TomTomEngine extends JsonOnlineRoutingEngine {
+
+	public TomTomEngine(@Nullable Map<String, String> params) {
+		super(params);
+	}
+
+	@NonNull
+	@Override
+	public OnlineRoutingEngine getType() {
+		return TOMTOM_TYPE;
+	}
+
+	@NonNull
+	@Override
+	public String getTitle() {
+		return "TomTom";
+	}
+
+	@NonNull
+	@Override
+	public String getTypeName() {
+		return "TOMTOM";
+	}
+
+	@NonNull
+	@Override
+	public String getStandardUrl() {
+		return "https://api.tomtom.com/routing/1/calculateRoute/";
+	}
+
+	@Override
+	protected void collectAllowedParameters(@NonNull Set<EngineParameter> params) {
+		params.add(EngineParameter.KEY);
+		params.add(EngineParameter.VEHICLE_KEY);
+		params.add(EngineParameter.CUSTOM_NAME);
+		params.add(EngineParameter.NAME_INDEX);
+		params.add(EngineParameter.CUSTOM_URL);
+		params.add(EngineParameter.API_KEY);
+	}
+
+	@Override
+	protected void collectAllowedVehicles(@NonNull List<VehicleType> vehicles) {
+		vehicles.add(new VehicleType("car", R.string.routing_engine_vehicle_type_car));
+		vehicles.add(new VehicleType("truck", R.string.routing_engine_vehicle_type_hgv));
+		vehicles.add(new VehicleType("bicycle", R.string.routing_engine_vehicle_type_bike));
+		vehicles.add(new VehicleType("pedestrian", R.string.routing_engine_vehicle_type_foot));
+	}
+
+	@Override
+	public OnlineRoutingEngine newInstance(Map<String, String> params) {
+		return new TomTomEngine(params);
+	}
+
+	@Override
+	public OnlineRoutingResponse responseByGpxFile(@NonNull OsmandApplication app, @NonNull GpxFile gpxFile,
+	                                               boolean initialCalculation, @Nullable RouteCalculationProgress calculationProgress) {
+		return null;
+	}
+
+	@Override
+	protected void makeFullUrl(@NonNull StringBuilder sb, @NonNull List<LatLon> path, @Nullable Float startBearing) {
+		for (int i = 0; i < path.size(); i++) {
+			LatLon point = path.get(i);
+			sb.append(point.getLatitude()).append(',').append(point.getLongitude());
+			if (i < path.size() - 1) {
+				sb.append(':');
+			}
+		}
+		sb.append("/json");
+		sb.append("?key=").append(getApiKey());
+		sb.append("&traffic=true");
+		sb.append("&routeType=fastest");
+		sb.append("&instructionsType=text");
+		String travelMode = getVehicleKeyForUrl();
+		if (!isEmpty(travelMode)) {
+			sb.append("&travelMode=").append(travelMode);
+		}
+	}
+
+	@NonNull
+	private String getApiKey() {
+		String apiKey = get(EngineParameter.API_KEY);
+		return apiKey != null ? apiKey : "";
+	}
+
+	@Nullable
+	@Override
+	protected OnlineRoutingResponse parseServerResponse(@NonNull JSONObject root,
+	                                                    @NonNull OsmandApplication app,
+	                                                    boolean leftSideNavigation) throws JSONException {
+		List<LatLon> points = new ArrayList<>();
+		JSONArray legs = root.getJSONArray("legs");
+		for (int i = 0; i < legs.length(); i++) {
+			JSONArray legPoints = legs.getJSONObject(i).getJSONArray("points");
+			for (int j = 0; j < legPoints.length(); j++) {
+				JSONObject point = legPoints.getJSONObject(j);
+				points.add(new LatLon(point.getDouble("latitude"), point.getDouble("longitude")));
+			}
+		}
+		if (isEmpty(points)) {
+			return null;
+		}
+		List<Location> route = convertRouteToLocationsList(points);
+		return new OnlineRoutingResponse(route, parseDirections(root, app, leftSideNavigation));
+	}
+
+	@NonNull
+	private List<RouteDirectionInfo> parseDirections(@NonNull JSONObject root, @NonNull OsmandApplication app,
+	                                                 boolean leftSideNavigation) throws JSONException {
+		List<RouteDirectionInfo> directions = new ArrayList<>();
+		JSONObject guidance = root.optJSONObject("guidance");
+		if (guidance == null) {
+			return directions;
+		}
+		JSONArray instructions = guidance.getJSONArray("instructions");
+		for (int i = 0; i < instructions.length(); i++) {
+			JSONObject instruction = instructions.getJSONObject(i);
+			int offset = instruction.getInt("routeOffsetInMeters");
+			int time = instruction.getInt("travelTimeInSeconds");
+			boolean last = i == instructions.length() - 1;
+			int distance = last ? 0 : instructions.getJSONObject(i + 1).getInt("routeOffsetInMeters") - offset;
+			int duration = last ? 0 : instructions.getJSONObject(i + 1).getInt("travelTimeInSeconds") - time;
+
+			String maneuver = instruction.getString("maneuver");
+			TurnType turnType = identifyTurnType(maneuver, instruction, leftSideNavigation);
+			RouteDirectionInfo direction = new RouteDirectionInfo(duration > 0 ? (float) distance / duration : 1f, turnType);
+			direction.setDistance(distance);
+			direction.routePointOffset = instruction.getInt("pointIndex");
+
+			String street = instruction.optString("street", "");
+			direction.setStreetName(street);
+			boolean terminal = "DEPART".equals(maneuver) || maneuver.startsWith("ARRIVE");
+			direction.setDescriptionRoute(terminal ? "" : (RouteCalculationResult.toString(turnType, app, false) + " " + street).trim());
+			directions.add(direction);
+		}
+		return directions;
+	}
+
+	@NonNull
+	private TurnType identifyTurnType(@NonNull String maneuver, @NonNull JSONObject instruction, boolean leftSide) {
+		switch (maneuver) {
+			case "TURN_LEFT":
+				return TurnType.fromString("TL", leftSide);
+			case "TURN_RIGHT":
+				return TurnType.fromString("TR", leftSide);
+			case "SHARP_LEFT":
+				return TurnType.fromString("TSHL", leftSide);
+			case "SHARP_RIGHT":
+				return TurnType.fromString("TSHR", leftSide);
+			case "BEAR_LEFT":
+				return TurnType.fromString("TSLL", leftSide);
+			case "BEAR_RIGHT":
+				return TurnType.fromString("TSLR", leftSide);
+			case "KEEP_LEFT":
+			case "MOTORWAY_EXIT_LEFT":
+				return TurnType.fromString("KL", leftSide);
+			case "KEEP_RIGHT":
+			case "MOTORWAY_EXIT_RIGHT":
+			case "TAKE_EXIT":
+				return TurnType.fromString("KR", leftSide);
+			case "MAKE_UTURN":
+			case "TRY_MAKE_UTURN":
+				return TurnType.fromString("TU", leftSide);
+			case "ROUNDABOUT_LEFT":
+			case "ROUNDABOUT_RIGHT":
+			case "ROUNDABOUT_CROSS":
+			case "ROUNDABOUT_BACK":
+				int exit = instruction.optInt("roundaboutExitNumber", 0);
+				return exit > 0 ? TurnType.getExitTurn(exit, 0f, leftSide) : TurnType.fromString("RNDB", leftSide);
+			default:
+				return TurnType.fromString("C", leftSide);
+		}
+	}
+
+	@NonNull
+	@Override
+	protected String getRootArrayKey() {
+		return "routes";
+	}
+
+	@NonNull
+	@Override
+	protected String getErrorMessageKey() {
+		return "message";
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/plugins/PluginsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/PluginsHelper.java
@@ -55,6 +55,7 @@ import net.osmand.plus.plugins.rastermaps.OsmandRasterMapsPlugin;
 import net.osmand.plus.plugins.skimaps.SkiMapsPlugin;
 import net.osmand.plus.plugins.astronomy.AstronomyPlugin;
 import net.osmand.plus.plugins.srtm.SRTMPlugin;
+import net.osmand.plus.plugins.traffic.TrafficPlugin;
 import net.osmand.plus.plugins.weather.WeatherPlugin;
 import net.osmand.plus.poi.PoiUIFilter;
 import net.osmand.plus.quickaction.QuickActionType;
@@ -119,6 +120,7 @@ public class PluginsHelper {
 		checkMarketPlugin(app, new ParkingPositionPlugin(app));
 		allPlugins.add(new OsmEditingPlugin(app));
 		allPlugins.add(new MapillaryPlugin(app));
+		allPlugins.add(new TrafficPlugin(app));
 		allPlugins.add(new ExternalSensorsPlugin(app));
 		allPlugins.add(new VehicleMetricsPlugin(app));
 		allPlugins.add(new AstronomyPlugin(app));

--- a/OsmAnd/src/net/osmand/plus/plugins/traffic/TrafficPlugin.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/traffic/TrafficPlugin.java
@@ -1,0 +1,184 @@
+package net.osmand.plus.plugins.traffic;
+
+import android.app.Activity;
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import net.osmand.Location;
+import net.osmand.StateChangedListener;
+import net.osmand.map.ITileSource;
+import net.osmand.map.TileSourceManager.TileSourceTemplate;
+import net.osmand.plus.OsmAndLocationProvider.OsmAndLocationListener;
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.R;
+import net.osmand.plus.activities.MapActivity;
+import net.osmand.plus.onlinerouting.EngineParameter;
+import net.osmand.plus.onlinerouting.engine.EngineType;
+import net.osmand.plus.onlinerouting.engine.OnlineRoutingEngine;
+import net.osmand.plus.plugins.OsmandPlugin;
+import net.osmand.plus.routing.RoutingHelper;
+import net.osmand.plus.settings.backend.ApplicationMode;
+import net.osmand.plus.settings.backend.preferences.CommonPreference;
+import net.osmand.plus.settings.fragments.SettingsScreenType;
+import net.osmand.plus.views.OsmandMapTileView;
+import net.osmand.plus.views.layers.MapTileLayer;
+import net.osmand.util.Algorithms;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TrafficPlugin extends OsmandPlugin implements OsmAndLocationListener {
+
+	public static final String ID = "osmand.traffic";
+
+	private static final String ROUTING_ENGINE_KEY = OnlineRoutingEngine.ONLINE_ROUTING_ENGINE_PREFIX + "tomtom_traffic";
+	private static final float ZORDER_TRAFFIC = 0.65f;
+	// leading dot keeps the layer out of the user-facing map source list (it is an overlay only, toggled via this plugin)
+	private static final String OVERLAY_NAME = ".TomTomTraffic";
+	// relative0 leaves free-flowing roads transparent and colours only slow segments, so the base map stays visible
+	private static final String FLOW_TILE_URL =
+			"https://api.tomtom.com/traffic/map/4/tile/flow/relative0/{0}/{1}/{2}.png?tileSize=256&key=";
+	private static final int EXPIRATION_MINUTES = 3;
+	private static final long REROUTE_INTERVAL = 2 * 60 * 1000;
+
+	public final CommonPreference<Boolean> TRAFFIC_ENABLED;
+	public final CommonPreference<Boolean> TRAFFIC_ROUTING;
+	public final CommonPreference<Boolean> TRAFFIC_AUTO_REROUTE;
+	public final CommonPreference<String> TOMTOM_API_KEY;
+
+	private final StateChangedListener<Boolean> enabledListener = change -> refreshOverlay();
+	private final StateChangedListener<String> apiKeyListener = change -> refreshOverlay();
+
+	private MapTileLayer trafficLayer;
+	private String appliedKey;
+	private long lastRerouteTime;
+	private boolean locationListenerRegistered;
+
+	public TrafficPlugin(@NonNull OsmandApplication app) {
+		super(app);
+		TRAFFIC_ENABLED = registerBooleanPreference("traffic_overlay_enabled", false).makeProfile();
+		TRAFFIC_ROUTING = registerBooleanPreference("traffic_routing", false).makeProfile();
+		TRAFFIC_AUTO_REROUTE = registerBooleanPreference("traffic_auto_reroute", true).makeProfile();
+		TOMTOM_API_KEY = registerStringPreference("tomtom_api_key", "").makeGlobal().makeShared();
+		TRAFFIC_ENABLED.addListener(enabledListener);
+		TOMTOM_API_KEY.addListener(apiKeyListener);
+	}
+
+	@Override
+	public String getId() {
+		return ID;
+	}
+
+	@Override
+	public String getName() {
+		return app.getString(R.string.traffic_plugin_name);
+	}
+
+	@Override
+	public CharSequence getDescription(boolean linksEnabled) {
+		return app.getString(R.string.traffic_plugin_description);
+	}
+
+	@Override
+	public boolean isEnableByDefault() {
+		return false;
+	}
+
+	@Nullable
+	@Override
+	public SettingsScreenType getSettingsScreenType() {
+		return SettingsScreenType.TRAFFIC_SETTINGS;
+	}
+
+	@Override
+	public boolean init(@NonNull OsmandApplication app, @Nullable Activity activity) {
+		if (!locationListenerRegistered) {
+			app.getLocationProvider().addLocationListener(this);
+			locationListenerRegistered = true;
+		}
+		return true;
+	}
+
+	@Override
+	public void updateLocation(Location location) {
+		if (!isActive() || !TRAFFIC_AUTO_REROUTE.get()) {
+			return;
+		}
+		RoutingHelper routingHelper = app.getRoutingHelper();
+		ApplicationMode mode = routingHelper.getAppMode();
+		if (mode == null || !mode.getRouteService().isOnline() || !routingHelper.isFollowingMode()) {
+			return;
+		}
+		long now = System.currentTimeMillis();
+		if (now - lastRerouteTime >= REROUTE_INTERVAL) {
+			lastRerouteTime = now;
+			routingHelper.onSettingsChanged(mode, true);
+		}
+	}
+
+	@Nullable
+	public OnlineRoutingEngine getTrafficEngine(@NonNull ApplicationMode mode) {
+		if (!isActive() || !TRAFFIC_ROUTING.getModeValue(mode) || Algorithms.isEmpty(TOMTOM_API_KEY.get())) {
+			return null;
+		}
+		Map<String, String> params = new HashMap<>();
+		params.put(EngineParameter.KEY.name(), ROUTING_ENGINE_KEY);
+		params.put(EngineParameter.API_KEY.name(), TOMTOM_API_KEY.get());
+		params.put(EngineParameter.VEHICLE_KEY.name(), "car");
+		return EngineType.TOMTOM_TYPE.newInstance(params);
+	}
+
+	@Override
+	public void registerLayers(@NonNull Context context, @Nullable MapActivity mapActivity) {
+		OsmandMapTileView mapView = app.getOsmandMap().getMapView();
+		if (trafficLayer != null) {
+			mapView.removeLayer(trafficLayer);
+		}
+		trafficLayer = new MapTileLayer(context, false);
+	}
+
+	@Override
+	public void updateLayers(@NonNull Context context, @Nullable MapActivity mapActivity) {
+		if (trafficLayer == null) {
+			registerLayers(context, mapActivity);
+		}
+		OsmandMapTileView mapView = app.getOsmandMap().getMapView();
+		String apiKey = TOMTOM_API_KEY.get();
+		boolean show = isActive() && TRAFFIC_ENABLED.get() && !Algorithms.isEmpty(apiKey);
+		if (show) {
+			boolean changed = false;
+			if (!mapView.isLayerExists(trafficLayer)) {
+				mapView.addLayer(trafficLayer, ZORDER_TRAFFIC);
+				changed = true;
+			}
+			if (!apiKey.equals(appliedKey) || trafficLayer.getMap() == null) {
+				trafficLayer.setMap(buildTrafficTileSource(apiKey));
+				trafficLayer.setAlpha(255);
+				appliedKey = apiKey;
+				changed = true;
+			}
+			if (changed) {
+				mapView.refreshMap();
+			}
+		} else if (mapView.isLayerExists(trafficLayer)) {
+			mapView.removeLayer(trafficLayer);
+			trafficLayer.setMap(null);
+			appliedKey = null;
+			mapView.refreshMap();
+		}
+	}
+
+	private void refreshOverlay() {
+		app.runInUIThread(() -> updateLayers(app, null));
+	}
+
+	@NonNull
+	private static ITileSource buildTrafficTileSource(@NonNull String apiKey) {
+		TileSourceTemplate template = new TileSourceTemplate(OVERLAY_NAME,
+				FLOW_TILE_URL + apiKey, ".png", 22, 0, 256, 16, 18000);
+		template.setExpirationTimeMinutes(EXPIRATION_MINUTES);
+		return template;
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/plugins/traffic/TrafficSettingsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/traffic/TrafficSettingsFragment.java
@@ -1,0 +1,34 @@
+package net.osmand.plus.plugins.traffic;
+
+import androidx.preference.Preference;
+
+import net.osmand.plus.R;
+import net.osmand.plus.plugins.PluginsHelper;
+import net.osmand.plus.settings.fragments.BaseSettingsFragment;
+import net.osmand.plus.settings.preferences.EditTextPreferenceEx;
+
+public class TrafficSettingsFragment extends BaseSettingsFragment {
+
+	private final TrafficPlugin plugin = PluginsHelper.requirePlugin(TrafficPlugin.class);
+
+	@Override
+	protected void setupPreferences() {
+		EditTextPreferenceEx apiKey = findPreference(plugin.TOMTOM_API_KEY.getId());
+		if (apiKey != null) {
+			apiKey.setDescription(R.string.traffic_api_key_description);
+			apiKey.setSummary(plugin.TOMTOM_API_KEY.get());
+		}
+	}
+
+	@Override
+	public boolean onPreferenceChange(Preference preference, Object newValue) {
+		boolean changed = super.onPreferenceChange(preference, newValue);
+		if (changed) {
+			String key = preference.getKey();
+			if (plugin.TRAFFIC_ROUTING.getId().equals(key) || plugin.TOMTOM_API_KEY.getId().equals(key)) {
+				app.getRoutingHelper().onSettingsChanged(getSelectedAppMode(), true);
+			}
+		}
+		return changed;
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/routing/RouteProvider.java
+++ b/OsmAnd/src/net/osmand/plus/routing/RouteProvider.java
@@ -26,6 +26,8 @@ import net.osmand.plus.measurementtool.GpxApproximationParams;
 import net.osmand.plus.onlinerouting.OnlineRoutingHelper;
 import net.osmand.plus.onlinerouting.engine.OnlineRoutingEngine;
 import net.osmand.plus.onlinerouting.engine.OnlineRoutingEngine.OnlineRoutingResponse;
+import net.osmand.plus.plugins.PluginsHelper;
+import net.osmand.plus.plugins.traffic.TrafficPlugin;
 import net.osmand.plus.render.NativeOsmandLibrary;
 import net.osmand.plus.routing.GPXRouteParams.GPXRouteParamsBuilder;
 import net.osmand.plus.settings.backend.ApplicationMode;
@@ -127,9 +129,11 @@ public class RouteProvider {
 						params.mode.getRouteService().getName()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 			}
 			try {
-				RouteCalculationResult res;
 				boolean calcGPXRoute = shouldCalculateGpxRoute(params);
-				if (calcGPXRoute && !params.gpxRoute.calculateOsmAndRoute) {
+				RouteCalculationResult res = findTrafficRoute(params);
+				if (res != null) {
+					// live traffic-aware route provided by the traffic plugin
+				} else if (calcGPXRoute && !params.gpxRoute.calculateOsmAndRoute) {
 					res = gpxRouteHelper.calculateGpxRoute(params);
 				} else if (params.mode.getRouteService() == RouteService.OSMAND) {
 					res = findVectorMapsRoute(params, calcGPXRoute);
@@ -811,6 +815,25 @@ public class RouteProvider {
 		}
 
 		return new RouteCalculationResult("Route is empty");
+	}
+
+	private RouteCalculationResult findTrafficRoute(@NonNull RouteCalculationParams params) {
+		TrafficPlugin plugin = PluginsHelper.getActivePlugin(TrafficPlugin.class);
+		OnlineRoutingEngine engine = plugin != null ? plugin.getTrafficEngine(params.mode) : null;
+		if (engine == null) {
+			return null;
+		}
+		try {
+			OnlineRoutingResponse response = params.ctx.getOnlineRoutingHelper()
+					.calculateRouteOnline(engine, getPathFromParams(params), params);
+			if (response != null && !Algorithms.isEmpty(response.getRoute()) && !Algorithms.isEmpty(response.getDirections())) {
+				params.intermediates = null;
+				return new RouteCalculationResult(response.getRoute(), response.getDirections(), params, null, false);
+			}
+		} catch (IOException | JSONException e) {
+			log.error("Traffic routing failed", e);
+		}
+		return null;
 	}
 
 	private static List<LatLon> getPathFromParams(RouteCalculationParams params) {

--- a/OsmAnd/src/net/osmand/plus/settings/fragments/SettingsScreenType.java
+++ b/OsmAnd/src/net/osmand/plus/settings/fragments/SettingsScreenType.java
@@ -4,6 +4,7 @@ import net.osmand.plus.R;
 import net.osmand.plus.keyevent.fragments.MainExternalInputDevicesFragment;
 import net.osmand.plus.plugins.accessibility.AccessibilitySettingsFragment;
 import net.osmand.plus.plugins.aistracker.AisTrackerSettingsFragment;
+import net.osmand.plus.plugins.traffic.TrafficSettingsFragment;
 import net.osmand.plus.plugins.audionotes.MultimediaNotesFragment;
 import net.osmand.plus.plugins.development.DevelopmentSettingsFragment;
 import net.osmand.plus.plugins.externalsensors.ExternalSettingsWriteToTrackSettingsFragment;
@@ -54,6 +55,7 @@ public enum SettingsScreenType {
 	DANGEROUS_GOODS(DangerousGoodsFragment.class.getName(), true, ApplyQueryType.NONE, R.xml.dangerous_goods_parameters, R.layout.global_preference_toolbar),
 	EXTERNAL_INPUT_DEVICE(MainExternalInputDevicesFragment.class.getName(), true, ApplyQueryType.SNACK_BAR, R.xml.external_input_device_settings, R.layout.profile_preference_toolbar_with_switch),
 	AIS_SETTINGS(AisTrackerSettingsFragment.class.getName(), true, ApplyQueryType.SNACK_BAR, R.xml.ais_settings, R.layout.profile_preference_toolbar),
+	TRAFFIC_SETTINGS(TrafficSettingsFragment.class.getName(), true, ApplyQueryType.SNACK_BAR, R.xml.traffic_settings, R.layout.profile_preference_toolbar),
 	POSITION_ANIMATION(PositionAnimationFragment.class.getName(), true, ApplyQueryType.NONE, R.xml.position_animation_settings, R.layout.profile_preference_toolbar_with_switch);
 
 	public final String fragmentName;


### PR DESCRIPTION
Addresses #3565 (traffic data), #2068 (colour roads by congestion) and #6878 (route around jams).

OsmAnd has no live traffic. This adds it as an opt-in plugin: a TomTom congestion overlay and traffic-aware car routing. It is bring-your-own-key, no bundled token and no new dependency, so each user pastes their own free TomTom key, the same way the app already takes an OSRM/GraphHopper/ORS endpoint.

The overlay is the plugin's own `MapTileLayer` on TomTom's `relative0` flow tiles, so only slow roads colour and the base map shows through. It is additive, never touches the overlay/underlay slots, and stays out of the map-source picker. Routing hooks in at **a single point** in `RouteProvider.calculateRouteImpl`: when the plugin toggle is on it calculates with `TomTomEngine` (a normal `OnlineRoutingEngine`, `traffic=true`, guidance parsed to turn-by-turn), otherwise it falls straight through to the normal engine, so no engine is persisted and no profile is rewritten. Everything is one self-contained plugin, default off, with a single key field and toggles for overlay, routing, and periodic re-routing while driving.

One call for maintainers: keeping the key with the user is what sidesteps the reason traffic has stalled since #3565 (2017) - no free global traffic without trading user data. The only core touch is about 25 lines in `RouteProvider`. TomTom is used over raw REST (free tier, no card), and HERE is a drop-in if its explicit third-party-basemap licence is preferred.
