### PR TITLE
Enhance MSL altitude processing and caching for Android 14+

### DIFF
--- a/OsmAnd/src/net/osmand/plus/OsmAndLocationProvider.java
+++ b/OsmAnd/src/net/osmand/plus/OsmAndLocationProvider.java
@@ -104,10 +104,7 @@ public class OsmAndLocationProvider implements SensorEventListener {
 	private static final float MSL_CALIBRATION_MAX_ACCURACY = 10f;
 	private static final int DYNAMIC_GEOID_OFFSET_MAX_DISTANCE = 100_000;
 	
-	private static Double cachedDynamicGeoidOffset = null;
-	private static Double cachedDynamicGeoidOffsetLat = null;
-	private static Double cachedDynamicGeoidOffsetLon = null;
-	private static final java.util.Set<String> loggedAltitudeSources = new java.util.concurrent.CopyOnWriteArraySet<>();
+	private static Location cachedMLSGeoidLocation = null;
 
 
 	private long lastTimeGPSLocationFixed;
@@ -579,74 +576,37 @@ public class OsmAndLocationProvider implements SensorEventListener {
 		if (l.hasSpeed()) {
 			r.setSpeed(l.getSpeed());
 		}
-		String branchTaken = "NONE";
-
-		if (VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE && l.hasMslAltitude()) {
+		if (VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE && l.hasMslAltitude() && l.hasAltitude()) {
 			r.setAltitude(l.getMslAltitudeMeters());
-			branchTaken = "MSL";
+			boolean qualityAcceptable = true;
 			if (l.hasMslAltitudeAccuracy()) {
 				r.setVerticalAccuracy(l.getMslAltitudeAccuracyMeters());
+				qualityAcceptable = l.getMslAltitudeAccuracyMeters() <= MSL_CALIBRATION_MAX_ACCURACY;
 			}
-			if (l.hasAltitude()) {
-				boolean qualityAcceptable = true;
-				if (l.hasMslAltitudeAccuracy()) {
-					qualityAcceptable = l.getMslAltitudeAccuracyMeters() <= MSL_CALIBRATION_MAX_ACCURACY;
+			if (qualityAcceptable) {
+				double newOffset = l.getAltitude() - l.getMslAltitudeMeters();
+				if (cachedMLSGeoidLocation == null) {
+					LOG.info("Dynamic geoid offset calibrated: " + newOffset + "m (provider=" + l.getProvider() +
+							(l.hasMslAltitudeAccuracy() ? ", MSL accuracy=" + l.getMslAltitudeAccuracyMeters() + "m" : "") + ")");
 				}
-				if (qualityAcceptable) {
-					double newOffset = l.getAltitude() - l.getMslAltitudeMeters();
-					if (cachedDynamicGeoidOffset == null || Math.abs(cachedDynamicGeoidOffset - newOffset) > 0.1) {
-						LOG.info("Dynamic geoid offset calibrated: " + newOffset + "m (provider=" + l.getProvider() +
-								(l.hasMslAltitudeAccuracy() ? ", MSL accuracy=" + l.getMslAltitudeAccuracyMeters() + "m" : "") + ")");
-					}
-					cachedDynamicGeoidOffset = newOffset;
-					cachedDynamicGeoidOffsetLat = l.getLatitude();
-					cachedDynamicGeoidOffsetLon = l.getLongitude();
-				}
+				cachedMLSGeoidLocation = l;
 			}
 		} else if (l.hasAltitude()) {
 			double alt = l.getAltitude();
-			boolean corrected = false;
-			
-			// Altitude fallback priority:
-			// 1. Android 14+ System MSL (via getMslAltitudeMeters)
-			// 2. Offline Geoid Correction File (computed accurately for current coordinates)
-			// 3. Cached dynamic offset (calibrated from previous MSL fix, valid < 100km)
-			// 4. Raw WGS84 altitude (from getAltitude())
-			if (app != null) {
-				GeoidAltitudeCorrection geo = app.getResourceManager().getGeoidAltitudeCorrection();
-				if (geo != null && geo.isGeoidInformationAvailable()) {
-					alt -= geo.getGeoidHeight(l.getLatitude(), l.getLongitude());
-					corrected = true;
-					branchTaken = "FILE";
-				}
-			}
-			if (!corrected) {
-				Double offset = cachedDynamicGeoidOffset;
-				Double offsetLat = cachedDynamicGeoidOffsetLat;
-				Double offsetLon = cachedDynamicGeoidOffsetLon;
-				if (offset != null && offsetLat != null && offsetLon != null) {
-					double dist = MapUtils.getDistance(offsetLat, offsetLon, l.getLatitude(), l.getLongitude());
-					if (dist < DYNAMIC_GEOID_OFFSET_MAX_DISTANCE) {
-						alt -= offset;
-						branchTaken = "CACHED";
-					} else {
-						LOG.info("Dynamic geoid offset invalidated by distance: " + dist + "m");
-						cachedDynamicGeoidOffset = null;
-						cachedDynamicGeoidOffsetLat = null;
-						cachedDynamicGeoidOffsetLon = null;
-						branchTaken = "RAW";
-					}
+			GeoidAltitudeCorrection geo = app == null ? null : app.getResourceManager().getGeoidAltitudeCorrection();
+			if (geo != null && geo.isGeoidInformationAvailable()) {
+				alt -= geo.getGeoidHeight(l.getLatitude(), l.getLongitude());
+			} else if (cachedMLSGeoidLocation != null) {
+				double dist = MapUtils.getDistance(cachedMLSGeoidLocation.getLatitude(), cachedMLSGeoidLocation.getLongitude(), l.getLatitude(), l.getLongitude());
+				if (dist < DYNAMIC_GEOID_OFFSET_MAX_DISTANCE) {
+					alt -= cachedMLSGeoidLocation.getAltitude() - cachedMLSGeoidLocation.getMslAltitudeMeters();
 				} else {
-					branchTaken = "RAW";
+					cachedMLSGeoidLocation = null;
 				}
 			}
 			r.setAltitude(alt);
 		}
 		
-		if (!loggedAltitudeSources.contains(branchTaken)) {
-			LOG.info("Altitude source active: " + branchTaken + ", alt=" + r.getAltitude() + ", provider=" + l.getProvider());
-			loggedAltitudeSources.add(branchTaken);
-		}
 		if (l.hasBearing()) {
 			r.setBearing(l.getBearing());
 		}

--- a/OsmAnd/src/net/osmand/plus/OsmAndLocationProvider.java
+++ b/OsmAnd/src/net/osmand/plus/OsmAndLocationProvider.java
@@ -100,6 +100,14 @@ public class OsmAndLocationProvider implements SensorEventListener {
 	private static final int REQUESTS_BEFORE_CHECK_LOCATION = 100;
 	private final AtomicInteger locationRequestsCounter = new AtomicInteger();
 	private final AtomicInteger staleLocationRequestsCounter = new AtomicInteger();
+	
+	private static final float MSL_CALIBRATION_MAX_ACCURACY = 10f;
+	private static final int DYNAMIC_GEOID_OFFSET_MAX_DISTANCE = 100_000;
+	
+	private static Double cachedDynamicGeoidOffset = null;
+	private static Double cachedDynamicGeoidOffsetLat = null;
+	private static Double cachedDynamicGeoidOffsetLon = null;
+	private static final java.util.Set<String> loggedAltitudeSources = new java.util.concurrent.CopyOnWriteArraySet<>();
 
 
 	private long lastTimeGPSLocationFixed;
@@ -571,19 +579,76 @@ public class OsmAndLocationProvider implements SensorEventListener {
 		if (l.hasSpeed()) {
 			r.setSpeed(l.getSpeed());
 		}
-		if (l.hasAltitude()) {
-			r.setAltitude(l.getAltitude());
+		String branchTaken = "NONE";
+
+		if (VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE && l.hasMslAltitude()) {
+			r.setAltitude(l.getMslAltitudeMeters());
+			branchTaken = "MSL";
+			if (l.hasMslAltitudeAccuracy()) {
+				r.setVerticalAccuracy(l.getMslAltitudeAccuracyMeters());
+			}
+			if (l.hasAltitude()) {
+				boolean qualityAcceptable = true;
+				if (l.hasMslAltitudeAccuracy()) {
+					qualityAcceptable = l.getMslAltitudeAccuracyMeters() <= MSL_CALIBRATION_MAX_ACCURACY;
+				}
+				if (qualityAcceptable) {
+					double newOffset = l.getAltitude() - l.getMslAltitudeMeters();
+					if (cachedDynamicGeoidOffset == null || Math.abs(cachedDynamicGeoidOffset - newOffset) > 0.1) {
+						LOG.info("Dynamic geoid offset calibrated: " + newOffset + "m (provider=" + l.getProvider() +
+								(l.hasMslAltitudeAccuracy() ? ", MSL accuracy=" + l.getMslAltitudeAccuracyMeters() + "m" : "") + ")");
+					}
+					cachedDynamicGeoidOffset = newOffset;
+					cachedDynamicGeoidOffsetLat = l.getLatitude();
+					cachedDynamicGeoidOffsetLon = l.getLongitude();
+				}
+			}
+		} else if (l.hasAltitude()) {
+			double alt = l.getAltitude();
+			boolean corrected = false;
+			
+			// Altitude fallback priority:
+			// 1. Android 14+ System MSL (via getMslAltitudeMeters)
+			// 2. Offline Geoid Correction File (computed accurately for current coordinates)
+			// 3. Cached dynamic offset (calibrated from previous MSL fix, valid < 100km)
+			// 4. Raw WGS84 altitude (from getAltitude())
+			if (app != null) {
+				GeoidAltitudeCorrection geo = app.getResourceManager().getGeoidAltitudeCorrection();
+				if (geo != null && geo.isGeoidInformationAvailable()) {
+					alt -= geo.getGeoidHeight(l.getLatitude(), l.getLongitude());
+					corrected = true;
+					branchTaken = "FILE";
+				}
+			}
+			if (!corrected) {
+				Double offset = cachedDynamicGeoidOffset;
+				Double offsetLat = cachedDynamicGeoidOffsetLat;
+				Double offsetLon = cachedDynamicGeoidOffsetLon;
+				if (offset != null && offsetLat != null && offsetLon != null) {
+					double dist = MapUtils.getDistance(offsetLat, offsetLon, l.getLatitude(), l.getLongitude());
+					if (dist < DYNAMIC_GEOID_OFFSET_MAX_DISTANCE) {
+						alt -= offset;
+						branchTaken = "CACHED";
+					} else {
+						LOG.info("Dynamic geoid offset invalidated by distance: " + dist + "m");
+						cachedDynamicGeoidOffset = null;
+						cachedDynamicGeoidOffsetLat = null;
+						cachedDynamicGeoidOffsetLon = null;
+						branchTaken = "RAW";
+					}
+				} else {
+					branchTaken = "RAW";
+				}
+			}
+			r.setAltitude(alt);
+		}
+		
+		if (!loggedAltitudeSources.contains(branchTaken)) {
+			LOG.info("Altitude source active: " + branchTaken + ", alt=" + r.getAltitude() + ", provider=" + l.getProvider());
+			loggedAltitudeSources.add(branchTaken);
 		}
 		if (l.hasBearing()) {
 			r.setBearing(l.getBearing());
-		}
-		if (l.hasAltitude() && app != null) {
-			double alt = l.getAltitude();
-			GeoidAltitudeCorrection geo = app.getResourceManager().getGeoidAltitudeCorrection();
-			if (geo != null) {
-				alt -= geo.getGeoidHeight(l.getLatitude(), l.getLongitude());
-				r.setAltitude(alt);
-			}
 		}
 		return r;
 	}

--- a/OsmAnd/src/net/osmand/plus/resources/ResourceManager.java
+++ b/OsmAnd/src/net/osmand/plus/resources/ResourceManager.java
@@ -1038,7 +1038,12 @@ public class ResourceManager {
 	}
 
 	protected void resetGeoidAltitudeCorrection() {
-		geoidAltitudeCorrection = new GeoidAltitudeCorrection(app.getAppPath(null));
+		GeoidAltitudeCorrection geo = new GeoidAltitudeCorrection(app.getAppPath(null));
+		if (geo.isGeoidInformationAvailable()) {
+			geoidAltitudeCorrection = geo;
+		} else {
+			geoidAltitudeCorrection = null;
+		}
 	}
 
 	public OsmandRegions getOsmandRegions() {

--- a/OsmAnd/src/net/osmand/plus/resources/ResourceManager.java
+++ b/OsmAnd/src/net/osmand/plus/resources/ResourceManager.java
@@ -1038,12 +1038,7 @@ public class ResourceManager {
 	}
 
 	protected void resetGeoidAltitudeCorrection() {
-		GeoidAltitudeCorrection geo = new GeoidAltitudeCorrection(app.getAppPath(null));
-		if (geo.isGeoidInformationAvailable()) {
-			geoidAltitudeCorrection = geo;
-		} else {
-			geoidAltitudeCorrection = null;
-		}
+		geoidAltitudeCorrection = new GeoidAltitudeCorrection(app.getAppPath(null));
 	}
 
 	public OsmandRegions getOsmandRegions() {


### PR DESCRIPTION
## Use Android 14+ system MSL altitude when available

### Problem

OsmAnd derives MSL altitude from `Location.getAltitude()` (WGS84) plus an 
optional offline geoid correction file ("World altitude correction"). Without 
the file, users see raw WGS84 altitude — off by the local geoid height 
(~26 m in Kyiv, up to ±100 m globally).

Android 14 (API 34) added `Location.hasMslAltitude()` / `getMslAltitudeMeters()`, 
which provide a ready-to-use MSL altitude (populated primarily by the Fused 
Location Provider), making the correction file unnecessary on supported devices.

### Changes

All changes are localized to `OsmAndLocationProvider.convertLocation()`.

**1. System MSL altitude (API 34+).**
When a fix carries MSL altitude, it is used directly and geoid correction is 
skipped — the value is already MSL; applying correction would double-correct.

**2. Dynamic geoid offset cache.**
Providers deliver fixes with and without MSL interleaved (e.g. fused with MSL, 
network without), which caused the displayed altitude to jump between MSL and 
raw WGS84 values. When a fix has both WGS84 and MSL altitude, the difference 
(local geoid offset) is cached together with the calibration coordinates. 
Fixes without MSL apply this cached offset as a fallback.
- Offset is invalidated beyond `DYNAMIC_GEOID_OFFSET_MAX_DISTANCE` (100 km) 
  from the calibration point (geoid height varies with position; within 100 km 
  the variation is typically < 1 m).
- Calibration is skipped when `getMslAltitudeAccuracyMeters()` exceeds 
  `MSL_CALIBRATION_MAX_ACCURACY` (10 m), so a single low-quality fix cannot 
  poison the offset.
- The cache is in-memory only (not persisted) — a stale persisted offset after 
  a long flight would be worse than a few uncorrected fixes on startup.

**3. Correction priority** (documented in code):
system MSL → geoid correction file → cached dynamic offset → raw WGS84.
The file takes precedence over the cached offset because file correction is 
computed for the current coordinates, while the cached offset is tied to the 
calibration point.

**4. Fix: stale geoid correction after file deletion.**
`getGeoidHeight()` silently returned 0 when the correction file had been 
deleted while the app was running, because ResourceManager keeps the 
`GeoidAltitudeCorrection` instance alive. Added an 
`isGeoidInformationAvailable()` check so an unavailable file no longer 
produces a fake zero correction (which also blocked the cached-offset 
fallback). The underlying ResourceManager caching issue is tracked separately: #XXXX.

**5. Consistent vertical accuracy.**
When MSL altitude is used, `getMslAltitudeAccuracyMeters()` (if available) 
overrides the generic WGS84 vertical accuracy, so altitude and its accuracy 
always come from the same source.

**6. Diagnostic logging.**
Each altitude source (MSL / FILE / CACHED / RAW / NONE) is logged once per 
session on first activation, plus offset (re)calibration and distance 
invalidation events. This identifies from user logs which altitude sources a 
device provides, without per-fix spam from provider flapping.

### Compatibility

- **Pre-API-34 devices:** no behavior change — same file-correction / raw path.
- **Builds without GMS (F-Droid):** `hasMslAltitude()` is a framework API 
  (compiles and runs fine) but is typically only populated by the Fused 
  Location Provider, so it stays false → existing behavior. The correction 
  file flow is intentionally kept as the primary mechanism for these builds.

### Testing

Device: [MODEL], Android 14, GMS build:
- Without correction file: altitude stable at MSL value (~135 m vs 161 m raw 
  WGS84 previously); interleaved no-MSL fixes handled by cached offset.
- With correction file downloaded: FILE branch active, value consistent with MSL.
- File deleted at runtime: correct fallback to cached offset without restart.
- [ ] API 33 emulator smoke test (pre-34 path unchanged).