### PR TITLE
feat: add offline drone zone plugin

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -11,6 +11,21 @@
 	Strings for OsmAnd core
 	Thx - Hardy
 -->
+	<string name="drone_zones">Drone zones</string>
+	<string name="drone_zones_plugin_description">Shows offline UAS geographical zones from an installed OsmAnd drone-zone map package.</string>
+	<string name="drone_zone_restriction">Restriction</string>
+	<string name="drone_zone_restriction_req_authorization">Prior authorization required</string>
+	<string name="drone_zone_category">Category</string>
+	<string name="drone_zone_reasons">Reasons</string>
+	<string name="drone_zone_lower_limit">Lower limit</string>
+	<string name="drone_zone_upper_limit">Upper limit</string>
+	<string name="drone_zone_legal_basis">Legal basis</string>
+	<string name="drone_zone_source">Source</string>
+	<string name="drone_zone_dataset">Dataset</string>
+	<string name="drone_zone_validity">Data validity</string>
+	<string name="drone_zone_validity_value">%1$s – %2$s</string>
+	<string name="drone_zone_expired_warning">Warning: This drone-zone data is outside its validity period.</string>
+	<string name="drone_zone_disclaimer">This map display does not replace an individual flight authorization or an authoritative pre-flight check.</string>
 	<string name="astro_fit_eclipse_path">Fit eclipse path</string>
 	<string name="astro_show_map">Show map</string>
 	<string name="astro_hide_map">Hide map</string>

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/MenuController.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/MenuController.java
@@ -48,6 +48,8 @@ import net.osmand.plus.plugins.PluginsHelper;
 import net.osmand.plus.plugins.aistracker.AisObjectMenuController;
 import net.osmand.plus.plugins.audionotes.AudioVideoNoteMenuController;
 import net.osmand.plus.plugins.audionotes.Recording;
+import net.osmand.plus.plugins.drone.DroneZoneTags;
+import net.osmand.plus.plugins.drone.menu.DroneZoneMenuController;
 import net.osmand.plus.plugins.mapillary.MapillaryImage;
 import net.osmand.plus.plugins.mapillary.MapillaryMenuController;
 import net.osmand.plus.plugins.osmedit.OsmBugsLayer.OpenStreetNote;
