### PR TITLE
fix(ais): disable background reception by default

### DIFF
--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerPlugin.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerPlugin.java
@@ -91,7 +91,7 @@ public class AisTrackerPlugin extends OsmandPlugin {
 	public final CommonPreference<Boolean> AIS_DISPLAY_OWN_POSITION;
 	public static final Boolean AIS_DISPLAY_OWN_POSITION_DEFAULT = false;
     public final CommonPreference<Boolean> AIS_RECEIVE_IN_BACKGROUND;
-    public static final Boolean AIS_RECEIVE_IN_BACKGROUND_DEFAULT = true;
+    public static final Boolean AIS_RECEIVE_IN_BACKGROUND_DEFAULT = false;
 
 	/* timestamp of last AIS message received for all instances: */
 	private long lastMessageReceived = 0;


### PR DESCRIPTION
## Summary

Changes the default value of **Receive AIS data even if OsmAnd is paused** from `true` to `false`.

## Problem

Previously, enabling the AIS plugin also enabled background AIS reception by default.

When background reception is enabled, `AisTrackerPlugin` starts `NavigationService` with `USED_BY_AIS`. Since this is a foreground service, Android requires OsmAnd to display a persistent notification.

As a result, simply enabling the AIS plugin immediately displayed an AIS notification and allowed the listener to continue running in the background, potentially consuming battery and device resources without an explicit user choice.

### The existing lifecycle remains unchanged:
* AIS reception works while the map is active.
* The listener stops when OsmAnd is paused if background reception is disabled.
* Users can explicitly enable background reception in AIS settings.
* When background reception is enabled, NavigationService and its required foreground notification continue to work as before.

### Existing users

The new default applies to profiles where this preference has not been explicitly stored.

Profiles with an explicitly saved value of true keep their current setting. No migration is added, so the change does not override a user's previous conscious choice.

## Follow-up UI improvements

As a separate improvement, we could make background reception more explicit by:

* adding a battery and resource usage warning to the confirmation bottom sheet;
* adding a dedicated Start / Stop AIS tracking action or map widget, similar to track recording.

These UI changes are not included in this pull request.