### PR TITLE
Fix navigation exiting early with poor location position tolerance

### DIFF
--- a/OsmAnd/src/net/osmand/plus/routing/RoutingHelper.java
+++ b/OsmAnd/src/net/osmand/plus/routing/RoutingHelper.java
@@ -737,7 +737,7 @@ public class RoutingHelper {
 	}
 
 	public static float getPosTolerance(float accuracy) {
-		if (accuracy > 0) {
+		if (0 < accuracy && accuracy < POS_TOLERANCE) {
 			return POS_TOLERANCE / 2 + accuracy;
 		}
 		return POS_TOLERANCE;


### PR DESCRIPTION
When navigating and my phone locks, when it unlocks again, the position accuracy is very bad (the blue circle displayed on the map is several km big), and my navigation stops with 'you have reached your destination', even though I am often still several kilometers out from my destination.

This PR fixes this, I think, by limiting the position tolerance with an upper limit. Do note that I am unable to test it.