### PR TITLE
Allow copying the context menu title by long-pressing the header

### DIFF
--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/MapContextMenuFragment.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/MapContextMenuFragment.java
@@ -58,6 +58,7 @@ import net.osmand.plus.mapcontextmenu.MenuController.MenuState;
 import net.osmand.plus.mapcontextmenu.controllers.FavouritePointMenuController;
 import net.osmand.plus.mapcontextmenu.controllers.TransportStopController;
 import net.osmand.plus.mapcontextmenu.other.MenuObjectUtils;
+import net.osmand.plus.mapcontextmenu.other.ShareMenu;
 import net.osmand.plus.routepreparationmenu.ChooseRouteFragment;
 import net.osmand.plus.routepreparationmenu.MapRouteInfoMenu;
 import net.osmand.plus.settings.backend.menuitems.MainContextMenuItemsSettings;
@@ -324,6 +325,17 @@ public class MapContextMenuFragment extends BaseFullScreenFragment implements Do
 
 		GestureDetector singleTapDetector = new GestureDetector(view.getContext(), new SingleTapConfirm());
 		GestureDetector swipeDetector = new GestureDetector(view.getContext(), new HorizontalSwipeConfirm(true));
+		// the header consumes all touch events for the slide gestures, so copying
+		// the title (place name, OSM note text) is detected here as well
+		GestureDetector titleLongPressDetector = new GestureDetector(view.getContext(), new GestureDetector.SimpleOnGestureListener() {
+			@Override
+			public void onLongPress(MotionEvent e) {
+				String title = menu.getTitleStr();
+				if (!Algorithms.isEmpty(title)) {
+					ShareMenu.copyToClipboardWithToast(view.getContext(), title, true);
+				}
+			}
+		});
 
 		View.OnTouchListener slideTouchListener = new View.OnTouchListener() {
 			private float dy;
@@ -351,6 +363,7 @@ public class MapContextMenuFragment extends BaseFullScreenFragment implements Do
 			public boolean onTouch(View v, MotionEvent event) {
 
 				if (!hasMoved && event.getY() <= menuTopViewHeight) {
+					titleLongPressDetector.onTouchEvent(event);
 					if (singleTapDetector.onTouchEvent(event)) {
 						moving = false;
 						openMenuHalfScreen();


### PR DESCRIPTION
## Summary

Place names and OSM note texts shown as the context menu title are often needed elsewhere — a typical case is copying an OSM note text into a translator before answering it, since notes are frequently written in the local language. Info and description rows of the menu already support copy on long-press; the title did not.

## Implementation

A plain `OnLongClickListener` on the title `TextView` never receives events because the menu header consumes all touches for the slide gestures (`InterceptorLinearLayout` + `slideTouchListener`) — verified on an emulator, where the long-press fell through to the map and selected a new point. The long-press is therefore detected by a `GestureDetector` inside the existing `slideTouchListener`, in the same header-area branch that already handles tap-to-expand, and copies `menu.getTitleStr()` via the existing `ShareMenu.copyToClipboardWithToast()`. Movement cancels the long-press through the detector's built-in touch-slop handling, so the slide gestures are unaffected.

## Testing

Verified on an Android 15 (API 35) emulator with a debug build of this branch:
- long-press on the title → toast "Copied to clipboard: Testbakery Three" and the Android system clipboard overlay confirming the copied text;
- single tap on the header still expands the menu to half screen;
- dragging the header still slides the menu up/down.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Fable 5, reasoning effort: xhigh