### PR TITLE
Fix #24802 Gap between My location and Route line

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/util/MapUtils.java
+++ b/OsmAnd-java/src/main/java/net/osmand/util/MapUtils.java
@@ -24,6 +24,9 @@ import gnu.trove.map.hash.TIntObjectHashMap;
 public class MapUtils {
 
 	public static final int ROUNDING_ERROR = 3;
+	// for haversine use R = 6372.8 km instead of 6371 km
+	public static final double HAVERSINE_EARTH_RADIUS_METERS = 6372800.0;
+	public static final double VECTOR_LINE_EARTH_RADIUS_METERS = 6371000.0;
 	private static final int EARTH_RADIUS_B = 6356752;
 	static final int EARTH_RADIUS_A = 6378137;
 	public static final double MIN_LATITUDE = -85.0511;
@@ -193,24 +196,6 @@ public class MapUtils {
 	/**
 	 * Gets distance in meters
 	 */
-	public static double getDistance(double lat1, double lon1, double lat2, double lon2) {
-		double R = 6372.8; // for haversine use R = 6372.8 km instead of 6371 km
-		double dLat = toRadians(lat2 - lat1);
-		double dLon = toRadians(lon2 - lon1);
-		double sinHalfLat = Math.sin(dLat / 2);
-		double sinHalfLon = Math.sin(dLon / 2);
-		double a = sinHalfLat * sinHalfLat +
-				Math.cos(toRadians(lat1)) * Math.cos(toRadians(lat2)) *
-						sinHalfLon * sinHalfLon;
-		//double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
-		//return R * c * 1000;
-		// simplify haversine:
-		return (2 * R * 1000 * Math.asin(Math.sqrt(a)));
-	}
-
-	/**
-	 * Gets distance in meters
-	 */
 	public static double getDistance(LatLon l1, LatLon l2) {
 		return getDistance(l1.getLatitude(), l1.getLongitude(), l2.getLatitude(), l2.getLongitude());
 	}
@@ -220,6 +205,29 @@ public class MapUtils {
 	 */
 	public static double getDistance(Location l1, Location l2) {
 		return getDistance(l1.getLatitude(), l1.getLongitude(), l2.getLatitude(), l2.getLongitude());
+	}
+
+	/**
+	 * Gets distance in meters.
+	 */
+	public static double getDistance(double lat1, double lon1, double lat2, double lon2) {
+		return getDistance(lat1, lon1, lat2, lon2, HAVERSINE_EARTH_RADIUS_METERS);
+	}
+
+	/**
+	 * Gets distance in meters using the specified Earth radius.
+	 */
+	public static double getDistance(double lat1, double lon1, double lat2, double lon2, double earthRadiusMeters) {
+		double dLat = toRadians(lat2 - lat1);
+		double dLon = toRadians(lon2 - lon1);
+		double sinHalfLat = Math.sin(dLat / 2);
+		double sinHalfLon = Math.sin(dLon / 2);
+		double a = sinHalfLat * sinHalfLat
+				+ Math.cos(toRadians(lat1))
+				* Math.cos(toRadians(lat2))
+				* sinHalfLon
+				* sinHalfLon;
+		return 2 * earthRadiusMeters * Math.asin(Math.sqrt(a));
 	}
 
 	public static double checkLongitude(double longitude) {

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/KMapUtils.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/KMapUtils.kt
@@ -16,6 +16,9 @@ import kotlin.math.*
 object KMapUtils {
 
 	const val ROUNDING_ERROR = 3
+	// for haversine use R = 6372.8 km instead of 6371 km
+	const val HAVERSINE_EARTH_RADIUS_METERS = 6372800.0
+	const val VECTOR_LINE_EARTH_RADIUS_METERS = 6371000.0
 	private const val EARTH_RADIUS_B = 6356752
 	private const val EARTH_RADIUS_A = 6378137
 	const val MIN_LATITUDE = -85.0511
@@ -81,15 +84,23 @@ object KMapUtils {
 		return intArrayOf(finalX, finalY)
 	}
 
-	fun getDistance(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
-		val R = 6372.8 // for haversine use R = 6372.8 km instead of 6371 km
+	fun getDistance(
+		lat1: Double,
+		lon1: Double,
+		lat2: Double,
+		lon2: Double,
+		earthRadiusMeters: Double
+	): Double {
 		val dLat = (lat2 - lat1).toRadians()
 		val dLon = (lon2 - lon1).toRadians()
 		val sinHalfLat = sin(dLat / 2)
 		val sinHalfLon = sin(dLon / 2)
-		val a =
-			sinHalfLat * sinHalfLat + cos(lat1.toRadians()) * cos(lat2.toRadians()) * sinHalfLon * sinHalfLon
-		return 2 * R * 1000 * asin(sqrt(a))
+		val a = sinHalfLat * sinHalfLat + cos(lat1.toRadians()) * cos(lat2.toRadians()) * sinHalfLon * sinHalfLon
+		return 2 * earthRadiusMeters * asin(sqrt(a))
+	}
+
+	fun getDistance(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
+		return getDistance(lat1, lon1, lat2, lon2, HAVERSINE_EARTH_RADIUS_METERS)
 	}
 
 	fun getDistance(l1: KLatLon, l2: KLatLon): Double {

--- a/OsmAnd/src/net/osmand/plus/views/layers/geometry/GeometryWay.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/geometry/GeometryWay.java
@@ -255,7 +255,7 @@ public abstract class GeometryWay<T extends CommonGeometryWayContext, D extends 
 					double prevLon = locationProvider.getLongitude(previous);
 					double lat = locationProvider.getLatitude(i);
 					double lon = locationProvider.getLongitude(i);
-					dist = MapUtils.getDistance(prevLat, prevLon, lat, lon);
+					dist = calculateSegmentDistance(prevLat, prevLon, lat, lon);
 				}
 				if (!previousVisible && !ignorePrevious) {
 					if (previous != -1 && !isPreviousPointFarAway(locationProvider, previous, i)) {
@@ -422,9 +422,7 @@ public abstract class GeometryWay<T extends CommonGeometryWayContext, D extends 
 			}
 		}
 		if (lastProjection != null && lastX31 != 0 && lastY31 != 0) {
-			passedDist += (float) MapUtils.measuredDist31(
-					MapUtils.get31TileNumberX(lastProjection.getLongitude()),
-					MapUtils.get31TileNumberY(lastProjection.getLatitude()), lastX31, lastY31);
+			passedDist += (float) calculateProjectionDistance(lastProjection, lastX31, lastY31);
 		}
 
 		if (passedLineId > 0) {
@@ -450,6 +448,16 @@ public abstract class GeometryWay<T extends CommonGeometryWayContext, D extends 
 
 	protected boolean shouldDrawArrows() {
 		return true;
+	}
+
+	protected double calculateSegmentDistance(double lat1, double lon1, double lat2, double lon2) {
+		return MapUtils.getDistance(lat1, lon1, lat2, lon2);
+	}
+
+	protected double calculateProjectionDistance(@NonNull Location projection, int x31, int y31) {
+		return MapUtils.measuredDist31(
+				MapUtils.get31TileNumberX(projection.getLongitude()),
+				MapUtils.get31TileNumberY(projection.getLatitude()), x31, y31);
 	}
 
 	public void drawRouteSegment(@NonNull RotatedTileBox tb, @Nullable Canvas canvas,

--- a/OsmAnd/src/net/osmand/plus/views/layers/geometry/RouteGeometryWay.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/geometry/RouteGeometryWay.java
@@ -1,5 +1,7 @@
 package net.osmand.plus.views.layers.geometry;
 
+import static net.osmand.util.MapUtils.VECTOR_LINE_EARTH_RADIUS_METERS;
+
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Paint;
@@ -39,7 +41,6 @@ import gnu.trove.list.array.TByteArrayList;
 public class RouteGeometryWay extends
 		MultiColoringGeometryWay<RouteGeometryWayContext, MultiColoringGeometryWayDrawer<RouteGeometryWayContext>> {
 
-	private static final double VECTOR_LINE_EARTH_RADIUS = 6371000.0;
 	public static final int MIN_COLOR_SQUARE_DISTANCE = 15_000;
 
 	private final RoutingHelper helper;
@@ -286,16 +287,7 @@ public class RouteGeometryWay extends
 
 	private static double calculateNativeVectorLineDistance(double lat1, double lon1, double lat2, double lon2) {
 		// Keep startingDistance in the same metric as OsmAnd-core VectorLine_P::calculateShortestPath().
-		double dLat = Math.toRadians(lat2 - lat1);
-		double dLon = Math.toRadians(lon2 - lon1);
-		double sinHalfLat = Math.sin(dLat / 2.0);
-		double sinHalfLon = Math.sin(dLon / 2.0);
-		double a = sinHalfLat * sinHalfLat
-				+ Math.cos(Math.toRadians(lat1))
-				* Math.cos(Math.toRadians(lat2))
-				* sinHalfLon
-				* sinHalfLon;
-		return 2.0 * VECTOR_LINE_EARTH_RADIUS * Math.asin(Math.sqrt(a));
+		return MapUtils.getDistance(lat1, lon1, lat2, lon2, VECTOR_LINE_EARTH_RADIUS_METERS);
 	}
 
 	public void clearRoute() {

--- a/OsmAnd/src/net/osmand/plus/views/layers/geometry/RouteGeometryWay.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/geometry/RouteGeometryWay.java
@@ -39,6 +39,7 @@ import gnu.trove.list.array.TByteArrayList;
 public class RouteGeometryWay extends
 		MultiColoringGeometryWay<RouteGeometryWayContext, MultiColoringGeometryWayDrawer<RouteGeometryWayContext>> {
 
+	private static final double VECTOR_LINE_EARTH_RADIUS = 6371000.0;
 	public static final int MIN_COLOR_SQUARE_DISTANCE = 15_000;
 
 	private final RoutingHelper helper;
@@ -269,6 +270,32 @@ public class RouteGeometryWay extends
 	@Override
 	protected boolean shouldDrawArrows() {
 		return drawDirectionArrows;
+	}
+
+	@Override
+	protected double calculateSegmentDistance(double lat1, double lon1, double lat2, double lon2) {
+		return calculateNativeVectorLineDistance(lat1, lon1, lat2, lon2);
+	}
+
+	@Override
+	protected double calculateProjectionDistance(@NonNull Location projection, int x31, int y31) {
+		return calculateNativeVectorLineDistance(
+				projection.getLatitude(), projection.getLongitude(),
+				MapUtils.get31LatitudeY(y31), MapUtils.get31LongitudeX(x31));
+	}
+
+	private static double calculateNativeVectorLineDistance(double lat1, double lon1, double lat2, double lon2) {
+		// Keep startingDistance in the same metric as OsmAnd-core VectorLine_P::calculateShortestPath().
+		double dLat = Math.toRadians(lat2 - lat1);
+		double dLon = Math.toRadians(lon2 - lon1);
+		double sinHalfLat = Math.sin(dLat / 2.0);
+		double sinHalfLon = Math.sin(dLon / 2.0);
+		double a = sinHalfLat * sinHalfLat
+				+ Math.cos(Math.toRadians(lat1))
+				* Math.cos(Math.toRadians(lat2))
+				* sinHalfLon
+				* sinHalfLon;
+		return 2.0 * VECTOR_LINE_EARTH_RADIUS * Math.asin(Math.sqrt(a));
 	}
 
 	public void clearRoute() {


### PR DESCRIPTION
## Problem

During long navigation, the route line could gradually move away from the current location marker.

The issue was more noticeable at high zoom levels and increased with the traveled route distance. The marker stayed correctly positioned on the road, while the rendered route line was clipped slightly too far ahead, creating a visible gap.

## Root Cause

In OpenGL rendering, the route line is created as a native `VectorLine`. During navigation, we do not rebuild the whole line on every location update. Instead, the already passed part of the route is clipped by updating `startingDistance`.

This `startingDistance` is calculated on the Java side in `GeometryWay.cutStartOfCachedPath()` and then passed to native `VectorLine.setStartingDistance(...)`.

The problem was that Java-side route clipping distance and native `VectorLine` distance were calculated with slightly different Earth radius values. The difference is very small, but it accumulates as `startingDistance` grows during navigation.

For example, the radius mismatch is about `0.028%`, which gives roughly:

* `~2.8 m` difference after `10 km`;
* `~8.5 m` difference after `30 km`.

At high zoom levels, this accumulated difference becomes visually noticeable as a gap between the current location marker and the rendered route line.

Screen rotation temporarily fixed the issue because the renderer and cached route geometry were recreated, resetting the accumulated clipping distance.

## Solution

This PR keeps the default `GeometryWay` distance calculation unchanged, but overrides the route clipping distance calculation in `RouteGeometryWay`.

For route lines, `startingDistance` is now calculated with the same Earth radius as native `VectorLine`. This keeps Java-side clipping distance consistent with native route line rendering and prevents the route line from drifting forward over long navigation distances.

## Scope

This is a rendering-only fix.

It does not affect:

* route calculation;
* route progress;
* voice guidance;
* off-route detection;
* distance-to-destination calculation.

The change is localized to route line rendering and avoids changing global distance utilities, since different distance constants are used in different parts of the codebase for different purposes.

## Validation

Tested with long route simulation at maximum zoom.

Before the fix, the route line gradually drifted away from the current location marker as navigation progressed.

After the fix, the route line remains aligned with the marker during navigation.
