### PR TITLE
Fix crash and silent failure when deleting search history entries

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/data/MapObject.java
+++ b/OsmAnd-java/src/main/java/net/osmand/data/MapObject.java
@@ -252,8 +252,12 @@ public abstract class MapObject implements Comparable<MapObject> {
 
 	@Override
 	public String toString() {
-		return getClass().getSimpleName() + " " + name + "(" + (id == null || id < 0 ? id
-				: ObfConstants.getOsmIdFromMapObjectId(id)) + ")";
+		// no ternary here: mixing Long and long operands unboxes a null id and throws NPE
+		Long osmId = id;
+		if (id != null && id >= 0) {
+			osmId = ObfConstants.getOsmIdFromMapObjectId(id);
+		}
+		return getClass().getSimpleName() + " " + name + "(" + osmId + ")";
 	}
 
 	@Override

--- a/OsmAnd/src/net/osmand/plus/search/history/SearchHistoryHelper.java
+++ b/OsmAnd/src/net/osmand/plus/search/history/SearchHistoryHelper.java
@@ -212,7 +212,9 @@ public class SearchHistoryHelper {
 	}
 
 	public void remove(SearchResult searchResult) {
-		HistoryEntry entry = getHistoryEntry(searchResult.object);
+		HistoryEntry entry = searchResult instanceof SearchHistoryAPI.HistorySearchResult historySearchResult
+				? historySearchResult.getHistoryEntry()
+				: getHistoryEntry(searchResult.object);
 		if (entry == null) {
 			entry = getHistoryEntry(searchResult.relatedObject);
 		}
@@ -234,9 +236,9 @@ public class SearchHistoryHelper {
 					"Can't get PointDescription from SearchResult: %s, object: %s (%s), relatedObject: %s (%s), objectType: %s",
 					searchResult,
 					searchResult.object,
-					searchResult.object.getClass(),
+					searchResult.object != null ? searchResult.object.getClass() : null,
 					searchResult.relatedObject,
-					searchResult.relatedObject.getClass(),
+					searchResult.relatedObject != null ? searchResult.relatedObject.getClass() : null,
 					searchResult.objectType
 			));
 		}


### PR DESCRIPTION
Fixes #25373

## Problem

Deleting search history entries crashes the app, and even without the crash, entries for address objects are never actually removed. Two changes from 2026-06-20 interact here:

1. Since 000fb80376 ("Applied new search items styles to search history"), `SearchHistoryAPI.createSearchResult()` reconstructs typed objects for history rows: for `STREET` / `CITY` / `VILLAGE` / `HOUSE` / `STREET_INTERSECTION` / `POSTCODE` / `LOCATION` / `FAVORITE` / `WPT` entries, `result.object` / `result.relatedObject` are synthetic `Street` / `City` / … objects instead of the `HistoryEntry`. `SearchHistoryHelper.remove(SearchResult)` can only resolve `HistoryEntry`, `AbstractPoiType`, `PoiUIFilter` and `GPXInfo`, so for those rows deletion silently fails and falls through to the error-log branch.
2. That branch formats `searchResult.object` with `%s`. For streets this calls `MapObject.toString()`, which since bd8d57f7d67 contains a ternary mixing `Long` (`id`) and `long` (`ObfConstants.getOsmIdFromMapObjectId(id)`). The conditional operator applies binary numeric promotion to such operands (JLS 15.25), so a null `id` — which synthetic history streets have (`createRelatedCity()` / entries without stored OSM id) — is unboxed and throws the reported NPE:

```
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'long java.lang.Long.longValue()' on a null object reference
	at net.osmand.data.MapObject.toString(MapObject.java:253)
	...
	at net.osmand.plus.search.history.SearchHistoryHelper.remove(SearchHistoryHelper.java:233)
	at net.osmand.plus.settings.fragments.DeleteHistoryTask.doInBackground(DeleteHistoryTask.java:48)
```

The error-log call itself is also unsafe: for `LOCATION` entries `relatedObject` is null and `searchResult.relatedObject.getClass()` would throw as well.

## Fix

- `SearchHistoryHelper.remove(SearchResult)` takes the entry directly from `HistorySearchResult` — every history row built by `SearchHistoryAPI.createSearchResult()` is one, and `DeleteHistoryTask` is the only caller of `remove(SearchResult)`. This restores deletion for all object types in both the search and navigation history settings screens.
- `MapObject.toString()` avoids the unboxing ternary; a null id now prints as `null`, non-null and negative ids render exactly as before.
- The error-log fallback no longer dereferences potentially-null `object` / `relatedObject`.

## Testing

Compiled the patched `MapObject` against the current master snapshot jar (JLS semantics verified in isolation as well):

| Case | Unpatched (master jar) | Patched |
|---|---|---|
| `Street` with `id = null` | NPE — exactly the reported crash | `Street Hauptstraße(null)` |
| `id = 12800` | `Street Hauptstraße(6400)` | `Street Hauptstraße(6400)` |
| `id = -1` | `Street Hauptstraße(-1)` | `Street Hauptstraße(-1)` |

Note: the secondary observation in #25373 ("Show all on map" hits not marked on the map) is a separate issue and not addressed here.

---
Claude Code — Claude Fable 5, xhigh
