### PR TITLE
Fix #25099 outdated terrain maps on Updates tab

### DIFF
--- a/OsmAnd/src/net/osmand/plus/download/IndexItem.java
+++ b/OsmAnd/src/net/osmand/plus/download/IndexItem.java
@@ -260,10 +260,7 @@ public class IndexItem extends DownloadItem implements Comparable<IndexItem> {
 	}
 
 	public boolean isOutdated() {
-		return outdated
-				&& getType() != DownloadActivityType.HILLSHADE_FILE
-				&& getType() != DownloadActivityType.SLOPE_FILE
-				&& getType() != DownloadActivityType.GEOTIFF_FILE;
+		return outdated;
 	}
 
 	public void setOutdated(boolean outdated) {

--- a/OsmAnd/src/net/osmand/plus/download/OutdatedIndexesCollector.java
+++ b/OsmAnd/src/net/osmand/plus/download/OutdatedIndexesCollector.java
@@ -90,6 +90,8 @@ public class OutdatedIndexesCollector {
 				IndexConstants.WEATHER_EXT, indexActivatedFileNames);
 		listWithAlternatives(dateFormat, app.getAppPath(IndexConstants.ASTRO_DIR),
 				IndexConstants.STAR_MAP_INDEX_EXT, indexActivatedFileNames);
+		listWithAlternatives(dateFormat, app.getAppPath(IndexConstants.GEOTIFF_DIR),
+				IndexConstants.TIF_EXT, indexActivatedFileNames);
 
 		listWithAlternatives(dateFormat, app.getAppPath(""), IndexConstants.EXTRA_EXT, indexFileNames);
 		listWithAlternatives(dateFormat, app.getAppPath(IndexConstants.TILES_INDEX_DIR), IndexConstants.SQLITE_EXT,


### PR DESCRIPTION
Include GeoTIFF terrain files in the activated indexes scan so outdated 3D terrain maps are treated as installed update candidates. Also stop suppressing outdated state for terrain-like download types in IndexItem, allowing collected outdated items to be shown on the Updates tab.