### PR TITLE
Fixed opening_hours parser for per-month + per-day combinations

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/util/OpeningHoursParser.java
+++ b/OsmAnd-java/src/main/java/net/osmand/util/OpeningHoursParser.java
@@ -815,6 +815,16 @@ public class OpeningHoursParser {
 			return dayMonths != null;
 		}
 
+		// Returns true if dayMonths has at least one entry for the given month,
+		// meaning it was added as a partial range (e.g. "Jun 15-30") rather than
+		// a whole-month entry (e.g. "Jul") which only populates months[].
+		private boolean monthHasDayRestrictions(int month) {
+			for (boolean b : dayMonths[month]) {
+				if (b) return true;
+			}
+			return false;
+		}
+
 		/**
 		 * return an array representing the months of the rule
 		 *
@@ -1560,7 +1570,7 @@ public class OpeningHoursParser {
 			if (hasYears()) {
 				thisDay = isOpened(year, month, dmonth);
 			} else {
-				if (thisDay && hasDayMonths()) {
+				if (thisDay && hasDayMonths() && monthHasDayRestrictions(month)) {
 					thisDay = dayMonths[month][dmonth];
 				}
 			}
@@ -1574,7 +1584,7 @@ public class OpeningHoursParser {
 					previousDay = isOpened(year, month, dmonth - 1);
 				}
 			} else {
-				if (previousDay && hasDayMonths() && dmonth > 0) {
+				if (previousDay && hasDayMonths() && dmonth > 0 && monthHasDayRestrictions(month)) {
 					previousDay = dayMonths[month][dmonth - 1];
 				}
 			}
@@ -2109,7 +2119,7 @@ public class OpeningHoursParser {
 						}
 					}
 				}
-			} else if (t.type.ord() < currentParseParent.ord() && indexP == 0 && tokens.size() > i) {
+			} else if (t.type != TokenType.TOKEN_COMMA && t.type.ord() < currentParseParent.ord() && indexP == 0 && tokens.size() > i) {
 				BasicOpeningHourRule newRule = new BasicOpeningHourRule(basic.getSequenceIndex());
 				newRule.setComment(basic.getComment());
 				buildRule(newRule, tokens.subList(i, tokens.size()), rules);
@@ -2124,6 +2134,12 @@ public class OpeningHoursParser {
 				}
 			} else if (t.type == TokenType.TOKEN_DASH) {
 
+			} else if (t.type == TokenType.TOKEN_MONTH && currentParse == TokenType.TOKEN_DAY_MONTH && indexP == 0) {
+				// Standalone whole-month selector (e.g. "Jul" in "Jun 15-30,Jul,Aug") inside a
+				// day-of-month context. Set months[] directly so containsMonth() recognises it;
+				// also update prevToken so a subsequent TOKEN_DAY_MONTH (e.g. "Jul 6") can
+				// inherit this token as its parent.
+				basic.getMonths()[t.mainNumber] = true;
 			} else if (t.type.ord() == currentParse.ord()) {
 				if (indexP < 2) {
 					currentPair[indexP++] = t;

--- a/OsmAnd-java/src/test/java/net/osmand/util/OpeningHoursParserTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/util/OpeningHoursParserTest.java
@@ -316,6 +316,24 @@ public class OpeningHoursParserTest {
 		testOpened("29.03.2019 15:00", hours, true);
 		testOpened("26.04.2019 11:00", hours, false);
 
+		// Partial month range (Jun 15-30) combined with whole months (Jul, Aug) in one selector.
+		// The whole-month entries must match even though dayMonths[] is initialized for June.
+		// Date notes (2026): Jan 1=Thu; Jun 5=Fri, Jun 6=Sat, Jun 20=Sat, Jun 27=Sat;
+		//                    Jul 4=Sat, Jul 5=Sun; Aug 1=Sat, Aug 22=Sat.
+		hours = parseOpenedHours("Mo-Fr 08:00-22:30; Sa-Su,PH 09:00-20:30; Jun 15-30,Jul,Aug Sa-Su,PH 09:00-19:00");
+		System.out.println(hours);
+		testOpened("05.07.2026 19:40", hours, false); // Sunday in July after 19:00 — must be closed
+		testOpened("05.07.2026 11:00", hours, true);  // Sunday in July at 11:00 — open
+		testOpened("22.08.2026 18:00", hours, true);  // Saturday in August at 18:00 — open
+		testOpened("22.08.2026 19:40", hours, false); // Saturday in August after 19:00 — must be closed
+		testOpened("05.06.2026 19:40", hours, true);  // Friday in June (weekday, before Jun 15) — open until 22:30
+		testOpened("06.06.2026 19:40", hours, true);  // Saturday Jun 6 (before Jun 15) — normal 20:30 hours apply
+		testOpened("20.06.2026 18:00", hours, true);  // Saturday Jun 20 (within Jun 15-30) — summer hours apply
+		testOpened("20.06.2026 19:40", hours, false); // Saturday Jun 20 after 19:00 — must be closed
+		testOpened("27.06.2026 18:00", hours, true);  // Saturday Jun 27 (within Jun 15-30) — summer hours apply
+		testOpened("27.06.2026 19:40", hours, false); // Saturday Jun 27 after 19:00 — must be closed
+		testInfo("05.07.2026 11:00", hours, "Open until 19:00");
+
 		hours = parseOpenedHours("Apr 05-24: Fr 08:00-16:00");
 		System.out.println(hours);
 		testOpened("12.10.2018 11:00", hours, false);


### PR DESCRIPTION
Previous version of the `opening_hours` parser interpreted [values like](https://www.openstreetmap.org/node/10802071818#map=19/47.565279/19.083130) `"Jun 15-30,Jul,Aug Sa-Su,PH 09:00-19:00"` incorrectly as a result of 2+1 bugs in the implementation:

1. **Condition 2 fired for commas** (parsing bug): `TOKEN_COMMA` has `ord()` value of 2, while `TOKEN_MONTH` has 5, so when a comma appeared at `indexP = 0` inside a `TOKEN_DAY_MONTH` context, condition 2 (which creates a new sub-rule) fired instead of condition 3 (the comma handler). This split `",Jul,Aug Sa-Su,PH 09:00-19:00"` from the example above into a broken second rule. Fixed by adding `t.type != TokenType.TOKEN_COMMA` to the guard of condition 2

2. **Standalone whole-month tokens ignored** (parsing bug): tokens like `Jul` and `Aug` appearing after a comma while already inside a day-of-month context (e.g., after parsing `Jun 15-30`) had no matching condition in the parse loop and were silently discarded, so those months were never added to `monnths[]`. Fixed by new else-if branch that sets `basic.getMonths()[t.mainNumber] = true` when a `TOKEN_MONTH` appears at `TOKEN_DAY_MONTH` level with `indexP == 0`

3. **dayMonths check blocked whole-month entries** (evaluation bug): after the parser fix, `hasDayMonths()` returns `true` (initialized for "Jun 15-30"), but `dayMonths[6]` (July) is all-false because July was a whole-month entry with no day restriction. The old code incorrectly used that all-false array to block the rule from matching July. Fixed by new `monthHasDayRestrictions(month)` method that checks whether any day is actually set for that month; only apply the day-of-month restriction if it is.

A test was added to the failing case that fails as expected on the old version, while the new version makes it pass, along with all the others.