### PR TITLE
Fix #24969: add nearest to map center sort mode

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -11,6 +11,7 @@
 	Strings for OsmAnd core
 	Thx - Hardy
 -->
+	<string name="sort_by_nearest_to_current_location">Nearest to current location</string>
 	<string name="attached_media_delete_confirmation">Delete %1$d media items from this point? Media stored by the app and not attached anywhere else will also be deleted from the device.</string>
 	<string name="android_auto_missing_maps_desc">Download missing maps for the route to continue.</string>
 	<string name="android_auto_possible_missing_maps_desc">Possible missing maps. Try using existing maps to continue.</string>

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/dialogs/FavoriteComparator.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/dialogs/FavoriteComparator.java
@@ -29,10 +29,11 @@ public class FavoriteComparator implements Comparator<Object> {
 	public final Collator collator = OsmAndCollator.primaryCollator();
 	private final OsmandApplication app;
 
-	public FavoriteComparator(@NonNull FavoriteListSortMode sortMode, @NonNull LatLon latLon, OsmandApplication app) {
+	public FavoriteComparator(@NonNull FavoriteListSortMode sortMode, @NonNull OsmandApplication app) {
 		this.trackTab = null;
 		this.sortMode = sortMode;
-		this.latLon = SharedUtil.kLatLon(latLon);
+		LatLon referenceLocation = FavoriteSortModesHelper.getReferenceLocation(app, sortMode);
+		this.latLon = SharedUtil.kLatLon(referenceLocation);
 		this.app = app;
 	}
 
@@ -85,9 +86,8 @@ public class FavoriteComparator implements Comparator<Object> {
 				multiplier = sortMode == NAME_ASCENDING ? 1 : -1;
 				return multiplier * compareFavoritePointNames(point1, point2);
 			}
-			case NEAREST, FARTHEST -> {
-				multiplier = sortMode == NEAREST ? 1 : -1;
-				return multiplier * compareNearestPoints(point1, point2);
+			case NEAREST, NEAREST_TO_MAP_CENTER -> {
+				return compareNearestPoints(point1, point2);
 			}
 			case DATE_ASCENDING, DATE_DESCENDING -> {
 				multiplier = sortMode == DATE_DESCENDING ? -1 : 1;

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/dialogs/FavoriteFolderFragment.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/dialogs/FavoriteFolderFragment.java
@@ -329,8 +329,7 @@ public class FavoriteFolderFragment extends BaseFavoriteListFragment
 	}
 
 	private void sortItems(@NonNull List<Object> items, @NonNull FavoriteListSortMode sortMode) {
-		LatLon latLon = app.getMapViewTrackingUtilities().getDefaultLocation();
-		items.sort(new FavoriteComparator(sortMode, latLon, app));
+		items.sort(new FavoriteComparator(sortMode, app));
 	}
 
 	@NonNull

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/dialogs/FavoriteFoldersFragment.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/dialogs/FavoriteFoldersFragment.java
@@ -17,7 +17,6 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 
-import net.osmand.data.LatLon;
 import net.osmand.plus.R;
 import net.osmand.plus.helpers.AndroidUiHelper;
 import net.osmand.plus.importfiles.ImportHelper;
@@ -182,8 +181,7 @@ public class FavoriteFoldersFragment extends BaseFavoriteListFragment
 	}
 
 	private void sortItems(@NonNull List<Object> items, @NonNull FavoriteListSortMode sortMode) {
-		LatLon latLon = app.getMapViewTrackingUtilities().getDefaultLocation();
-		items.sort(new FavoriteComparator(sortMode, latLon, app));
+		items.sort(new FavoriteComparator(sortMode, app));
 	}
 
 	@Override

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/dialogs/FavoriteSortByBottomSheet.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/dialogs/FavoriteSortByBottomSheet.java
@@ -118,7 +118,7 @@ public class FavoriteSortByBottomSheet extends MenuBottomSheetDialogFragment {
 
 		private boolean shouldShowDivider(@NonNull FavoriteListSortMode mode) {
 			return mode == FavoriteListSortMode.LAST_MODIFIED || mode == FavoriteListSortMode.NAME_DESCENDING
-					|| mode == FavoriteListSortMode.FARTHEST;
+					|| mode == FavoriteListSortMode.NEAREST_TO_MAP_CENTER;
 					//|| mode == FavoriteSortMode.DATE_DESCENDING || mode == FavoriteSortMode.DISTANCE_ASCENDING;
 		}
 

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/dialogs/FavoriteSortModesHelper.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/dialogs/FavoriteSortModesHelper.java
@@ -3,6 +3,7 @@ package net.osmand.plus.myplaces.favorites.dialogs;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import net.osmand.data.LatLon;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.myplaces.favorites.FavoriteFolderPath;
 import net.osmand.plus.myplaces.favorites.FavoriteGroup;
@@ -98,6 +99,22 @@ public class FavoriteSortModesHelper {
 
 	public void syncSettings() {
 		saveToPreference();
+	}
+
+	@NonNull
+	public static LatLon getReferenceLocation(@NonNull OsmandApplication app,
+	                                           @NonNull FavoriteListSortMode sortMode) {
+		return sortMode == FavoriteListSortMode.NEAREST_TO_MAP_CENTER
+				? app.getMapViewTrackingUtilities().getMapLocation()
+				: app.getMapViewTrackingUtilities().getDefaultLocation();
+	}
+
+	@Nullable
+	public static LatLon getDisplayReferenceLocation(@NonNull OsmandApplication app,
+	                                                  @NonNull FavoriteListSortMode sortMode) {
+		return sortMode == FavoriteListSortMode.NEAREST_TO_MAP_CENTER
+				? getReferenceLocation(app, sortMode)
+				: null;
 	}
 
 	private void loadFromPreference() {

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/dialogs/FavoriteViewHolder.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/dialogs/FavoriteViewHolder.java
@@ -167,8 +167,9 @@ public class FavoriteViewHolder extends RecyclerView.ViewHolder {
 
 	public void bindLocation(@NonNull FavoriteListSortMode sortMode, @NonNull FavouritePoint favouritePoint,
 	                         boolean showFolderNameOnSecondLine) {
+		LatLon fromLoc = FavoriteSortModesHelper.getDisplayReferenceLocation(app, sortMode);
 		LatLon toLoc = new LatLon(favouritePoint.getLatitude(), favouritePoint.getLongitude());
-		UpdateLocationInfo info = new UpdateLocationInfo(app, null, toLoc);
+		UpdateLocationInfo info = new UpdateLocationInfo(app, fromLoc, toLoc);
 		String descriptionText = getFormattedDistance(app, info, locationViewCache).toString();
 		updateDirectionDrawable(app, directionIcon, info, locationViewCache);
 

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/dialogs/SearchFavoriteFragment.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/dialogs/SearchFavoriteFragment.java
@@ -394,8 +394,7 @@ public class SearchFavoriteFragment extends BaseFullScreenDialogFragment impleme
 	}
 
 	private void sortItems(@NonNull List<Object> items, @NonNull FavoriteListSortMode sortMode) {
-		LatLon latLon = app.getMapViewTrackingUtilities().getDefaultLocation();
-		items.sort(new FavoriteComparator(sortMode, latLon, app));
+		items.sort(new FavoriteComparator(sortMode, app));
 	}
 
 	private List<Object> getAdapterItems() {

--- a/OsmAnd/src/net/osmand/plus/settings/enums/FavoriteListSortMode.kt
+++ b/OsmAnd/src/net/osmand/plus/settings/enums/FavoriteListSortMode.kt
@@ -22,12 +22,12 @@ enum class FavoriteListSortMode(
         iconId = R.drawable.ic_action_sort_by_name_descending,
     ),
     NEAREST(
-        nameId = R.string.distance_nearest,
+        nameId = R.string.sort_by_nearest_to_current_location,
         iconId = R.drawable.ic_action_nearby,
     ),
-    FARTHEST(
-        nameId = R.string.distance_farthest,
-        iconId = R.drawable.ic_action_nearby,
+    NEAREST_TO_MAP_CENTER(
+        nameId = R.string.sort_by_nearest_to_map_center,
+        iconId = R.drawable.ic_action_nearest_map_center,
     ),
     DATE_ASCENDING(
         nameId = R.string.sort_date_ascending,
@@ -58,7 +58,7 @@ enum class FavoriteListSortMode(
                     .toTypedArray()
             } else {
                 entries
-                    .filter { it != NEAREST && it != FARTHEST }
+                    .filter { it != NEAREST && it != NEAREST_TO_MAP_CENTER }
                     .toTypedArray()
             }
         }


### PR DESCRIPTION
- Add a Favorites sort option for distance from the current map center
- Remove the old Farthest option from Favorites sorting
- Keep existing Nearest sorting based on the default location
- Sort and display Favorites distances from the map center for the new mode
- Preserve backward compatibility for old persisted sort values