### PR TITLE
Add English phrase for amenity=luggage_locker

### DIFF
--- a/OsmAnd/res/values/phrases.xml
+++ b/OsmAnd/res/values/phrases.xml
@@ -4987,6 +4987,7 @@
 	<string name="poi_avalanche_transceiver_checkpoint">Avalanche transceiver checkpoint</string>
 
 	<string name="poi_parcel_locker">Parcel locker</string>
+	<string name="poi_luggage_locker">Luggage locker</string>
 
 	<string name="poi_tiles">Tiles store</string>
 


### PR DESCRIPTION
Companion of https://github.com/osmandapp/OsmAnd-resources/pull/1396, which adds `amenity=luggage_locker` to `poi_types.xml` (fixes https://github.com/osmandapp/OsmAnd/issues/22680 together with it). Adds the English display name next to the parcel locker phrase; translations follow via Weblate as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Fable 5, reasoning effort: xhigh