### PR TITLE
Fix favorite points: description line breaks, icon/address from edited POIs, replace dialog distances

### DIFF
--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/MenuBuilder.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/MenuBuilder.java
@@ -118,12 +118,14 @@ import org.apache.commons.logging.Log;
 import java.lang.ref.WeakReference;
 import java.text.DateFormat;
 import java.util.*;
+import java.util.regex.Pattern;
 
 public class MenuBuilder {
 
 	private static final Log LOG = PlatformUtil.getLog(MenuBuilder.class);
 	public static final float SHADOW_HEIGHT_TOP_DP = 17f;
 	public static final int TITLE_LIMIT = 60;
+	private static final Pattern HTML_TAG_PATTERN = Pattern.compile("<\\s*[a-zA-Z]+[^>]*>");
 
 	protected static final String[] arrowChars = {"=>", " - "};
 
@@ -1062,7 +1064,7 @@ public class MenuBuilder {
 		textView.setTypeface(DEFAULT);
 		textView.setTextSize(16);
 		textView.setTextColor(ColorUtilities.getPrimaryTextColor(app, !light));
-		textView.setText(WikiArticleHelper.getPartialContent(description));
+		textView.setText(getDescriptionPreview(description));
 
 		if (customization.isFeatureEnabled(CONTEXT_MENU_LINKS_ID) && Linkify.addLinks(textView, Linkify.ALL)) {
 			textView.setMovementMethod(null);
@@ -1092,6 +1094,15 @@ public class MenuBuilder {
 		setDividerWidth(true);
 
 		return ll;
+	}
+
+	private String getDescriptionPreview(@NonNull String description) {
+		if (HTML_TAG_PATTERN.matcher(description).find()) {
+			return WikiArticleHelper.getPartialContent(description);
+		}
+		// plain text descriptions (e.g. of favorite points) keep their line breaks,
+		// the view is limited by maxLines and the "Read Full" button
+		return description;
 	}
 
 	protected void handlePhoneClick(@Nullable String title, @Nullable String text, @NonNull View view) {

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/editors/FavoritePointEditor.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/editors/FavoritePointEditor.java
@@ -13,9 +13,11 @@ import net.osmand.data.FavouritePoint;
 import net.osmand.data.LatLon;
 import net.osmand.osm.edit.Entity;
 import net.osmand.osm.edit.Entity.EntityType;
+import net.osmand.osm.edit.OSMSettings.OSMTagKey;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.activities.MapActivity;
 import net.osmand.plus.myplaces.favorites.FavoriteGroup;
+import net.osmand.plus.plugins.osmedit.OsmEditingPlugin;
 import net.osmand.plus.plugins.osmedit.data.OpenstreetmapPoint;
 import net.osmand.plus.render.RenderingIcons;
 import net.osmand.search.AmenitySearcher;
@@ -73,6 +75,11 @@ public class FavoritePointEditor extends PointEditor {
 		}
 		favorite = new FavouritePoint(latLon.getLatitude(), latLon.getLongitude(), title, lastCategory, altitude, 0);
 		favorite.setDescription("");
+		if (Algorithms.isEmpty(address) && object instanceof OpenstreetmapPoint point) {
+			// use the address entered in the OSM editor, reverse geocoding
+			// is not available for edited points yet
+			address = getEntityAddress(point.getEntity());
+		}
 		favorite.setAddress(address.isEmpty() ? title : address);
 
 		Amenity amenity = null;
@@ -97,7 +104,25 @@ public class FavoritePointEditor extends PointEditor {
 		} else if (object instanceof RenderedObject renderedObject) {
 			setMapObject(renderedObject);
 		}
+		if (object instanceof OpenstreetmapPoint point) {
+			// the icon should reflect the possibly modified type of the edited POI,
+			// map data may still contain the previous type (or none for created POIs)
+			int iconId = OsmEditingPlugin.getPoiTypeIconId(app, point.getEntity());
+			if (iconId != 0) {
+				favorite.setIconId(iconId);
+			}
+		}
 		FavoritePointEditorFragment.showInstance(mapActivity);
+	}
+
+	@NonNull
+	private String getEntityAddress(@NonNull Entity entity) {
+		String street = entity.getTag(OSMTagKey.ADDR_STREET);
+		String houseNumber = entity.getTag(OSMTagKey.ADDR_HOUSE_NUMBER);
+		if (!Algorithms.isEmpty(street)) {
+			return Algorithms.isEmpty(houseNumber) ? street : street + " " + houseNumber;
+		}
+		return "";
 	}
 
 	private void setAmenity(@NonNull Amenity amenity) {

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/editors/SelectFavouriteToReplaceBottomSheet.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/editors/SelectFavouriteToReplaceBottomSheet.java
@@ -56,6 +56,14 @@ public class SelectFavouriteToReplaceBottomSheet extends SelectFavouriteBottomSh
 	}
 
 	@Nullable
+	@Override
+	protected LatLon getReferenceLocation() {
+		// when replacing, distances should relate to the new point, not to the current location
+		FavouritePoint point = getReplacementPoint();
+		return point != null ? new LatLon(point.getLatitude(), point.getLongitude()) : null;
+	}
+
+	@Nullable
 	private FavouritePoint getReplacementPoint() {
 		Fragment target = getTargetFragment();
 		if (target instanceof FavoritePointEditorFragment editorFragment) {

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/other/FavouritesAdapter.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/other/FavouritesAdapter.java
@@ -8,10 +8,12 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import net.osmand.data.FavouritePoint;
+import net.osmand.data.LatLon;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.R;
 import net.osmand.plus.myplaces.favorites.FavoriteFolderFormatter;
@@ -34,6 +36,13 @@ public class FavouritesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 		this.app = (OsmandApplication) context.getApplicationContext();
 		this.favouritePoints = FavouritePoints;
 		cache = UpdateLocationUtils.getUpdateLocationViewCache(context);
+	}
+
+	/**
+	 * Show distances and directions relative to the given location instead of the current one
+	 */
+	public void setReferenceLocation(@Nullable LatLon location) {
+		cache.specialFrom = location;
 	}
 
 	@Override

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/other/SelectFavouriteBottomSheet.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/other/SelectFavouriteBottomSheet.java
@@ -50,6 +50,7 @@ public abstract class SelectFavouriteBottomSheet extends MenuBottomSheetDialogFr
 		sortMode = settings.FAVORITES_SORT_MODE.get();
 
 		adapter = new FavouritesAdapter(requireContext(), points);
+		adapter.setReferenceLocation(getReferenceLocation());
 		favouritesHelper = app.getFavoritesHelper();
 		if (favouritesHelper.isFavoritesLoaded()) {
 			loadFavorites();
@@ -122,9 +123,12 @@ public abstract class SelectFavouriteBottomSheet extends MenuBottomSheetDialogFr
 
 	private void sortFavourites() {
 		Collator collator = Collator.getInstance();
-		Location location = app.getLocationProvider().getLastStaleKnownLocation();
-		LatLon latLon = location != null ? new LatLon(location.getLatitude(), location.getLongitude())
-				: app.getMapViewTrackingUtilities().getMapLocation();
+		LatLon latLon = getReferenceLocation();
+		if (latLon == null) {
+			Location location = app.getLocationProvider().getLastStaleKnownLocation();
+			latLon = location != null ? new LatLon(location.getLatitude(), location.getLongitude())
+					: app.getMapViewTrackingUtilities().getMapLocation();
+		}
 
 		FavouritesComparator comparator = new FavouritesComparator(app, collator, latLon, sortMode);
 		Collections.sort(points, comparator);
@@ -208,6 +212,15 @@ public abstract class SelectFavouriteBottomSheet extends MenuBottomSheetDialogFr
 	@Override
 	protected int getCustomHeight() {
 		return dpToPx(300);
+	}
+
+	/**
+	 * @return the location distances and directions should relate to,
+	 * or null to use the current location
+	 */
+	@Nullable
+	protected LatLon getReferenceLocation() {
+		return null;
 	}
 
 	protected abstract void onFavouriteSelected(@NonNull FavouritePoint favourite);

--- a/OsmAnd/src/net/osmand/plus/plugins/osmedit/OsmEditingPlugin.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/osmedit/OsmEditingPlugin.java
@@ -13,6 +13,7 @@ import android.text.TextUtils;
 import android.text.style.StyleSpan;
 import android.view.View;
 
+import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -66,6 +67,7 @@ import net.osmand.plus.plugins.osmedit.quickactions.AddPOIAction;
 import net.osmand.plus.plugins.osmedit.quickactions.ShowHideOSMBugAction;
 import net.osmand.plus.plugins.osmedit.quickactions.ShowHideOSMEditsAction;
 import net.osmand.plus.quickaction.QuickActionType;
+import net.osmand.plus.render.RenderingIcons;
 import net.osmand.plus.settings.backend.preferences.CommonPreference;
 import net.osmand.plus.settings.backend.preferences.OsmandPreference;
 import net.osmand.plus.settings.enums.ThemeUsageContext;
@@ -93,6 +95,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 
@@ -623,6 +626,30 @@ public class OsmEditingPlugin extends OsmandPlugin {
 	@Override
 	public Drawable getAssetResourceImage() {
 		return app.getUIUtilities().getIcon(R.drawable.osm_editing);
+	}
+
+	/**
+	 * Resolve the icon of the (possibly modified) POI type of an edited entity
+	 */
+	@DrawableRes
+	public static int getPoiTypeIconId(@NonNull OsmandApplication app, @NonNull Entity entity) {
+		String poiTranslation = entity.getTag(POI_TYPE_TAG);
+		if (poiTranslation != null) {
+			Map<String, PoiType> poiTypeMap = app.getPoiTypes().getAllTranslatedNames(false);
+			PoiType poiType = poiTypeMap.get(poiTranslation.toLowerCase());
+			if (poiType != null) {
+				String id = null;
+				if (RenderingIcons.containsBigIcon(poiType.getIconKeyName())) {
+					id = poiType.getIconKeyName();
+				} else if (RenderingIcons.containsBigIcon(poiType.getOsmTag() + "_" + poiType.getOsmValue())) {
+					id = poiType.getOsmTag() + "_" + poiType.getOsmValue();
+				}
+				if (id != null) {
+					return RenderingIcons.getBigIconResourceId(id);
+				}
+			}
+		}
+		return 0;
 	}
 
 	public static String getEditName(OsmPoint point) {

--- a/OsmAnd/src/net/osmand/plus/plugins/osmedit/OsmEditsAdapter.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/osmedit/OsmEditsAdapter.java
@@ -16,18 +16,14 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 
-import net.osmand.osm.PoiType;
-import net.osmand.osm.edit.Entity;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.R;
 import net.osmand.plus.settings.enums.ThemeUsageContext;
 import net.osmand.plus.utils.UiUtilities;
 import net.osmand.plus.plugins.osmedit.data.OpenstreetmapPoint;
 import net.osmand.plus.plugins.osmedit.data.OsmPoint;
-import net.osmand.plus.render.RenderingIcons;
 
 import java.util.List;
-import java.util.Map;
 
 public class OsmEditsAdapter extends ArrayAdapter<Object> {
 
@@ -247,23 +243,7 @@ public class OsmEditsAdapter extends ArrayAdapter<Object> {
 	private Drawable getIcon(OsmPoint point) {
 		if (point.getGroup() == OsmPoint.Group.POI) {
 			OpenstreetmapPoint osmPoint = (OpenstreetmapPoint) point;
-			int iconResId = 0;
-			String poiTranslation = osmPoint.getEntity().getTag(Entity.POI_TYPE_TAG);
-			if (poiTranslation != null) {
-				Map<String, PoiType> poiTypeMap = app.getPoiTypes().getAllTranslatedNames(false);
-				PoiType poiType = poiTypeMap.get(poiTranslation.toLowerCase());
-				if (poiType != null) {
-					String id = null;
-					if (RenderingIcons.containsBigIcon(poiType.getIconKeyName())) {
-						id = poiType.getIconKeyName();
-					} else if (RenderingIcons.containsBigIcon(poiType.getOsmTag() + "_" + poiType.getOsmValue())) {
-						id = poiType.getOsmTag() + "_" + poiType.getOsmValue();
-					}
-					if (id != null) {
-						iconResId = RenderingIcons.getBigIconResourceId(id);
-					}
-				}
-			}
+			int iconResId = OsmEditingPlugin.getPoiTypeIconId(app, osmPoint.getEntity());
 			if (iconResId == 0) {
 				iconResId = R.drawable.ic_action_info_dark;
 			}

--- a/OsmAnd/src/net/osmand/plus/plugins/osmedit/OsmEditsLayer.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/osmedit/OsmEditsLayer.java
@@ -27,7 +27,6 @@ import net.osmand.data.LatLon;
 import net.osmand.data.PointDescription;
 import net.osmand.data.QuadRect;
 import net.osmand.data.RotatedTileBox;
-import net.osmand.osm.PoiType;
 import net.osmand.osm.edit.Entity;
 import net.osmand.plus.AppInitEvents;
 import net.osmand.plus.AppInitializeListener;
@@ -42,7 +41,6 @@ import net.osmand.plus.plugins.osmedit.data.OsmNotesPoint;
 import net.osmand.plus.plugins.osmedit.data.OsmPoint;
 import net.osmand.plus.plugins.osmedit.helpers.OpenstreetmapLocalUtil;
 import net.osmand.plus.plugins.osmedit.helpers.OsmBugsLocalUtil;
-import net.osmand.plus.render.RenderingIcons;
 import net.osmand.plus.utils.ColorUtilities;
 import net.osmand.plus.utils.NativeUtilities;
 import net.osmand.plus.views.OsmandMapTileView;
@@ -62,7 +60,6 @@ import net.osmand.util.MapUtils;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 public class OsmEditsLayer extends OsmandMapLayer implements IContextMenuProvider, IMoveObjectProvider,
 		MapTextProvider<OpenstreetmapPoint> {
@@ -224,21 +221,8 @@ public class OsmEditsLayer extends OsmandMapLayer implements IContextMenuProvide
 		if (osmPoint.getGroup() == POI) {
 			OpenstreetmapPoint osmP = (OpenstreetmapPoint) osmPoint;
 			int iconResId = 0;
-			String poiTranslation = osmP.getEntity().getTag(Entity.POI_TYPE_TAG);
-			if (poiTranslation != null && ctx != null) {
-				Map<String, PoiType> poiTypeMap = app.getPoiTypes().getAllTranslatedNames(false);
-				PoiType poiType = poiTypeMap.get(poiTranslation.toLowerCase());
-				if (poiType != null) {
-					String id = null;
-					if (RenderingIcons.containsBigIcon(poiType.getIconKeyName())) {
-						id = poiType.getIconKeyName();
-					} else if (RenderingIcons.containsBigIcon(poiType.getOsmTag() + "_" + poiType.getOsmValue())) {
-						id = poiType.getOsmTag() + "_" + poiType.getOsmValue();
-					}
-					if (id != null) {
-						iconResId = RenderingIcons.getBigIconResourceId(id);
-					}
-				}
+			if (ctx != null) {
+				iconResId = OsmEditingPlugin.getPoiTypeIconId(app, osmP.getEntity());
 			}
 			if (iconResId == 0) {
 				iconResId = R.drawable.ic_action_info_dark;


### PR DESCRIPTION
## Summary

Three independent fixes around favorite points, all reported or confirmed by the same set of issues:

Fixes #18655
Fixes #18648
Fixes #5930

## Root causes and changes

### Line breaks in favorite descriptions (#18655)

The description preview row in the context menu passed every description through `WikiArticleHelper.getPartialContent()`, which starts with `source.replaceAll("\n", "")` — appropriate for Wikipedia HTML, destructive for plain text entered by the user. `MenuBuilder.buildDescriptionRow()` now keeps plain text (no HTML tags) as is, so line breaks survive; HTML content (Wikipedia/Wikivoyage articles, amenity descriptions with markup) keeps using the existing partial-content path. The preview stays bounded by `maxLines(10)` + ellipsis + the "Read Full" button, which already showed the correct full text before (as noted in the issue).

### Icon and address of favorites created from edited POIs (#18648)

`FavoritePointEditor.add()` resolved the amenity for an `OpenstreetmapPoint` via the map-data searcher. Map data still contains the *pre-edit* type (or nothing for newly created POIs), so the favorite icon fell back to the last-used icon and the address field was filled with the place *name*:
- The icon is now derived from the `poi_type` tag of the *edited* entity — the same resolution `OsmEditsLayer`/`OsmEditsAdapter` already use, deduplicated into `OsmEditingPlugin.getPoiTypeIconId()`.
- If reverse geocoding provides no street (typical for local edits), the address is now taken from the `addr:street`/`addr:housenumber` tags entered in the POI editor.
- The map-data amenity lookup is kept for origin name and extensions.

Related: #18388 tracks the wrong subtype ordering for map amenities (milestone next-backend); the scenario reported there in the comments (favorite from an *edited* POI getting the icon of the last created favorite) is fixed by this PR.

### Distances in the "replace favorite" list (#5930)

`SelectFavouriteToReplaceBottomSheet` sorted and displayed favorites by distance from the current location. When replacing, the relevant reference is the *new point*. The base sheet now exposes `getReferenceLocation()` (default: current location, so `SelectFavouriteToGoBottomSheet` is unchanged) and the replace sheet returns the new point's location; `FavouritesAdapter` forwards it via the existing `UpdateLocationViewCache.specialFrom` mechanism (same pattern as the quick search list), so distances *and* direction arrows are relative to the new point.

## Testing

Verified end-to-end on an Android 15 (API 35) emulator running a debug build of this branch:
- **#18655**: favorite with a four-line plain-text description → the context menu description row shows all four lines with line breaks (before: one merged line).
- **#18648**: enabled the OSM editing plugin, created a POI (type *Cafe*, street *Teststrasse*, number *42*) as a local edit, then "Add favorite" from it → the editor preselects the cafe icon (icon category "Food") and the address field contains "Teststrasse 42" (before: default/last-used icon and the POI name as address).
- **#5930**: with the device GPS fixed ~5 mi away, opened the replace dialog for a new point → both listed favorites show distance/sorting relative to the new point (0.55 mi / 1.04 mi, matching the geodesic distances of the test fixture to the meter).
- Static checks: all callers of `buildDescriptionRow` (favorites, amenity and place-details menus — all bounded previews) and both duplicated icon-resolution sites reviewed; `SelectFavouriteToGoBottomSheet` keeps current-location behavior via the null default.
- No Gradle tasks were run by the agent (per AGENTS.md); the build for verification was produced locally by the contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Fable 5, reasoning effort: xhigh