### PR TITLE
Fix #25127 location marker position in split-screen mode

### DIFF
--- a/OsmAnd/src/net/osmand/plus/helpers/MapDisplayPositionManager.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/MapDisplayPositionManager.java
@@ -185,19 +185,25 @@ public class MapDisplayPositionManager implements ViewportListener {
 				if (rect.isEmpty()) {
 					continue;
 				}
+				Rect localRect = getLocalCoveredScreenRect(rect, tileBox);
+				if (localRect == null) {
+					continue;
+				}
 
 				int width = right - left;
 				int height = bottom - top;
+				float centerX = (left + right) / 2f;
+				float centerY = (top + bottom) / 2f;
 
-				boolean leftHalf = rect.exactCenterX() < width / 2f;
-				boolean topHalf = rect.exactCenterY() < height / 2f;
+				boolean leftHalf = localRect.exactCenterX() < centerX;
+				boolean topHalf = localRect.exactCenterY() < centerY;
 
 				int shrinkWidth = leftHalf
-						? Math.max(left, rect.right) - left
-						: right - Math.min(right, rect.left);
+						? Math.max(left, localRect.right) - left
+						: right - Math.min(right, localRect.left);
 				int shrinkHeight = topHalf
-						? Math.max(top, rect.bottom) - top
-						: bottom - Math.min(bottom, rect.top);
+						? Math.max(top, localRect.bottom) - top
+						: bottom - Math.min(bottom, localRect.top);
 
 				int lostAreaByWidth = shrinkWidth * height;
 				int lostAreaByHeight = shrinkHeight * width;
@@ -223,6 +229,21 @@ public class MapDisplayPositionManager implements ViewportListener {
 		}
 
 		return new Rect(left, top, right, bottom);
+	}
+
+	@Nullable
+	private Rect getLocalCoveredScreenRect(@NonNull Rect screenRect, @NonNull RotatedTileBox tileBox) {
+		View view = mapView.getView();
+		if (view == null) {
+			return null;
+		}
+		int[] mapLocationOnScreen = AndroidUtils.getLocationOnScreen(view);
+		Rect localRect = new Rect(screenRect);
+		localRect.offset(-mapLocationOnScreen[0], -mapLocationOnScreen[1]);
+		if (!localRect.intersect(0, 0, tileBox.getPixWidth(), tileBox.getPixHeight())) {
+			return null;
+		}
+		return localRect;
 	}
 
 	private void refreshMapIfNeeded(boolean shouldRefreshMap) {

--- a/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
+++ b/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
@@ -593,6 +593,11 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 		return view != null ? view.getHeight() : 0;
 	}
 
+	@Nullable
+	public View getView() {
+		return view;
+	}
+
 	@NonNull
 	public OsmandApplication getApplication() {
 		return app;


### PR DESCRIPTION
Convert covered UI rects from screen coordinates to map-local coordinates before calculating the visible map area.

Previously, covered screen rects were used directly with RotatedTileBox dimensions. This worked in fullscreen and in top/left split-screen cases, but failed when the map view was shifted on screen, for example when OsmAnd was placed in the bottom or right side of Android split-screen.

As a result, UI panels could be interpreted as being in the wrong part of the map view, causing the current location marker to be positioned outside of the visible map area.

Also use the center of the current visible rect when deciding which side should be shrunk, making the calculation more robust when several UI panels are applied sequentially.