### PR TITLE
Keep quick search FABs above the navigation bar in edge-to-edge mode

### DIFF
--- a/OsmAnd/src/net/osmand/plus/search/dialogs/QuickSearchDialogFragment.java
+++ b/OsmAnd/src/net/osmand/plus/search/dialogs/QuickSearchDialogFragment.java
@@ -29,6 +29,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.ContextCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
@@ -2914,19 +2915,35 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 
 		boolean showOnMapVisible = showOnMapFab != null && showOnMapFab.getVisibility() == View.VISIBLE;
 		if (showOnMapVisible) {
-			FrameLayout.LayoutParams parameter = (FrameLayout.LayoutParams) showOnMapFab.getLayoutParams();
-			parameter.setMargins(parameter.leftMargin, parameter.topMargin, parameter.rightMargin, bottomMargin);
-			showOnMapFab.setLayoutParams(parameter);
+			updateFabBottomMargin(showOnMapFab, bottomMargin);
 		}
 
 		if (fabVisible) {
 			if (showOnMapVisible) {
 				bottomMargin += getDimensionPixelSize(R.dimen.fab_size_with_shadow);
 			}
-			FrameLayout.LayoutParams parameter = (FrameLayout.LayoutParams) fab.getLayoutParams();
-			parameter.setMargins(parameter.leftMargin, parameter.topMargin, parameter.rightMargin, bottomMargin);
-			fab.setLayoutParams(parameter);
+			updateFabBottomMargin(fab, bottomMargin);
 		}
+	}
+
+	private void updateFabBottomMargin(@NonNull View fabView, int bottomMargin) {
+		// keep the insets framework in sync: it recomputes margins from this tag on every dispatch
+		fabView.setTag(R.id.initial_margin_bottom, bottomMargin);
+		FrameLayout.LayoutParams parameter = (FrameLayout.LayoutParams) fabView.getLayoutParams();
+		parameter.setMargins(parameter.leftMargin, parameter.topMargin, parameter.rightMargin,
+				bottomMargin + getFabBottomInset());
+		fabView.setLayoutParams(parameter);
+	}
+
+	private int getFabBottomInset() {
+		WindowInsetsCompat insets = getLastRootInsets();
+		if (insets == null) {
+			return 0;
+		}
+		// same mask as InsetTarget.createFab(), so both code paths compute the same margin
+		int typeMask = WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.ime()
+				| WindowInsetsCompat.Type.displayCutout();
+		return insets.getInsets(typeMask).bottom;
 	}
 
 	private void updateSendEmptySearchBottomBar(boolean sendSearchQueryVisible) {


### PR DESCRIPTION
Fixes #25382

## Problem

As @scaidermern diagnosed, the blue save-filter FAB in the quick search results overlaps the Android navigation bar in edge-to-edge mode, so its lower half does not react to taps (screenshot in the issue). The show-on-map FAB is affected the same way.

## Cause

`QuickSearchDialogFragment.getInsetTargets()` correctly declares both FABs via `InsetTarget.createFab()`, and the insets framework initially lifts them above the navigation bar. But `updateFabMargins()` overwrites the bottom margin with static dimension values whenever FAB visibility changes — which happens exactly when the save FAB appears (custom filter applied → results shown). Since no new insets dispatch follows, the FAB stays at 12dp from the screen edge, partially behind the navigation bar.

QA could not reproduce it reliably (#25382 comment) because the outcome depends on timing/ordering of insets dispatches vs. visibility changes — e.g. an IME-close dispatch *after* the FAB was shown re-applies the correct margin via `InsetsUtils.applyMargin()`.

## Fix

`updateFabMargins()` now:
- adds the current bottom inset (same type mask as `InsetTarget.createFab()`: system bars + IME + display cutout, taken from `getLastRootInsets()`) to the computed margin, and
- syncs the `initial_margin_bottom` tag that `InsetsUtils.applyMargin()` uses, so the next insets dispatch recomputes exactly the same margin instead of resetting the stacked offsets (two visible FABs / raised margin above the "send empty search" bar).

This keeps the manual stacking logic and the insets framework consistent in both directions. On devices without edge-to-edge, `getLastRootInsets()` is null and behavior is unchanged.

## Testing

Verified by code-path analysis of the insets framework (`InsetsUtils.applyMargin()` stores initial margins in view tags and recomputes `initial + insets.bottom` on every dispatch); all interleavings of insets dispatch and `updateFabMargins()` now produce the same margin. Happy to adjust if device testing by QA shows anything off.

---
Claude Code — Claude Fable 5, xhigh
