### PR TITLE
Use mapper-provided romanized names (ja-Latn, ko-Latn) instead of machine transliteration

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/data/MapObject.java
+++ b/OsmAnd-java/src/main/java/net/osmand/data/MapObject.java
@@ -212,9 +212,23 @@ public abstract class MapObject implements Comparable<MapObject> {
 		if (!Algorithms.isEmpty(enName)) {
 			return unzipContent(this.enName);
 		} else if (!Algorithms.isEmpty(getName()) && transliterate) {
-			return TransliterationHelper.transliterate(getName());
+			String latinScriptName = getLatinScriptName();
+			return latinScriptName != null ? latinScriptName : TransliterationHelper.transliterate(getName());
 		}
 		return ""; //$NON-NLS-1$
+	}
+
+	// mapper-provided romanization (name:ja-Latn, name:ko-Latn, name:sr-Latn, ...) reads correctly,
+	// unlike machine transliteration which e.g. renders Japanese kanji with Chinese readings
+	private String getLatinScriptName() {
+		if (names != null) {
+			for (Entry<String, String> entry : names.entrySet()) {
+				if (entry.getKey().toLowerCase().endsWith("-latn") && !Algorithms.isEmpty(entry.getValue())) {
+					return unzipContent(entry.getValue());
+				}
+			}
+		}
+		return null;
 	}
 
 	public void setEnName(String enName) {

--- a/OsmAnd-java/src/main/java/net/osmand/osm/MapRenderingTypes.java
+++ b/OsmAnd-java/src/main/java/net/osmand/osm/MapRenderingTypes.java
@@ -29,7 +29,7 @@ public abstract class MapRenderingTypes {
 
 	private static final Log log = PlatformUtil.getLog(MapRenderingTypes.class);
 	public static final String[] langs = new String[] { "af", "als", "ar", "az", "be", "bg", "bn", "bpy", "br", "bs", "ca", "ceb", "ckb", "crh", "cs", "cy", "da", "de", "el", "eo", "es", "et", "eu", "fa", "fi", "fr", "fy", "ga", "gl", "he", "hi", "hsb",
-		"hr", "ht", "hu", "hy", "id", "is", "it", "ja", "ka", "kk", "kn", "ko", "ku", "la", "lb", "lo", "lt", "lv", "mi", "mk", "ml", "mr", "ms", "nds", "new", "nl", "nn", "no", "nv", "oc", "os", "pl", "pms", "pt", "ro", "ru", "sat", "sc", "sh", "sk", "sl", "sq", "sr", "sr-latn", "sv", "sw", "ta", "te", "th", "tl", "tr", "uk", "vi", "vo", "zh", "zh-hans", "zh-hant",  };
+		"hr", "ht", "hu", "hy", "id", "is", "it", "ja", "ja-latn", "ka", "kk", "kn", "ko", "ko-latn", "ku", "la", "lb", "lo", "lt", "lv", "mi", "mk", "ml", "mr", "ms", "nds", "new", "nl", "nn", "no", "nv", "oc", "os", "pl", "pms", "pt", "ro", "ru", "sat", "sc", "sh", "sk", "sl", "sq", "sr", "sr-latn", "sv", "sw", "ta", "te", "th", "tl", "tr", "uk", "vi", "vo", "zh", "zh-hans", "zh-hant",  };
 	
 	public static final Set<String> langsSet = new TreeSet<>(Arrays.asList(langs)); 
 	

--- a/OsmAnd-java/src/main/java/net/osmand/osm/edit/EntityParser.java
+++ b/OsmAnd-java/src/main/java/net/osmand/osm/edit/EntityParser.java
@@ -44,7 +44,8 @@ public class EntityParser {
 		for (Map.Entry<String, String> entry : tags.entrySet()) {
 			String ts = entry.getKey();
 			if (ts.startsWith("name:") && !ts.equals(OSMTagKey.NAME_EN.getValue())) {
-				String lang = ts.substring(("name:").length());
+				// langsSet holds lowercase codes while OSM uses BCP 47 capitalization (name:sr-Latn, name:zh-Hans)
+				String lang = ts.substring(("name:").length()).toLowerCase();
 				if (MapRenderingTypes.langsSet.contains(lang)) {
 					mo.setName(lang, entry.getValue());
 				}


### PR DESCRIPTION
Fixes #25267

## Problem

For objects without `name:en`, OsmAnd falls back to machine transliteration (Junidecode), which produces wrong results especially for Japanese — kanji get Chinese readings. Example from the issue, way 1175336500 (大山阿夫利神社, `name:ja-Latn` = "Oyama Afuri Jinja"):

- current English fallback: **"Da Shan A Fu Li Shen She"**
- mapper-provided romanization: **"Oyama Afuri Jinja"**

The mapper-provided names can't even be used today because `name:ja-Latn` (165,044 uses) and `name:ko-Latn` (138,850 uses) are not in `MapRenderingTypes.langs`, so they are dropped during map creation (unlike `sr-latn` / `zh-hans` / `zh-hant`, which are already indexed).

## Changes

1. **`MapRenderingTypes.langs`**: add `ja-latn` and `ko-latn` (placed next to `ja` / `ko`, matching the existing `sr-latn` style). Takes effect once maps are regenerated.
2. **`EntityParser.parseMapObject()`**: lowercase the language suffix before the `langsSet` lookup and store names under the lowercase code. Production parsing already lowercases tag keys (`Entity.putTag`), but code paths using `putTagNoLC` — e.g. the OSM editing download, which sets `setConvertTagsToLC(false)` — preserve OSM's BCP 47 capitalization (`name:ja-Latn`, `name:sr-Latn`) and previously failed the lookup.
3. **`MapObject.getEnName(true)`**: prefer a stored Latin-script name (key ending in `-latn`) over machine transliteration when `name:en` is missing. Explicit `name:en` still wins; behavior with transliteration disabled is unchanged; objects without a romanized name fall back to Junidecode exactly as before.

`int_name` (907k uses) could be a further fallback candidate, but it is not indexed today and not guaranteed to be Latin script, so it is left out of this PR.

## Testing

Compiled the patched classes against the current master snapshot jar and ran a standalone test (class-shadowing), 14 checks — all pass with the patch; the unpatched jar shows the current behavior:

| Check | Unpatched master | Patched |
|---|---|---|
| `name:ja-Latn` indexed (lowercased keys, production path) | dropped | `ja-latn` ✓ |
| `name:ko-Latn` indexed | dropped | `ko-latn` ✓ |
| `name:ja-Latn`/`name:sr-Latn` via case-preserving path (`putTagNoLC`) | dropped | indexed ✓ |
| `getEnName(true)` for 大山阿夫利神社 with `ja-Latn` | "Da Shan A Fu Li Shen She" | "Oyama Afuri Jinja" |
| `name:sr-latn`, `name:zh-Hans`, `name:de` (production path) | indexed | indexed (unchanged) |
| unknown language suffix | dropped | dropped (unchanged) |
| explicit `name:en` precedence | wins | wins (unchanged) |
| Junidecode fallback without romanized name (Москва) | "Moskva" | "Moskva" (unchanged) |
| `getEnName(false)` without `name:en` | empty | empty (unchanged) |

---
Claude Code — Claude Fable 5, xhigh
