### PR TITLE
Add rendering_attr_surface_clay_name and rendering_attr_surface_laterite_name

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -3507,6 +3507,8 @@ You need to activate the sensor so OsmAnd can find it.</string>
     <string name="rendering_attr_surface_grass_paver_name">Grass paver</string>
     <string name="rendering_attr_surface_ground_name">Ground</string>
     <string name="rendering_attr_surface_dirt_name">Dirt</string>
+    <string name="rendering_attr_surface_clay_name">Clay</string>
+    <string name="rendering_attr_surface_laterite_name">Laterite</string>
     <string name="rendering_attr_surface_mud_name">Mud</string>
     <string name="rendering_attr_surface_ice_name">Ice</string>
     <string name="rendering_attr_surface_salt_name">Salt</string>


### PR DESCRIPTION
Follow-up to [OsmAnd-resources#1397](https://github.com/osmandapp/OsmAnd-resources/pull/1397), which registered `surface=clay` and `surface=laterite` as retained values in `obf_creation/rendering_types.xml` and gave them speed factors in `routing/routing.xml`. A same-day follow-up commit ([711b568](https://github.com/osmandapp/OsmAnd-resources/commit/711b568)) also wired both into the `routeInfo_surface` rendering attribute in `default.render.xml` (`attrStringValue="surface_clay"` / `"surface_laterite"`), which drives the surface breakdown shown in route details.

That attribute resolves to `rendering_attr_surface_<value>_name` string resources, but those were never added here, every other surface value in that `<case>` list (`dirt`, `mud`, `ice`, `salt`, etc.) has a matching string, `clay` and `laterite` didn't. This adds the two missing entries, placed next to `dirt` to match the ordering in `default.render.xml`.

`surface=laterite` was approved via OSM's proposal process ([Proposal:Surface=laterite](https://wiki.openstreetmap.org/wiki/Proposal:Surface%3Dlaterite), 29-0-0) and is documented at [Tag:surface=laterite](https://wiki.openstreetmap.org/wiki/Tag:surface%3Dlaterite).