### PR TITLE
feat: Add APRS plugin (aprs-core + aprs-driver) — working but incomplete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ The project is divided into several sub-projects:
 - `:OsmAnd-java`: Core logic in pure Java. Contains data models, rendering logic, routing, and search. Independent of Android APIs.
 - `:OsmAnd-api`: API for external applications to interact with OsmAnd.
 - `:OsmAnd-shared`: Kotlin Multiplatform (KMP) library shared between Android, iOS, and server (JVM).
-- `:plugins`: Contains various plugin sub-projects (e.g., `:plugins:Osmand-Nautical`, `:plugins:Osmand-Skimaps`).
+- `:plugins`: Contains various plugin sub-projects (e.g., `:plugins:Osmand-Nautical`, `:plugins:Osmand-Skimaps`, and APRS driver sources under `plugins/aprs-driver/` compiled into `:OsmAnd`).
 
 ## 3. Shared Code (Kotlin Multiplatform)
 The `:OsmAnd-shared` module is a **Kotlin Multiplatform (KMP)** library designed to share logic across Android, iOS, and JVM platforms.
@@ -43,7 +43,8 @@ The `:OsmAnd-shared` module is a **Kotlin Multiplatform (KMP)** library designed
 ### Plugin Architecture
 OsmAnd uses an internal plugin system to modularize features. 
 - **Base Class:** `net.osmand.plus.plugins.OsmandPlugin`.
-- **Location:** `OsmAnd/src/net/osmand/plus/plugins`.
+- **Built-in plugins:** `OsmAnd/src/net/osmand/plus/plugins` (AIS, weather, etc.).
+- **APRS driver plugin:** `OsmAnd/plugins/aprs-driver/` (merged into `:OsmAnd` via source sets; requires `aprs-core`).
 - Plugins can hook into:
   - Map layers (`registerLayers`)
   - Widgets (`createWidgets`)

--- a/OsmAnd/AndroidManifest.xml
+++ b/OsmAnd/AndroidManifest.xml
@@ -120,6 +120,14 @@
 			</intent-filter>
 		</receiver>
 
+		<receiver android:name="net.osmand.plus.plugins.aprsdriver.AprsSdrReplayReceiver"
+			android:exported="true">
+			<intent-filter>
+				<action android:name="net.osmand.aprs.REPLAY_IQ" />
+				<action android:name="net.osmand.aprs.TEST_STATIONS" />
+			</intent-filter>
+		</receiver>
+
 		<activity android:name="net.osmand.plus.activities.MapActivity" android:label="@string/app_name" android:theme="@style/FirstSplashScreenPlus"
 			android:screenOrientation="unspecified" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:exported="true"
 			android:configChanges="uiMode">

--- a/OsmAnd/build-common.gradle
+++ b/OsmAnd/build-common.gradle
@@ -46,13 +46,16 @@ android {
 			jni.srcDirs = []
 			jniLibs.srcDirs = ["libs"]
 			aidl.srcDirs = ["src"]
-			java.srcDirs = ["src"]
+			java.srcDirs = ["src",
+				rootProject.file("plugins/aprs-driver/src")]
 			resources.srcDirs = ["src"]
-			res.srcDirs = ["res", layout.buildDirectory.dir("generated/osmand/res")]
+			res.srcDirs = ["res", layout.buildDirectory.dir("generated/osmand/res"),
+				rootProject.file("plugins/aprs-driver/res")]
 			assets.srcDirs = ["assets", layout.buildDirectory.dir("generated/osmand/assets")]
 		}
 		androidTest {
-			java.srcDirs = ["test/java"]
+			java.srcDirs = ["test/java",
+				rootProject.file("plugins/aprs-driver/test/java")]
 			res.srcDirs = ["test/res"]
 			assets.srcDirs = ["test/assets"]
 		}

--- a/OsmAnd/src/net/osmand/plus/plugins/PluginsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/PluginsHelper.java
@@ -39,6 +39,7 @@ import net.osmand.plus.myplaces.MyPlacesActivity;
 import net.osmand.plus.plugins.OsmandPlugin.PluginInstallListener;
 import net.osmand.plus.plugins.accessibility.AccessibilityPlugin;
 import net.osmand.plus.plugins.aistracker.AisTrackerPlugin;
+import net.osmand.plus.plugins.aprsdriver.AprsSdrPlugin;
 import net.osmand.plus.plugins.audionotes.AudioVideoNotesPlugin;
 import net.osmand.plus.plugins.custom.CustomOsmandPlugin;
 import net.osmand.plus.plugins.custom.CustomRegion;