@@ -233,7 +235,12 @@ public abstract class MenuController extends BaseMenuController implements Colla
 			} else if (object instanceof AvoidRoadInfo) {
 				menuController = new ImpassibleRoadsMenuController(mapActivity, pointDescription, (AvoidRoadInfo) object);
 			} else if (object instanceof RenderedObject) {
-				menuController = new RenderedObjectMenuController(mapActivity, pointDescription, (RenderedObject) object);
+				RenderedObject renderedObject = (RenderedObject) object;
+				if (DroneZoneTags.isDroneZone(renderedObject.getTags())) {
+					menuController = new DroneZoneMenuController(mapActivity, pointDescription, renderedObject);
+				} else {
+					menuController = new RenderedObjectMenuController(mapActivity, pointDescription, renderedObject);
+				}
 			} else if (object instanceof MapillaryImage) {
 				menuController = new MapillaryMenuController(mapActivity, pointDescription, (MapillaryImage) object);
 			} else if (object instanceof AisObject) {

--- a/OsmAnd/src/net/osmand/plus/plugins/PluginsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/PluginsHelper.java
@@ -43,6 +43,7 @@ import net.osmand.plus.plugins.audionotes.AudioVideoNotesPlugin;
 import net.osmand.plus.plugins.custom.CustomOsmandPlugin;
 import net.osmand.plus.plugins.custom.CustomRegion;
 import net.osmand.plus.plugins.development.OsmandDevelopmentPlugin;
+import net.osmand.plus.plugins.drone.DroneZonesPlugin;
 import net.osmand.plus.plugins.externalsensors.ExternalSensorsPlugin;
 import net.osmand.plus.plugins.mapillary.MapillaryPlugin;
 import net.osmand.plus.plugins.monitoring.OsmandMonitoringPlugin;
@@ -112,6 +113,7 @@ public class PluginsHelper {
 		allPlugins.add(new OsmandMonitoringPlugin(app));
 		checkMarketPlugin(app, new SRTMPlugin(app));
 		allPlugins.add(new WeatherPlugin(app));
+		allPlugins.add(new DroneZonesPlugin(app));
 		checkMarketPlugin(app, new NauticalMapsPlugin(app));
 		allPlugins.add(new AisTrackerPlugin(app));
 		checkMarketPlugin(app, new SkiMapsPlugin(app));

--- a/OsmAnd/src/net/osmand/plus/plugins/drone/DroneZoneObfSelection.kt
+++ b/OsmAnd/src/net/osmand/plus/plugins/drone/DroneZoneObfSelection.kt
@@ -1,0 +1,119 @@
+package net.osmand.plus.plugins.drone
+
+import net.osmand.NativeLibrary.RenderedObject
+import net.osmand.binary.BinaryMapDataObject
+import net.osmand.binary.BinaryMapIndexReader
+import net.osmand.data.LatLon
+import net.osmand.plus.OsmandApplication
+import net.osmand.plus.plugins.PluginsHelper
+import net.osmand.plus.views.layers.MapSelectionResult
+import net.osmand.util.MapUtils
+import java.util.LinkedHashMap
+
+/** Renderer-independent hit testing for UAS polygons stored in an OBF. */
+object DroneZoneObfSelection {
+	private const val MIN_ZOOM = 9
+
+	@JvmStatic
+	fun collect(app: OsmandApplication, result: MapSelectionResult, zoom: Int) {
+		if (zoom < MIN_ZOOM || PluginsHelper.getEnabledPlugin(DroneZonesPlugin::class.java) == null) return
+		if (!app.settings.getCustomRenderBooleanProperty(DroneZonesPlugin.RENDER_PROPERTY).get()) return
+
+		val point = result.pointLatLon
+		val x31 = MapUtils.get31TileNumberX(point.longitude)
+		val y31 = MapUtils.get31TileNumberY(point.latitude)
+		val filter = BinaryMapIndexReader.SearchFilter { types, mapIndex ->
+			var droneZone = false
+			for (i in 0 until types.size()) {
+				val type = mapIndex.decodeType(types[i])
+				if (type?.tag == DroneZoneTags.ZONE && type.value == "yes") {
+					droneZone = true
+					break
+				}
+			}
+			droneZone
+		}
+
+		val existing = result.allObjects.mapNotNull { selected ->
+			(selected.`object`() as? RenderedObject)?.takeIf { DroneZoneTags.isDroneZone(it.tags) }
+				?.let { zoneKey(it.id, it.tags) }
+		}.toMutableSet()
+
+		for (mapObject in app.resourceManager.renderer.searchMapObjectsAt(x31, y31, zoom, filter)) {
+			if (!contains(mapObject, x31, y31)) continue
+			val renderedObject = toRenderedObject(mapObject, point)
+			val key = zoneKey(renderedObject.id, renderedObject.tags)
+			if (existing.add(key)) {
+				result.collect(renderedObject, null)
+				result.objectLatLon = point
+			}
+		}
+	}
+
+	private fun zoneKey(id: Long?, tags: Map<String, String>): String =
+		"${tags[DroneZoneTags.SOURCE_ID].orEmpty()}|${id ?: 0L}"
+
+	private fun contains(mapObject: BinaryMapDataObject, x31: Int, y31: Int): Boolean {
+		if (!mapObject.isArea || !containsRing(mapObject.coordinates, x31, y31)) return false
+		return mapObject.polygonInnerCoordinates?.none { containsRing(it, x31, y31) } ?: true
+	}
+
+	private fun containsRing(coordinates: IntArray?, x31: Int, y31: Int): Boolean {
+		if (coordinates == null || coordinates.size < 6) return false
+		var inside = false
+		var j = coordinates.size - 2
+		var i = 0
+		while (i < coordinates.size) {
+			val xi = coordinates[i]
+			val yi = coordinates[i + 1]
+			val xj = coordinates[j]
+			val yj = coordinates[j + 1]
+			if ((yi > y31) != (yj > y31)) {
+				val intersectionX = (xj - xi).toDouble() * (y31 - yi) / (yj - yi) + xi
+				if (x31 < intersectionX) inside = !inside
+			}
+			j = i
+			i += 2
+		}
+		return inside
+	}
+
+	private fun toRenderedObject(mapObject: BinaryMapDataObject, selectedPoint: LatLon): RenderedObject {
+		val tags = decodeTags(mapObject)
+		return RenderedObject().apply {
+			setNativeId(mapObject.id)
+			for (i in 0 until mapObject.pointsLength) {
+				addLocation(mapObject.getPoint31XTile(i), mapObject.getPoint31YTile(i))
+			}
+			for ((tag, value) in tags) {
+				putTag(tag, value)
+				when {
+					tag == "name" -> setName(value)
+					tag.startsWith("name:") -> setName(tag.substringAfter(':'), value)
+				}
+			}
+			setLabelX(mapObject.labelX)
+			setLabelY(mapObject.labelY)
+			labelLatLon = selectedPoint
+			markAsPolygon(true)
+			setVisible(true)
+			order = 7
+		}
+	}
+
+	private fun decodeTags(mapObject: BinaryMapDataObject): Map<String, String> {
+		val tags = LinkedHashMap<String, String>()
+		fun decode(types: IntArray?) {
+			if (types == null) return
+			for (type in types) {
+				mapObject.mapIndex.decodeType(type)?.let { tags[it.tag] = it.value }
+			}
+		}
+		decode(mapObject.types)
+		decode(mapObject.additionalTypes)
+		mapObject.orderedObjectNames?.forEach { (type, value) ->
+			mapObject.mapIndex.decodeType(type)?.let { tags[it.tag] = value }
+		}
+		return tags
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/plugins/drone/DroneZoneRenderedObjectParser.kt
+++ b/OsmAnd/src/net/osmand/plus/plugins/drone/DroneZoneRenderedObjectParser.kt
@@ -1,0 +1,86 @@
+package net.osmand.plus.plugins.drone
+
+import net.osmand.NativeLibrary.RenderedObject
+import net.osmand.plus.plugins.drone.model.DroneZone
+import net.osmand.plus.plugins.drone.model.DroneZoneDatasetInfo
+import net.osmand.plus.plugins.drone.model.DroneZoneLink
+import net.osmand.plus.plugins.drone.model.RawValue
+import net.osmand.plus.plugins.drone.model.VerticalLimit
+import java.text.ParseException
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object DroneZoneRenderedObjectParser {
+	private val knownRestrictions = setOf("REQ_AUTHORIZATION")
+	private val knownReasons = setOf("AIR_TRAFFIC", "NATURE", "NOISE", "POPULATION", "PRIVACY", "SENSITIVE")
+	private val knownReferences = setOf("AGL", "AMSL")
+	private val knownUnits = setOf("m", "ft")
+
+	fun parse(renderedObject: RenderedObject, language: String = Locale.getDefault().language): DroneZone {
+		return parse(renderedObject.tags, language)
+	}
+
+	fun parse(tags: Map<String, String>, language: String): DroneZone {
+		require(DroneZoneTags.isDroneZone(tags)) { "Rendered object is not a drone zone" }
+		val normalizedLanguage = language.lowercase(Locale.ROOT).substringBefore('-')
+		val name = tags["name:$normalizedLanguage"] ?: tags["name"] ?: tags[DroneZoneTags.SOURCE_ID].orEmpty()
+		val unit = raw(tags[DroneZoneTags.UNIT], knownUnits)
+
+		fun vertical(valueTag: String, referenceTag: String): VerticalLimit? {
+			val value = tags[valueTag] ?: return null
+			return VerticalLimit(value, unit, raw(tags[referenceTag], knownReferences))
+		}
+
+		val validTo = tags[DroneZoneTags.VALID_TO]
+		return DroneZone(
+			sourceId = tags[DroneZoneTags.SOURCE_ID],
+			identifier = tags[DroneZoneTags.IDENTIFIER],
+			name = name,
+			restriction = raw(tags[DroneZoneTags.RESTRICTION], knownRestrictions),
+			variant = tags[DroneZoneTags.VARIANT]?.let { raw(it) },
+			typeCode = tags[DroneZoneTags.TYPE_CODE]?.let { raw(it) },
+			reasons = tags[DroneZoneTags.REASONS].orEmpty().split(';').filter { it.isNotBlank() }.map { raw(it, knownReasons) },
+			lowerLimit = vertical(DroneZoneTags.LOWER, DroneZoneTags.LOWER_REF),
+			upperLimit = vertical(DroneZoneTags.UPPER, DroneZoneTags.UPPER_REF),
+			legalTexts = localizedValue(tags, "uas_legal", normalizedLanguage)?.lines()?.filter { it.isNotBlank() }.orEmpty(),
+			links = localizedLinks(tags, normalizedLanguage),
+			dataset = DroneZoneDatasetInfo(
+				id = tags[DroneZoneTags.DATASET],
+				provider = tags[DroneZoneTags.PROVIDER],
+				source = tags[DroneZoneTags.SOURCE],
+				validFrom = tags[DroneZoneTags.VALID_FROM],
+				validTo = validTo,
+				expired = validTo?.let { parseDate(it)?.before(Date()) } ?: false,
+			),
+		)
+	}
+
+	private fun raw(value: String?, known: Set<String>? = null): RawValue {
+		val raw = value.orEmpty()
+		return RawValue(raw, if (known == null || raw in known) raw else null)
+	}
+
+	private fun localizedValue(tags: Map<String, String>, prefix: String, language: String): String? {
+		return tags[DroneZoneTags.localized(prefix, language)]
+			?: tags[DroneZoneTags.localized(prefix, "de")]
+			?: tags[DroneZoneTags.localized(prefix, "en")]
+	}
+
+	private fun localizedLinks(tags: Map<String, String>, language: String): List<DroneZoneLink> {
+		val urls = localizedValue(tags, "uas_link", language)?.lines().orEmpty()
+		val texts = localizedValue(tags, "uas_link_text", language)?.lines().orEmpty()
+		return urls.filter { it.isNotBlank() }.mapIndexed { index, url -> DroneZoneLink(texts.getOrNull(index) ?: url, url) }
+	}
+
+	private fun parseDate(value: String): Date? {
+		for (pattern in listOf("yyyy-MM-dd'T'HH:mm:ss.SSSX", "yyyy-MM-dd'T'HH:mm:ssX")) {
+			try {
+				return SimpleDateFormat(pattern, Locale.US).parse(value)
+			} catch (_: ParseException) {
+				// Try the next supported ISO-8601 representation.
+			}
+		}
+		return null
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/plugins/drone/DroneZoneTags.kt
+++ b/OsmAnd/src/net/osmand/plus/plugins/drone/DroneZoneTags.kt
@@ -1,0 +1,28 @@
+package net.osmand.plus.plugins.drone
+
+object DroneZoneTags {
+	const val ZONE = "uas_zone"
+	const val SCHEMA = "uas_schema"
+	const val SOURCE = "uas_source"
+	const val SOURCE_ID = "uas_source_id"
+	const val IDENTIFIER = "uas_identifier"
+	const val COUNTRY = "uas_country"
+	const val RESTRICTION = "uas_restriction"
+	const val VARIANT = "uas_variant"
+	const val TYPE_CODE = "uas_type_code"
+	const val REASONS = "uas_reasons"
+	const val LOWER = "uas_lower"
+	const val LOWER_REF = "uas_lower_ref"
+	const val UPPER = "uas_upper"
+	const val UPPER_REF = "uas_upper_ref"
+	const val UNIT = "uas_uom"
+	const val PROVIDER = "uas_provider"
+	const val DATASET = "uas_dataset"
+	const val VALID_FROM = "uas_valid_from"
+	const val VALID_TO = "uas_valid_to"
+
+	@JvmStatic
+	fun isDroneZone(tags: Map<String, String>): Boolean = tags[ZONE] == "yes"
+
+	fun localized(prefix: String, language: String): String = "$prefix:$language"
+}

--- a/OsmAnd/src/net/osmand/plus/plugins/drone/DroneZonesPlugin.kt
+++ b/OsmAnd/src/net/osmand/plus/plugins/drone/DroneZonesPlugin.kt
@@ -1,0 +1,72 @@
+package net.osmand.plus.plugins.drone
+
+import android.view.View
+import net.osmand.plus.OsmandApplication
+import net.osmand.plus.R
+import net.osmand.plus.activities.MapActivity
+import net.osmand.plus.plugins.OsmandPlugin
+import net.osmand.plus.settings.backend.preferences.CommonPreference
+import net.osmand.plus.widgets.ctxmenu.ContextMenuAdapter
+import net.osmand.plus.widgets.ctxmenu.callback.OnDataChangeUiAdapter
+import net.osmand.plus.widgets.ctxmenu.callback.OnRowItemClick
+import net.osmand.plus.widgets.ctxmenu.data.ContextMenuItem
+import net.osmand.render.RenderingRuleProperty
+
+class DroneZonesPlugin(app: OsmandApplication) : OsmandPlugin(app) {
+	companion object {
+		const val ID = "osmand.drone.zones"
+		const val RENDER_PROPERTY = "droneZones"
+	}
+
+	override fun getId(): String = ID
+
+	override fun getName(): String = app.getString(R.string.drone_zones)
+
+	override fun getDescription(linksEnabled: Boolean): CharSequence =
+		app.getString(R.string.drone_zones_plugin_description)
+
+	override fun getLogoResourceId(): Int = R.drawable.ic_action_layers
+
+	override fun isEnableByDefault(): Boolean = true
+
+	override fun getRenderPropertyPrefix(): String = "drone"
+
+	override fun registerLayerContextMenuActions(
+		adapter: ContextMenuAdapter,
+		mapActivity: MapActivity,
+		customRules: MutableList<RenderingRuleProperty>,
+	) {
+		val property = customRules.firstOrNull { it.attrName == RENDER_PROPERTY } ?: return
+		customRules.remove(property)
+		val preference = settings.getCustomRenderBooleanProperty(RENDER_PROPERTY)
+		val selected = preference.get()
+		adapter.addItem(
+			ContextMenuItem(ID)
+				.setTitleId(R.string.drone_zones, mapActivity)
+				.setSecondaryDescription(app.getString(if (selected) R.string.shared_string_on else R.string.shared_string_off))
+				.setSelected(selected)
+				.setColor(app, if (selected) R.color.osmand_orange else ContextMenuItem.INVALID_ID)
+				.setIcon(R.drawable.ic_action_layers)
+				.setListener(toggleListener(preference, mapActivity)),
+		)
+	}
+
+	private fun toggleListener(preference: CommonPreference<Boolean>, mapActivity: MapActivity) = object : OnRowItemClick() {
+		override fun onRowItemClick(uiAdapter: OnDataChangeUiAdapter, view: View, item: ContextMenuItem): Boolean = false
+
+		override fun onContextMenuClick(
+			uiAdapter: OnDataChangeUiAdapter?,
+			view: View?,
+			item: ContextMenuItem,
+			isChecked: Boolean,
+		): Boolean {
+			preference.set(isChecked)
+			item.setSelected(isChecked)
+			item.setColor(app, if (isChecked) R.color.osmand_orange else ContextMenuItem.INVALID_ID)
+			item.setSecondaryDescription(app.getString(if (isChecked) R.string.shared_string_on else R.string.shared_string_off))
+			uiAdapter?.onDataSetChanged()
+			mapActivity.refreshMapComplete()
+			return true
+		}
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/plugins/drone/menu/DroneZoneMenuController.kt
+++ b/OsmAnd/src/net/osmand/plus/plugins/drone/menu/DroneZoneMenuController.kt
@@ -1,0 +1,63 @@
+package net.osmand.plus.plugins.drone.menu
+
+import net.osmand.NativeLibrary.RenderedObject
+import net.osmand.data.LatLon
+import net.osmand.data.PointDescription
+import net.osmand.plus.R
+import net.osmand.plus.activities.MapActivity
+import net.osmand.plus.mapcontextmenu.controllers.RenderedObjectMenuController
+import net.osmand.plus.plugins.drone.DroneZoneRenderedObjectParser
+import net.osmand.plus.plugins.drone.model.RawValue
+
+class DroneZoneMenuController(
+	private val activity: MapActivity,
+	pointDescription: PointDescription,
+	renderedObject: RenderedObject,
+) : RenderedObjectMenuController(activity, pointDescription, renderedObject) {
+	private val zone = DroneZoneRenderedObjectParser.parse(renderedObject, preferredMapLangLC)
+
+	override fun getTypeStr(): String = activity.getString(R.string.drone_zones)
+
+	override fun getRightIconId(): Int = R.drawable.ic_action_layers
+
+	override fun addPlainMenuItems(typeStr: String?, pointDescription: PointDescription?, latLon: LatLon?) {
+		row(R.drawable.ic_action_info_dark, R.string.drone_zone_restriction, restrictionText(zone.restriction))
+		zone.typeCode?.let { row(R.drawable.ic_action_info_dark, R.string.drone_zone_category, it.raw) }
+		if (zone.reasons.isNotEmpty()) {
+			row(R.drawable.ic_action_info_dark, R.string.drone_zone_reasons, zone.reasons.joinToString(", ") { it.raw })
+		}
+		zone.lowerLimit?.let { row(R.drawable.ic_action_altitude_min, R.string.drone_zone_lower_limit, it.format()) }
+		zone.upperLimit?.let { row(R.drawable.ic_action_altitude_max, R.string.drone_zone_upper_limit, it.format()) }
+		if (zone.legalTexts.isNotEmpty()) {
+			row(R.drawable.ic_action_note_dark, R.string.drone_zone_legal_basis, zone.legalTexts.joinToString("\n"))
+		}
+		zone.links.forEach { link ->
+			addPlainMenuItem(R.drawable.ic_action_link, null, link.url, link.text, true, true, null)
+		}
+		val source = listOfNotNull(zone.dataset.provider, zone.dataset.source).filter { it.isNotBlank() }.joinToString(" · ")
+		row(R.drawable.ic_action_data, R.string.drone_zone_source, source)
+		zone.dataset.id?.let { row(R.drawable.ic_action_data, R.string.drone_zone_dataset, it) }
+		val validFrom = zone.dataset.validFrom
+		val validTo = zone.dataset.validTo
+		if (validFrom != null && validTo != null) {
+			row(R.drawable.ic_action_time_span, R.string.drone_zone_validity, activity.getString(R.string.drone_zone_validity_value, validFrom, validTo))
+		}
+		if (zone.dataset.expired) {
+			row(R.drawable.ic_action_warning_colored, 0, activity.getString(R.string.drone_zone_expired_warning))
+		}
+		row(R.drawable.ic_action_info_outlined, 0, activity.getString(R.string.drone_zone_disclaimer))
+	}
+
+	private fun restrictionText(value: RawValue): String {
+		return when (value.knownSemantic) {
+			"REQ_AUTHORIZATION" -> activity.getString(R.string.drone_zone_restriction_req_authorization)
+			else -> value.raw
+		}
+	}
+
+	private fun row(icon: Int, labelRes: Int, value: String) {
+		if (value.isNotBlank()) {
+			addPlainMenuItem(icon, null, value, if (labelRes == 0) null else activity.getString(labelRes), false, false, null)
+		}
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/plugins/drone/model/DroneZone.kt
+++ b/OsmAnd/src/net/osmand/plus/plugins/drone/model/DroneZone.kt
@@ -1,0 +1,43 @@
+package net.osmand.plus.plugins.drone.model
+
+data class RawValue(
+	val raw: String,
+	val knownSemantic: String? = null,
+)
+
+data class VerticalLimit(
+	val value: String,
+	val unit: RawValue,
+	val reference: RawValue,
+) {
+	fun format(): String = listOf(value, unit.raw, reference.raw).filter { it.isNotBlank() }.joinToString(" ")
+}
+
+data class DroneZoneLink(
+	val text: String,
+	val url: String,
+)
+
+data class DroneZoneDatasetInfo(
+	val id: String?,
+	val provider: String?,
+	val source: String?,
+	val validFrom: String?,
+	val validTo: String?,
+	val expired: Boolean,
+)
+
+data class DroneZone(
+	val sourceId: String?,
+	val identifier: String?,
+	val name: String,
+	val restriction: RawValue,
+	val variant: RawValue?,
+	val typeCode: RawValue?,
+	val reasons: List<RawValue>,
+	val lowerLimit: VerticalLimit?,
+	val upperLimit: VerticalLimit?,
+	val legalTexts: List<String>,
+	val links: List<DroneZoneLink>,
+	val dataset: DroneZoneDatasetInfo,
+)

--- a/OsmAnd/src/net/osmand/plus/render/MapRenderRepositories.java
+++ b/OsmAnd/src/net/osmand/plus/render/MapRenderRepositories.java
@@ -634,6 +634,27 @@ public class MapRenderRepositories {
 	public RotatedTileBox getCheckedBox() {
 		return checkedBox;
 	}
+
+	/**
+	 * Reads map objects whose bounding boxes contain the requested map point.
+	 * The rendering readers are reused under the same lock as {@link #loadMap},
+	 * so callers don't race the renderer or open another copy of every OBF.
+	 */
+	@NonNull
+	public synchronized List<BinaryMapDataObject> searchMapObjectsAt(int x31, int y31, int zoom,
+	                                                               @NonNull BinaryMapIndexReader.SearchFilter filter) {
+		List<BinaryMapDataObject> result = new ArrayList<>();
+		for (BinaryMapIndexReader reader : files.values()) {
+			SearchRequest<BinaryMapDataObject> request = BinaryMapIndexReader.buildSearchRequest(
+					x31, x31 + 1, y31, y31 + 1, zoom, filter);
+			try {
+				result.addAll(reader.searchMapIndex(request));
+			} catch (IOException e) {
+				log.debug("Map-object point search failed for " + reader.getRegionNames(), e);
+			}
+		}
+		return result;
+	}
 	
 	public int getCheckedRenderedState() {
 		// to track necessity of map download (1 (if basemap) + 2 (if normal map)

--- a/OsmAnd/src/net/osmand/plus/render/RendererRegistry.java
+++ b/OsmAnd/src/net/osmand/plus/render/RendererRegistry.java
@@ -57,6 +57,7 @@ public class RendererRegistry {
 	public static final String ROUTES_RENDER = "Routes";
 	public static final String OSMASSISTANT_RENDER = "OSM Assistant";
 	public static final String PUBLICTRANSPORTROUTES_RENDER = "Public transport routes";
+	public static final String DRONE_RENDER = "Drone zones";
 
 	public static boolean IGNORE_CACHED_STYLES = false; // enable to overwrite RENDERERS_DIR styles (debug)
 
@@ -100,6 +101,7 @@ public class RendererRegistry {
 		internalRenderers.put(ROUTES_RENDER, "routes" + ADDON_RENDERER_INDEX_EXT);
 		internalRenderers.put(OSMASSISTANT_RENDER, "osmassistant" + ADDON_RENDERER_INDEX_EXT);
 		internalRenderers.put(PUBLICTRANSPORTROUTES_RENDER, "publictransportroutes" + ADDON_RENDERER_INDEX_EXT);
+		internalRenderers.put(DRONE_RENDER, "drone" + ADDON_RENDERER_INDEX_EXT);
 	}
 
 	@Nullable

--- a/OsmAnd/src/net/osmand/plus/views/layers/MapSelectionHelper.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/MapSelectionHelper.java
@@ -33,6 +33,7 @@ import net.osmand.osm.OsmRouteType;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.configmap.ConfigureMapUtils;
 import net.osmand.plus.mapcontextmenu.controllers.SelectedGpxMenuController.SelectedGpxPoint;
+import net.osmand.plus.plugins.drone.DroneZoneObfSelection;
 import net.osmand.plus.plugins.osmedit.OsmBugsLayer.OpenStreetNote;
 import net.osmand.plus.render.MapRenderRepositories;
 import net.osmand.plus.render.NativeOsmandLibrary;
@@ -139,6 +140,7 @@ public class MapSelectionHelper {
 		} else if (nativeLib != null) {
 			selectObjectsFromNative(result, rules, nativeLib, tileBox, point);
 		}
+		DroneZoneObfSelection.collect(app, result, tileBox.getZoom());
 	}
 
 	protected void collectObjectsFromLayers(@NonNull MapSelectionResult result,


### PR DESCRIPTION
In most (all?) countries there are certain restrictions of where and under what circumstances it is allowed to fly drones.
I use OsmAnd as my main map app but always had to switch do worse applications to look up those zones, so I finally made some effort to add a drone geozone layer feature in OsmAnd myself.

It's a rough PoC, but I want to discuss this feature and what to do to get it upstream before wasting to much effort on the wrong things.
Apart from this repo I also have a patchset in the resource repo, will open a separate PR once the general approach is confirmed:
https://github.com/kiney/OsmAnd-resources/tree/geozones

Also created a fresh repo with a data import pipeline:
https://github.com/kiney/osmand-drone-layer-pipeline

it uses official german drone geozone data (DIPUL) which is licensed as CC BY-ND. In my understanding of that license distribution of resulting OBF files should be ok, as long as the data itself isn't altered.
The data model itself is inspired by the german data but should be universal.
Sadly I don't know any international data source, so probably a seperate data import pipeline is needed for every country that published such data.

AI disclosure: most of the code was written using codex gpt5.6. I couldn't find any AI policy in the repo, but as there's an AGENT.md file I figured this is ok.
This PR text is human written by me and I will human-read every feedback

Some screenshots:
<table style="width:100%">
  <tr>
<th><img src="https://github.com/user-attachments/assets/bc0d3a43-c088-457d-87f8-8a21c10bdd43"  width="300" height="auto"/> </th>
 <th><img src="https://github.com/user-attachments/assets/dfd84190-f2c2-4bc6-aff5-84c3389f4acc"  width="300" height="auto"/> </th>
 <th><img src="https://github.com/user-attachments/assets/d7f11ff7-b58c-477a-9afe-83bd9f24f31a"  width="300" height="auto"/> </td>
  </tr>
</table>
