### PR TITLE
Simplify route line distance overrides

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/layers/geometry/GeometryWay.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/geometry/GeometryWay.java
@@ -255,7 +255,7 @@ public abstract class GeometryWay<T extends CommonGeometryWayContext, D extends 
 					double prevLon = locationProvider.getLongitude(previous);
 					double lat = locationProvider.getLatitude(i);
 					double lon = locationProvider.getLongitude(i);
-					dist = calculateSegmentDistance(prevLat, prevLon, lat, lon);
+					dist = getSegmentDistance(prevLat, prevLon, lat, lon);
 				}
 				if (!previousVisible && !ignorePrevious) {
 					if (previous != -1 && !isPreviousPointFarAway(locationProvider, previous, i)) {
@@ -422,7 +422,7 @@ public abstract class GeometryWay<T extends CommonGeometryWayContext, D extends 
 			}
 		}
 		if (lastProjection != null && lastX31 != 0 && lastY31 != 0) {
-			passedDist += (float) calculateProjectionDistance(lastProjection, lastX31, lastY31);
+			passedDist += (float) getProjectionDistance(lastProjection, lastX31, lastY31);
 		}
 
 		if (passedLineId > 0) {
@@ -450,11 +450,11 @@ public abstract class GeometryWay<T extends CommonGeometryWayContext, D extends 
 		return true;
 	}
 
-	protected double calculateSegmentDistance(double lat1, double lon1, double lat2, double lon2) {
+	protected double getSegmentDistance(double lat1, double lon1, double lat2, double lon2) {
 		return MapUtils.getDistance(lat1, lon1, lat2, lon2);
 	}
 
-	protected double calculateProjectionDistance(@NonNull Location projection, int x31, int y31) {
+	protected double getProjectionDistance(@NonNull Location projection, int x31, int y31) {
 		return MapUtils.measuredDist31(
 				MapUtils.get31TileNumberX(projection.getLongitude()),
 				MapUtils.get31TileNumberY(projection.getLatitude()), x31, y31);

--- a/OsmAnd/src/net/osmand/plus/views/layers/geometry/RouteGeometryWay.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/geometry/RouteGeometryWay.java
@@ -274,20 +274,18 @@ public class RouteGeometryWay extends
 	}
 
 	@Override
-	protected double calculateSegmentDistance(double lat1, double lon1, double lat2, double lon2) {
-		return calculateNativeVectorLineDistance(lat1, lon1, lat2, lon2);
+	protected double getSegmentDistance(double lat1, double lon1, double lat2, double lon2) {
+		return MapUtils.getDistance(lat1, lon1, lat2, lon2, VECTOR_LINE_EARTH_RADIUS_METERS);
 	}
 
 	@Override
-	protected double calculateProjectionDistance(@NonNull Location projection, int x31, int y31) {
-		return calculateNativeVectorLineDistance(
-				projection.getLatitude(), projection.getLongitude(),
-				MapUtils.get31LatitudeY(y31), MapUtils.get31LongitudeX(x31));
-	}
-
-	private static double calculateNativeVectorLineDistance(double lat1, double lon1, double lat2, double lon2) {
-		// Keep startingDistance in the same metric as OsmAnd-core VectorLine_P::calculateShortestPath().
-		return MapUtils.getDistance(lat1, lon1, lat2, lon2, VECTOR_LINE_EARTH_RADIUS_METERS);
+	protected double getProjectionDistance(@NonNull Location projection, int x31, int y31) {
+		return MapUtils.getDistance(
+				projection.getLatitude(),
+				projection.getLongitude(),
+				MapUtils.get31LatitudeY(y31),
+				MapUtils.get31LongitudeX(x31),
+				VECTOR_LINE_EARTH_RADIUS_METERS);
 	}
 
 	public void clearRoute() {


### PR DESCRIPTION
Remove the extra helper wrapper and call MapUtils.getDistance(...) directly from RouteGeometryWay overrides.