### PR TITLE
Fix opening hours: "off" rule handling, month overrides, "PH Su" parsing, nth weekdays

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/util/OpeningHoursParser.java
+++ b/OsmAnd-java/src/main/java/net/osmand/util/OpeningHoursParser.java
@@ -473,11 +473,29 @@ public class OpeningHoursParser {
 		}
 
 		private String getTime(Calendar cal, int limit, boolean opening, int sequenceIndex) {
+			if (!opening) {
+				// an overnight session of the previous day which is still open ends before
+				// anything the rules of the current day contribute (like "Fr 09:00-16:30"
+				// while a "Mo-Th 09:00-00:30" session is running at Friday 00:15)
+				String spillOverClosing = getSpillOverClosing(cal, limit, sequenceIndex);
+				if (!Algorithms.isEmpty(spillOverClosing)) {
+					return spillOverClosing;
+				}
+			}
 			String time = getTimeDay(cal, limit, opening, sequenceIndex);
 			if (Algorithms.isEmpty(time)) {
 				time = getTimeAnotherDay(cal, limit, opening, sequenceIndex);
 			}
 			return time;
+		}
+
+		private String getSpillOverClosing(Calendar cal, int limit, int sequenceIndex) {
+			for (OpeningHoursRule r : getRules(sequenceIndex)) {
+				if (r.containsPreviousDay(cal) && r.containsMonth(cal) && r.isOpenedForTime(cal, true)) {
+					return r.getTime(cal, true, limit, false);
+				}
+			}
+			return "";
 		}
 
 		private String getTimeDay(Calendar cal, int limit, boolean opening, int sequenceIndex) {
@@ -1419,7 +1437,9 @@ public class OpeningHoursParser {
 						} else if (time > endTime && days[ad] && checkAnotherDay) {
 							diff = 24 * 60 - endTime  + time;
 						}
-						if (limit == WITHOUT_TIME_LIMIT || ((diff != -1 && diff <= limit) || limit == CURRENT_DAY_TIME_LIMIT)) {
+						// don't accept the time if the day checks above didn't match (diff == -1),
+						// otherwise a "Mo-Th 09:00-00:30" rule reports Friday night as opening at 09:00
+						if (limit == WITHOUT_TIME_LIMIT || (diff != -1 && (diff <= limit || limit == CURRENT_DAY_TIME_LIMIT))) {
 							return startTime;
 						}
 					}

--- a/OsmAnd-java/src/main/java/net/osmand/util/OpeningHoursParser.java
+++ b/OsmAnd-java/src/main/java/net/osmand/util/OpeningHoursParser.java
@@ -482,19 +482,60 @@ public class OpeningHoursParser {
 
 		private String getTimeDay(Calendar cal, int limit, boolean opening, int sequenceIndex) {
 			String atTime = "";
+			int atTimeMinutes = -1;
 			ArrayList<OpeningHoursRule> rules = getRules(sequenceIndex);
 			OpeningHoursRule prevRule = null;
 			for (OpeningHoursRule r : rules) {
-				if (r.containsDay(cal) && r.containsMonth(cal)) {
+				if (appliesToDay(r, cal)) {
 					if (atTime.length() > 0 && prevRule != null && !r.hasOverlapTimes(cal, prevRule, true)) {
 						return atTime;
+					}
+					if (isTimeRestrictedOffRule(r) && atTimeMinutes >= 0) {
+						// Rules like "Jul-Aug 19:00-19:30 off" make only their own time ranges "off",
+						// so they adjust a time found by previous rules instead of discarding it
+						BasicOpeningHourRule offRule = (BasicOpeningHourRule) r;
+						int offTimeMinutes = offRule.getTimeMinutes(cal, false, limit, opening);
+						int currentTimeMinutes = cal.get(Calendar.HOUR_OF_DAY) * 60 + cal.get(Calendar.MINUTE);
+						if (opening) {
+							if (offRule.containsTime(atTimeMinutes)) {
+								// the opening time found before is turned off, it moves to the end of the "off" range
+								atTimeMinutes = offTimeMinutes;
+								atTime = offRule.formatResult(offTimeMinutes);
+							}
+						} else if (offTimeMinutes >= currentTimeMinutes && offTimeMinutes < atTimeMinutes) {
+							// the "off" range starts before the closing time found before, so it closes earlier
+							atTimeMinutes = offTimeMinutes;
+							atTime = offRule.formatResult(offTimeMinutes);
+						}
+					} else if (r instanceof BasicOpeningHourRule) {
+						BasicOpeningHourRule rule = (BasicOpeningHourRule) r;
+						atTimeMinutes = rule.getTimeMinutes(cal, false, limit, opening);
+						atTime = rule.formatResult(atTimeMinutes);
 					} else {
 						atTime = r.getTime(cal, false, limit, opening);
+						atTimeMinutes = -1;
 					}
+					prevRule = r;
 				}
-				prevRule = r;
 			}
 			return atTime;
+		}
+
+		/**
+		 * Check if the rule applies to the calendar day of "cal", including rules defined
+		 * by day-month or year ranges (like "Dec 24-Dec 31 off") which don't set weekdays
+		 */
+		private boolean appliesToDay(OpeningHoursRule r, Calendar cal) {
+			if (r instanceof BasicOpeningHourRule) {
+				return ((BasicOpeningHourRule) r).appliesToDay(cal);
+			}
+			return r.containsDay(cal) && r.containsMonth(cal);
+		}
+
+		private boolean isTimeRestrictedOffRule(OpeningHoursRule r) {
+			return r instanceof BasicOpeningHourRule
+					&& ((BasicOpeningHourRule) r).isOff()
+					&& ((BasicOpeningHourRule) r).timesSize() > 0;
 		}
 
 		private String getTimeAnotherDay(Calendar cal, int limit, boolean opening, int sequenceIndex) {
@@ -1346,7 +1387,10 @@ public class OpeningHoursParser {
 
 		@Override
 		public String getTime(Calendar cal, boolean checkAnotherDay, int limit, boolean opening) {
-			StringBuilder sb = new StringBuilder();
+			return formatResult(getTimeMinutes(cal, checkAnotherDay, limit, opening));
+		}
+
+		int getTimeMinutes(Calendar cal, boolean checkAnotherDay, int limit, boolean opening) {
 			int d = getCurrentDay(cal);
 			int ad = opening ? getNextDay(d) : getPreviousDay(d);
 			int time = getCurrentTimeInMinutes(cal);
@@ -1357,9 +1401,10 @@ public class OpeningHoursParser {
 					if (startTime < endTime || endTime == -1) {
 						if (days[d] && !checkAnotherDay) {
 							int diff = startTime - time;
-							if (limit == WITHOUT_TIME_LIMIT || (time <= startTime && (diff <= limit || limit == CURRENT_DAY_TIME_LIMIT))) { 
-								formatTime(startTime, sb);
-								break;
+							// for "off" rules skip time ranges that are already over
+							if ((limit == WITHOUT_TIME_LIMIT && (!off || diff >= 0))
+									|| (time <= startTime && (diff <= limit || limit == CURRENT_DAY_TIME_LIMIT))) {
+								return startTime;
 							}
 						}
 					} else {
@@ -1370,8 +1415,7 @@ public class OpeningHoursParser {
 							diff = 24 * 60 - endTime  + time;
 						}
 						if (limit == WITHOUT_TIME_LIMIT || ((diff != -1 && diff <= limit) || limit == CURRENT_DAY_TIME_LIMIT)) {
-							formatTime(startTime, sb);
-							break;
+							return startTime;
 						}
 					}
 				} else {
@@ -1379,8 +1423,7 @@ public class OpeningHoursParser {
 						if (days[d] && !checkAnotherDay) {
 							int diff = endTime - time;
 							if ((limit == WITHOUT_TIME_LIMIT && diff >= 0) || (time <= endTime && diff <= limit)) {
-								formatTime(endTime, sb);
-								break;
+								return endTime;
 							}
 						}
 					} else {
@@ -1391,17 +1434,67 @@ public class OpeningHoursParser {
 							diff = endTime - time;
 						}
 						if (limit == WITHOUT_TIME_LIMIT || (diff != -1 && diff <= limit)) {
-							formatTime(endTime, sb);
-							break;
+							return endTime;
 						}
 					}
 				}
 			}
+			return -1;
+		}
+
+		String formatResult(int timeMinutes) {
+			if (timeMinutes < 0) {
+				return "";
+			}
+			StringBuilder sb = new StringBuilder();
+			formatTime(timeMinutes, sb);
 			String res = sb.toString();
 			if (res.length() > 0 && !Algorithms.isEmpty(comment)) {
 				res += " - " + comment;
 			}
 			return res;
+		}
+
+		/**
+		 * Check if the time "timeMinutes" (in minutes of the day) is within the time ranges of this rule
+		 */
+		boolean containsTime(int timeMinutes) {
+			for (int i = 0; i < startTimes.size(); i++) {
+				int startTime = startTimes.get(i);
+				int endTime = endTimes.get(i);
+				if (endTime == -1 || startTime >= endTime) {
+					// open-ended or over-midnight range
+					if (timeMinutes >= startTime || (endTime != -1 && timeMinutes < endTime)) {
+						return true;
+					}
+				} else if (timeMinutes >= startTime && timeMinutes < endTime) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		/**
+		 * Check if the rule applies to the calendar day of "cal", including rules defined
+		 * by day-month or year ranges which don't set weekdays
+		 */
+		public boolean appliesToDay(Calendar cal) {
+			if (!containsMonth(cal)) {
+				return false;
+			}
+			int month = cal.get(Calendar.MONTH);
+			int dmonth = cal.get(Calendar.DAY_OF_MONTH) - 1;
+			boolean thisDay = true;
+			if (hasYears()) {
+				thisDay = isOpened(cal.get(Calendar.YEAR), month, dmonth);
+			} else if (hasDayMonths()) {
+				thisDay = dayMonths[month][dmonth];
+			}
+			return thisDay && (!hasDays || containsDay(cal));
+		}
+
+		public boolean isOff() {
+			return off;
 		}
 
 		@Override

--- a/OsmAnd-java/src/main/java/net/osmand/util/OpeningHoursParser.java
+++ b/OsmAnd-java/src/main/java/net/osmand/util/OpeningHoursParser.java
@@ -1453,7 +1453,10 @@ public class OpeningHoursParser {
 						}
 					} else {
 						int diff = -1;
-						if (time <= endTime && days[d] && !checkAnotherDay) {
+						if ((time >= startTime || time <= endTime) && days[d] && !checkAnotherDay) {
+							// still inside an overnight session of the current day: the closing
+							// time is "endTime" on the next calendar day, so during the evening
+							// part (time >= startTime) the minutes-to-close must cross midnight
 							diff = 24 * 60 - time + endTime;
 						} else if (time < endTime && days[ad] && checkAnotherDay) {
 							diff = endTime - time;

--- a/OsmAnd-java/src/main/java/net/osmand/util/OpeningHoursParser.java
+++ b/OsmAnd-java/src/main/java/net/osmand/util/OpeningHoursParser.java
@@ -777,6 +777,11 @@ public class OpeningHoursParser {
 		private boolean hasDays = false;
 
 		/**
+		 * nth weekday of the month masks per day (like "Su[1]"), see parseNthMask
+		 */
+		private int[] dayNth = null;
+
+		/**
 		 * represents the list on which month it is open.
 		 * Day number 0 is JANUARY.
 		 */
@@ -1090,7 +1095,7 @@ public class OpeningHoursParser {
 				int endTime = this.endTimes.get(i);
 				if (startTime < endTime || endTime == -1) {
 					// one day working like 10:00-20:00 (not 20:00-04:00)
-					if (days[d] && !checkPrevious) {
+					if (days[d] && matchesDayNth(d, cal) && !checkPrevious) {
 						if (time >= startTime && (endTime == -1 || time <= endTime)) {
 							return !off;
 						}
@@ -1098,9 +1103,9 @@ public class OpeningHoursParser {
 				} else {
 					// opening_hours includes day wrap like
 					// "We 20:00-03:00" or "We 07:00-07:00"
-					if (time >= startTime && days[d] && !checkPrevious) {
+					if (time >= startTime && days[d] && matchesDayNth(d, cal) && !checkPrevious) {
 						return !off;
-					} else if (time < endTime && days[p] && checkPrevious) {
+					} else if (time < endTime && days[p] && matchesPreviousDayNth(p, cal) && checkPrevious) {
 						// check in previous day
 						return !off;
 					}
@@ -1490,11 +1495,40 @@ public class OpeningHoursParser {
 			} else if (hasDayMonths()) {
 				thisDay = dayMonths[month][dmonth];
 			}
-			return thisDay && (!hasDays || containsDay(cal));
+			return thisDay && (!hasDays || (containsDay(cal) && matchesDayNth(getCurrentDay(cal), cal)));
 		}
 
 		public boolean isOff() {
 			return off;
+		}
+
+		void setDayNthMask(int day, int mask) {
+			if (dayNth == null) {
+				dayNth = new int[7];
+			}
+			dayNth[day] = mask;
+		}
+
+		/**
+		 * Check if the day of "cal" matches the nth weekday restriction of "day" (like "Su[1]"), if any
+		 */
+		private boolean matchesDayNth(int day, Calendar cal) {
+			if (dayNth == null || dayNth[day] == 0) {
+				return true;
+			}
+			int mask = dayNth[day];
+			int dmonth = cal.get(Calendar.DAY_OF_MONTH) - 1;
+			int nthFromEnd = (cal.getActualMaximum(Calendar.DAY_OF_MONTH) - 1 - dmonth) / 7;
+			return (mask & (1 << (dmonth / 7))) != 0 || (mask & (1 << (5 + nthFromEnd))) != 0;
+		}
+
+		private boolean matchesPreviousDayNth(int previousDay, Calendar cal) {
+			if (dayNth == null || dayNth[previousDay] == 0) {
+				return true;
+			}
+			Calendar pcal = (Calendar) cal.clone();
+			pcal.add(Calendar.DAY_OF_MONTH, -1);
+			return matchesDayNth(previousDay, pcal);
 		}
 
 		@Override
@@ -1524,6 +1558,9 @@ public class OpeningHoursParser {
 						builder.append(", "); //$NON-NLS-1$
 					}
 					builder.append(daysNames[getDayIndex(i)]);
+					if (dayNth != null && dayNth[i] != 0) {
+						appendNthString(builder, dayNth[i]);
+					}
 					dash = false;
 				}
 			}
@@ -1551,6 +1588,21 @@ public class OpeningHoursParser {
 			if(!first) {
 				builder.append(" ");
 			}
+		}
+
+		private static void appendNthString(StringBuilder builder, int mask) {
+			builder.append("[");
+			boolean first = true;
+			for (int bit = 0; bit < 10; bit++) {
+				if ((mask & (1 << bit)) != 0) {
+					if (!first) {
+						builder.append(",");
+					}
+					builder.append(bit < 5 ? bit + 1 : 4 - bit);
+					first = false;
+				}
+			}
+			builder.append("]");
 		}
 
 		/**
@@ -1658,7 +1710,7 @@ public class OpeningHoursParser {
 				}
 			}
 			if (thisDay && hasDays) {
-				thisDay = days[day];
+				thisDay = days[day] && matchesDayNth(day, cal);
 			}
 			// potential error for Dec 31 12:00-01:00
 			boolean previousDay = true; // hasDays || hasDayMonths() || hasFullYears(); // CHECK?
@@ -1672,7 +1724,7 @@ public class OpeningHoursParser {
 				}
 			}
 			if (previousDay && hasDays) {
-				previousDay = days[previous];
+				previousDay = days[previous] && matchesPreviousDayNth(previous, cal);
 			}
 			if (!thisDay && !previousDay) {
 				return 0;
@@ -1870,6 +1922,7 @@ public class OpeningHoursParser {
 			text = Integer.toString(mainNumber);
 		}
 		int mainNumber = -1;
+		int nthMask = 0;
 		TokenType type;
 		String text;
 		Token parent;
@@ -1917,17 +1970,26 @@ public class OpeningHoursParser {
 		int startWord = 0;
 		StringBuilder commentStr = new StringBuilder();
 		boolean comment = false;
+		boolean bracket = false;
 		for (int i = 0; i <= localRuleString.length(); i++) {
 			char ch = i == localRuleString.length() ? ' ' : localRuleString.charAt(i);
+			if (i == localRuleString.length()) {
+				bracket = false;
+			}
 			boolean delimiter = false;
 			Token del = null;
-			if (Character.isWhitespace(ch)) {
-				delimiter = true;
+			if (ch == '[' && !comment) {
+				// keep nth weekday brackets like "Su[1]" or "Su[-1]" together as one token
+				bracket = true;
+			} else if (ch == ']' && !comment) {
+				bracket = false;
+			} else if (Character.isWhitespace(ch)) {
+				delimiter = !bracket;
 			} else if (ch == ':') {
 				del = new Token(TokenType.TOKEN_COLON, ":");
-			} else if (ch == '-') {
+			} else if (ch == '-' && !bracket) {
 				del = new Token(TokenType.TOKEN_DASH, "-");
-			} else if (ch == ',') {
+			} else if (ch == ',' && !bracket) {
 				del = new Token(TokenType.TOKEN_COMMA, ",");
 			} else if (ch == '"') {
 				if (comment) {
@@ -1959,6 +2021,9 @@ public class OpeningHoursParser {
 		for (Token t : tokens) {
 			if (t.type == TokenType.TOKEN_UNKNOWN) {
 				findInArray(t, daysStr, TokenType.TOKEN_DAY_WEEK);
+			}
+			if (t.type == TokenType.TOKEN_UNKNOWN) {
+				findNthWeekday(t, daysStr);
 			}
 			if (t.type == TokenType.TOKEN_UNKNOWN) {
 				findInArray(t, monthsStr, TokenType.TOKEN_MONTH);
@@ -2041,6 +2106,15 @@ public class OpeningHoursParser {
 							: tokenDayMonth ? null : basic.getDays();
 					for (Token[] pair : listOfPairs) {
 						if (pair[0] != null && pair[1] != null) {
+							Token holidayToken = pair[0].type == TokenType.TOKEN_HOLIDAY ? pair[0]
+									: pair[1].type == TokenType.TOKEN_HOLIDAY ? pair[1] : null;
+							if (holidayToken != null
+									&& (pair[0].type == TokenType.TOKEN_DAY_WEEK || pair[1].type == TokenType.TOKEN_DAY_WEEK)) {
+								// "PH Su" means "public holidays falling on Sunday", so the weekday only
+								// restricts the holiday and must not fill the weekday range Mo-Su (#23990)
+								setHolidayFlag(basic, holidayToken.mainNumber);
+								continue;
+							}
 							Token firstMonthToken = pair[0].parent == null && pair[0].type == TokenType.TOKEN_MONTH ? pair[0] : pair[0].parent;
 							Token lastMonthToken = pair[1].parent == null && pair[1].type == TokenType.TOKEN_MONTH ? pair[1] : pair[1].parent;
 							if (tokenDayMonth && firstMonthToken != null) {
@@ -2110,13 +2184,7 @@ public class OpeningHoursParser {
 
 						} else if (pair[0] != null) {
 							if (pair[0].type == TokenType.TOKEN_HOLIDAY) {
-								if (pair[0].mainNumber == 0) {
-									basic.publicHoliday = true;
-								} else if (pair[0].mainNumber == 1) {
-									basic.schoolHoliday = true;
-								} else if (pair[0].mainNumber == 2) {
-									basic.easter = true;
-								}
+								setHolidayFlag(basic, pair[0].mainNumber);
 							} else if (pair[0].mainNumber >= 0) {
 								Token firstMonthToken = pair[0].parent;
 								if (tokenDayMonth && firstMonthToken != null) {
@@ -2124,6 +2192,9 @@ public class OpeningHoursParser {
 								}
 								if (array != null) {
 									array[pair[0].mainNumber] = true;
+									if (pair[0].type == TokenType.TOKEN_DAY_WEEK && pair[0].nthMask != 0) {
+										basic.setDayNthMask(pair[0].mainNumber, pair[0].nthMask);
+									}
 								}
 							}
 						}
@@ -2246,6 +2317,16 @@ public class OpeningHoursParser {
 		rules.add(0, basic);
 	}
 
+	private static void setHolidayFlag(BasicOpeningHourRule basic, int holidayIndex) {
+		if (holidayIndex == 0) {
+			basic.publicHoliday = true;
+		} else if (holidayIndex == 1) {
+			basic.schoolHoliday = true;
+		} else if (holidayIndex == 2) {
+			basic.easter = true;
+		}
+	}
+
 	private static void fillFirstLastYearsDayOfMonth(BasicOpeningHourRule basic, Token[] pair) {
 		int startMonth = pair[0].parent == null ? pair[0].mainNumber : pair[0].parent.mainNumber;
 		int startDayOfMonth = pair[0].parent == null ? 0 : pair[0].mainNumber;
@@ -2287,6 +2368,51 @@ public class OpeningHoursParser {
 				break;
 			}
 		}
+	}
+
+	/**
+	 * Recognize nth weekday tokens like "su[1]", "su[-1]" or "su[1,3]"
+	 */
+	private static void findNthWeekday(Token t, String[] daysStr) {
+		int bracket = t.text.indexOf('[');
+		if (bracket <= 0 || !t.text.endsWith("]")) {
+			return;
+		}
+		String day = t.text.substring(0, bracket);
+		for (int i = 0; i < daysStr.length; i++) {
+			if (daysStr[i].equals(day)) {
+				int mask = parseNthMask(t.text.substring(bracket + 1, t.text.length() - 1));
+				if (mask != 0) {
+					t.type = TokenType.TOKEN_DAY_WEEK;
+					t.mainNumber = i;
+					t.nthMask = mask;
+				}
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Parse an nth weekday list like "1", "-1" or "1,3" into a bit mask:
+	 * bits 0-4 for the 1st-5th weekday of the month, bits 5-9 for the last-5th last one
+	 */
+	private static int parseNthMask(String list) {
+		int mask = 0;
+		for (String part : list.split(",")) {
+			try {
+				int n = Integer.parseInt(part.trim());
+				if (n >= 1 && n <= 5) {
+					mask |= 1 << (n - 1);
+				} else if (n <= -1 && n >= -5) {
+					mask |= 1 << (4 - n);
+				} else {
+					return 0;
+				}
+			} catch (NumberFormatException e) {
+				return 0;
+			}
+		}
+		return mask;
 	}
 
 	private static List<List<String>> splitSequences(String format) {

--- a/OsmAnd-java/src/test/java/net/osmand/util/OpeningHoursParserTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/util/OpeningHoursParserTest.java
@@ -645,6 +645,67 @@ public class OpeningHoursParserTest {
 		testGetShortInfo();
 		testTimeRestrictedOffRules();
 		testMonthRuleOverride();
+		testHolidayWithWeekday();
+		testNthWeekdayOfMonth();
+	}
+
+	private void testHolidayWithWeekday() throws ParseException {
+		// "PH Su" means "public holidays falling on Sunday" and must not fill
+		// the weekday range Mo-Su (#23990)
+		OpeningHoursParser.initLocalStrings(Locale.UK);
+		OpeningHoursParser.setTwelveHourFormattingEnabled(false, Locale.UK);
+		OpeningHours hours = parseOpenedHours("Tu-Sa,PH 10:00-12:00,14:00-19:00; PH Su off");
+		System.out.println(hours);
+		testParsedAndAssembledCorrectly("Tu-Sa, PH 10:00-12:00, 14:00-19:00; PH off", hours);
+		testOpened("07.10.2025 11:00", hours, true);  // regular Tuesday must stay open
+		testOpened("05.10.2025 11:00", hours, false); // regular Sunday
+		testOpened("06.10.2025 11:00", hours, false); // Monday
+		testInfo("07.10.2025 11:00", hours, "Will close at 12:00");
+
+		// without holiday info the rule can not be applied to regular weekdays
+		hours = parseOpenedHours("PH Su 08:30-12:30");
+		System.out.println(hours);
+		testParsedAndAssembledCorrectly("PH 08:30-12:30", hours);
+		testOpened("06.10.2025 09:00", hours, false); // Monday
+		testOpened("05.10.2025 09:00", hours, false); // regular Sunday
+
+		hours = parseOpenedHours("SH Mo-Fr 10:00-14:00");
+		System.out.println(hours);
+		testOpened("06.10.2025 11:00", hours, false); // regular Monday
+	}
+
+	private void testNthWeekdayOfMonth() throws ParseException {
+		// nth weekday of the month like "Su[1]", "Su[-1]" or "Su[1,3]" (#23990)
+		OpeningHoursParser.initLocalStrings(Locale.UK);
+		OpeningHoursParser.setTwelveHourFormattingEnabled(false, Locale.UK);
+		OpeningHours hours = parseOpenedHours("Jul Su[1] 08:00-18:00");
+		System.out.println(hours);
+		testParsedAndAssembledCorrectly("Jul Su[1] 08:00-18:00", hours);
+		testOpened("06.07.2025 10:00", hours, true);  // 1st Sunday of July
+		testOpened("13.07.2025 10:00", hours, false); // 2nd Sunday
+		testOpened("07.07.2025 10:00", hours, false); // Monday
+		testOpened("01.06.2025 10:00", hours, false); // Sunday outside July
+
+		hours = parseOpenedHours("Nov Su[-1] 08:00-18:00");
+		System.out.println(hours);
+		testParsedAndAssembledCorrectly("Nov Su[-1] 08:00-18:00", hours);
+		testOpened("30.11.2025 10:00", hours, true);  // last Sunday of November
+		testOpened("23.11.2025 10:00", hours, false); // 4th but not last Sunday
+
+		hours = parseOpenedHours("Su[1,3] 08:00-12:00");
+		System.out.println(hours);
+		testOpened("05.10.2025 09:00", hours, true);  // 1st Sunday
+		testOpened("12.10.2025 09:00", hours, false); // 2nd Sunday
+		testOpened("19.10.2025 09:00", hours, true);  // 3rd Sunday
+
+		// full rule from #23990
+		hours = parseOpenedHours("Tu-Sa,PH 10:00-12:00,14:00-19:00; PH Su off; May 01,Dec 25 off; Jul Su[1] 08:00-18:00; Nov Su[4] 08:00-18:00");
+		System.out.println(hours);
+		testOpened("07.10.2025 11:00", hours, true);  // regular Tuesday
+		testOpened("01.05.2025 11:00", hours, false); // May 1st
+		testOpened("06.07.2025 09:00", hours, true);  // 1st Sunday of July
+		testOpened("23.11.2025 09:00", hours, true);  // 4th Sunday of November
+		testOpened("05.10.2025 11:00", hours, false); // regular Sunday
 	}
 
 	private void testTimeRestrictedOffRules() throws ParseException {

--- a/OsmAnd-java/src/test/java/net/osmand/util/OpeningHoursParserTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/util/OpeningHoursParserTest.java
@@ -643,6 +643,80 @@ public class OpeningHoursParserTest {
 		testComma();
 		testYearFormats();
 		testGetShortInfo();
+		testTimeRestrictedOffRules();
+		testMonthRuleOverride();
+	}
+
+	private void testTimeRestrictedOffRules() throws ParseException {
+		// "off" rules with time ranges must only turn off their own time windows
+		// and must not discard opening/closing times found by other rules (#22907)
+		OpeningHoursParser.initLocalStrings(Locale.UK);
+		OpeningHoursParser.setTwelveHourFormattingEnabled(false, Locale.UK);
+		OpeningHours hours = parseOpenedHours("Mo-Fr 08:30-12:30,14:00-19:30; Sa 09:00-12:30; Jul-Aug 19:00-19:30 off; PH off");
+		System.out.println(hours);
+		// Wednesday inside the Jul-Aug period
+		testOpened("02.07.2025 13:50", hours, false);
+		testInfo("02.07.2025 13:50", hours, "Will open at 14:00");
+		testInfo("02.07.2025 05:00", hours, "Open from 08:30");
+		testInfo("02.07.2025 10:00", hours, "Open until 12:30");
+		testInfo("02.07.2025 12:20", hours, "Will close at 12:30");
+		// the "off" range shortens the evening interval
+		testOpened("02.07.2025 14:05", hours, true);
+		testInfo("02.07.2025 14:05", hours, "Open until 19:00");
+		testOpened("02.07.2025 19:10", hours, false);
+		testInfo("02.07.2025 21:00", hours, "Will open tomorrow at 08:30");
+		// outside the Jul-Aug period the "off" rule has no effect
+		testInfo("03.09.2025 13:50", hours, "Will open at 14:00");
+		testInfo("03.09.2025 14:05", hours, "Open until 19:30");
+
+		// lunch break: reopening time is the end of the "off" range
+		hours = parseOpenedHours("Mo-Fr 08:00-18:00; Mo-Fr 12:00-13:00 off");
+		System.out.println(hours);
+		testOpened("06.10.2025 12:30", hours, false);
+		testInfo("06.10.2025 12:30", hours, "Will open at 13:00");
+		testInfo("06.10.2025 10:30", hours, "Will close at 12:00");
+		testInfo("06.10.2025 14:00", hours, "Open until 18:00");
+
+		// a passed "off" range must not affect the closing time anymore (#22931)
+		hours = parseOpenedHours("Tu-Fr 08:00-17:00; Mo-Fr 12:00-13:00 off \"Lunch\"");
+		System.out.println(hours);
+		testInfo("07.10.2025 09:00", hours, "Open until 12:00 - Lunch");
+		testInfo("07.10.2025 12:30", hours, "Will open at 13:00 - Lunch");
+		testInfo("07.10.2025 15:00", hours, "Will close at 17:00");
+
+		// multiple "off" time ranges in one rule
+		hours = parseOpenedHours("Mo-Fr 08:00-20:00; Mo-Fr 10:00-10:30,15:00-15:30 off");
+		System.out.println(hours);
+		testInfo("06.10.2025 09:00", hours, "Will close at 10:00");
+		testInfo("06.10.2025 10:15", hours, "Will open at 10:30");
+		testInfo("06.10.2025 12:00", hours, "Open until 15:00");
+		testInfo("06.10.2025 16:00", hours, "Open until 20:00");
+
+		// whole-day "off" rules by year/day-month ranges must discard the opening time of that day (#21780)
+		hours = parseOpenedHours("Mo-Fr 09:00-20:00; Sa 09:00-18:00; 2025 Jan 07 - 2025 Feb 26 closed");
+		System.out.println(hours);
+		testOpened("23.01.2025 07:40", hours, false);
+		testInfo("23.01.2025 07:40", hours, "2025 Jan 7-2025 Feb 26 off");
+		testOpened("23.01.2025 12:00", hours, false);
+		testInfo("27.02.2025 09:30", hours, "Open until 20:00");
+		testInfo("06.01.2025 12:00", hours, "Open until 20:00");
+	}
+
+	private void testMonthRuleOverride() throws ParseException {
+		// later month rules override the default rule also inside the default time window (#23457)
+		OpeningHoursParser.initLocalStrings(Locale.UK);
+		OpeningHoursParser.setTwelveHourFormattingEnabled(false, Locale.UK);
+		OpeningHours hours = parseOpenedHours("07:00-17:00; Mar 07:00-19:00; Apr 07:00-21:00; May-Aug 07:00-22:00; Sep 07:00-21:00; Oct 07:00-19:00");
+		System.out.println(hours);
+		testOpened("12.09.2025 14:09", hours, true);
+		testInfo("12.09.2025 14:09", hours, "Open until 21:00");
+		testInfo("12.09.2025 18:00", hours, "Open until 21:00");
+		testInfo("12.09.2025 20:00", hours, "Will close at 21:00");
+		testOpened("12.09.2025 21:30", hours, false);
+		testInfo("12.09.2025 21:30", hours, "Will open tomorrow at 07:00");
+		testInfo("12.01.2025 14:09", hours, "Open until 17:00");
+		testInfo("12.06.2025 21:30", hours, "Will close at 22:00");
+		testInfo("12.03.2025 18:30", hours, "Will close at 19:00");
 	}
 
 	private void testGetShortInfo() throws ParseException {

--- a/OsmAnd-java/src/test/java/net/osmand/util/OpeningHoursParserTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/util/OpeningHoursParserTest.java
@@ -647,6 +647,33 @@ public class OpeningHoursParserTest {
 		testMonthRuleOverride();
 		testHolidayWithWeekday();
 		testNthWeekdayOfMonth();
+		testOvernightNextOpening();
+	}
+
+	private void testOvernightNextOpening() throws ParseException {
+		// overnight rules of other days must not report an opening time for today,
+		// and a still running overnight session determines the closing time
+		OpeningHoursParser.initLocalStrings(Locale.UK);
+		OpeningHoursParser.setTwelveHourFormattingEnabled(false, Locale.UK);
+		OpeningHours hours = parseOpenedHours("Mo-Th,Su 09:00-00:30; Fr 09:00-16:30");
+		System.out.println(hours);
+		// Friday evening: Saturday is closed, so the next opening is on Sunday
+		// (was "Open from 09:00", which means "opens today")
+		testOpened("06.02.2026 21:00", hours, false);
+		testInfo("06.02.2026 21:00", hours, "Will open on 09:00 Sun.");
+		testInfo("06.02.2026 19:00", hours, "Will open on 09:00 Sun.");
+		// Friday 00:15 is inside the Thursday session which ends 00:30
+		// (was "Open until 16:30" from the Friday rule)
+		testOpened("06.02.2026 00:15", hours, true);
+		testInfo("06.02.2026 00:15", hours, "Will close at 00:30");
+		// unchanged behavior around it
+		testInfo("06.02.2026 12:00", hours, "Open until 16:30");
+		testInfo("06.02.2026 15:00", hours, "Will close at 16:30");
+		testOpened("07.02.2026 12:00", hours, false);
+		testInfo("07.02.2026 12:00", hours, "Will open tomorrow at 09:00");
+		testOpened("08.02.2026 23:00", hours, true);
+		testInfo("08.02.2026 23:00", hours, "Open until 00:30");
+		testInfo("09.02.2026 07:00", hours, "Will open at 09:00");
 	}
 
 	private void testHolidayWithWeekday() throws ParseException {

--- a/OsmAnd-java/src/test/java/net/osmand/util/OpeningHoursParserTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/util/OpeningHoursParserTest.java
@@ -648,6 +648,7 @@ public class OpeningHoursParserTest {
 		testHolidayWithWeekday();
 		testNthWeekdayOfMonth();
 		testOvernightNextOpening();
+		testRealWorldSchedules();
 	}
 
 	private void testOvernightNextOpening() throws ParseException {
@@ -671,9 +672,131 @@ public class OpeningHoursParserTest {
 		testInfo("06.02.2026 15:00", hours, "Will close at 16:30");
 		testOpened("07.02.2026 12:00", hours, false);
 		testInfo("07.02.2026 12:00", hours, "Will open tomorrow at 09:00");
+		// Sunday evening: the overnight session closes at 00:30 the next day, so the
+		// "closing soon" warning must also trigger before midnight (was "Open until 00:30")
 		testOpened("08.02.2026 23:00", hours, true);
-		testInfo("08.02.2026 23:00", hours, "Open until 00:30");
+		testInfo("08.02.2026 22:00", hours, "Open until 00:30"); // 2.5 h to closing
+		testInfo("08.02.2026 23:00", hours, "Will close at 00:30"); // 1.5 h to closing
+		testInfo("08.02.2026 23:50", hours, "Will close at 00:30"); // 40 min to closing
 		testInfo("09.02.2026 07:00", hours, "Will open at 09:00");
+	}
+
+	// Real-world schedules (the kind actually tagged on OSM shops, bars, markets, museums)
+	// exercising the fixes of this PR end to end: time-restricted "off", seasonal month
+	// overrides, nth weekday of month and overnight next-open/close.
+	private void testRealWorldSchedules() throws ParseException {
+		OpeningHoursParser.initLocalStrings(Locale.UK);
+		OpeningHoursParser.setTwelveHourFormattingEnabled(false, Locale.UK);
+
+		// weekend-only nightclub, overnight into the next morning; next opening after the
+		// last overnight day (Sat) skips the whole week to the following Friday
+		OpeningHours hours = parseOpenedHours("Fr,Sa 20:00-04:00");
+		System.out.println(hours);
+		testParsedAndAssembledCorrectly("Fr, Sa 20:00-04:00", hours);
+		testInfo("03.01.2025 19:00", hours, "Will open at 20:00");     // Fri, opens in 1 h
+		testInfo("03.01.2025 23:30", hours, "Open until 04:00");       // Fri night, closes 04:00
+		testInfo("04.01.2025 02:00", hours, "Will close at 04:00");    // Sat 02:00, Fri session
+		testInfo("05.01.2025 01:00", hours, "Open until 04:00");       // Sun 01:00, Sat session
+		testOpened("05.01.2025 05:00", hours, false);
+		testInfo("05.01.2025 05:00", hours, "Will open on 20:00 Fri."); // closed until next Fri
+		testInfo("06.01.2025 12:00", hours, "Will open on 20:00 Fri.");
+
+		// neighbourhood bar, mix of overnight and non-overnight days; the "closing soon"
+		// warning must trigger before midnight for the overnight days too
+		hours = parseOpenedHours("We-Th 18:00-01:00; Fr-Sa 18:00-03:00; Su 16:00-23:00");
+		System.out.println(hours);
+		testParsedAndAssembledCorrectly("We, Th 18:00-01:00; Fr, Sa 18:00-03:00; Su 16:00-23:00", hours);
+		testInfo("04.06.2025 23:30", hours, "Will close at 01:00");    // Wed 23:30 -> 90 min to close
+		testInfo("05.06.2025 00:30", hours, "Will close at 01:00");    // Thu 00:30, Wed session
+		testInfo("07.06.2025 02:00", hours, "Will close at 03:00");    // Sat 02:00, Fri session
+		testInfo("08.06.2025 22:00", hours, "Will close at 23:00");    // Sun evening
+		testOpened("08.06.2025 03:00", hours, false);
+		testInfo("08.06.2025 03:00", hours, "Open from 16:00");        // Sun early morning, opens 16:00
+		testInfo("10.06.2025 20:00", hours, "Will open tomorrow at 18:00"); // Tue closed
+
+		// ice-cream parlour with a reduced winter schedule that wraps the year end (Dec-Feb);
+		// the winter rule must win inside the summer time window too (#23457 family)
+		hours = parseOpenedHours("Mo-Su 12:00-22:00; Dec-Feb Mo-Su 13:00-18:00");
+		System.out.println(hours);
+		testInfo("15.01.2026 14:00", hours, "Open until 18:00");       // winter override
+		testOpened("07.02.2026 12:30", hours, false);
+		testInfo("07.02.2026 12:30", hours, "Will open at 13:00");     // 12:30 winter-closed
+		testInfo("10.12.2025 20:00", hours, "Will open tomorrow at 13:00");
+		testInfo("20.06.2025 21:00", hours, "Will close at 22:00");    // summer
+		testInfo("30.11.2025 19:00", hours, "Open until 22:00");       // Nov still summer
+
+		// museum with a Monday closing day and a wrap-around winter season (Nov-Mar)
+		hours = parseOpenedHours("Tu-Su 10:00-18:00; Nov-Mar Tu-Su 10:00-16:00");
+		System.out.println(hours);
+		testInfo("14.02.2026 15:00", hours, "Will close at 16:00");    // winter
+		testInfo("15.05.2025 17:00", hours, "Will close at 18:00");    // summer
+		testOpened("08.06.2025 19:00", hours, false);
+		testInfo("08.06.2025 19:00", hours, "Will open on 10:00 Tue."); // Sun evening, Mon closed
+		testInfo("20.01.2026 17:00", hours, "Will open tomorrow at 10:00");
+		testInfo("20.12.2025 07:30", hours, "Open from 10:00");
+
+		// pharmacy with a lunch closure; a passed lunch break must not shorten the afternoon
+		// closing time (#22931) and the reopening is the end of the "off" range
+		hours = parseOpenedHours("Mo-Fr 08:30-18:30; Sa 09:00-13:00; Mo-Fr 13:00-14:00 off");
+		System.out.println(hours);
+		testParsedAndAssembledCorrectly("Mo-Fr 08:30-18:30; Sa 09:00-13:00; Mo-Fr 13:00-14:00 off", hours);
+		testInfo("02.06.2025 10:30", hours, "Open until 13:00");       // closes for lunch
+		testOpened("02.06.2025 13:20", hours, false);
+		testInfo("02.06.2025 13:20", hours, "Will open at 14:00");     // lunch break
+		testInfo("02.06.2025 15:00", hours, "Open until 18:30");       // afternoon, full closing time
+		testInfo("02.06.2025 17:00", hours, "Will close at 18:30");
+		testInfo("07.06.2025 11:00", hours, "Will close at 13:00");    // Saturday
+		testInfo("08.06.2025 12:00", hours, "Will open tomorrow at 08:30");
+
+		// weekly farmers market plus a "first Sunday of the month" special during the season
+		hours = parseOpenedHours("We,Sa 07:00-13:00; Apr-Oct Su[1] 08:00-16:00");
+		System.out.println(hours);
+		testParsedAndAssembledCorrectly("We, Sa 07:00-13:00; Apr-Oct Su[1] 08:00-16:00", hours);
+		testOpened("06.07.2025 07:30", hours, false);
+		testInfo("06.07.2025 07:30", hours, "Will open at 08:00");     // 1st Sunday of July
+		testInfo("06.07.2025 09:00", hours, "Open until 16:00");
+		testInfo("06.07.2025 15:00", hours, "Will close at 16:00");
+		testOpened("13.07.2025 10:00", hours, false);                 // 2nd Sunday, no market
+		testInfo("13.07.2025 10:00", hours, "Will open on 07:00 Wed.");
+		testInfo("04.10.2025 12:00", hours, "Will close at 13:00");    // Saturday market
+		testOpened("07.01.2025 08:00", hours, false);                 // January, out of season
+
+		// rural church sharing a priest: mass on 1st/3rd/5th Sundays in the morning,
+		// on 2nd/4th Sundays in the evening; the tricky 5th-Sunday occurrence must count
+		hours = parseOpenedHours("Su[1,3,5] 09:00-10:00; Su[2,4] 18:00-19:00");
+		System.out.println(hours);
+		testParsedAndAssembledCorrectly("Su[1,3,5] 09:00-10:00; Su[2,4] 18:00-19:00", hours);
+		testOpened("03.08.2025 09:30", hours, true);                  // 1st Sunday morning
+		testInfo("03.08.2025 09:30", hours, "Will close at 10:00");
+		testOpened("10.08.2025 09:30", hours, false);                 // 2nd Sunday, no morning mass
+		testInfo("10.08.2025 09:30", hours, "Open from 18:00");
+		testInfo("10.08.2025 18:30", hours, "Will close at 19:00");   // 2nd Sunday evening
+		testOpened("31.08.2025 09:45", hours, true);                  // 5th Sunday counts
+		testInfo("31.08.2025 09:45", hours, "Will close at 10:00");
+		testInfo("06.08.2025 12:00", hours, "Will open on 18:00 Sun."); // next is 2nd Sunday
+
+		// bakery open every day including Sunday morning, closed on public holidays; the
+		// trailing "PH off" must not disturb the regular Sunday hours
+		hours = parseOpenedHours("Mo-Fr 06:00-18:30; Sa 06:30-13:00; Su 07:30-11:00; PH off");
+		System.out.println(hours);
+		testParsedAndAssembledCorrectly("Mo-Fr 06:00-18:30; Sa 06:30-13:00; Su 07:30-11:00; PH off", hours);
+		testInfo("12.10.2025 08:00", hours, "Open until 11:00");       // Sunday morning
+		testInfo("12.10.2025 09:30", hours, "Will close at 11:00");
+		testOpened("12.10.2025 12:00", hours, false);
+		testInfo("12.10.2025 12:00", hours, "Will open tomorrow at 06:00");
+		testInfo("11.10.2025 13:30", hours, "Will open tomorrow at 07:30"); // Sat -> Sun
+		testInfo("10.10.2025 18:00", hours, "Will close at 18:30");    // Friday
+		testInfo("06.10.2025 03:00", hours, "Open from 06:00");
+
+		// self-service car wash with a reduced-noise winter evening off window; the seasonal
+		// "off" must only shorten its own window and only in its months
+		hours = parseOpenedHours("Mo-Sa 07:00-21:00; Nov-Feb 19:00-21:00 off");
+		System.out.println(hours);
+		testInfo("15.01.2025 18:30", hours, "Will close at 19:00");    // winter, off shortens evening
+		testInfo("16.07.2025 18:30", hours, "Open until 21:00");       // summer, no off
+		testInfo("16.07.2025 19:30", hours, "Will close at 21:00");
+		testInfo("16.07.2025 04:30", hours, "Open from 07:00");
+		testInfo("15.01.2025 06:00", hours, "Will open at 07:00");
 	}
 
 	private void testHolidayWithWeekday() throws ParseException {

--- a/OsmAnd-java/src/test/java/net/osmand/util/OpeningHoursParserTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/util/OpeningHoursParserTest.java
@@ -706,6 +706,18 @@ public class OpeningHoursParserTest {
 		testOpened("06.07.2025 09:00", hours, true);  // 1st Sunday of July
 		testOpened("23.11.2025 09:00", hours, true);  // 4th Sunday of November
 		testOpened("05.10.2025 11:00", hours, false); // regular Sunday
+
+		// library from #7857, the "Sa[1,3]" rule was parsed as "24/7" before
+		hours = parseOpenedHours("Jul-Aug Mo,Tu 13:00-19:00; Jul-Aug We-Fr 08:00-14:00; Jul-Aug Sa off; "
+				+ "Jan-Jun,Sep-Dec Mo,Tu 13:00-19:00; Jan-Jun,Sep-Dec We-Fr 08:00-16:00; Jan-Jun,Sep-Dec Sa[1,3] 09:00-13:00; PH off");
+		System.out.println(hours);
+		testOpened("05.11.2019 05:00", hours, false); // issue scenario: Tuesday 5 AM, was "open 24/7"
+		testOpened("05.11.2019 14:00", hours, true);
+		testOpened("01.11.2025 10:00", hours, true);  // 1st Saturday of November
+		testOpened("08.11.2025 10:00", hours, false); // 2nd Saturday
+		testOpened("15.11.2025 10:00", hours, true);  // 3rd Saturday
+		testOpened("05.07.2025 10:00", hours, false); // Saturday in July is off
+		testOpened("09.07.2025 09:00", hours, true);  // Wednesday in July
 	}
 
 	private void testTimeRestrictedOffRules() throws ParseException {


### PR DESCRIPTION
## Summary

This PR fixes two independent problem areas in `OpeningHoursParser`:
- the **"Will open at ... / Open until ..." status** computed in `OpeningHours.getTimeDay()` (three defects), and
- the **parsing of holiday-with-weekday selectors and nth-weekday-of-month syntax** (two defects).

Fixes #22907
Fixes #23457
Fixes #21780
Fixes #23990
Fixes #7857 (the nth-weekday support also fixes the 2019 library report — `Jan-Jun,Sep-Dec Sa[1,3] 09:00-13:00` was parsed as "open 24\/7"; regression test with the exact schedule added)
Partially addresses #22931 (the wrong closing-time calculation; the red highlighting of all schedule lines in the context menu is UI-side and not covered here)

## Root causes

### Evaluation (`getTimeDay`)

1. **`prevRule` could point to a rule that does not apply to the current day** (#23457). `prevRule` was updated on *every* loop iteration, so for `07:00-17:00; ...; May-Aug 07:00-22:00; Sep 07:00-21:00` evaluated on Sep 12, the overlap check for the `Sep` rule ran against the non-matching `May-Aug` rule, returned `false`, and `getTimeDay` returned the stale default closing time `17:00` early.

2. **Time-restricted `off` rules overwrite instead of merge** (#22907, #22931). A rule like `Jul-Aug 19:00-19:30 off` matches the whole day via `containsDay()`/`containsMonth()`. When its `getTime()` produced no time (or the wrong one), it *replaced* a valid time already found by earlier rules:
   - during the lunch break, the valid "opens at 14:00" was replaced by an empty string, so the info fell through to "Will open tomorrow at 08:30";
   - in the morning, "Open until 12:30" was replaced by the off-range start "19:00";
   - an already passed off-range (`12:00-13:00 off` at 15:00) still replaced the real closing time `17:00` (#22931).
   Now the off rule only *adjusts* the previously found time: an opening time inside the off range moves to the range end, and a closing time is shortened only if the off range starts after the current time and before the found closing time.

3. **Rules defined by day-month or year ranges were invisible to `getTimeDay`** (#21780). `2025 Jan 07 - 2025 Feb 26 closed` does not set weekdays, so `containsDay()` is `false` and the rule was skipped — before 09:00 the app showed "Will open at 09:00" although the place was closed for weeks. The new `appliesToDay()` mirrors the day-applicability logic of `calculate()` (day-month masks and year ranges included, no previous-day spillover).

4. **Overnight rules of other days produced wrong times for today.** For `Mo-Th,Su 09:00-00:30; Fr 09:00-16:30` on Friday evening the app showed "Open from 09:00" — which by its semantics means "opens later today" — although Friday hours were over and Saturday is closed (next opening: Sunday). `getTimeMinutes()` accepted `CURRENT_DAY_TIME_LIMIT` in the overnight branch even when the day checks had not matched. It now requires a matching day, so the info correctly falls through to "Will open on 09:00 Sun.". Additionally, while an overnight session of the previous day is still running (Friday 00:15 during the Thursday session), the closing time now comes from that session ("Will close at 00:30") instead of the current day rule ("Open until 16:30").

Supporting refactor: `BasicOpeningHourRule.getTime()` is split into `getTimeMinutes()` (returns minutes, `-1` for none) + `formatResult()`, unchanged in behavior, so `getTimeDay` can compare times numerically. While there, the `WITHOUT_TIME_LIMIT` branch now skips *already passed* off-ranges (`!off || diff >= 0`), which picks the correct range when one rule contains several off windows (`10:00-10:30,15:00-15:30 off`).

### Parsing (#23990)

4. **`PH Su off` was parsed as the weekday range `Mo-Su off`.** `TOKEN_HOLIDAY` and `TOKEN_DAY_WEEK` share the same parse order, so `PH Su` formed a range pair and `fillRuleArray` treated the `PH` token index `0` as *Monday* — the shop from the report was displayed as **"24/7 closed"** even on regular Tuesdays, and `PH Su 08:30-12:30` opened the POI *every* day. Per the opening_hours specification, a weekday after a holiday token restricts the holiday ("public holidays falling on Sunday"). Since OsmAnd has no holiday calendar, such rules now conservatively set only the holiday flag (like `PH off` alone does) and no longer touch regular weekdays. Display note: the weekday restriction is currently dropped when re-assembling the rule string (`PH Su off` renders as `PH off`).

5. **Nth weekday of month (`Jul Su[1] 08:00-18:00`) was silently dropped**, turning the rule into "all days of July"; a rule *starting* with such a token (`Su[1,3] 08:00-12:00`) made the whole value unparseable (`null`). The tokenizer now keeps `Su[1]`-style tokens together (`-`/`,` inside brackets are not delimiters), recognizes `Su[1]`, `Su[-1]` and `Su[1,3]`, stores an nth-mask per weekday, and applies it in `calculate()`, `isOpenedForTime()` and `appliesToDay()`. `toRuleString()` re-assembles the syntax correctly.

## Behavior change (before → after)

`Mo-Fr 08:30-12:30,14:00-19:30; Sa 09:00-12:30; Jul-Aug 19:00-19:30 off; PH off` (#22907, Wed inside Jul–Aug):

| Time | Before | After |
|---|---|---|
| 05:00 | Will open tomorrow at 08:30 | Open from 08:30 |
| 10:00 | Open until 19:00 | Open until 12:30 |
| 12:20 | Open until 19:00 | Will close at 12:30 |
| 13:50 | Will open tomorrow at 08:30 | Will open at 14:00 |
| 14:05 | Open until 19:00 | Open until 19:00 (unchanged, off range shortens the evening) |

`07:00-17:00; Mar 07:00-19:00; Apr 07:00-21:00; May-Aug 07:00-22:00; Sep 07:00-21:00; Oct 07:00-19:00` (#23457):

| Time | Before | After |
|---|---|---|
| Sep 12, 14:09 | Open until 17:00 | Open until 21:00 |
| Sep 12, 18:00 | Open until 21:00 | Open until 21:00 (unchanged) |
| Jan 12, 14:09 | Open until 17:00 | Open until 17:00 (unchanged) |

`Mo-Fr 09:00-20:00; Sa 09:00-18:00; 2025 Jan 07 - 2025 Feb 26 closed` (#21780):

| Time | Before | After |
|---|---|---|
| Jan 23, 07:40 | Will open at 09:00 | 2025 Jan 7-2025 Feb 26 off |
| Feb 27, 09:30 | Open until 20:00 | Open until 20:00 (unchanged) |

`Tu-Sa,PH 10:00-12:00,14:00-19:00; PH Su off` (#23990):

| Time | Before | After |
|---|---|---|
| Tue 11:00 | closed, "24/7 off" | open, "Will close at 12:00" |
| regular Sun 11:00 | closed, "24/7 off" | closed, "Will open on 10:00 Tue." |
| assembled rule | `Tu-Sa, PH 10:00-12:00, 14:00-19:00; 24/7 off` | `Tu-Sa, PH 10:00-12:00, 14:00-19:00; PH off` |

`Jul Su[1] 08:00-18:00` (#23990):

| Time | Before | After |
|---|---|---|
| 1st Sunday of July | open | open (unchanged) |
| 2nd Sunday of July | open | closed |
| Monday in July | open | closed |
| assembled rule | `Jul Mo-Su 08:00-18:00` | `Jul Su[1] 08:00-18:00` |

`Tu-Fr 08:00-17:00; Mo-Fr 12:00-13:00 off "Lunch"` (#22931):

| Time | Before | After |
|---|---|---|
| 09:00 | Open until 12:00 - Lunch | Open until 12:00 - Lunch (unchanged) |
| 15:00 | Open until 12:00 - Lunch | Will close at 17:00 |

## Testing

- New test coverage in `OpeningHoursParserTest` (`testTimeRestrictedOffRules`, `testMonthRuleOverride`, `testHolidayWithWeekday`, `testNthWeekdayOfMonth`): all scenarios above plus behavior locks for cases that must **not** change (whole-day `off`/`closed` rules, lunch-break reopening, `PH off`/`Sa,Su,PH` comma form on regular days, split intervals, overnight rules, `||` fallback sequences, multiple off windows, the complete rule string from #23990).
- The new tests fail on current master exactly at the reported scenarios and pass with the fix.
- The complete existing `OpeningHoursParserTest` suite passes unchanged (run standalone with JUnit 4 under JDK 17).
- Verified that the changed evaluation paths only feed `OpeningHours.Info` (POI status line in the app, Android Auto, search results); conditional-access routing (`BinaryMapRouteReaderAdapter`) and the "Open now" POI filter go through `isOpenedForTimeV2()`/`calculate()`, which now additionally understand nth-weekday restrictions.
- Not verified on a device/emulator; no Gradle tasks were run locally (per AGENTS.md).

Note: #11571 ("months-range off" evaluating as 24/7 open) no longer reproduces on current master. Follow-up candidates not covered here: Easter date computation (#22010), localized PH/SH strings (#25225), POI time zones (#21825).

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Fable 5, reasoning effort: xhigh