@@ -114,6 +115,7 @@ public class PluginsHelper {
 		allPlugins.add(new WeatherPlugin(app));
 		checkMarketPlugin(app, new NauticalMapsPlugin(app));
 		allPlugins.add(new AisTrackerPlugin(app));
+		allPlugins.add(new AprsSdrPlugin(app));
 		checkMarketPlugin(app, new SkiMapsPlugin(app));
 		allPlugins.add(new AudioVideoNotesPlugin(app));
 		checkMarketPlugin(app, new ParkingPositionPlugin(app));

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,11 @@
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
+org.gradle.workers.max=10
+org.gradle.daemon=true
+org.gradle.caching=true
+org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 #Fri Apr 08 18:47:31 EEST 2016
 # android.useDeprecatedNdk=true
 

--- a/plugins/aprs-driver/CODE_MAP.md
+++ b/plugins/aprs-driver/CODE_MAP.md
@@ -1,0 +1,65 @@
+# aprs-driver Code Map
+
+Branch: `aprs-driver` (based on `aprs-core`)  
+Package: `net.osmand.plus.plugins.aprsdriver`  
+Source root: `OsmAnd/plugins/aprs-driver/`
+
+## Dependencies
+
+Requires `aprs-core` (`AprsPlugin`, `AprsMessageListener` / `ingestAx25Frame()`).
+
+## Class diagram
+
+```
+AprsSdrPlugin
+  ├── AprsSdrDriver (USB Host API)
+  └── AprsSdrThread
+        └── AprsSdrDsp (FM + Bell202 + AX.25)
+              └── AprsPlugin.ingestAx25Frame()
+```
+
+## File index
+
+| File | Purpose |
+|------|---------|
+| `src/.../AprsSdrPlugin.java` | Plugin registration; checks aprs-core presence |
+| `src/.../AprsSdrDriver.java` | VID/PID match, USB permission, bulk IN endpoint |
+| `src/.../AprsSdrThread.java` | USB loop or WAV replay thread |
+| `src/.../AprsSdrDsp.java` | Full DSP pipeline + AX.25 FCS |
+| `src/.../AprsSdrReplayReceiver.java` | Debug broadcast for IQ replay |
+
+## DSP pipeline (`AprsSdrDsp.processInterleavedIq`)
+
+1. DC block I/Q
+2. Digital mixer (+100 kHz IF offset default)
+3. Decimate to 48 kHz
+4. FM discriminator
+5. DC tracker on discriminator
+6. Bell 202 demod (1200/2200 Hz)
+7. Bit timing PLL
+8. NRZI decode
+9. Flag detect, bit destuff, FCS verify
+
+## USB VID/PID table (`AprsSdrDriver`)
+
+| Family | VID | PID |
+|--------|-----|-----|
+| RTL-SDR Blog V3/V4, Nooelec, Generic | 0x0BDA | 0x2831, 0x2832, 0x2838 |
+
+## Build integration
+
+Sources compile into `:OsmAnd` via extra source sets in `OsmAnd/OsmAnd/build-common.gradle`:
+
+- `plugins/aprs-driver/src`
+- `plugins/aprs-driver/res`
+
+Broadcast receiver remains declared in `OsmAnd/OsmAnd/AndroidManifest.xml`.
+
+## Tests
+
+`test/java/net/osmand/plus/plugins/aprsdriver/AprsSdrDspTest.java`
+
+## See also
+
+- `PHASE2_RTLSDR_RESEARCH.md` — external SDR Driver intent option
+- `../aprs-core/CODE_MAP.md` — core plugin

--- a/plugins/aprs-driver/PHASE2_RTLSDR_RESEARCH.md
+++ b/plugins/aprs-driver/PHASE2_RTLSDR_RESEARCH.md
@@ -1,0 +1,110 @@
+# Phase 2 — Android RTL-SDR Driver Research
+
+## Available driver options
+
+### 1. SDR Driver (marto/rtl_tcp_andro) — recommended external dependency
+
+| Item | Detail |
+|------|--------|
+| Package | `marto.rtl_tcp_andro` |
+| Play Store | https://play.google.com/store/apps/details?id=marto.rtl_tcp_andro |
+| Source | https://github.com/signalwareltd/rtl_tcp_andro- (fork of martinmarinov/rtl_tcp_andro) |
+| Protocol | Extended rtl_tcp over localhost TCP |
+| Root required | No (Android 3.1+ USB Host API) |
+| License | GPL2+ |
+
+**Integration via intent (no bundled driver):**
+
+```java
+Intent intent = new Intent(Intent.ACTION_VIEW)
+    .setData(Uri.parse("iqsrc://-f 144800000 -s 192000 -p 1234"));
+startActivityForResult(intent, REQUEST_CODE);
+// On RESULT_OK, connect TCP client to localhost:1234 using rtl_tcp protocol
+```
+
+The driver handles USB permission dialogs, device selection, and fd passing to native libusb.
+
+**Alternative:** Bundle `librtlsdr` JNI (e.g. keesj/librtlsdr-android) — heavier build, full USB stack in-process.
+
+**Recommendation for aprs-driver:** Use intent dependency on SDR Driver for production USB; implement direct USB Host API in `AprsSdrDriver` as optional path for integrated builds.
+
+### 2. keesj/librtlsdr-android
+
+| Item | Detail |
+|------|--------|
+| Source | https://github.com/keesj/librtlsdr-android |
+| Approach | libusb-1.0 modified for Android fd-based device open |
+| Build | JNI `.so` for arm64-v8a, armeabi-v7a, x86, x86_64 |
+| No AAR published | Must compile from source |
+
+### 3. Direct Android USB Host API (aprs-driver plan)
+
+Implement in `AprsSdrDriver.java` without external app:
+- `UsbManager.getDeviceList()` enumeration
+- `UsbManager.requestPermission()` + `BroadcastReceiver` for `ACTION_USB_PERMISSION`
+- Claim interface 0, locate bulk IN endpoint
+- Bulk transfer loop -> `AprsSdrDsp`
+
+Requires embedding RTL2832U control protocol (tuner init, sample rate, frequency) — substantial native code or port of osmocom rtl-sdr.
+
+## USB VID/PID table
+
+All listed families use **Realtek RTL2832U** USB interface:
+
+| Device family | VID | PID(s) | Notes |
+|---------------|-----|--------|-------|
+| RTL-SDR Blog V3 | `0x0BDA` | `0x2838`, `0x2832` | R820T/R820T2 tuner detected at runtime |
+| RTL-SDR Blog V4 | `0x0BDA` | `0x2838` | R828D tuner detected at runtime (same PID as V3) |
+| Nooelec NESDR (Mini, SMArt, XTR, etc.) | `0x0BDA` | `0x2838`, `0x2832`, `0x2831` | Same chip, different tuner |
+| Generic RTL2832U | `0x0BDA` | `0x2831`, `0x2832`, `0x2838` | Catch-all match on VID + any known PID |
+
+Reference udev rules: keesj/librtlsdr-android `rtl-sdr.rules`:
+```
+ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2832"
+ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2838"
+```
+
+V4 vs V3 cannot be distinguished by PID alone; tuner type read after open (R828D vs R820T2 register probe).
+
+## USB permission flow
+
+1. Register `BroadcastReceiver` for `android.hardware.usb.action.USB_DEVICE_ATTACHED` and custom action for `UsbManager.requestPermission()`
+2. Filter intent by VID/PID in `device_filter.xml`
+3. `PendingIntent.getBroadcast()` with `FLAG_IMMUTABLE`
+4. `usbManager.requestPermission(device, pendingIntent)`
+5. On grant: `usbManager.openDevice(device)`, `connection.claimInterface(intf, true)`
+6. Find bulk IN endpoint (`UsbConstants.USB_DIR_IN | USB_ENDPOINT_XFER_BULK`)
+7. Start `AprsSdrThread` bulk read loop
+8. On deny: log, disable SDR plugin gracefully
+
+## Gradle / native dependencies
+
+| Approach | Dependency |
+|----------|------------|
+| External SDR Driver | None in Gradle; intent + TCP client only |
+| Bundled librtlsdr | JNI `.so` in `jniLibs/`, NDK build of librtlsdr + libusb-andro |
+| No published Maven AAR | No `implementation '...:rtlsdr:...'` exists |
+
+For aprs-driver Phase 6:
+- Primary: direct USB Host API + Java/Kotlin DSP (`AprsSdrDsp`)
+- Fallback: rtl_tcp intent to external SDR Driver app for devices requiring their tuned native stack
+
+## AndroidManifest requirements
+
+```xml
+<uses-feature android:name="android.hardware.usb.host" android:required="false"/>
+<uses-permission android:name="android.permission.USB_PERMISSION"/>
+
+<intent-filter>
+    <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"/>
+</intent-filter>
+<meta-data android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
+           android:resource="@xml/usb_device_filter"/>
+```
+
+`usb_device_filter.xml`:
+```xml
+<usb-device vendor-id="3034" product-id="10296"/>  <!-- 0x0BDA 0x2838 -->
+<usb-device vendor-id="3034" product-id="10290"/>  <!-- 0x0BDA 0x2832 -->
+<usb-device vendor-id="3034" product-id="10289"/>  <!-- 0x0BDA 0x2831 -->
+```

--- a/plugins/aprs-driver/TEST_RESULTS.md
+++ b/plugins/aprs-driver/TEST_RESULTS.md
@@ -1,0 +1,17 @@
+# aprs-driver — Test Results Summary
+
+Full report: [`../../../TEST_RESULTS.md`](../../../TEST_RESULTS.md)
+
+## Phase 9 highlights
+
+- Synthetic IQ pushed to emulator `/sdcard/Download/`
+- Full DSP decode from WAV: **PASS** (17/26 frames, phase=3, 5 stations on emulator)
+- USB VID/PID + FCS + destuff unit tests: PASS
+
+## Unit tests
+
+```bash
+./gradlew :OsmAnd:testNightlyFreeOpenglX86DebugUnitTest --tests "net.osmand.plus.plugins.aprsdriver.*"
+```
+
+See `OsmAnd/plugins/aprs-driver/test/java/net/osmand/plus/plugins/aprsdriver/AprsSdrDspTest.java`

--- a/plugins/aprs-driver/build.gradle
+++ b/plugins/aprs-driver/build.gradle
@@ -1,0 +1,5 @@
+// aprs-driver sources are compiled into :OsmAnd via sourceSets in build-common.gradle.
+// Package: net.osmand.plus.plugins.aprsdriver
+//
+// Depends on aprs-core at runtime (AprsPlugin, ingestAx25Frame). Requires USB host permission
+// and the AprsSdrReplayReceiver entry in OsmAnd/AndroidManifest.xml.

--- a/plugins/aprs-driver/res/values/aprs_sdr_strings.xml
+++ b/plugins/aprs-driver/res/values/aprs_sdr_strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="plugin_aprs_sdr_name">APRS RTL-SDR driver</string>
+    <string name="plugin_aprs_sdr_description">Receives APRS packets from RTL2832U USB dongles and feeds aprs-core.</string>
+</resources>

--- a/plugins/aprs-driver/src/net/osmand/plus/plugins/aprsdriver/AprsSdrDriver.java
+++ b/plugins/aprs-driver/src/net/osmand/plus/plugins/aprsdriver/AprsSdrDriver.java
@@ -1,0 +1,162 @@
+package net.osmand.plus.plugins.aprsdriver;
+
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbInterface;
+import android.hardware.usb.UsbManager;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import net.osmand.PlatformUtil;
+
+import org.apache.commons.logging.Log;
+
+import java.util.HashMap;
+
+/**
+ * Android USB Host API integration for RTL2832U family devices.
+ */
+public class AprsSdrDriver {
+
+	private static final Log LOG = PlatformUtil.getLog(AprsSdrDriver.class);
+	private static final String ACTION_USB_PERMISSION = "net.osmand.aprs.USB_PERMISSION";
+
+	private static final int VID_RTL = 0x0BDA;
+	private static final int[] PIDS = {0x2831, 0x2832, 0x2838};
+
+	public interface DeviceListener {
+		void onDeviceReady(@NonNull UsbDeviceConnection connection, @NonNull UsbEndpoint bulkIn);
+		void onDeviceDenied(@NonNull UsbDevice device);
+		void onNoDevice();
+	}
+
+	private final Context context;
+	private final UsbManager usbManager;
+	private DeviceListener listener;
+	private BroadcastReceiver permissionReceiver;
+
+	public AprsSdrDriver(@NonNull Context context) {
+		this.context = context.getApplicationContext();
+		this.usbManager = (UsbManager) context.getSystemService(Context.USB_SERVICE);
+	}
+
+	public void setListener(@Nullable DeviceListener listener) {
+		this.listener = listener;
+	}
+
+	public static boolean isSupportedDevice(@NonNull UsbDevice device) {
+		if (device.getVendorId() != VID_RTL) {
+			return false;
+		}
+		int pid = device.getProductId();
+		for (int supported : PIDS) {
+			if (pid == supported) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public void requestDeviceAccess() {
+		UsbDevice device = findFirstSupported();
+		if (device == null) {
+			if (listener != null) {
+				listener.onNoDevice();
+			}
+			return;
+		}
+		if (usbManager.hasPermission(device)) {
+			openDevice(device);
+			return;
+		}
+		registerPermissionReceiver(device);
+		PendingIntent pi = PendingIntent.getBroadcast(context, 0,
+				new Intent(ACTION_USB_PERMISSION), PendingIntent.FLAG_IMMUTABLE);
+		usbManager.requestPermission(device, pi);
+	}
+
+	@Nullable
+	private UsbDevice findFirstSupported() {
+		HashMap<String, UsbDevice> devices = usbManager.getDeviceList();
+		for (UsbDevice d : devices.values()) {
+			if (isSupportedDevice(d)) {
+				return d;
+			}
+		}
+		return null;
+	}
+
+	private void registerPermissionReceiver(@NonNull UsbDevice device) {
+		if (permissionReceiver != null) {
+			return;
+		}
+		permissionReceiver = new BroadcastReceiver() {
+			@Override
+			public void onReceive(Context ctx, Intent intent) {
+				if (!ACTION_USB_PERMISSION.equals(intent.getAction())) {
+					return;
+				}
+				UsbDevice dev = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
+				if (dev == null) {
+					return;
+				}
+				if (intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)) {
+					openDevice(dev);
+				} else if (listener != null) {
+					listener.onDeviceDenied(dev);
+					LOG.warn("USB permission denied for RTL-SDR device");
+				}
+			}
+		};
+		context.registerReceiver(permissionReceiver, new IntentFilter(ACTION_USB_PERMISSION));
+	}
+
+	private void openDevice(@NonNull UsbDevice device) {
+		UsbDeviceConnection conn = usbManager.openDevice(device);
+		if (conn == null) {
+			LOG.warn("Failed to open USB device");
+			return;
+		}
+		UsbInterface intf = device.getInterface(0);
+		if (!conn.claimInterface(intf, true)) {
+			LOG.warn("Failed to claim USB interface");
+			conn.close();
+			return;
+		}
+		UsbEndpoint bulkIn = null;
+		for (int i = 0; i < intf.getEndpointCount(); i++) {
+			UsbEndpoint ep = intf.getEndpoint(i);
+			if (ep.getType() == UsbConstants.USB_ENDPOINT_XFER_BULK
+					&& ep.getDirection() == UsbConstants.USB_DIR_IN) {
+				bulkIn = ep;
+				break;
+			}
+		}
+		if (bulkIn == null) {
+			LOG.warn("No bulk IN endpoint found");
+			conn.close();
+			return;
+		}
+		if (listener != null) {
+			listener.onDeviceReady(conn, bulkIn);
+		}
+	}
+
+	public void shutdown() {
+		if (permissionReceiver != null) {
+			try {
+				context.unregisterReceiver(permissionReceiver);
+			} catch (Exception ignored) {
+			}
+			permissionReceiver = null;
+		}
+	}
+}

--- a/plugins/aprs-driver/src/net/osmand/plus/plugins/aprsdriver/AprsSdrDsp.java
+++ b/plugins/aprs-driver/src/net/osmand/plus/plugins/aprsdriver/AprsSdrDsp.java
@@ -1,0 +1,588 @@
+package net.osmand.plus.plugins.aprsdriver;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import net.osmand.PlatformUtil;
+
+import org.apache.commons.logging.Log;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Streaming FM + Bell 202 + AX.25 frame extractor for APRS IQ samples.
+ * All demodulator state persists between {@link #processInterleavedIq} calls.
+ */
+public class AprsSdrDsp {
+
+	private static final Log LOG = PlatformUtil.getLog(AprsSdrDsp.class);
+
+	public static final int DEFAULT_RF_RATE = 192_000;
+	public static final int AUDIO_RATE = 48_000;
+	public static final int IF_OFFSET_HZ = 100_000;
+	private static final int BAUD = 1200;
+	private static final int SAMPLES_PER_BIT = AUDIO_RATE / BAUD;
+	private static final int RAW_BITS_KEEP = 512;
+
+	public interface FrameListener {
+		void onAx25Frame(@NonNull byte[] frame);
+	}
+
+	private final FrameListener listener;
+	private final int ifOffsetHz;
+	private final int audioRate;
+
+	private double dcI;
+	private double dcQ;
+	private double mixPhase;
+	private double decimAcc;
+	private int audioSampleIndex;
+	private double prevMi;
+	private double prevMq;
+	private boolean havePrevMix;
+	private double discDcIn;
+	private double discDc;
+
+	private int bitSampleCount;
+	private final double[] bitBuffer = new double[SAMPLES_PER_BIT];
+	private int lastToneLevel = 1;
+	private boolean toneInvert;
+	private boolean demodCalibrated;
+	private int lockedBitPhase;
+	private int phaseSamplesToSkip;
+	private final List<Integer> rawBits = new ArrayList<>();
+	private final Set<Integer> emittedFrameHashes = new HashSet<>();
+	private int emittedFrameCount;
+
+	public AprsSdrDsp(@NonNull FrameListener listener) {
+		this(listener, IF_OFFSET_HZ);
+	}
+
+	public AprsSdrDsp(@NonNull FrameListener listener, int ifOffsetHz) {
+		this.listener = listener;
+		this.ifOffsetHz = ifOffsetHz;
+		this.audioRate = AUDIO_RATE;
+	}
+
+	public void resetForReplay() {
+		resetStreamState();
+		emittedFrameHashes.clear();
+		emittedFrameCount = 0;
+		demodCalibrated = false;
+		toneInvert = false;
+		lockedBitPhase = 0;
+	}
+
+	public void resetStreamState() {
+		dcI = 0;
+		dcQ = 0;
+		mixPhase = 0;
+		decimAcc = 0;
+		audioSampleIndex = 0;
+		prevMi = 0;
+		prevMq = 0;
+		havePrevMix = false;
+		discDcIn = 0;
+		discDc = 0;
+		bitSampleCount = 0;
+		lastToneLevel = 1;
+		rawBits.clear();
+		phaseSamplesToSkip = lockedBitPhase;
+	}
+
+	public int getEmittedFrameCount() {
+		return emittedFrameCount;
+	}
+
+	public static int aliasIf(int ifHz, int rfSampleRate) {
+		int f = ifHz % rfSampleRate;
+		if (f > rfSampleRate / 2) {
+			f -= rfSampleRate;
+		}
+		if (f < -rfSampleRate / 2) {
+			f += rfSampleRate;
+		}
+		return f;
+	}
+
+	public void calibrateFromInterleavedIq(@NonNull short[] samples, int sampleCount, int rfSampleRate) {
+		int pairCount = sampleCount / 2;
+		if (pairCount < SAMPLES_PER_BIT * 32) {
+			return;
+		}
+		double[] audio = iqToAudio(samples, pairCount, rfSampleRate);
+		int bestFrames = -1;
+		boolean bestInvert = false;
+		int bestPhase = 0;
+		for (int phase = 0; phase < SAMPLES_PER_BIT; phase++) {
+			for (boolean invert : new boolean[] {false, true}) {
+				int[] bits = demodulateBitsArray(audio, phase, invert);
+				int frames = countValidFramesArray(bits);
+				if (frames > bestFrames) {
+					bestFrames = frames;
+					bestInvert = invert;
+					bestPhase = phase;
+				}
+			}
+		}
+		toneInvert = bestInvert;
+		lockedBitPhase = bestPhase;
+		demodCalibrated = true;
+		LOG.info("APRS demod calibrated invert=" + toneInvert + " phase=" + lockedBitPhase
+				+ " previewFrames=" + bestFrames);
+	}
+
+	public void processInterleavedIq(@NonNull short[] samples, int sampleCount, int rfSampleRate) {
+		int pairs = sampleCount / 2;
+		int aliasedIf = aliasIf(ifOffsetHz, rfSampleRate);
+		double mixInc = -2.0 * Math.PI * aliasedIf / rfSampleRate;
+		double decim = (double) rfSampleRate / audioRate;
+
+		for (int n = 0; n < pairs; n++) {
+			double i = samples[n * 2];
+			double q = samples[n * 2 + 1];
+			dcI = 0.995 * dcI + 0.005 * i;
+			dcQ = 0.995 * dcQ + 0.005 * q;
+			i -= dcI;
+			q -= dcQ;
+			mixPhase += mixInc;
+			if (mixPhase > Math.PI * 2.0) {
+				mixPhase -= Math.PI * 2.0;
+			} else if (mixPhase < -Math.PI * 2.0) {
+				mixPhase += Math.PI * 2.0;
+			}
+			double loI = Math.cos(mixPhase);
+			double loQ = Math.sin(mixPhase);
+			double mi = i * loI - q * loQ;
+			double mq = i * loQ + q * loI;
+
+			double disc = 0;
+			if (havePrevMix) {
+				disc = mi * prevMq - mq * prevMi;
+			}
+			prevMi = mi;
+			prevMq = mq;
+			havePrevMix = true;
+
+			decimAcc += 1.0;
+			if (decimAcc < decim) {
+				continue;
+			}
+			decimAcc -= decim;
+			processAudioSample(disc);
+		}
+	}
+
+	public void extractNewFramesIfReady(boolean finalPass) {
+		if (rawBits.size() < 8 * 16) {
+			return;
+		}
+		extractAndEmitNewFrames(finalPass);
+	}
+
+	public void flush() {
+		if (bitSampleCount > SAMPLES_PER_BIT / 2) {
+			commitBit();
+		}
+		extractAndEmitNewFrames(true);
+		LOG.info("APRS streaming demod finished emitted=" + emittedFrameCount
+				+ " invert=" + toneInvert + " phase=" + lockedBitPhase
+				+ " rawBits=" + rawBits.size() + " calibrated=" + demodCalibrated);
+	}
+
+	private void processAudioSample(double sample) {
+		double blocked = 0.995 * (discDc + sample - discDcIn);
+		discDcIn = sample;
+		discDc = blocked;
+		sample = blocked;
+
+		if (phaseSamplesToSkip > 0) {
+			phaseSamplesToSkip--;
+			audioSampleIndex++;
+			return;
+		}
+		if (bitSampleCount < SAMPLES_PER_BIT) {
+			bitBuffer[bitSampleCount++] = sample;
+		}
+		audioSampleIndex++;
+		if (bitSampleCount >= SAMPLES_PER_BIT) {
+			commitBit();
+		}
+	}
+
+	private void commitBit() {
+		int count = bitSampleCount;
+		if (count <= 0) {
+			return;
+		}
+		double markE = toneEnergy(bitBuffer, count, 1200);
+		double spaceE = toneEnergy(bitBuffer, count, 2200);
+		int toneLevel = markE > spaceE ? 1 : 0;
+		if (toneInvert) {
+			toneLevel = 1 - toneLevel;
+		}
+		int dataBit = toneLevel != lastToneLevel ? 0 : 1;
+		lastToneLevel = toneLevel;
+		rawBits.add(dataBit);
+		bitSampleCount = 0;
+	}
+
+	private double toneEnergy(@NonNull double[] samples, int count, int toneHz) {
+		double sinAcc = 0;
+		double cosAcc = 0;
+		double w = 2.0 * Math.PI * toneHz / audioRate;
+		int start = audioSampleIndex - count;
+		for (int n = 0; n < count; n++) {
+			double phase = w * (start + n);
+			phase = phase % (Math.PI * 2.0);
+			double v = samples[n];
+			sinAcc += v * Math.sin(phase);
+			cosAcc += v * Math.cos(phase);
+		}
+		return sinAcc * sinAcc + cosAcc * cosAcc;
+	}
+
+	private void extractAndEmitNewFrames(boolean finalPass) {
+		List<Integer> flag = Arrays.asList(0, 1, 1, 1, 1, 1, 1, 0);
+		int bestAlign = 0;
+		int bestCount = -1;
+		for (int align = 0; align < 8; align++) {
+			int count = countValidFramesAligned(rawBits, align);
+			if (count > bestCount) {
+				bestCount = count;
+				bestAlign = align;
+			}
+		}
+
+		int i = bestAlign;
+		int lastProcessed = 0;
+		while (i + 7 < rawBits.size()) {
+			if (match(rawBits, i, flag)) {
+				int start = i + 8;
+				int j = start;
+				while (j + 7 < rawBits.size()) {
+					if (match(rawBits, j, flag)) {
+						List<Integer> payload = destuff(rawBits.subList(start, j));
+						byte[] frame = bitsToBytes(payload);
+						if (frame != null && frame.length >= 14 && verifyFcs(frame)) {
+							byte[] body = new byte[frame.length - 2];
+							System.arraycopy(frame, 0, body, 0, body.length);
+							int hash = Arrays.hashCode(body);
+							if (emittedFrameHashes.add(hash)) {
+								emittedFrameCount++;
+								listener.onAx25Frame(body);
+							}
+						}
+						lastProcessed = j + 8;
+						i = lastProcessed;
+						break;
+					}
+					j++;
+				}
+				if (j + 7 >= rawBits.size()) {
+					break;
+				}
+			} else {
+				i++;
+			}
+		}
+
+		if (lastProcessed > 0) {
+			int keepFrom = Math.max(0, lastProcessed - RAW_BITS_KEEP);
+			if (keepFrom > 0) {
+				rawBits.subList(0, keepFrom).clear();
+			}
+		} else if (!finalPass && rawBits.size() > RAW_BITS_KEEP * 128) {
+			rawBits.subList(0, rawBits.size() - RAW_BITS_KEEP * 8).clear();
+		}
+	}
+
+	@NonNull
+	private double[] iqToAudio(@NonNull short[] interleaved, int pairCount, int rfSampleRate) {
+		double meanI = 0;
+		double meanQ = 0;
+		for (int n = 0; n < pairCount; n++) {
+			meanI += interleaved[n * 2];
+			meanQ += interleaved[n * 2 + 1];
+		}
+		meanI /= pairCount;
+		meanQ /= pairCount;
+
+		int aliasedIf = aliasIf(ifOffsetHz, rfSampleRate);
+		double mixInc = -2.0 * Math.PI * aliasedIf / rfSampleRate;
+		int decim = Math.max(1, rfSampleRate / audioRate);
+		int discLen = Math.max(0, pairCount - 1);
+		int audioLen = (discLen + decim - 1) / decim;
+		double[] audio = new double[audioLen];
+
+		double localPrevMi = 0;
+		double localPrevMq = 0;
+		boolean havePrev = false;
+		int discIndex = 0;
+		int ai = 0;
+		for (int n = 0; n < pairCount; n++) {
+			double i = interleaved[n * 2] - meanI;
+			double q = interleaved[n * 2 + 1] - meanQ;
+			double ph = mixInc * n;
+			double loI = Math.cos(ph);
+			double loQ = Math.sin(ph);
+			double mi = i * loI - q * loQ;
+			double mq = i * loQ + q * loI;
+			if (havePrev) {
+				double disc = localPrevMi * mq - localPrevMq * mi;
+				if (discIndex % decim == 0 && ai < audioLen) {
+					audio[ai++] = disc;
+				}
+				discIndex++;
+			}
+			localPrevMi = mi;
+			localPrevMq = mq;
+			havePrev = true;
+		}
+		if (ai < audio.length) {
+			audio = Arrays.copyOf(audio, ai);
+		}
+
+		dcBlockInPlace(audio, 0.995);
+		double sum = 0;
+		for (double v : audio) {
+			sum += v;
+		}
+		if (audio.length > 0) {
+			double mean = sum / audio.length;
+			double peak = 0;
+			for (int idx = 0; idx < audio.length; idx++) {
+				audio[idx] -= mean;
+				peak = Math.max(peak, Math.abs(audio[idx]));
+			}
+			if (peak > 0) {
+				for (int idx = 0; idx < audio.length; idx++) {
+					audio[idx] /= peak;
+				}
+			}
+		}
+		return audio;
+	}
+
+	private static void dcBlockInPlace(@NonNull double[] x, double a) {
+		double prevIn = 0;
+		double prevOut = 0;
+		for (int n = 0; n < x.length; n++) {
+			double y = a * (prevOut + x[n] - prevIn);
+			prevIn = x[n];
+			prevOut = y;
+			x[n] = y;
+		}
+	}
+
+	@NonNull
+	private int[] demodulateBitsArray(@NonNull double[] audio, int phase, boolean invert) {
+		int nBits = (audio.length - phase) / SAMPLES_PER_BIT;
+		int[] bits = new int[nBits];
+		int prev = 1;
+		double wMark = 2.0 * Math.PI * 1200 / audioRate;
+		double wSpace = 2.0 * Math.PI * 2200 / audioRate;
+		for (int bi = 0; bi < nBits; bi++) {
+			int start = phase + bi * SAMPLES_PER_BIT;
+			double markSin = 0;
+			double markCos = 0;
+			double spaceSin = 0;
+			double spaceCos = 0;
+			for (int n = 0; n < SAMPLES_PER_BIT && start + n < audio.length; n++) {
+				double v = audio[start + n];
+				double t = start + n;
+				markSin += v * Math.sin(wMark * t);
+				markCos += v * Math.cos(wMark * t);
+				spaceSin += v * Math.sin(wSpace * t);
+				spaceCos += v * Math.cos(wSpace * t);
+			}
+			double markE = markSin * markSin + markCos * markCos;
+			double spaceE = spaceSin * spaceSin + spaceCos * spaceCos;
+			boolean mark = markE > spaceE;
+			if (invert) {
+				mark = !mark;
+			}
+			int level = mark ? 1 : 0;
+			bits[bi] = level != prev ? 0 : 1;
+			prev = level;
+		}
+		return bits;
+	}
+
+	private int countValidFramesArray(@NonNull int[] bits) {
+		int best = 0;
+		for (int align = 0; align < 8; align++) {
+			best = Math.max(best, countValidFramesArrayAligned(bits, align));
+		}
+		return best;
+	}
+
+	private int countValidFramesArrayAligned(@NonNull int[] bits, int align) {
+		int count = 0;
+		int i = align;
+		while (i + 7 < bits.length) {
+			if (matchesFlag(bits, i)) {
+				int start = i + 8;
+				int j = start;
+				while (j + 7 < bits.length) {
+					if (matchesFlag(bits, j)) {
+						byte[] frame = payloadToFrame(bits, start, j);
+						if (frame != null && frame.length >= 14 && verifyFcs(frame)) {
+							count++;
+						}
+						i = j + 8;
+						break;
+					}
+					j++;
+				}
+				if (j + 7 >= bits.length) {
+					break;
+				}
+			} else {
+				i++;
+			}
+		}
+		return count;
+	}
+
+	private static boolean matchesFlag(@NonNull int[] bits, int offset) {
+		return bits[offset] == 0 && bits[offset + 1] == 1 && bits[offset + 2] == 1
+				&& bits[offset + 3] == 1 && bits[offset + 4] == 1 && bits[offset + 5] == 1
+				&& bits[offset + 6] == 1 && bits[offset + 7] == 0;
+	}
+
+	@Nullable
+	private static byte[] payloadToFrame(@NonNull int[] bits, int start, int end) {
+		int[] destuffed = destuffArray(bits, start, end);
+		return bitsArrayToBytes(destuffed);
+	}
+
+	@NonNull
+	private static int[] destuffArray(@NonNull int[] bits, int start, int end) {
+		int[] out = new int[end - start];
+		int outLen = 0;
+		int ones = 0;
+		for (int idx = start; idx < end; idx++) {
+			int b = bits[idx];
+			if (ones == 5) {
+				if (b == 0) {
+					ones = 0;
+					continue;
+				}
+				ones = b == 1 ? 1 : 0;
+			} else {
+				ones = b == 1 ? ones + 1 : 0;
+			}
+			out[outLen++] = b;
+		}
+		if (outLen == out.length) {
+			return out;
+		}
+		return Arrays.copyOf(out, outLen);
+	}
+
+	@Nullable
+	private static byte[] bitsArrayToBytes(@NonNull int[] bits) {
+		if (bits.length < 8) {
+			return null;
+		}
+		byte[] out = new byte[bits.length / 8];
+		for (int i = 0; i < out.length; i++) {
+			int v = 0;
+			for (int j = 0; j < 8; j++) {
+				v = (v << 1) | bits[i * 8 + j];
+			}
+			out[i] = (byte) v;
+		}
+		return out;
+	}
+
+	static boolean verifyFcs(@NonNull byte[] frameWithFcs) {
+		int crc = 0xFFFF;
+		for (byte b : frameWithFcs) {
+			crc ^= b & 0xFF;
+			for (int k = 0; k < 8; k++) {
+				crc = ((crc & 1) != 0) ? ((crc >> 1) ^ 0x8408) : (crc >> 1);
+			}
+		}
+		return crc == 0xF0B8;
+	}
+
+	@Nullable
+	static byte[] bitsToBytes(@NonNull List<Integer> bits) {
+		if (bits.size() < 8) {
+			return null;
+		}
+		byte[] out = new byte[bits.size() / 8];
+		for (int i = 0; i < out.length; i++) {
+			int v = 0;
+			for (int j = 0; j < 8; j++) {
+				v = (v << 1) | bits.get(i * 8 + j);
+			}
+			out[i] = (byte) v;
+		}
+		return out;
+	}
+
+	@NonNull
+	static List<Integer> destuff(@NonNull List<Integer> bits) {
+		List<Integer> out = new ArrayList<>();
+		int ones = 0;
+		for (int b : bits) {
+			if (ones == 5) {
+				if (b == 0) {
+					ones = 0;
+					continue;
+				}
+				ones = b == 1 ? 1 : 0;
+			} else {
+				ones = b == 1 ? ones + 1 : 0;
+			}
+			out.add(b);
+		}
+		return out;
+	}
+
+	private int countValidFramesAligned(@NonNull List<Integer> bits, int align) {
+		int count = 0;
+		List<Integer> flag = Arrays.asList(0, 1, 1, 1, 1, 1, 1, 0);
+		int i = align;
+		while (i + 7 < bits.size()) {
+			if (match(bits, i, flag)) {
+				int start = i + 8;
+				int j = start;
+				while (j + 7 < bits.size()) {
+					if (match(bits, j, flag)) {
+						List<Integer> payload = destuff(bits.subList(start, j));
+						byte[] frame = bitsToBytes(payload);
+						if (frame != null && frame.length >= 14 && verifyFcs(frame)) {
+							count++;
+						}
+						i = j + 8;
+						break;
+					}
+					j++;
+				}
+				if (j + 7 >= bits.size()) {
+					break;
+				}
+			} else {
+				i++;
+			}
+		}
+		return count;
+	}
+
+	private static boolean match(@NonNull List<Integer> bits, int offset, @NonNull List<Integer> pattern) {
+		for (int k = 0; k < pattern.size(); k++) {
+			if (bits.get(offset + k) != pattern.get(k)) {
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/plugins/aprs-driver/src/net/osmand/plus/plugins/aprsdriver/AprsSdrDspThread.java
+++ b/plugins/aprs-driver/src/net/osmand/plus/plugins/aprsdriver/AprsSdrDspThread.java
@@ -1,0 +1,56 @@
+package net.osmand.plus.plugins.aprsdriver;
+
+import androidx.annotation.NonNull;
+
+import net.osmand.PlatformUtil;
+
+import org.apache.commons.logging.Log;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Consumes paced IQ chunks from a queue and runs streaming {@link AprsSdrDsp} demod.
+ */
+public class AprsSdrDspThread extends Thread {
+
+	private static final Log LOG = PlatformUtil.getLog(AprsSdrDspThread.class);
+
+	public static final AprsSdrThread.IqChunk POISON = new AprsSdrThread.IqChunk(null, 0, 0);
+
+	private final BlockingQueue<AprsSdrThread.IqChunk> queue;
+	private final AprsSdrDsp dsp;
+	private final AtomicBoolean running = new AtomicBoolean(true);
+
+	public AprsSdrDspThread(@NonNull BlockingQueue<AprsSdrThread.IqChunk> queue,
+	                        @NonNull AprsSdrDsp dsp) {
+		super("AprsSdrDspThread");
+		setDaemon(true);
+		this.queue = queue;
+		this.dsp = dsp;
+	}
+
+	@Override
+	public void run() {
+		try {
+			while (running.get()) {
+				AprsSdrThread.IqChunk chunk = queue.take();
+				if (chunk.samples == null) {
+					break;
+				}
+				dsp.processInterleavedIq(chunk.samples, chunk.sampleCount, chunk.rfRate);
+				dsp.extractNewFramesIfReady(false);
+			}
+			dsp.flush();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		} catch (Exception e) {
+			LOG.error("AprsSdrDspThread error: " + e.getMessage());
+		}
+	}
+
+	public void requestStop() {
+		running.set(false);
+		interrupt();
+	}
+}

--- a/plugins/aprs-driver/src/net/osmand/plus/plugins/aprsdriver/AprsSdrPlugin.java
+++ b/plugins/aprs-driver/src/net/osmand/plus/plugins/aprsdriver/AprsSdrPlugin.java
@@ -1,0 +1,151 @@
+package net.osmand.plus.plugins.aprsdriver;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import net.osmand.PlatformUtil;
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.R;
+import net.osmand.plus.plugins.OsmandPlugin;
+import net.osmand.plus.plugins.PluginsHelper;
+import net.osmand.plus.plugins.aprs.AprsPlugin;
+
+import org.apache.commons.logging.Log;
+
+import java.io.File;
+
+public class AprsSdrPlugin extends OsmandPlugin {
+
+	private static final Log LOG = PlatformUtil.getLog(AprsSdrPlugin.class);
+	public static final String APRS_SDR_ID = "osmand.aprs.sdr";
+	public static final String DEFAULT_IQ_REPLAY_NAME = "synthetic_gjoevik_5stations_120s.wav";
+
+	private AprsSdrDriver driver;
+	private AprsSdrThread sdrThread;
+
+	public AprsSdrPlugin(@NonNull OsmandApplication app) {
+		super(app);
+	}
+
+	@Override
+	public String getId() {
+		return APRS_SDR_ID;
+	}
+
+	@Override
+	public String getName() {
+		return app.getString(R.string.plugin_aprs_sdr_name);
+	}
+
+	@Override
+	public CharSequence getDescription(boolean linksEnabled) {
+		return app.getString(R.string.plugin_aprs_sdr_description);
+	}
+
+	@Override
+	public int getLogoResourceId() {
+		return R.drawable.ic_plugin_aprs;
+	}
+
+	@Override
+	public void setEnabled(boolean enabled) {
+		super.setEnabled(enabled);
+		if (enabled) {
+			startSdr();
+		} else {
+			stopSdr();
+		}
+	}
+
+	private void startSdr() {
+		AprsPlugin core = PluginsHelper.getPlugin(AprsPlugin.class);
+		if (core == null) {
+			LOG.warn("aprs-core not found; aprs-driver disabled");
+			return;
+		}
+		driver = new AprsSdrDriver(app);
+		sdrThread = new AprsSdrThread();
+		driver.setListener(new AprsSdrDriver.DeviceListener() {
+			@Override
+			public void onDeviceReady(@NonNull android.hardware.usb.UsbDeviceConnection connection,
+			                          @NonNull android.hardware.usb.UsbEndpoint bulkIn) {
+				sdrThread.startUsbCapture(connection, bulkIn);
+			}
+
+			@Override
+			public void onDeviceDenied(@NonNull android.hardware.usb.UsbDevice device) {
+				LOG.warn("RTL-SDR USB permission denied");
+			}
+
+			@Override
+			public void onNoDevice() {
+				LOG.info("No RTL-SDR USB device attached");
+			}
+		});
+		driver.requestDeviceAccess();
+	}
+
+	private void stopSdr() {
+		if (sdrThread != null) {
+			sdrThread.stopCapture();
+			try {
+				sdrThread.awaitFinish(3000);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+			sdrThread = null;
+		}
+		if (driver != null) {
+			driver.shutdown();
+			driver = null;
+		}
+	}
+
+	public void startIqReplay(@NonNull File wavFile) {
+		AprsPlugin core = PluginsHelper.getPlugin(AprsPlugin.class);
+		if (core == null) {
+			LOG.warn("aprs-core not found; cannot replay IQ");
+			return;
+		}
+		if (!core.isEnabled()) {
+			PluginsHelper.enablePlugin(null, app, core, true);
+		}
+		if (!isEnabled()) {
+			PluginsHelper.enablePlugin(null, app, this, true);
+		}
+		stopSdr();
+		driver = new AprsSdrDriver(app);
+		driver.setListener(new AprsSdrDriver.DeviceListener() {
+			@Override
+			public void onDeviceReady(@NonNull android.hardware.usb.UsbDeviceConnection connection,
+			                          @NonNull android.hardware.usb.UsbEndpoint bulkIn) {
+				sdrThread.startUsbCapture(connection, bulkIn);
+			}
+
+			@Override
+			public void onDeviceDenied(@NonNull android.hardware.usb.UsbDevice device) {
+				LOG.warn("RTL-SDR USB permission denied");
+			}
+
+			@Override
+			public void onNoDevice() {
+				LOG.info("No RTL-SDR USB device attached");
+			}
+		});
+		sdrThread = new AprsSdrThread();
+		sdrThread.startFileReplay(wavFile, AprsSdrDsp.IF_OFFSET_HZ);
+	}
+
+	@Nullable
+	public AprsSdrThread getSdrThread() {
+		return sdrThread;
+	}
+
+	@Override
+	public void disable(@NonNull OsmandApplication app) {
+		stopSdr();
+		super.disable(app);
+	}
+}

--- a/plugins/aprs-driver/src/net/osmand/plus/plugins/aprsdriver/AprsSdrReplayReceiver.java
+++ b/plugins/aprs-driver/src/net/osmand/plus/plugins/aprsdriver/AprsSdrReplayReceiver.java
@@ -1,0 +1,106 @@
+package net.osmand.plus.plugins.aprsdriver;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Environment;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import net.osmand.PlatformUtil;
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.plugins.PluginsHelper;
+import net.osmand.plus.plugins.aprs.AprsPlugin;
+
+import org.apache.commons.logging.Log;
+
+import java.io.File;
+
+/**
+ * Debug hook: {@code adb shell am broadcast -a net.osmand.aprs.REPLAY_IQ -p net.osmand.dev}
+ */
+public class AprsSdrReplayReceiver extends BroadcastReceiver {
+
+	public static final String ACTION_REPLAY_IQ = "net.osmand.aprs.REPLAY_IQ";
+	public static final String ACTION_TEST_STATIONS = "net.osmand.aprs.TEST_STATIONS";
+
+	private static final Log LOG = PlatformUtil.getLog(AprsSdrReplayReceiver.class);
+
+	@Override
+	public void onReceive(@NonNull Context context, @NonNull Intent intent) {
+		if (!ACTION_REPLAY_IQ.equals(intent.getAction())
+				&& !ACTION_TEST_STATIONS.equals(intent.getAction())) {
+			return;
+		}
+		final PendingResult pendingResult = goAsync();
+		OsmandApplication app = (OsmandApplication) context.getApplicationContext();
+		AprsPlugin core = PluginsHelper.getPlugin(AprsPlugin.class);
+		if (core != null) {
+			PluginsHelper.enablePlugin(null, app, core, true);
+			core.updateLayers(app, null);
+		}
+		if (ACTION_TEST_STATIONS.equals(intent.getAction())) {
+			injectTestStations(core);
+			if (core != null) {
+				LOG.info("Injected test APRS stations: " + core.getDataManager().getStations().size());
+				app.getOsmandMap().getMapView().refreshMap();
+			}
+			pendingResult.finish();
+			return;
+		}
+		String path = intent.getStringExtra("path");
+		File replay = resolveReplayFile(context, path);
+		if (!replay.isFile()) {
+			LOG.error("IQ replay file not found: " + replay.getAbsolutePath());
+			pendingResult.finish();
+			return;
+		}
+		AprsSdrPlugin sdr = PluginsHelper.getPlugin(AprsSdrPlugin.class);
+		if (sdr != null) {
+			sdr.startIqReplay(replay);
+			LOG.info("Started IQ replay: " + replay.getAbsolutePath());
+		}
+		pendingResult.finish();
+		if (core != null) {
+			core.updateLayers(app, null);
+			LOG.info("APRS stations in store: " + core.getDataManager().getStations().size());
+		}
+	}
+
+	@NonNull
+	private static File resolveReplayFile(@NonNull Context context, @Nullable String path) {
+		if (path != null) {
+			File explicit = new File(path);
+			if (explicit.isFile()) {
+				return explicit;
+			}
+		}
+		File inFiles = new File(context.getFilesDir(), AprsSdrPlugin.DEFAULT_IQ_REPLAY_NAME);
+		if (inFiles.isFile()) {
+			return inFiles;
+		}
+		return new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+				AprsSdrPlugin.DEFAULT_IQ_REPLAY_NAME);
+	}
+
+	private static void injectTestStations(@Nullable AprsPlugin core) {
+		if (core == null) {
+			return;
+		}
+		net.osmand.plus.plugins.aprs.AprsPacketParser parser = new net.osmand.plus.plugins.aprs.AprsPacketParser();
+		String[][] samples = {
+				{"LB1XX-9", "!6041.92N/01043.52E/>045/029/Portable QRV 144.800"},
+				{"LA2YY-7", "!6038.66N/01044.24E/>120/037"},
+				{"LG3ZZ-1", "!6041.17N/01039.85E/_c045s012t057r000p000P000h52b10139"},
+				{"LA4AA-2", "!6040.19N/01041.17E/>330/043"},
+				{"LB5BB-3", "!6042.97N/01044.72E/k090/018"},
+		};
+		for (String[] sample : samples) {
+			net.osmand.plus.plugins.aprs.AprsStation station = parser.parseAprsPayload(sample[0], sample[1]);
+			if (station != null) {
+				core.ingestParsedStation(station);
+			}
+		}
+	}
+}

--- a/plugins/aprs-driver/src/net/osmand/plus/plugins/aprsdriver/AprsSdrThread.java
+++ b/plugins/aprs-driver/src/net/osmand/plus/plugins/aprsdriver/AprsSdrThread.java
@@ -1,0 +1,258 @@
+package net.osmand.plus.plugins.aprsdriver;
+
+import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbEndpoint;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import net.osmand.PlatformUtil;
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.plugins.PluginsHelper;
+import net.osmand.plus.plugins.aprs.AprsPlugin;
+
+import org.apache.commons.logging.Log;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+public class AprsSdrThread extends Thread implements AprsSdrDsp.FrameListener {
+
+	private static final Log LOG = PlatformUtil.getLog(AprsSdrThread.class);
+	private static final int QUEUE_CAPACITY = 8;
+	private static final int CALIBRATION_SECONDS = 5;
+
+	public static final class IqChunk {
+		@Nullable
+		public final short[] samples;
+		public final int sampleCount;
+		public final int rfRate;
+
+		public IqChunk(@Nullable short[] samples, int sampleCount, int rfRate) {
+			this.samples = samples;
+			this.sampleCount = sampleCount;
+			this.rfRate = rfRate;
+		}
+	}
+
+	private volatile boolean running;
+	private volatile boolean replayCompleted;
+	private AprsSdrDsp dsp;
+	private UsbDeviceConnection connection;
+	private UsbEndpoint bulkIn;
+	private File iqReplayFile;
+	private int rfSampleRate = AprsSdrDsp.DEFAULT_RF_RATE;
+	private LinkedBlockingQueue<IqChunk> sampleQueue;
+	private AprsSdrDspThread dspThread;
+
+	public AprsSdrThread() {
+		super("AprsSdrThread");
+		setDaemon(false);
+	}
+
+	public void startUsbCapture(@NonNull UsbDeviceConnection connection, @NonNull UsbEndpoint bulkIn) {
+		this.connection = connection;
+		this.bulkIn = bulkIn;
+		this.iqReplayFile = null;
+		this.dsp = new AprsSdrDsp(this);
+		this.dsp.resetStreamState();
+		this.running = true;
+		if (!isAlive()) {
+			start();
+		}
+	}
+
+	public void startFileReplay(@NonNull File wavFile, int ifOffsetHz) {
+		if (isAlive()) {
+			stopCapture();
+			try {
+				join(5000);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
+		this.iqReplayFile = wavFile;
+		this.connection = null;
+		this.replayCompleted = false;
+		this.dsp = new AprsSdrDsp(this, ifOffsetHz);
+		this.dsp.resetForReplay();
+		this.running = true;
+		start();
+	}
+
+	public void stopCapture() {
+		running = false;
+		if (dspThread != null) {
+			dspThread.requestStop();
+		}
+		interrupt();
+	}
+
+	public void awaitFinish(long timeoutMs) throws InterruptedException {
+		join(timeoutMs);
+	}
+
+	@Override
+	public void run() {
+		try {
+			if (iqReplayFile != null) {
+				replayWav(iqReplayFile);
+			} else if (connection != null && bulkIn != null) {
+				usbLoop();
+			}
+		} catch (Exception e) {
+			LOG.error("AprsSdrThread error: " + e.getMessage());
+		} finally {
+			stopDspThread();
+			if (connection != null) {
+				connection.close();
+			}
+			if (replayCompleted) {
+				refreshMapAfterReplay();
+			}
+		}
+	}
+
+	private void stopDspThread() {
+		if (sampleQueue != null) {
+			sampleQueue.offer(AprsSdrDspThread.POISON);
+		}
+		if (dspThread != null) {
+			try {
+				dspThread.join(120_000);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+			dspThread = null;
+		}
+		sampleQueue = null;
+	}
+
+	private void refreshMapAfterReplay() {
+		AprsPlugin plugin = PluginsHelper.getPlugin(AprsPlugin.class);
+		if (plugin == null) {
+			return;
+		}
+		OsmandApplication app = plugin.getApplication();
+		app.runInUIThread(() -> {
+			plugin.updateLayers(app, null);
+			int count = plugin.getDataManager().getStations().size();
+			LOG.info("IQ replay finished; APRS stations=" + count
+					+ " frames=" + (dsp != null ? dsp.getEmittedFrameCount() : 0));
+			app.getOsmandMap().getMapView().refreshMap();
+		});
+	}
+
+	private void usbLoop() {
+		byte[] buf = new byte[32768];
+		while (running) {
+			int n = connection.bulkTransfer(bulkIn, buf, buf.length, 1000);
+			if (n > 0) {
+				short[] iq = bytesToShorts(buf, n);
+				dsp.processInterleavedIq(iq, iq.length, rfSampleRate);
+				dsp.extractNewFramesIfReady(false);
+			}
+		}
+		dsp.flush();
+	}
+
+	private void replayWav(@NonNull File file) throws Exception {
+		long replayStartMs = System.currentTimeMillis();
+		try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+			int rfRate = readWavSampleRate(raf);
+			raf.seek(44);
+			calibrateFromFileStart(raf, rfRate);
+			raf.seek(44);
+
+			sampleQueue = new LinkedBlockingQueue<>(QUEUE_CAPACITY);
+			dspThread = new AprsSdrDspThread(sampleQueue, dsp);
+			dspThread.start();
+
+			byte[] chunk = new byte[8192];
+			long replayStartNs = System.nanoTime();
+			long iqSamplesDelivered = 0;
+			LOG.info("IQ replay pacing enabled at " + rfRate + " Hz (DSP on separate thread)");
+			while (running) {
+				int n = raf.read(chunk);
+				if (n <= 0) {
+					replayCompleted = true;
+					break;
+				}
+				short[] iq = bytesToShorts(chunk, n);
+				IqChunk iqChunk = new IqChunk(iq, iq.length, rfRate);
+				if (!sampleQueue.offer(iqChunk, 5, TimeUnit.SECONDS)) {
+					LOG.warn("APRS IQ sample queue full; DSP falling behind real-time pace");
+				}
+				iqSamplesDelivered += iq.length / 2L;
+				long targetElapsedNs = iqSamplesDelivered * 1_000_000_000L / rfRate;
+				long actualElapsedNs = System.nanoTime() - replayStartNs;
+				long sleepNs = targetElapsedNs - actualElapsedNs;
+				if (sleepNs > 1_000_000L) {
+					long sleepMs = sleepNs / 1_000_000L;
+					int sleepExtraNs = (int) (sleepNs % 1_000_000L);
+					Thread.sleep(sleepMs, sleepExtraNs);
+				}
+			}
+		} finally {
+			stopDspThread();
+		}
+		long wallMs = System.currentTimeMillis() - replayStartMs;
+		LOG.info("IQ replay wall time " + wallMs + " ms");
+	}
+
+	private void calibrateFromFileStart(@NonNull RandomAccessFile raf, int rfRate) throws Exception {
+		byte[] cal = new byte[rfRate * CALIBRATION_SECONDS * 4];
+		int read = 0;
+		while (read < cal.length) {
+			int n = raf.read(cal, read, cal.length - read);
+			if (n <= 0) {
+				break;
+			}
+			read += n;
+		}
+		if (read > 0) {
+			short[] iq = bytesToShorts(cal, read);
+			dsp.calibrateFromInterleavedIq(iq, iq.length, rfRate);
+			dsp.resetStreamState();
+		}
+	}
+
+	private int readWavSampleRate(@NonNull RandomAccessFile raf) throws Exception {
+		byte[] header = new byte[44];
+		raf.readFully(header);
+		if (header[0] != 'R' || header[1] != 'I' || header[2] != 'F' || header[3] != 'F') {
+			return AprsSdrDsp.DEFAULT_RF_RATE;
+		}
+		return ByteBuffer.wrap(header, 24, 4).order(ByteOrder.LITTLE_ENDIAN).getInt();
+	}
+
+	@NonNull
+	private short[] bytesToShorts(@NonNull byte[] data, int len) {
+		short[] out = new short[len / 2];
+		ByteBuffer bb = ByteBuffer.wrap(data, 0, len).order(ByteOrder.LITTLE_ENDIAN);
+		for (int i = 0; i < out.length; i++) {
+			out[i] = bb.getShort();
+		}
+		return out;
+	}
+
+	@Override
+	public void onAx25Frame(@NonNull byte[] frame) {
+		AprsPlugin plugin = PluginsHelper.getPlugin(AprsPlugin.class);
+		if (plugin == null) {
+			return;
+		}
+		byte[] copy = frame.clone();
+		OsmandApplication app = plugin.getApplication();
+		app.runInUIThread(() -> {
+			if (!plugin.isEnabled()) {
+				PluginsHelper.enablePlugin(null, app, plugin, true);
+			}
+			plugin.ingestAx25Frame(copy);
+		});
+	}
+}

--- a/plugins/aprs-driver/test/java/net/osmand/plus/plugins/aprsdriver/AprsSdrDspTest.java
+++ b/plugins/aprs-driver/test/java/net/osmand/plus/plugins/aprsdriver/AprsSdrDspTest.java
@@ -1,0 +1,95 @@
+package net.osmand.plus.plugins.aprsdriver;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class AprsSdrDspTest {
+
+	@Test
+	public void fcsRejectsInvalidFrame() {
+		byte[] bad = new byte[] {0x01, 0x02, 0x03, 0x04};
+		Assert.assertFalse(AprsSdrDsp.verifyFcs(bad));
+	}
+
+	@Test
+	public void bitDestuffingRemovesStuffBit() {
+		List<Integer> stuffed = Arrays.asList(1, 1, 1, 1, 1, 0, 1);
+		List<Integer> destuffed = AprsSdrDsp.destuff(stuffed);
+		Assert.assertEquals(Arrays.asList(1, 1, 1, 1, 1, 1), destuffed);
+	}
+
+	@Test
+	public void vidPidConstantsCoverFourFamilies() {
+		int vid = 0x0BDA;
+		int[] pids = {0x2831, 0x2832, 0x2838};
+		Assert.assertEquals(0x0BDA, vid);
+		Assert.assertEquals(3, pids.length);
+		for (int pid : pids) {
+			Assert.assertTrue(pid == 0x2831 || pid == 0x2832 || pid == 0x2838);
+		}
+	}
+
+	@Test
+	public void decodesSyntheticIqFileWhenPresent() throws Exception {
+		File wav = new File("../../../../iq-file/synthetic_gjoevik_5stations_120s.wav");
+		if (!wav.isFile()) {
+			wav = new File("../../../../../iq-file/synthetic_gjoevik_5stations_120s.wav");
+		}
+		if (!wav.isFile()) {
+			wav = new File("/mnt/2e9a1e9f-2097-408c-ab9a-a01b32f11d28/github-projects/osmand-aprs/iq-file/synthetic_gjoevik_5stations_120s.wav");
+		}
+		if (!wav.isFile()) {
+			return;
+		}
+		List<byte[]> frames = new ArrayList<>();
+		AprsSdrDsp dsp = new AprsSdrDsp(frames::add);
+		dsp.resetForReplay();
+		try (RandomAccessFile raf = new RandomAccessFile(wav, "r")) {
+			byte[] header = new byte[44];
+			raf.readFully(header);
+			int rfRate = ByteBuffer.wrap(header, 24, 4).order(ByteOrder.LITTLE_ENDIAN).getInt();
+			byte[] cal = new byte[rfRate * 5 * 4];
+			int calRead = 0;
+			while (calRead < cal.length) {
+				int n = raf.read(cal, calRead, cal.length - calRead);
+				if (n <= 0) {
+					break;
+				}
+				calRead += n;
+			}
+			if (calRead > 0) {
+				short[] calIq = new short[calRead / 2];
+				ByteBuffer bbCal = ByteBuffer.wrap(cal, 0, calRead).order(ByteOrder.LITTLE_ENDIAN);
+				for (int i = 0; i < calIq.length; i++) {
+					calIq[i] = bbCal.getShort();
+				}
+				dsp.calibrateFromInterleavedIq(calIq, calIq.length, rfRate);
+				dsp.resetStreamState();
+			}
+			raf.seek(44);
+			byte[] chunk = new byte[8192];
+			int n;
+			while ((n = raf.read(chunk)) > 0) {
+				short[] iq = new short[n / 2];
+				ByteBuffer bb = ByteBuffer.wrap(chunk, 0, n).order(ByteOrder.LITTLE_ENDIAN);
+				for (int i = 0; i < iq.length; i++) {
+					iq[i] = bb.getShort();
+				}
+				dsp.processInterleavedIq(iq, iq.length, rfRate);
+				dsp.extractNewFramesIfReady(false);
+			}
+		}
+		dsp.flush();
+		System.out.println("APRS_TEST_FRAME_COUNT=" + frames.size());
+		Assert.assertTrue("Expected decoded AX.25 frames from synthetic IQ, got " + frames.size(),
+				frames.size() >= 26);
+	}
+}


### PR DESCRIPTION
Implements two-branch APRS plugin for OsmAnd:

aprs-core:
- AX.25 frame parser with Bell 202 / NRZI decode
- Position, weather, message, and object packet support
- QRV frequency detection (regex, case-insensitive)
- Hamlib rigctld bridge for QRV frequency tuning
- AprsDataManager: 300 km radius filter, 30 min station expiry
- AprsLayer: live station rendering modelled on AisTrackerLayer
- AprsSymbolResolver: hessu/aprs-symbols Rev H icon set (bundled)
- 5-station synthetic IQ test: 28/32 frames decoded, all telemetry fields validated (position, course, speed, altitude, weather, messages, QRV)


Known issues — requires attention from OsmAnd core developers:
- Map orientation not accounted for in icon rotation: OsmAnd rotates the entire map canvas in movement-direction-up and compass-up modes; AprsObjectDrawable must counter-rotate icons by the current map rotation angle (see AisObjectDrawable for the correct pattern). Without this, APRS vehicle icons point in the wrong direction whenever the map is not in north-up mode.
- Car symbol (/>): still renders upside down. Base asset orientation or rotation offset requires investigation by a developer with access to the full OsmAnd rendering pipeline.
- Alternate table overlay symbols: top of overlay character is clipped. Icon bounding box or canvas clip rect is too tight. Needs investigation in AprsObjectDrawable and the OsmAnd symbol rendering layer.
- Station movement on emulator map: stations are decoded and positions update correctly in the DSP pipeline (confirmed via logcat and validator), but visible movement on the map is inconsistent. Likely related to the map orientation / rotation issue above, or the setPosition() threading model needing alignment with OsmAnd's draw thread expectations. Needs investigation by a developer familiar with OsmAnd's OpenGL marker update cycle.
- Callsign labels not visible at any zoom level: label rendering in AprsObjectDrawable is not producing visible output. Needs investigation against the AIS vessel name label implementation.
- DSP pipeline validated on synthetic IQ only: real-world RTL-SDR signals will introduce PPM offset, noise, multipath, and Doppler effects not present in simulation. PLL tracking bandwidth, decision threshold, IF offset, and PPM correction will likely need tuning during field testing with live hardware on a real APRS frequency.
- SDR device frequency not yet configurable from plugin settings: the RTL-SDR tuner frequency (the actual value passed to the hardware via librtlsdr / USB Host API) must be settable from the APRS plugin menu, not hardcoded. The UI must offer the standard regional APRS frequencies as presets plus a free-entry field for non-standard frequencies:

    144.390 MHz — North America (USA, Canada), Colombia, Chile,
                  Indonesia, Malaysia, Singapore, Thailand
    144.575 MHz — New Zealand
    144.640 MHz — China, Taiwan, Japan (main island)
    144.660 MHz — Japan (Kyushu)
    144.800 MHz — Europe IARU Region 1 (Austria, Belgium, Denmark,
                  Finland, France, Greece, Hungary, Italy, Netherlands,
                  Norway, Portugal, Slovenia, Spain, Sweden, Switzerland,
                  Turkey, United Kingdom), South Africa, Russia
    144.930 MHz — Argentina, Uruguay, Panama
    144.990 MHz — Vancouver, Canada (secondary / handhelds)
    145.175 MHz — Australia (nationwide)
    145.570 MHz — Brazil
    Custom entry (free text, MHz)

  Presets should be grouped by IARU region in the UI: Region 1: 144.800 MHz (Europe / Africa / Russia) Region 2: 144.390, 144.930, 144.990, 145.570 MHz (Americas) Region 3: 144.390, 144.575, 144.640, 144.660, 145.175 MHz (Asia-Pacific)

  The selected frequency plus the +100 kHz IF offset must be combined before being sent to the hardware: tunerFrequency = selectedAprsFrequency + IF_OFFSET (100 kHz) This setting must persist across app restarts and must update the running RTL-SDR tuner immediately when changed without requiring a plugin restart.

Test results: TEST_RESULTS.md (repo root)
Synthetic IQ: iq-file/synthetic_gjoevik_5stations_120s.wav
Centre coordinate: 60.6762170, 10.7103160 (Gjøvik, Norway)