### PR TITLE
Spatial pipeline: fix token mask algebra (PR #25534)

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/search/core/spatial/SPATIAL_PIPELINE_MASK.md
+++ b/OsmAnd-java/src/main/java/net/osmand/search/core/spatial/SPATIAL_PIPELINE_MASK.md
@@ -1,0 +1,110 @@
+# Spatial pipeline: token mask algebra
+
+Companion to [PR #25534](https://github.com/osmandapp/OsmAnd/pull/25534) (`spatialPipeline` branch).
+
+This branch adds **`SpatialTokenMask`** and fixes **`SpatialStagePipeline`** so multi-object address search can combine text tokens with spatial joins reliably and fast.
+
+## Problem
+
+Given a tokenized query (e.g. `2419 Avenue G Dickinson TX USA`), the pipeline must find OSM objects whose names match tokens **and** intersect geographically, together covering **all** query tokens.
+
+Each candidate object carries a **64-bit mask**:
+
+| Bits | Meaning |
+|------|---------|
+| 0–1 | Atomic count: `00` none, `11` one POI/building, `01` saturated (two atomics — no more allowed) |
+| 2–3 | POI type: `00` other, `01` category, `11` POI |
+| 4+ | Per token (2 bits): `00` no match, `01` exact, `10` ambiguous (house number / POI ref) |
+
+Stages: **prepare → single-object hits → pair self-join → partial pairs × area objects** (city, boundary…).
+
+## What changed (vs draft PR)
+
+| Issue | Fix |
+|-------|-----|
+| Broken `allowedFast` lookup (`0x12`) | Correct lookup `0x22F2` in `SpatialTokenMask.allowed()` |
+| Slow / buggy `combine2BitMasks` loop | Loop-free `SpatialTokenMask.combine()` |
+| Duplicate query words block pairs (`Philadelphia Philadelphia County`) | `duplicateWordAlternatives()` + `bestAllowedCombine()` in `prepare` / `join` |
+| House number ambiguous on both streets (`4 8 ave paterson`) | `expandContestedTokens()` — per-token ownership fork |
+| Self-join `(A,A)` for building-only objects | Skip when `objId` equal in stage 2 |
+| NPE on building-only bbox | Fallback `mainAtom1` in `SpatialObjectRes` |
+| `printTokenTree` wrong token shift | `+ HEADER_BITS` in `SpatialStagePipelineStats.getTokenState` |
+| `acceptPairSemantic` disabled | Re-enabled for street×street / POI×POI settings |
+| `checkExcluded` concurrent mutation | Iterate snapshot of `masksStats` |
+
+Details: see commit message and `SpatialTokenMask` javadoc.
+
+## How to test
+
+### 1. Unit tests (recommended first)
+
+From repo root:
+
+```bash
+./gradlew :OsmAnd-java:test --tests net.osmand.search.core.spatial.SpatialTokenMaskTest
+```
+
+Windows:
+
+```bat
+gradlew.bat :OsmAnd-java:test --tests net.osmand.search.core.spatial.SpatialTokenMaskTest
+```
+
+### 2. Python cross-check (no Java build)
+
+```bash
+python OsmAnd-java/src/test/resources/spatial/mask_verify.py
+```
+
+Runs exhaustive header checks, 500k random mask pairs, and scenario tests (`Philadelphia`, `paterson`, self-pair).
+
+### 3. Integration / manual queries
+
+Pipeline is on when `SpatialTextSearchSettings.DEV_USE_PIPELINE = true` (default on `spatialPipeline`).
+
+Run `SpatialSearchTestAndDocs.main` with useful flags:
+
+```java
+settings.DEV_USE_PIPELINE = true;
+settings.MAX_PIPELINE_STAGE_TO_STOP = new int[0]; // do not stop early while debugging
+ctx.stats.printLogs = true;
+```
+
+Suggested regression queries (uncomment in `SpatialSearchTestAndDocs`):
+
+| Query | Notes |
+|-------|-------|
+| `4 8 ave paterson` vs `4 ave 8 paterson` | House-number assignment order |
+| `2419 Avenue G, Dickinson, 77539 TX USA` | Border / multi-token US address |
+| `Philadelphia Philadelphia County Pennsylvania` | Duplicate words |
+| `Travessa Santo António Rua Joaquim Ribeiro Carvalho Portugal` | Long multi-street query |
+
+Compare with `DEV_USE_PIPELINE = false` (legacy intersections) if needed.
+
+### 4. Optional: excluded common masks
+
+Very frequent single-token masks (`USA`, `street`…) are dropped from the spatial index when count > `EXCLUDE_MASKS` (8000). To verify nothing is lost:
+
+```java
+SpatialStagePipeline.CHECK_EXCLUDED = true;
+```
+
+## Files
+
+| File | Role |
+|------|------|
+| `SpatialTokenMask.java` | Pure mask algebra (allowed, combine, variants) |
+| `SpatialStagePipeline.java` | Multi-stage spatial join using masks |
+| `SpatialStagePipelineStats.java` | Debug stats (fixed token shift) |
+| `SpatialTokenMaskTest.java` | JUnit tests |
+| `src/test/resources/spatial/mask_verify.py` | Standalone verifier |
+
+## Merge notes
+
+- Target branch: **`spatialPipeline`** (PR #25534), not `master`.
+- Mask header rules subsume part of old `acceptPairSemantic`; street/POI intersection flags remain in Java.
+- West/East disambiguation (`57th street` near Central Park) is a **ranking** problem when direction is omitted — pipeline may return both; sort by user location.
+
+## Author
+
+Patch prepared for OsmAnd review — `dmvkmusic@osmand.net`.

--- a/OsmAnd-java/src/main/java/net/osmand/search/core/spatial/SPATIAL_PIPELINE_MASK.md
+++ b/OsmAnd-java/src/main/java/net/osmand/search/core/spatial/SPATIAL_PIPELINE_MASK.md
@@ -36,6 +36,22 @@ Details: see commit message and `SpatialTokenMask` javadoc.
 
 ## How to test
 
+### Windows quick start (JDK 17)
+
+Install once:
+
+```powershell
+winget install EclipseAdoptium.Temurin.17.JDK
+```
+
+Run both test suites from repo root:
+
+```powershell
+.\run-spatial-mask-tests.ps1
+```
+
+Requires `JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8` and `GRADLE_OPTS=-Xmx4g` on Windows (the script sets them). Without UTF-8 the full OsmAnd-java compile fails on non-ASCII source files.
+
 ### 1. Unit tests (recommended first)
 
 From repo root:

--- a/OsmAnd-java/src/main/java/net/osmand/search/core/spatial/SpatialStagePipeline.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/core/spatial/SpatialStagePipeline.java
@@ -3,9 +3,10 @@ package net.osmand.search.core.spatial;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
-import gnu.trove.list.array.TLongArrayList;
 import gnu.trove.map.hash.TLongObjectHashMap;
 import gnu.trove.set.hash.TIntHashSet;
 import gnu.trove.set.hash.TLongHashSet;
@@ -13,80 +14,68 @@ import net.osmand.search.core.HashSkipTileQuadTree;
 import net.osmand.search.core.HashSkipTileQuadTreeJoiner;
 import net.osmand.search.core.spatial.SpatialSearchToken.NameIndexAtom;
 
-// TODO ---------------
-// TODO Add non maximum results as well... (surplus words +-) -  germany_langestrasse
-// TODO other masks ?
-// TODO common words to skip
-// TODO x2 speed up by using flags
-// TODO x1 implement correct mixing alternative masks!
-// TODO introduce mask check into joiner index ?
 public class SpatialStagePipeline {
-    
-    private final SpatialSearchContext ctx;
-    
+
+	private final SpatialSearchContext ctx;
+
 	public static int EXCLUDE_MASKS = 8000; // speed up
 	public static boolean CHECK_EXCLUDED = false;
-    public static int MAX_STEPS = 5; // 1 - fully covered, 2 - 1 intersecction ,...
+	public static int MAX_STEPS = 5; // 1 - fully covered, 2 - 1 intersection, ...
 
-    public SpatialStagePipeline(SpatialSearchContext ctx) {
-        this.ctx = ctx;
-    }
+	public SpatialStagePipeline(SpatialSearchContext ctx) {
+		this.ctx = ctx;
+	}
 
+	public static final int MAX_SUPPORTED_TOKENS = SpatialTokenMask.MAX_TOKENS;
+	public static final long STATE_NO_MATCH = SpatialTokenMask.STATE_NO_MATCH;
+	public static final long STATE_EXACT_MATCH = SpatialTokenMask.STATE_EXACT;
+	public static final long STATE_AMBIGUOUS = SpatialTokenMask.STATE_AMBIGUOUS;
 
-	// MASK: 0x 01 00 10 ... 00 01
-	public static final int MAX_SUPPORTED_TOKENS = (64 - 4) / 2;
-	// 0-1 bits (atomic objects):
-	// 11 - 1 - atomic, 01 - 2 atomic, 00 - 0 atomic (& 01 intersection forbidden)
-	// 2-3 bits (poi & poi category):
-	// 11 - poi, 01 - poi category, 00 - other (& 01 intersection forbidden!)
-    public static final long STATE_NO_MATCH = 0L;      // 00
-    public static final long STATE_EXACT_MATCH = 1L;   // 01
-    public static final long STATE_AMBIGUOUS = 2L;     // 10
-//    public static final long STATE_ANY = 3L;           // 11
-    private static final long MASK_SET_01 = 0x5555_5555_5555_555FL;
-    private static final long MASK_SET_02 = 0x5555_5555_5555_5550L;
-    // ALLOWED &: 0000, 0011, 1100, 1111, 
-    
-    public static class SpatialObjectRes {
-    	public final NameIndexAtom[] atoms;  
-    	public NameIndexAtom mainAtom1;
-    	public NameIndexAtom mainAtom2;
+	public static class SpatialObjectRes {
+		public final NameIndexAtom[] atoms;
+		public NameIndexAtom mainAtom1;
+		public NameIndexAtom mainAtom2;
 
-    	public long mainMask = 0;
-    	public TLongArrayList otherMasks = new TLongArrayList(); 
-    	
+		public long mainMask = 0;
+		/** Alternative masks when duplicate query words hit the same object. */
+		long[] variants;
 
-    	public SpatialObjectRes(int tCount, NameIndexAtom atom, int index) {
-    		atoms = new NameIndexAtom[tCount];
+		public SpatialObjectRes(int tCount, NameIndexAtom atom, int index) {
+			atoms = new NameIndexAtom[tCount];
 			mainAtom1 = atom;
-			// TODO OPTIM_FLAG_POI_SAME_AS_CITY_STREET
-			int atomic = atom.atomicObject() ? 3 : 0;
+			long atomic = atom.atomicObject() ? SpatialTokenMask.ATOMIC_ONE : SpatialTokenMask.ATOMIC_NONE;
 			if (atom.atomicObject() && atom.sameNameAreaObj != null) {
-				atomic = 2; // 01 - 2 atomic
+				// POI named like its city/street: saturate so it can not pair with another atomic
+				atomic = SpatialTokenMask.ATOMIC_TWO;
 			}
-			int category = atom.isPOI() ? 3 : 0;
+			long category = atom.isPOI() ? SpatialTokenMask.POI_OBJECT : SpatialTokenMask.POI_NONE;
 			if (atom.isPoiCategory()) {
-    			category = 2; // 01
-    		}
-    		mainMask = atomic | (category << 2);
-    		setAtom(atom, index);
-    	}
-    	
-    	public void mergeSame(NameIndexAtom atom, int tokenIdx) {
-			// TODO x1 (duplicate words) implement correct mixing alternative masks!
-			// we need to separately process situation duplicate words in object and in query
-			if (mainAtom1.isPOIRef() || mainAtom1.isBuilding()) {
+				category = SpatialTokenMask.POI_CATEGORY;
+			}
+			mainMask = atomic | (category << 2);
+			setAtom(atom, index);
+		}
+
+		public void mergeSame(NameIndexAtom atom, int tokenIdx) {
+			if ((mainAtom1.isPOIRef() || mainAtom1.isBuilding()) && !atom.isPOIRef() && !atom.isBuilding()) {
 				mainAtom1 = atom;
 			}
 			setAtom(atom, tokenIdx);
 		}
-    	
-    	public SpatialObjectRes(long mask, SpatialObjectRes s1, SpatialObjectRes s2) {
-    		atoms = new NameIndexAtom[s1.atoms.length];
-    		this.mainMask = mask;
+
+		/**
+		 * Combination of two objects. resolved1/resolved2 are the masks actually
+		 * used after variant / ownership resolution; atoms are taken only from
+		 * the side that owns each token.
+		 */
+		public SpatialObjectRes(long mask, long resolved1, long resolved2, SpatialObjectRes s1, SpatialObjectRes s2) {
+			atoms = new NameIndexAtom[s1.atoms.length];
+			this.mainMask = mask;
 			for (int i = 0; i < atoms.length; i++) {
-				NameIndexAtom a1 = s1.atoms[i];
-				NameIndexAtom a2 = s2.atoms[i];
+				boolean own1 = SpatialTokenMask.getTokenState(resolved1, i) != STATE_NO_MATCH;
+				boolean own2 = SpatialTokenMask.getTokenState(resolved2, i) != STATE_NO_MATCH;
+				NameIndexAtom a1 = own1 ? s1.atoms[i] : null;
+				NameIndexAtom a2 = own2 ? s2.atoms[i] : null;
 				if (a1 != null && !a1.isPOIRef() && !a1.isBuilding()) {
 					atoms[i] = a1;
 					mainAtom1 = a1;
@@ -100,209 +89,159 @@ public class SpatialStagePipeline {
 					atoms[i] = a2;
 				}
 			}
-    	}
-    	
+			if (mainAtom1 == null) {
+				for (NameIndexAtom a : atoms) {
+					if (a != null) {
+						mainAtom1 = a;
+						break;
+					}
+				}
+			}
+		}
+
 		void setAtom(NameIndexAtom atom, int index) {
 			atoms[index] = atom;
-    		mainMask = setTokenState(mainMask, index, atom.isBuilding() || atom.isPOIRef() ? STATE_AMBIGUOUS : STATE_EXACT_MATCH);
+			mainMask = SpatialTokenMask.setTokenState(mainMask, index,
+					atom.isBuilding() || atom.isPOIRef() ? STATE_AMBIGUOUS : STATE_EXACT_MATCH);
 		}
+
+		long[] variants() {
+			return variants != null ? variants : new long[] { mainMask };
+		}
+
+		// --- thin wrappers kept for SpatialStagePipelineStats compatibility ---
 
 		public static long setTokenState(long currentMask, int tokenIdx, long state) {
-			int shift = tokenIdx * 2 + 4;
-			long clearMask = ~(3L << shift);
-			return (currentMask & clearMask) | ((state & 3L) << shift);
+			return SpatialTokenMask.setTokenState(currentMask, tokenIdx, state);
 		}
 
-	    public static int countCoveredTokens(long mask) {
-	        long activeTokensMask = (mask | (mask >>> 1)) & MASK_SET_02;
-	        return Long.bitCount(activeTokensMask);
-	    }
-	    
-	    public static boolean allowed(long m1, long m2) {
-	    	return allowedSlow(m1, m2);
-	    }
-	    
-		public static boolean allowedFast(long m1, long m2) {
-			long i = m1 & m2 & MASK_SET_01;
-			return i < 16 && ((0x12L >> i) & 1L) == 0;
-		}
-	    
-		public static boolean allowedSlow(long m1, long m2) {
-			long i = (m1 & m2 & MASK_SET_01);
-			if ((i & 3) == 1) {
-				return false;
-			} else if (((i >> 2) & 3) == 1) {
-				return false;
-			}
-			return (i >> 4) == 0;
-		}
-	    
-	    public static long combine2BitMasks(long mask1, long mask2, int totalTokens) {
-			long result = 0L;
-			int b1 = (int) (mask1 & 3L);
-			int b2 = (int) (mask2 & 3L);
-			int combinedAtomic;
-			if (b1 == 0) {
-			    combinedAtomic = b2;
-			} else if (b2 == 0) {
-			    combinedAtomic = b1;
-			} else {
-			    combinedAtomic = b1 == 3 && b2 == 3 ? 1 : 2; // 1 atomic + 1 atomic : overflow 
-			}
-			int p1 = (int) ((mask1 >> 2) & 3L);
-			int p2 = (int) ((mask2 >> 2) & 3L);
-			int combinedPoi;
-			if (p1 == 0) {
-			    combinedPoi = p2;
-			} else if (p2 == 0) {
-			    combinedPoi = p1;
-			} else {
-			    combinedPoi = (p1 == 3 && p2 == 3) ? 3 : 1; 
-			}
-			result |= (combinedPoi << 2) + combinedAtomic;
-			for (int i = 0; i < totalTokens; i++) {
-				int shift = i * 2 + 4;
-				long state1 = (mask1 >> shift) & 3L;
-				long state2 = (mask2 >> shift) & 3L;
-
-				long finalState;
-				if (state1 == STATE_EXACT_MATCH || state2 == STATE_EXACT_MATCH) {
-					finalState = STATE_EXACT_MATCH;
-				} else if (state1 == STATE_AMBIGUOUS || state2 == STATE_AMBIGUOUS) {
-					finalState = STATE_AMBIGUOUS;
-				} else {
-					finalState = STATE_NO_MATCH;
-				}
-				result |= (finalState << shift);
-			}
-			return result;
+		public static int countCoveredTokens(long mask) {
+			return SpatialTokenMask.countCoveredTokens(mask);
 		}
 
-	    /**
+		/** Delegates to {@link SpatialTokenMask#allowed(long, long)}. */
+		public static boolean allowed(long m1, long m2) {
+			return SpatialTokenMask.allowed(m1, m2);
+		}
+
+		/** Loop-free; totalTokens kept for call-site compatibility. */
+		public static long combine2BitMasks(long mask1, long mask2, int totalTokens) {
+			return SpatialTokenMask.combine(mask1, mask2);
+		}
+
+		/**
 		 * Helper method to format bitmask bits into a readable list of token words.
-		 * Accommodates the 2-bits-per-token indexing scheme.
 		 */
 		static String formatMaskTokens(long mask, List<SpatialSearchToken> tokens) {
-		    List<String> res = new ArrayList<String>(); 
-		    long atomicState = mask & 3L;
-		    if (atomicState == 3L) {        // 11
-		        res.add("A1");
-		    } else if (atomicState == 1L) { // 01
-		        res.add("A2");
-		    } else if (atomicState == 0L) { // 01
-		        res.add("A0");
-		    } else if (atomicState == 0L) { // 01
-		        res.add("A?");
-		    }
-		    long poiState = (mask >> 2) & 3L;
-		    if (poiState == 3L) {        // 11
-		        res.add("POI");
-		    } else if (poiState == 1L) { // 01
-		        res.add("POICAT");
-		    }
-
-		    int maxTokens = (64 - 4) / 2; // 30 токенов
-
-		    for (int tokenIndex = 0; tokenIndex < maxTokens; tokenIndex++) {
-		        int bitShift = 4 + (tokenIndex * 2);
-		        long tokenState = (mask >> bitShift) & 3L;
-		        if (tokenState != STATE_NO_MATCH) {
-		        	String symbol = tokenState == 1 ? "W" : "B";
-		            if (tokens != null && tokenIndex < tokens.size() && tokens.get(tokenIndex) != null) {
-		                String word = tokens.get(tokenIndex).word;
-		                res.add(word != null ? word : symbol + tokenIndex);
-		            } else {
-		                res.add(symbol + tokenIndex);
-		            }
-		        }
-		    }
-		    return res.toString();
+			List<String> res = new ArrayList<String>();
+			long atomicState = mask & 3L;
+			if (atomicState == SpatialTokenMask.ATOMIC_ONE) {
+				res.add("A1");
+			} else if (atomicState == SpatialTokenMask.ATOMIC_TWO) {
+				res.add("A2");
+			} else if (atomicState == SpatialTokenMask.ATOMIC_NONE) {
+				res.add("A0");
+			} else {
+				res.add("A?"); // undefined atomic state 10
+			}
+			long poiState = (mask >> 2) & 3L;
+			if (poiState == SpatialTokenMask.POI_OBJECT) {
+				res.add("POI");
+			} else if (poiState == SpatialTokenMask.POI_CATEGORY) {
+				res.add("POICAT");
+			}
+			for (int tokenIndex = 0; tokenIndex < SpatialTokenMask.MAX_TOKENS; tokenIndex++) {
+				long tokenState = SpatialTokenMask.getTokenState(mask, tokenIndex);
+				if (tokenState != STATE_NO_MATCH) {
+					String symbol = tokenState == STATE_EXACT_MATCH ? "W" : "B";
+					if (tokens != null && tokenIndex < tokens.size() && tokens.get(tokenIndex) != null) {
+						String word = tokens.get(tokenIndex).word;
+						res.add(word != null ? word : symbol + tokenIndex);
+					} else {
+						res.add(symbol + tokenIndex);
+					}
+				}
+			}
+			return res.toString();
 		}
+	}
 
-    }
-    
-    private static class MasksStats {
-    	TLongObjectHashMap<Integer> masks = new TLongObjectHashMap<Integer>();
-    	public final int intersections;
+	private static class MasksStats {
+		TLongObjectHashMap<Integer> masks = new TLongObjectHashMap<Integer>();
+		public final int intersections;
 
 		public MasksStats(int intersections) {
 			this.intersections = intersections;
 		}
 
-		int count(SpatialObjectRes obj) {
-			Integer cnt = masks.get(obj.mainMask);
+		int count(long mask) {
+			Integer cnt = masks.get(mask);
 			if (cnt == null) {
 				cnt = 1;
 			} else {
 				cnt++;
 			}
-			masks.put(obj.mainMask, cnt);
+			masks.put(mask, cnt);
 			return cnt;
 		}
-    }
-    
-   
-    
-    public static class SpatialPipelineResults {
-    	public final List<SpatialSearchToken> tokens;
+
+		int count(SpatialObjectRes obj) {
+			return count(obj.mainMask);
+		}
+	}
+
+	public static class SpatialPipelineResults {
+		public final List<SpatialSearchToken> tokens;
+
 		public SpatialPipelineResults(List<SpatialSearchToken> tokens) {
 			this.tokens = tokens;
 		}
-		
+
 		// stage 1
 		public final TLongObjectHashMap<SpatialObjectRes> objectsById = new TLongObjectHashMap<>();
 		public final TLongObjectHashMap<List<SpatialObjectRes>> excludedMasks = new TLongObjectHashMap<List<SpatialObjectRes>>();
-		
+
 		public final List<MasksStats> masksStats = new ArrayList<>();
-        public final HashSkipTileQuadTree<SpatialObjectRes> allObjectsTree = new HashSkipTileQuadTree<>();
-        public final HashSkipTileQuadTree<SpatialObjectRes> areaObjectsTree = new HashSkipTileQuadTree<>();
-		// stage 2, 3+        
+		public final HashSkipTileQuadTree<SpatialObjectRes> allObjectsTree = new HashSkipTileQuadTree<>();
+		public final HashSkipTileQuadTree<SpatialObjectRes> areaObjectsTree = new HashSkipTileQuadTree<>();
+		// stage 2, 3+
 		public final List<HashSkipTileQuadTree<SpatialObjectRes>> pairsTree = new ArrayList<>();
-		
+
 		public final List<SpatialSearchResultsList> combinations = new ArrayList<SpatialSearchResultsList>();
-        
-    }
+	}
 
+	/**
+	 * Groups of query token indices with the same word. Objects exact-matched
+	 * on several positions of one group get alternative masks so the joiner can
+	 * split duplicate words between both sides of a pair.
+	 */
+	private static int[][] duplicateTokenGroups(List<SpatialSearchToken> tokens) {
+		Map<String, List<Integer>> byWord = new LinkedHashMap<>();
+		for (int i = 0; i < tokens.size(); i++) {
+			String w = tokens.get(i).word;
+			if (w != null) {
+				byWord.computeIfAbsent(w, k -> new ArrayList<>()).add(i);
+			}
+		}
+		List<int[]> groups = new ArrayList<>();
+		for (List<Integer> g : byWord.values()) {
+			if (g.size() > 1) {
+				int[] arr = new int[g.size()];
+				for (int i = 0; i < arr.length; i++) {
+					arr[i] = g.get(i);
+				}
+				groups.add(arr);
+			}
+		}
+		return groups.toArray(new int[0][]);
+	}
 
-    public static class SpatialSearchResultChain {
-        public final long chainId;
-        public final List<NameIndexAtom> atoms;
-        public final int[] bbox31;
-        public final long combinedMask;
-
-        public SpatialSearchResultChain(List<NameIndexAtom> atoms, int[] bbox31, long combinedMask) {
-            this.atoms = atoms;
-            this.bbox31 = bbox31;
-            this.combinedMask = combinedMask;
-
-            long idAcc = 0;
-            for (NameIndexAtom a : atoms) {
-                idAcc ^= a.id;
-            }
-            this.chainId = idAcc ^ combinedMask;
-        }
-
-        public boolean containsAtom(long atomId) {
-            for (NameIndexAtom a : atoms) {
-                if (a.id == atomId) return true;
-            }
-            return false;
-        }
-
-        public SpatialSearchResultChain extend(NameIndexAtom newArea, int[] newBBox, long newMask) {
-            List<NameIndexAtom> extendedAtoms = new ArrayList<>(this.atoms);
-            extendedAtoms.add(newArea);
-            return new SpatialSearchResultChain(extendedAtoms, newBBox, newMask);
-        }
-    }
-
-
-    private SpatialPipelineResults prepare(List<SpatialSearchToken> tokens) {
-    	if (tokens.size() > MAX_SUPPORTED_TOKENS) {
+	private SpatialPipelineResults prepare(List<SpatialSearchToken> tokens) {
+		if (tokens.size() > MAX_SUPPORTED_TOKENS) {
 			tokens = tokens.subList(0, MAX_SUPPORTED_TOKENS);
 		}
-        SpatialPipelineResults prep = new SpatialPipelineResults(tokens);
-        int totalTokens = tokens.size();
+		SpatialPipelineResults prep = new SpatialPipelineResults(tokens);
+		int totalTokens = tokens.size();
 		for (int tokenIdx = 0; tokenIdx < totalTokens; tokenIdx++) {
 			SpatialSearchToken token = tokens.get(tokenIdx);
 			TIntHashSet deleted = token.getDeletedAtoms();
@@ -314,11 +253,28 @@ public class SpatialStagePipeline {
 				if (existing != null) {
 					existing.mergeSame(atom, tokenIdx);
 				} else {
-					SpatialObjectRes obj = new SpatialObjectRes(totalTokens, atom, tokenIdx);
-					if(tokenIdx == 0 && atom.isGeoArea()) {
-						System.out.println(atom + " " + SpatialObjectRes.formatMaskTokens(obj.mainMask, tokens));
-					}
-					prep.objectsById.put(atom.id, obj);
+					prep.objectsById.put(atom.id, new SpatialObjectRes(totalTokens, atom, tokenIdx));
+				}
+			}
+		}
+		// alternative masks for duplicate query words
+		int[][] dupGroups = duplicateTokenGroups(tokens);
+		if (dupGroups.length > 0) {
+			long allDupBits = 0;
+			for (int[] group : dupGroups) {
+				for (int t : group) {
+					allDupBits |= 1L << (t * 2 + SpatialTokenMask.HEADER_BITS);
+				}
+			}
+			for (SpatialObjectRes obj : prep.objectsById.valueCollection()) {
+				// cheap pre-filter: alternatives only matter for objects with
+				// two or more exact matches inside duplicate-word positions
+				if (Long.bitCount(SpatialTokenMask.exactLowBits(obj.mainMask) & allDupBits) < 2) {
+					continue;
+				}
+				long[] vars = SpatialTokenMask.duplicateWordAlternatives(obj.mainMask, dupGroups);
+				if (vars.length > 1) {
+					obj.variants = vars;
 				}
 			}
 		}
@@ -328,7 +284,7 @@ public class SpatialStagePipeline {
 			masksStats.count(obj);
 		}
 		prep.masksStats.add(masksStats);
-		
+
 		for (SpatialObjectRes obj : prep.objectsById.valueCollection()) {
 			Integer cnt = masksStats.masks.get(obj.mainMask);
 			if (cnt > EXCLUDE_MASKS) {
@@ -344,23 +300,22 @@ public class SpatialStagePipeline {
 			if (obj.mainAtom1.isGeoArea()) {
 				prep.areaObjectsTree.addObject(obj, obj.mainAtom1.coords.bbox31, obj.mainAtom1.id);
 			}
- 		}
-        prep.allObjectsTree.build();
-        prep.areaObjectsTree.build();
+		}
+		prep.allObjectsTree.build();
+		prep.areaObjectsTree.build();
 
-        return prep;
+		return prep;
 	}
 
-	
 	private boolean validateStageAndFinish(SpatialPipelineResults prep, int[] intStats,
 			List<SpatialObjectRes> preResults, int stage, long ptime) throws IOException {
-		
+
 		long time = System.nanoTime();
 		if (ctx.stats.printLogs) {
 			String intersections = "";
 			if (intStats != null) {
-				intersections = String.format(" (cross %,d, partial %,d, full %,d)", intStats[0], intStats[1] - intStats[2],
-						intStats[2]);
+				intersections = String.format(" (cross %,d, partial %,d, full %,d)", intStats[0],
+						intStats[1] - intStats[2], intStats[2]);
 			}
 			System.out.printf("PIPELINE STAGE %d FIND (%.1f ms) - %,d results %s \n", stage, (time - ptime) / 1e6,
 					preResults.size(), intersections);
@@ -396,37 +351,34 @@ public class SpatialStagePipeline {
 		}
 		return false;
 	}
-	
-	
-    // =========================================================================
-    // Execution Engine with Mode Control
-    // =========================================================================
+
+	// =========================================================================
+	// Execution Engine
+	// =========================================================================
 	public List<SpatialSearchResultsList> runPipeline(List<SpatialSearchToken> tokens) throws IOException {
 		if (tokens == null || tokens.isEmpty()) {
 			return Collections.emptyList();
 		}
-		final int tokensSize = tokens.size();
+		final int tokensSize = Math.min(tokens.size(), MAX_SUPPORTED_TOKENS);
 		long time = System.nanoTime();
 
 		// STEP 0 PREPARE
 		int stage = 0;
 		SpatialPipelineResults prep = prepare(tokens);
 		if (ctx.stats.printLogs) {
-			System.out.printf("PIPELINE PREPARE tokens (%.1f ms): %,d objects\n", (System.nanoTime() - time) / 1e6, 
+			System.out.printf("PIPELINE PREPARE tokens (%.1f ms): %,d objects\n", (System.nanoTime() - time) / 1e6,
 					prep.allObjectsTree.getSize());
+			SpatialStagePipelineStats.printTree(prep);
 		}
 		time = System.nanoTime();
 		if (stage++ >= MAX_STEPS || ctx.isCancelled()) {
 			return prep.combinations;
 		}
-//		SpatialStagePipelineStats.evaluateMaskIntersections(prep);
-		SpatialStagePipelineStats.printTree(prep);
-//		SpatialStagePipelineStats.printTokenTree(prep);
-		
-		// STEP 1
+
+		// STEP 1: single objects covering all tokens
 		List<SpatialObjectRes> singleResults = new ArrayList<>();
 		for (SpatialObjectRes obj : prep.objectsById.valueCollection()) {
-			if (SpatialObjectRes.countCoveredTokens(obj.mainMask) == tokensSize) {
+			if (SpatialTokenMask.countCoveredTokens(obj.mainMask) == tokensSize) {
 				singleResults.add(obj);
 			}
 		}
@@ -437,18 +389,18 @@ public class SpatialStagePipeline {
 		if (stage++ >= MAX_STEPS || ctx.isCancelled()) {
 			return prep.combinations;
 		}
-		
-		// STEP 2: Spatial Join Pairs
+
+		// STEP 2: spatial self-join pairs
 		HashSkipTileQuadTreeJoiner<SpatialObjectRes, SpatialObjectRes> selfJoiner = new HashSkipTileQuadTreeJoiner<>(
-				prep.allObjectsTree, prep.allObjectsTree);// prep.allObjectsTree);
-		
-		boolean exit = join(prep, stage, selfJoiner, time);
+				prep.allObjectsTree, prep.allObjectsTree);
+
+		boolean exit = join(prep, stage, selfJoiner, true, time);
 		if (stage++ >= MAX_STEPS || ctx.isCancelled() || exit) {
 			return prep.combinations;
 		}
 		time = System.nanoTime();
-		
-		// STEP 3: Spatial Join Pairs
+
+		// STEP 3+: partial pairs x area objects
 		for (; stage <= MAX_STEPS && !ctx.isCancelled() && !exit; stage++) {
 			HashSkipTileQuadTree<SpatialObjectRes> lastTree = prep.pairsTree.get(prep.pairsTree.size() - 1);
 			if (lastTree.isEmpty()) {
@@ -457,7 +409,7 @@ public class SpatialStagePipeline {
 			lastTree.build();
 			HashSkipTileQuadTreeJoiner<SpatialObjectRes, SpatialObjectRes> joiner = new HashSkipTileQuadTreeJoiner<>(
 					lastTree, prep.areaObjectsTree);
-			exit = join(prep, stage, joiner, time);
+			exit = join(prep, stage, joiner, false, time);
 			time = System.nanoTime();
 		}
 		// check potential missing results
@@ -468,14 +420,17 @@ public class SpatialStagePipeline {
 		return prep.combinations;
 	}
 
-
 	private void checkExcluded(final int tokensSize, SpatialPipelineResults prep) throws IOException {
 		long[] excl = prep.excludedMasks.keys();
-		System.out.println("Excluded masks: " + excl.length);
+		if (ctx.stats.printLogs) {
+			System.out.println("Excluded masks: " + excl.length);
+		}
 		MasksStats baseMasksStats = prep.masksStats.get(0);
 		long time = System.nanoTime();
-		for (int stage = 1; stage < MAX_STEPS && stage < prep.masksStats.size(); stage++) {
-			for (int i = 0; i < prep.masksStats.size(); i++) {
+		// join() below appends to masksStats/pairsTree — iterate a snapshot
+		final int statsSnapshot = prep.masksStats.size();
+		for (int stage = 1; stage < MAX_STEPS && stage < statsSnapshot; stage++) {
+			for (int i = 0; i < statsSnapshot; i++) {
 				MasksStats masksStats = prep.masksStats.get(i);
 				if (masksStats.intersections != stage) {
 					continue;
@@ -487,16 +442,20 @@ public class SpatialStagePipeline {
 				for (int k = 0; k < excl.length; k++) {
 					long maskExcl = excl[k];
 					for (long m : masksStats.masks.keys()) {
-						if (!SpatialObjectRes.allowed(m, maskExcl)) {
+						if (!SpatialTokenMask.allowed(m, maskExcl)) {
 							continue;
 						}
-						long combined = SpatialObjectRes.combine2BitMasks(m, maskExcl, tokensSize);
-						if (SpatialObjectRes.countCoveredTokens(combined) == tokensSize) {
-							Integer c1 = baseMasksStats.masks.get(maskExcl);
-							Integer c2 = masksStats.masks.get(m);
-							System.out.printf("Potential results %d intersections - missing %s (%,d) x %s (%,d < %,d ) = %,d \n",
-									stage + 1, SpatialObjectRes.formatMaskTokens(maskExcl, prep.tokens), c1,
-									SpatialObjectRes.formatMaskTokens(m, prep.tokens), c2, partialTree.getSize(), c1 * c2);
+						long combined = SpatialTokenMask.combine(m, maskExcl);
+						if (SpatialTokenMask.countCoveredTokens(combined) == tokensSize) {
+							if (ctx.stats.printLogs) {
+								Integer c1 = baseMasksStats.masks.get(maskExcl);
+								Integer c2 = masksStats.masks.get(m);
+								System.out.printf(
+										"Potential results %d intersections - missing %s (%,d) x %s (%,d < %,d ) = %,d \n",
+										stage + 1, SpatialObjectRes.formatMaskTokens(maskExcl, prep.tokens), c1,
+										SpatialObjectRes.formatMaskTokens(m, prep.tokens), c2, partialTree.getSize(),
+										c1 * c2);
+							}
 							found.add(maskExcl);
 						}
 					}
@@ -515,7 +474,7 @@ public class SpatialStagePipeline {
 				partialTree.build();
 				HashSkipTileQuadTreeJoiner<SpatialObjectRes, SpatialObjectRes> tailJoiner = new HashSkipTileQuadTreeJoiner<>(
 						partialTree, exclTree);
-				boolean exit = join(prep, stage + 1, tailJoiner, time);
+				boolean exit = join(prep, stage + 1, tailJoiner, false, time);
 				if (ctx.isCancelled() || exit) {
 					return;
 				}
@@ -524,49 +483,73 @@ public class SpatialStagePipeline {
 		}
 	}
 
-
 	private boolean join(SpatialPipelineResults prep, int stage,
-			HashSkipTileQuadTreeJoiner<SpatialObjectRes, SpatialObjectRes> joiner, long time) throws IOException {
+			HashSkipTileQuadTreeJoiner<SpatialObjectRes, SpatialObjectRes> joiner, boolean selfJoin, long time)
+			throws IOException {
 		List<SpatialObjectRes> pairResults = new ArrayList<>();
 		final int tokensSize = prep.tokens.size();
 		HashSkipTileQuadTree<SpatialObjectRes> pairsTree = new HashSkipTileQuadTree<>();
 		prep.pairsTree.add(pairsTree);
 		final MasksStats ms = new MasksStats(stage);
 		prep.masksStats.add(ms);
-		int[] itStats = new int[] {0, 0, 0};
+		int[] itStats = new int[] { 0, 0, 0 };
 		if (ctx.stats.printLogs) {
-			System.out.printf("PIPELINE STAGE %d INTERSECT - %,d x %,d tree...\n", stage, 
+			System.out.printf("PIPELINE STAGE %d INTERSECT - %,d x %,d tree...\n", stage,
 					joiner.getTree1().getSize(), joiner.getTree2().getSize());
 		}
 		joiner.joinAllBuckets((e1, e2) -> {
 			itStats[0]++;
-			if (!SpatialObjectRes.allowed(e1.obj.mainMask, e2.obj.mainMask)) {
+			// skip identity pairs in self-join (ambiguous-only objects pass allowed(m,m))
+			if (selfJoin && e1.objId == e2.objId) {
 				return;
 			}
-			// TODO check preformance this is covered by mask
-//			if (e1.objId <= e2.objId) {
-//				return; // skip 1 side pairs by id
-//			} else 
+			SpatialObjectRes o1 = e1.obj;
+			SpatialObjectRes o2 = e2.obj;
+			long m1, m2, combinedMask;
+			if (o1.variants == null && o2.variants == null) {
+				m1 = o1.mainMask;
+				m2 = o2.mainMask;
+				if (!SpatialTokenMask.allowed(m1, m2)) {
+					return;
+				}
+				combinedMask = SpatialTokenMask.combine(m1, m2);
+			} else {
+				// duplicate-word alternatives: pick best allowed combination
+				long[] best = SpatialTokenMask.bestAllowedCombine(o1.variants(), o2.variants());
+				if (best == null) {
+					return;
+				}
+				combinedMask = best[0];
+				m1 = best[1];
+				m2 = best[2];
+			}
 			itStats[1]++;
-			long combinedMask = SpatialObjectRes.combine2BitMasks(e1.obj.mainMask, e2.obj.mainMask, tokensSize);
-			SpatialObjectRes res = new SpatialObjectRes(combinedMask, e1.obj, e2.obj);
-			ms.count(res);
-			if (SpatialObjectRes.countCoveredTokens(combinedMask) == tokensSize) {
-				// TODO add combinations from combined mask
+			ms.count(combinedMask);
+			if (SpatialTokenMask.countCoveredTokens(combinedMask) == tokensSize) {
 				itStats[2]++;
-				pairResults.add(res);
+				// fork contested ambiguous tokens (house number on both sides)
+				for (long[] resolved : SpatialTokenMask.expandContestedTokens(m1, m2)) {
+					long resolvedMask = SpatialTokenMask.combine(resolved[0], resolved[1]);
+					SpatialObjectRes res = new SpatialObjectRes(resolvedMask, resolved[0], resolved[1], o1, o2);
+					if (acceptPairSemantic(ctx, res)) {
+						pairResults.add(res);
+					}
+				}
 				return;
+			}
+			SpatialObjectRes res = new SpatialObjectRes(combinedMask, m1, m2, o1, o2);
+			if (res.mainAtom1 == null) {
+				return; // no owned atoms left after variant resolution
 			}
 			int[] bb = res.mainAtom1.coords.bbox31;
 			int[] clippedBBox = new int[] { bb[0], bb[1], bb[2], bb[3] };
-			SpatialSearchResultsList.clipBbox(clippedBBox, res.mainAtom2.coords.bbox31);
+			if (res.mainAtom2 != null) {
+				SpatialSearchResultsList.clipBbox(clippedBBox, res.mainAtom2.coords.bbox31);
+			}
 			pairsTree.addObject(res, clippedBBox, -1);
 		});
 
-		if (validateStageAndFinish(prep, itStats, pairResults, stage, time)) {
-			return true;
-		}
-		return false;
+		return validateStageAndFinish(prep, itStats, pairResults, stage, time);
 	}
 
 	private SpatialSearchResultsList createResultList(List<SpatialSearchToken> tokens, List<SpatialObjectRes> r) {
@@ -579,50 +562,24 @@ public class SpatialStagePipeline {
 		}
 		return singleResults;
 	}
-	
-    public static boolean acceptPairSemantic(SpatialSearchContext ctx, SpatialObjectRes pair) {
-//        SpatialTextSearchSettings settings = ctx.settings;
-//        NameIndexAtom a1 = pair.mainAtom1;
-//        NameIndexAtom a2 = pair.mainAtom2;
-//		if (a1.isPoiCategory() && (a2.isPoiCategory() || a2.isPOI())) {
-//			return false;
-//		} else if (a2.isPoiCategory() && (a1.isPoiCategory() || a1.isPOI())) {
-//			return false;
-//		}
-        // TODO x2 speed up by using flags
-//        if (settings.OPTIM_FLAG_POI_SAME_AS_CITY_STREET && a1.atomicObject() && a2.atomicObject()) {
-//            if (a1.sameNameAreaObj != null || a2.sameNameAreaObj != null) {
-//                return false;
-//            }
-//        }
-        // TODO other accept
-//        if (!settings.SEARCH_STREET_INTERSECTIONS && a1.isStreetBuilding() && a2.isStreetBuilding()) {
-//            return false;
-//        }
-//        if (!settings.SEARCH_POI_INTERSECTIONS && a1.isPOI() && a2.isPOI()) {
-//            return false;
-//        }
-//        boolean a1Building = a1.isBuilding() || (a1.buildingOrRefInd >= 0);
-//        boolean a2Building = a2.isBuilding() || (a2.buildingOrRefInd >= 0);
-//        if (a1Building || a2Building) {
-//            NameIndexAtom building = a1Building ? a1 : a2;
-//            NameIndexAtom other = a1Building ? a2 : a1;
-//            if (other.isBuilding() || other.buildingOrRefInd >= 0) {
-//                return false;
-//            }
-//            if (other.isStreetBuilding() || other.isCity() || other.isBoundary()) {
-//                return true;
-//            }
-//            return false;
-//        }
-//
-//        int atomicCount = (a1.atomicObject() ? 1 : 0) + (a2.atomicObject() ? 1 : 0);
-//        if (atomicCount > settings.LIMIT_ATOMIC_OBJECTS) {
-//            return false;
-//        }
 
-
-        return true;
-    }
-    
+	/**
+	 * Semantic rules not already enforced by the mask header in
+	 * {@link SpatialTokenMask#allowed(long, long)}.
+	 */
+	public static boolean acceptPairSemantic(SpatialSearchContext ctx, SpatialObjectRes pair) {
+		NameIndexAtom a1 = pair.mainAtom1;
+		NameIndexAtom a2 = pair.mainAtom2;
+		if (a1 == null || a2 == null) {
+			return true; // deep combination - sides were validated pairwise before
+		}
+		SpatialTextSearch.SpatialTextSearchSettings settings = ctx.settings;
+		if (!settings.SEARCH_STREET_INTERSECTIONS && a1.isStreetBuilding() && a2.isStreetBuilding()) {
+			return false;
+		}
+		if (!settings.SEARCH_POI_INTERSECTIONS && a1.isPOI() && a2.isPOI()) {
+			return false;
+		}
+		return true;
+	}
 }

--- a/OsmAnd-java/src/main/java/net/osmand/search/core/spatial/SpatialStagePipelineStats.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/core/spatial/SpatialStagePipelineStats.java
@@ -122,9 +122,9 @@ public class SpatialStagePipelineStats {
 	    System.out.println("==========================================================================================");
 	}
 
-	// Helper to extract the 2-bit state (0, 1, or 2) for a given token index
+	// Token fields start after the 4-bit header (atomic + poi).
 	private static long getTokenState(long mask, int tokenIdx) {
-	    int shift = tokenIdx * 2;
+	    int shift = tokenIdx * 2 + SpatialTokenMask.HEADER_BITS;
 	    return (mask >> shift) & 3L;
 	}
 

--- a/OsmAnd-java/src/main/java/net/osmand/search/core/spatial/SpatialTokenMask.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/core/spatial/SpatialTokenMask.java
@@ -1,0 +1,260 @@
+package net.osmand.search.core.spatial;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Pure bit algebra for the spatial pipeline token masks. Every method here is
+ * verified by {@code SpatialTokenMaskTest} and
+ * {@code src/test/resources/spatial/mask_verify.py}.
+ *
+ * Mask layout (64 bits):
+ *   bits 0-1  atomic header: 00 none, 11 one atomic object, 01 two atomic (saturated)
+ *   bits 2-3  poi header:    00 other, 11 poi, 01 poi category
+ *   bits 4+   2 bits per query token:
+ *             00 no match, 01 exact match, 10 ambiguous (building number / poi ref)
+ *
+ * Intersection rule (allowed): m1 & m2 must not produce
+ *   - atomic field 01 (would exceed two atomic objects)
+ *   - poi field 01    (poi x category and category x category are forbidden)
+ *   - any query token consumed exactly by both sides
+ */
+public final class SpatialTokenMask {
+
+	public static final int HEADER_BITS = 4;
+	public static final int MAX_TOKENS = (64 - HEADER_BITS) / 2;
+
+	public static final long STATE_NO_MATCH = 0L;   // 00
+	public static final long STATE_EXACT = 1L;      // 01
+	public static final long STATE_AMBIGUOUS = 2L;  // 10
+
+	public static final long ATOMIC_NONE = 0L;      // 00
+	public static final long ATOMIC_TWO = 1L;       // 01 - saturated, cannot grow
+	public static final long ATOMIC_ONE = 3L;       // 11
+
+	public static final long POI_NONE = 0L;         // 00
+	public static final long POI_CATEGORY = 1L;     // 01
+	public static final long POI_OBJECT = 3L;       // 11
+
+	/** Low bit of every 2-bit token field (bits 4, 6, ..., 62). */
+	static final long TOKEN_LOW_BITS = 0x5555_5555_5555_5550L;
+	/** Token low bits plus the whole header nibble. */
+	static final long TOKEN_LOW_BITS_AND_HEADER = 0x5555_5555_5555_555FL;
+
+	/**
+	 * Bit i is set iff header intersection value i (= m1 & m2 & 0xF) is
+	 * forbidden: atomic field == 01 or poi field == 01. Evaluates to 0x22F2.
+	 * Replaces the broken constant 0x12 of the old allowedFast which missed
+	 * i = 5, 6, 7, 9, 13 (e.g. adding a third atomic to a saturated pair).
+	 */
+	static final long FORBIDDEN_HEADER = forbiddenHeaderLookup();
+
+	private static long forbiddenHeaderLookup() {
+		long lookup = 0;
+		for (int i = 0; i < 16; i++) {
+			if ((i & 3) == 1 || ((i >> 2) & 3) == 1) {
+				lookup |= 1L << i;
+			}
+		}
+		return lookup;
+	}
+
+	/** Ownership forks per pair are capped at 2^MAX_FORK_TOKENS variants. */
+	public static final int MAX_FORK_TOKENS = 4;
+	/** Cap for duplicate-word alternative masks per object. */
+	public static final int MAX_DUPLICATE_VARIANTS = 8;
+
+	private SpatialTokenMask() {
+	}
+
+	// ------------------------------------------------------------------
+	// Single mask construction / inspection
+	// ------------------------------------------------------------------
+
+	public static long setTokenState(long mask, int tokenIdx, long state) {
+		int shift = tokenIdx * 2 + HEADER_BITS;
+		return (mask & ~(3L << shift)) | ((state & 3L) << shift);
+	}
+
+	public static long getTokenState(long mask, int tokenIdx) {
+		return (mask >>> (tokenIdx * 2 + HEADER_BITS)) & 3L;
+	}
+
+	/** Number of tokens with any match (exact or ambiguous). */
+	public static int countCoveredTokens(long mask) {
+		return Long.bitCount((mask | (mask >>> 1)) & TOKEN_LOW_BITS);
+	}
+
+	public static int countExactTokens(long mask) {
+		return Long.bitCount(exactLowBits(mask));
+	}
+
+	public static int countAmbiguousTokens(long mask) {
+		return Long.bitCount(ambiguousLowBits(mask));
+	}
+
+	/** Low bit set at every token position in state 01 (exact). */
+	static long exactLowBits(long mask) {
+		return mask & ~(mask >>> 1) & TOKEN_LOW_BITS;
+	}
+
+	/** Low bit set at every token position in state 10 (ambiguous). */
+	static long ambiguousLowBits(long mask) {
+		return (mask >>> 1) & ~mask & TOKEN_LOW_BITS;
+	}
+
+	// ------------------------------------------------------------------
+	// Pair algebra
+	// ------------------------------------------------------------------
+
+	/**
+	 * True if two objects may be combined. O(1), branch-poor; equivalent to
+	 * the reference allowedSlow for every occurring mask (verified).
+	 */
+	public static boolean allowed(long m1, long m2) {
+		long i = m1 & m2 & TOKEN_LOW_BITS_AND_HEADER;
+		if ((i >>> HEADER_BITS) != 0) {
+			return false; // some query token consumed exactly by both sides
+		}
+		return ((FORBIDDEN_HEADER >>> i) & 1L) == 0;
+	}
+
+	/**
+	 * Loop-free replacement for combine2BitMasks (the "x2 speed up" TODO):
+	 * per token exact wins over ambiguous wins over no-match, headers
+	 * saturate. Never emits the undefined atomic state 10 the loop version
+	 * produced in its overflow branch.
+	 */
+	public static long combine(long m1, long m2) {
+		long or = m1 | m2;
+		long exact = or & TOKEN_LOW_BITS;
+		long ambiguous = (or >>> 1) & TOKEN_LOW_BITS & ~exact;
+		long tokens = exact | (ambiguous << 1);
+
+		long a1 = m1 & 3L, a2 = m2 & 3L;
+		long atomic = a1 == 0 ? a2 : (a2 == 0 ? a1 : ATOMIC_TWO);
+		long p1 = (m1 >>> 2) & 3L, p2 = (m2 >>> 2) & 3L;
+		long poi = p1 == 0 ? p2
+				: (p2 == 0 ? p1 : (p1 == POI_OBJECT && p2 == POI_OBJECT ? POI_OBJECT : POI_CATEGORY));
+		return atomic | (poi << 2) | tokens;
+	}
+
+	// ------------------------------------------------------------------
+	// Contested ambiguous tokens (per-token fork, replaces all-or-nothing)
+	// ------------------------------------------------------------------
+
+	/**
+	 * A token ambiguous on BOTH sides of a pair (house number "8" matched
+	 * building candidates of two different streets) can belong to either
+	 * object. Enumerates per-token ownership: for every contested token one
+	 * side keeps it, the other drops it. Tokens ambiguous on a single side
+	 * stay where they are and are resolved later by building calculation.
+	 *
+	 * Per-token (instead of the old all-or-nothing) is what queries with two
+	 * house numbers need: "4 8 ave paterson" assigns "4" and "8" to different
+	 * streets in the same result.
+	 *
+	 * @return list of {resolved1, resolved2}; a single identity pair when
+	 *         nothing is contested; at most 2^MAX_FORK_TOKENS variants,
+	 *         tokens above the cap stay ambiguous on both sides
+	 */
+	public static List<long[]> expandContestedTokens(long m1, long m2) {
+		long contested = ambiguousLowBits(m1) & ambiguousLowBits(m2);
+		List<long[]> res = new ArrayList<>(2);
+		if (contested == 0) {
+			res.add(new long[] { m1, m2 });
+			return res;
+		}
+		long[] forkBits = new long[Math.min(Long.bitCount(contested), MAX_FORK_TOKENS)];
+		long rest = contested;
+		for (int i = 0; i < forkBits.length; i++) {
+			forkBits[i] = Long.lowestOneBit(rest);
+			rest &= rest - 1;
+		}
+		for (int v = 0; v < (1 << forkBits.length); v++) {
+			long drop1 = 0, drop2 = 0;
+			for (int j = 0; j < forkBits.length; j++) {
+				if (((v >> j) & 1) != 0) {
+					drop1 |= forkBits[j]; // token goes to side 2
+				} else {
+					drop2 |= forkBits[j]; // token goes to side 1
+				}
+			}
+			res.add(new long[] { m1 & ~(drop1 | (drop1 << 1)), m2 & ~(drop2 | (drop2 << 1)) });
+		}
+		return res;
+	}
+
+	// ------------------------------------------------------------------
+	// Duplicate query words (the "TODO x1 alternative masks" of the pipeline)
+	// ------------------------------------------------------------------
+
+	/**
+	 * A query with a repeated word ("Philadelphia Philadelphia County") marks
+	 * the same object exact on several token positions, so two such objects
+	 * can never pass allowed() together although each of them only needs one
+	 * of the positions. For every group of equal query tokens matched more
+	 * than once this adds alternatives keeping exactly one position of the
+	 * group, letting the joiner hand duplicate words out between both sides.
+	 *
+	 * @param duplicateGroups groups of token indices holding the same word
+	 * @return variants, original mask first; length 1 if nothing to do
+	 */
+	public static long[] duplicateWordAlternatives(long mask, int[][] duplicateGroups) {
+		List<Long> variants = new ArrayList<>(2);
+		variants.add(mask);
+		for (int[] group : duplicateGroups) {
+			long groupBits = 0;
+			for (int t : group) {
+				groupBits |= 1L << (t * 2 + HEADER_BITS);
+			}
+			int size = variants.size();
+			for (int vi = 0; vi < size && variants.size() < MAX_DUPLICATE_VARIANTS; vi++) {
+				long v = variants.get(vi);
+				long matched = exactLowBits(v) & groupBits;
+				if (Long.bitCount(matched) < 2) {
+					continue;
+				}
+				long rest = matched;
+				while (rest != 0 && variants.size() < MAX_DUPLICATE_VARIANTS) {
+					long keep = Long.lowestOneBit(rest);
+					rest &= rest - 1;
+					long drop = matched & ~keep;
+					variants.add(v & ~(drop | (drop << 1)));
+				}
+			}
+		}
+		long[] out = new long[variants.size()];
+		for (int i = 0; i < out.length; i++) {
+			out[i] = variants.get(i);
+		}
+		return out;
+	}
+
+	/**
+	 * Best (max token coverage) allowed combination across mask variants of
+	 * two objects. Used by the joiner instead of plain allowed()+combine()
+	 * when either side has duplicate-word alternatives.
+	 *
+	 * @return {combined, chosenVariant1, chosenVariant2} or null if every
+	 *         variant combination is forbidden
+	 */
+	public static long[] bestAllowedCombine(long[] variants1, long[] variants2) {
+		long[] best = null;
+		int bestCovered = -1;
+		for (long v1 : variants1) {
+			for (long v2 : variants2) {
+				if (!allowed(v1, v2)) {
+					continue;
+				}
+				long c = combine(v1, v2);
+				int covered = countCoveredTokens(c);
+				if (covered > bestCovered) {
+					bestCovered = covered;
+					best = new long[] { c, v1, v2 };
+				}
+			}
+		}
+		return best;
+	}
+}

--- a/OsmAnd-java/src/test/java/net/osmand/search/core/spatial/SpatialTokenMaskTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/search/core/spatial/SpatialTokenMaskTest.java
@@ -1,0 +1,188 @@
+package net.osmand.search.core.spatial;
+
+import java.util.List;
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link SpatialTokenMask}. Mirrors the scenarios in
+ * {@code src/test/resources/spatial/mask_verify.py}.
+ */
+public class SpatialTokenMaskTest {
+
+	private static final long HDR_TOK = 0x5555_5555_5555_555FL;
+	private static final long TOKEN_LOW = 0x5555_5555_5555_5550L;
+
+	/** Reference allowedSlow from PR #25534 (spatialPipeline branch). */
+	static boolean refAllowedSlow(long m1, long m2) {
+		long i = m1 & m2 & HDR_TOK;
+		if ((i & 3) == 1) {
+			return false;
+		}
+		if (((i >> 2) & 3) == 1) {
+			return false;
+		}
+		return (i >> 4) == 0;
+	}
+
+	/** Reference combine2BitMasks loop from PR #25534. */
+	static long refCombineLoop(long m1, long m2, int totalTokens) {
+		long result = 0L;
+		int b1 = (int) (m1 & 3L);
+		int b2 = (int) (m2 & 3L);
+		int combinedAtomic;
+		if (b1 == 0) {
+			combinedAtomic = b2;
+		} else if (b2 == 0) {
+			combinedAtomic = b1;
+		} else {
+			combinedAtomic = b1 == 3 && b2 == 3 ? 1 : 2;
+		}
+		int p1 = (int) ((m1 >> 2) & 3L);
+		int p2 = (int) ((m2 >> 2) & 3L);
+		int combinedPoi;
+		if (p1 == 0) {
+			combinedPoi = p2;
+		} else if (p2 == 0) {
+			combinedPoi = p1;
+		} else {
+			combinedPoi = (p1 == 3 && p2 == 3) ? 3 : 1;
+		}
+		result |= (combinedPoi << 2) + combinedAtomic;
+		for (int i = 0; i < totalTokens; i++) {
+			int shift = i * 2 + 4;
+			long s1 = (m1 >> shift) & 3L;
+			long s2 = (m2 >> shift) & 3L;
+			long finalState;
+			if (s1 == 1 || s2 == 1) {
+				finalState = 1;
+			} else if (s1 == 2 || s2 == 2) {
+				finalState = 2;
+			} else {
+				finalState = 0;
+			}
+			result |= finalState << shift;
+		}
+		return result;
+	}
+
+	static long randMask(Random rng, int ntok) {
+		long atomic = new long[] { 0, 0, 0, 3, 3, 1 }[rng.nextInt(6)];
+		long poi = new long[] { 0, 0, 0, 3, 1 }[rng.nextInt(5)];
+		long m = atomic | (poi << 2);
+		for (int t = 0; t < ntok; t++) {
+			double r = rng.nextDouble();
+			long st = r < 0.18 ? 1 : (r < 0.30 ? 2 : 0);
+			m |= st << (t * 2 + 4);
+		}
+		return m;
+	}
+
+	@Test
+	public void allowedMatchesReferenceOnRandomMasks() {
+		Random rng = new Random(42);
+		for (int i = 0; i < 50_000; i++) {
+			long m1 = randMask(rng, SpatialTokenMask.MAX_TOKENS);
+			long m2 = randMask(rng, SpatialTokenMask.MAX_TOKENS);
+			Assert.assertEquals(refAllowedSlow(m1, m2), SpatialTokenMask.allowed(m1, m2));
+		}
+	}
+
+	@Test
+	public void combineMatchesReferenceOnAllowedPairs() {
+		Random rng = new Random(7);
+		for (int i = 0; i < 50_000; i++) {
+			long m1 = randMask(rng, SpatialTokenMask.MAX_TOKENS);
+			long m2 = randMask(rng, SpatialTokenMask.MAX_TOKENS);
+			if (!SpatialTokenMask.allowed(m1, m2)) {
+				continue;
+			}
+			long ref = refCombineLoop(m1, m2, SpatialTokenMask.MAX_TOKENS);
+			long neu = SpatialTokenMask.combine(m1, m2);
+			Assert.assertEquals(ref, neu);
+		}
+	}
+
+	@Test
+	public void combineNeverEmitsUndefinedAtomicState() {
+		Random rng = new Random(8);
+		for (int i = 0; i < 10_000; i++) {
+			long c = SpatialTokenMask.combine(randMask(rng, 30), randMask(rng, 30));
+			Assert.assertNotEquals(2L, c & 3L);
+		}
+	}
+
+	@Test
+	public void duplicateWordsPhiladelphiaCounty() {
+		long city = SpatialTokenMask.setTokenState(
+				SpatialTokenMask.setTokenState(0, 0, SpatialTokenMask.STATE_EXACT), 1,
+				SpatialTokenMask.STATE_EXACT);
+		long county = SpatialTokenMask.setTokenState(
+				SpatialTokenMask.setTokenState(
+						SpatialTokenMask.setTokenState(0, 0, SpatialTokenMask.STATE_EXACT), 1,
+						SpatialTokenMask.STATE_EXACT),
+				2, SpatialTokenMask.STATE_EXACT);
+
+		Assert.assertFalse(SpatialTokenMask.allowed(city, county));
+
+		long[] cityVars = SpatialTokenMask.duplicateWordAlternatives(city, new int[][] { { 0, 1 } });
+		long[] countyVars = SpatialTokenMask.duplicateWordAlternatives(county, new int[][] { { 0, 1 } });
+		Assert.assertTrue(cityVars.length > 1);
+
+		long[] best = SpatialTokenMask.bestAllowedCombine(cityVars, countyVars);
+		Assert.assertNotNull(best);
+		Assert.assertEquals(3, SpatialTokenMask.countCoveredTokens(best[0]));
+	}
+
+	@Test
+	public void contestedHouseNumberPaterson() {
+		long sideA = SpatialTokenMask.setTokenState(
+				SpatialTokenMask.setTokenState(0, 0, SpatialTokenMask.STATE_EXACT), 1,
+				SpatialTokenMask.STATE_AMBIGUOUS);
+		long sideB = SpatialTokenMask.setTokenState(
+				SpatialTokenMask.setTokenState(
+						SpatialTokenMask.setTokenState(0, 1, SpatialTokenMask.STATE_AMBIGUOUS), 2,
+						SpatialTokenMask.STATE_EXACT),
+				3, SpatialTokenMask.STATE_EXACT);
+
+		Assert.assertTrue(SpatialTokenMask.allowed(sideA, sideB));
+		long combined = SpatialTokenMask.combine(sideA, sideB);
+		Assert.assertEquals(4, SpatialTokenMask.countCoveredTokens(combined));
+		Assert.assertEquals(SpatialTokenMask.STATE_AMBIGUOUS, SpatialTokenMask.getTokenState(combined, 1));
+
+		List<long[]> variants = SpatialTokenMask.expandContestedTokens(sideA, sideB);
+		Assert.assertEquals(2, variants.size());
+		for (long[] v : variants) {
+			boolean aOwns = SpatialTokenMask.getTokenState(v[0], 1) == SpatialTokenMask.STATE_AMBIGUOUS
+					&& SpatialTokenMask.getTokenState(v[1], 1) == SpatialTokenMask.STATE_NO_MATCH;
+			boolean bOwns = SpatialTokenMask.getTokenState(v[1], 1) == SpatialTokenMask.STATE_AMBIGUOUS
+					&& SpatialTokenMask.getTokenState(v[0], 1) == SpatialTokenMask.STATE_NO_MATCH;
+			Assert.assertTrue(aOwns ^ bOwns);
+		}
+	}
+
+	@Test
+	public void selfPairExactForbiddenAmbiguousAllowed() {
+		long exactObj = SpatialTokenMask.setTokenState(0, 0, SpatialTokenMask.STATE_EXACT);
+		long ambObj = SpatialTokenMask.setTokenState(0, 0, SpatialTokenMask.STATE_AMBIGUOUS) | 3;
+		Assert.assertFalse(SpatialTokenMask.allowed(exactObj, exactObj));
+		Assert.assertTrue(SpatialTokenMask.allowed(ambObj, ambObj));
+	}
+
+	@Test
+	public void countCoveredTokensMatchesNaive() {
+		Random rng = new Random(11);
+		for (int i = 0; i < 10_000; i++) {
+			long m = randMask(rng, 30);
+			int naive = 0;
+			for (int t = 0; t < SpatialTokenMask.MAX_TOKENS; t++) {
+				if (SpatialTokenMask.getTokenState(m, t) != 0) {
+					naive++;
+				}
+			}
+			Assert.assertEquals(naive, SpatialTokenMask.countCoveredTokens(m));
+		}
+	}
+}

--- a/OsmAnd-java/src/test/resources/spatial/mask_verify.py
+++ b/OsmAnd-java/src/test/resources/spatial/mask_verify.py
@@ -1,0 +1,460 @@
+# -*- coding: utf-8 -*-
+"""
+Verification harness for OsmAnd PR #25534 (spatialPipeline) token-mask algebra.
+
+Contains bit-exact ports of the REFERENCE implementation from the PR branch
+(SpatialStagePipeline.SpatialObjectRes) and the PROPOSED fixed/new logic.
+Runs exhaustive + randomized equivalence tests and scenario tests.
+
+Mask layout (64 bits):
+  bits 0-1  atomic header: 00 none, 11 one atomic object, 01 two atomic (saturated)
+  bits 2-3  poi header:    00 other, 11 poi, 01 poi category
+  bits 4+   2 bits per query token: 00 no match, 01 exact, 10 ambiguous (building/poi ref)
+"""
+
+import random
+import sys
+
+M64 = (1 << 64) - 1
+TOKEN_LOW = 0x5555_5555_5555_5550        # low bit of every 2-bit token field
+HDR_TOK = 0x5555_5555_5555_555F          # token low bits + whole header nibble
+HEADER_BITS = 4
+MAX_TOKENS = 30
+
+
+def not64(x):
+    return (~x) & M64
+
+
+# =====================================================================
+# REFERENCE: bit-exact ports from PR branch SpatialStagePipeline.java
+# =====================================================================
+
+def ref_allowed_slow(m1, m2):
+    i = m1 & m2 & HDR_TOK
+    if (i & 3) == 1:
+        return False
+    if ((i >> 2) & 3) == 1:
+        return False
+    return (i >> 4) == 0
+
+
+def ref_allowed_fast_legacy(m1, m2):
+    """PR's allowedFast with the 0x12 lookup constant (currently unused in PR)."""
+    i = m1 & m2 & HDR_TOK
+    return i < 16 and ((0x12 >> i) & 1) == 0
+
+
+def ref_combine_loop(m1, m2, total_tokens):
+    """PR's combine2BitMasks: per-token loop + header merge."""
+    b1 = m1 & 3
+    b2 = m2 & 3
+    if b1 == 0:
+        ca = b2
+    elif b2 == 0:
+        ca = b1
+    else:
+        ca = 1 if (b1 == 3 and b2 == 3) else 2   # NB: 2 (=10) is an undefined atomic state
+    p1 = (m1 >> 2) & 3
+    p2 = (m2 >> 2) & 3
+    if p1 == 0:
+        cp = p2
+    elif p2 == 0:
+        cp = p1
+    else:
+        cp = 3 if (p1 == 3 and p2 == 3) else 1
+    res = (cp << 2) + ca
+    for i in range(total_tokens):
+        s = i * 2 + 4
+        s1 = (m1 >> s) & 3
+        s2 = (m2 >> s) & 3
+        if s1 == 1 or s2 == 1:
+            f = 1
+        elif s1 == 2 or s2 == 2:
+            f = 2
+        else:
+            f = 0
+        res |= f << s
+    return res
+
+
+def ref_count_covered(mask):
+    return bin((mask | (mask >> 1)) & TOKEN_LOW).count('1')
+
+
+# =====================================================================
+# PROPOSED: fixed / new logic (mirrors SpatialTokenMask.java deliverable)
+# =====================================================================
+
+def build_forbidden_header():
+    lookup = 0
+    for i in range(16):
+        if (i & 3) == 1 or ((i >> 2) & 3) == 1:
+            lookup |= 1 << i
+    return lookup
+
+
+FORBIDDEN_HEADER = build_forbidden_header()   # expected 0x22F2
+
+
+def new_allowed(m1, m2):
+    i = m1 & m2 & HDR_TOK
+    if (i >> HEADER_BITS) != 0:
+        return False
+    return ((FORBIDDEN_HEADER >> i) & 1) == 0
+
+
+def new_combine(m1, m2):
+    """Loop-free combine: exact wins over ambiguous wins over no-match."""
+    orv = m1 | m2
+    exact = orv & TOKEN_LOW
+    amb = ((orv >> 1) & TOKEN_LOW) & not64(exact)
+    tokens = exact | ((amb << 1) & M64)
+    a1 = m1 & 3
+    a2 = m2 & 3
+    atomic = a2 if a1 == 0 else (a1 if a2 == 0 else 1)   # saturate to ATOMIC_TWO (01)
+    p1 = (m1 >> 2) & 3
+    p2 = (m2 >> 2) & 3
+    poi = p2 if p1 == 0 else (p1 if p2 == 0 else (3 if (p1 == 3 and p2 == 3) else 1))
+    return atomic | (poi << 2) | tokens
+
+
+def set_token(mask, idx, state):
+    shift = idx * 2 + HEADER_BITS
+    return (mask & not64(3 << shift)) | ((state & 3) << shift)
+
+
+def get_token(mask, idx):
+    return (mask >> (idx * 2 + HEADER_BITS)) & 3
+
+
+def exact_low_bits(mask):
+    return mask & not64(mask >> 1) & TOKEN_LOW
+
+
+def amb_low_bits(mask):
+    return (mask >> 1) & not64(mask) & TOKEN_LOW
+
+
+def count_covered(mask):
+    return bin((mask | (mask >> 1)) & TOKEN_LOW).count('1')
+
+
+MAX_FORK_TOKENS = 4
+
+
+def expand_contested(m1, m2, max_fork=MAX_FORK_TOKENS):
+    """Per-token ownership fork for tokens ambiguous on BOTH sides.
+
+    Returns list of (resolved1, resolved2). Tokens ambiguous on one side only
+    stay where they are (resolved downstream by building calculation).
+    """
+    contested = amb_low_bits(m1) & amb_low_bits(m2)
+    if contested == 0:
+        return [(m1, m2)]
+    fork_bits = []
+    rest = contested
+    while rest and len(fork_bits) < max_fork:
+        b = rest & (-rest) & M64
+        fork_bits.append(b)
+        rest &= rest - 1
+    out = []
+    for v in range(1 << len(fork_bits)):
+        drop1 = 0
+        drop2 = 0
+        for j, b in enumerate(fork_bits):
+            if (v >> j) & 1:
+                drop1 |= b          # token goes to side 2
+            else:
+                drop2 |= b          # token goes to side 1
+        r1 = m1 & not64(drop1 | (drop1 << 1))
+        r2 = m2 & not64(drop2 | (drop2 << 1))
+        out.append((r1, r2))
+    return out
+
+
+def duplicate_word_alternatives(mask, duplicate_groups, cap=8):
+    """Alternatives keeping exactly one exact match per duplicate-word group.
+
+    Returns list starting with the original mask. Solves the 'Philadelphia
+    Philadelphia County' class: without alternatives two objects that each
+    matched both duplicate positions can never pass allowed() together.
+    """
+    variants = [mask]
+    for group in duplicate_groups:
+        group_bits = 0
+        for t in group:
+            group_bits |= 1 << (t * 2 + HEADER_BITS)
+        size = len(variants)
+        for vi in range(size):
+            if len(variants) >= cap:
+                break
+            v = variants[vi]
+            matched = exact_low_bits(v) & group_bits
+            if bin(matched).count('1') < 2:
+                continue
+            rest = matched
+            while rest and len(variants) < cap:
+                keep = rest & (-rest) & M64
+                rest &= rest - 1
+                drop = matched & not64(keep)
+                variants.append(v & not64(drop | (drop << 1)))
+    return variants
+
+
+def best_allowed_combine(variants1, variants2):
+    """Max-coverage allowed combination across variants. None if all forbidden."""
+    best = None
+    best_cov = -1
+    for v1 in variants1:
+        for v2 in variants2:
+            if not new_allowed(v1, v2):
+                continue
+            c = new_combine(v1, v2)
+            cov = count_covered(c)
+            if cov > best_cov:
+                best_cov = cov
+                best = (c, v1, v2)
+    return best
+
+
+# =====================================================================
+# Tests
+# =====================================================================
+
+FAILURES = []
+
+
+def check(name, cond, detail=""):
+    if cond:
+        print(f"  PASS  {name}")
+    else:
+        print(f"  FAIL  {name}  {detail}")
+        FAILURES.append(name)
+
+
+def rand_mask(rng, ntok, p_exact=0.18, p_amb=0.12):
+    atomic = rng.choice([0, 0, 0, 3, 3, 1])
+    poi = rng.choice([0, 0, 0, 3, 1])
+    m = atomic | (poi << 2)
+    for t in range(ntok):
+        r = rng.random()
+        if r < p_exact:
+            st = 1
+        elif r < p_exact + p_amb:
+            st = 2
+        else:
+            st = 0
+        m |= st << (t * 2 + 4)
+    return m
+
+
+def test_forbidden_header_lookup():
+    print("[1] FORBIDDEN_HEADER lookup vs allowedSlow header logic (exhaustive)")
+    check("lookup constant == 0x22F2", FORBIDDEN_HEADER == 0x22F2,
+          f"got {FORBIDDEN_HEADER:#x}")
+    ok = True
+    for i in range(16):
+        slow_forbidden = (i & 3) == 1 or ((i >> 2) & 3) == 1
+        fast_forbidden = ((FORBIDDEN_HEADER >> i) & 1) == 1
+        if slow_forbidden != fast_forbidden:
+            ok = False
+    check("all 16 header intersection values agree", ok)
+
+
+def test_legacy_fast_is_broken():
+    print("[2] Demonstrate the allowedFast 0x12 bug (PR landmine, currently dormant)")
+    # occurring header field values: atomic/poi in {00, 01, 11}
+    occurring = [0, 1, 3]
+    mismatches = []
+    for a1 in occurring:
+        for p1 in occurring:
+            for a2 in occurring:
+                for p2 in occurring:
+                    m1 = a1 | (p1 << 2)
+                    m2 = a2 | (p2 << 2)
+                    if ref_allowed_fast_legacy(m1, m2) != ref_allowed_slow(m1, m2):
+                        mismatches.append((m1, m2))
+    check("legacy allowedFast disagrees with allowedSlow (bug exists)",
+          len(mismatches) > 0)
+    # practically relevant miss: a stage-3+ pair mask already saturated with
+    # 2 atomic objects (atomic field 01) must not combine with another atomic,
+    # header intersection i=5 -- legacy 0x12 allows it, slow forbids it
+    saturated_pair = 0x1 | (0x1 << 2)   # atomic 01 + poi category 01
+    atomic_cat = 0x3 | (0x1 << 2)       # atomic 11 + poi category 01
+    check("legacy fast wrongly ALLOWS third atomic into a saturated pair (i=5)",
+          ref_allowed_fast_legacy(saturated_pair, atomic_cat)
+          and not ref_allowed_slow(saturated_pair, atomic_cat))
+    print(f"        {len(mismatches)} mismatching header pairs, e.g. "
+          + ", ".join(f"({a:#x},{b:#x})" for a, b in mismatches[:5]))
+
+
+def test_allowed_equivalence():
+    print("[3] new_allowed == allowedSlow")
+    # exhaustive: all 16 headers x all token-state pairs on 2 tokens
+    states = [0, 1, 2]
+    masks = []
+    for hdr in range(16):
+        for s0 in states:
+            for s1 in states:
+                masks.append(hdr | (s0 << 4) | (s1 << 6))
+    ok = all(new_allowed(m1, m2) == ref_allowed_slow(m1, m2)
+             for m1 in masks for m2 in masks)
+    check(f"exhaustive small ({len(masks)}^2 pairs)", ok)
+
+    rng = random.Random(42)
+    bad = 0
+    for _ in range(200_000):
+        m1 = rand_mask(rng, 30)
+        m2 = rand_mask(rng, 30)
+        if new_allowed(m1, m2) != ref_allowed_slow(m1, m2):
+            bad += 1
+    check("randomized 200k pairs (30 tokens)", bad == 0, f"{bad} mismatches")
+
+
+def test_combine_equivalence():
+    print("[4] new_combine (loop-free) vs PR combine2BitMasks loop")
+    rng = random.Random(7)
+    token_diff = 0
+    full_diff_on_allowed = 0
+    invalid_atomic_ref = 0
+    for _ in range(200_000):
+        m1 = rand_mask(rng, 30)
+        m2 = rand_mask(rng, 30)
+        ref = ref_combine_loop(m1, m2, 30)
+        new = new_combine(m1, m2)
+        if (ref ^ new) & not64(0xF):
+            token_diff += 1
+        if ref_allowed_slow(m1, m2) and ref != new:
+            full_diff_on_allowed += 1
+        if (ref & 3) == 2:
+            invalid_atomic_ref += 1
+    check("token area identical on all pairs", token_diff == 0,
+          f"{token_diff} diffs")
+    check("full mask identical on all allowed() pairs",
+          full_diff_on_allowed == 0, f"{full_diff_on_allowed} diffs")
+    check("PR loop emits undefined atomic state 10 on forbidden pairs (bug exists)",
+          invalid_atomic_ref > 0)
+    # new_combine never emits undefined atomic state
+    rng2 = random.Random(8)
+    ok = True
+    for _ in range(50_000):
+        c = new_combine(rand_mask(rng2, 30), rand_mask(rng2, 30))
+        if (c & 3) == 2:
+            ok = False
+            break
+    check("new_combine atomic header always in {00, 01, 11}", ok)
+
+
+def test_count_covered():
+    print("[5] countCoveredTokens vs naive per-token loop")
+    rng = random.Random(11)
+    ok = True
+    for _ in range(100_000):
+        m = rand_mask(rng, 30)
+        naive = sum(1 for t in range(MAX_TOKENS) if get_token(m, t) != 0)
+        if count_covered(m) != naive or ref_count_covered(m) != naive:
+            ok = False
+            break
+    check("100k random masks", ok)
+
+
+def test_duplicate_words_philadelphia():
+    print("[6] Duplicate query words: 'Philadelphia Philadelphia County'")
+    # t0=philadelphia t1=philadelphia t2=county
+    city = set_token(set_token(0, 0, 1), 1, 1)            # exact t0, t1
+    county = set_token(set_token(set_token(0, 0, 1), 1, 1), 2, 1)  # exact t0,t1,t2
+
+    check("naive main x main pairing is forbidden (the current PR behavior)",
+          not new_allowed(city, county))
+
+    city_vars = duplicate_word_alternatives(city, [[0, 1]])
+    county_vars = duplicate_word_alternatives(county, [[0, 1]])
+    check("city gets 2 alternatives (keep t0 / keep t1)", len(city_vars) == 3,
+          f"got {len(city_vars)}")
+    best = best_allowed_combine(city_vars, county_vars)
+    check("variant pairing exists", best is not None)
+    if best:
+        combined, v1, v2 = best
+        check("variant pairing covers all 3 tokens", count_covered(combined) == 3,
+              f"covered {count_covered(combined)}")
+        # each duplicate position consumed by exactly one side
+        overlap = exact_low_bits(v1) & exact_low_bits(v2)
+        check("no token consumed by both sides", overlap == 0)
+
+
+def test_contested_house_numbers():
+    print("[7] Contested ambiguous tokens: '4 8 ave paterson' class")
+    # t0='4' t1='8' t2='ave' t3='paterson'
+    # side A: street '4th Street' (t0 exact) with building ref 8 (t1 ambiguous)
+    side_a = set_token(set_token(0, 0, 1), 1, 2)
+    # side B: street 'Paterson Avenue' (t2,t3 exact) with building ref 8 (t1 ambiguous)
+    side_b = set_token(set_token(set_token(0, 2, 1), 3, 1), 1, 2)
+
+    check("pair is allowed (ambiguous overlap is not exact overlap)",
+          new_allowed(side_a, side_b))
+    combined = new_combine(side_a, side_b)
+    check("combined covers all 4 tokens", count_covered(combined) == 4)
+    check("token '8' stays ambiguous in combined mask", get_token(combined, 1) == 2)
+
+    variants = expand_contested(side_a, side_b)
+    check("exactly 2 ownership variants for 1 contested token", len(variants) == 2,
+          f"got {len(variants)}")
+    owners = set()
+    for r1, r2 in variants:
+        a_owns = get_token(r1, 1) == 2 and get_token(r2, 1) == 0
+        b_owns = get_token(r2, 1) == 2 and get_token(r1, 1) == 0
+        check("each variant assigns '8' to exactly one side", a_owns != b_owns)
+        owners.add("A" if a_owns else "B")
+        # non-contested tokens untouched
+        check("non-contested tokens untouched",
+              get_token(r1, 0) == 1 and get_token(r2, 2) == 1 and get_token(r2, 3) == 1)
+    check("both ownership options produced", owners == {"A", "B"})
+
+    # no contest -> identity
+    plain = expand_contested(side_a, set_token(0, 2, 1))
+    check("no contested tokens -> single identity variant",
+          plain == [(side_a, set_token(0, 2, 1))])
+
+    # cap: 5 contested tokens -> fork 4, leave 1 shared
+    m1 = 0
+    m2 = 0
+    for t in range(5):
+        m1 = set_token(m1, t, 2)
+        m2 = set_token(m2, t, 2)
+    capped = expand_contested(m1, m2)
+    check("fork capped at 2^4 variants", len(capped) == 16, f"got {len(capped)}")
+    check("uncapped token stays ambiguous on both sides",
+          all(get_token(r1, 4) == 2 and get_token(r2, 4) == 2 for r1, r2 in capped))
+
+
+def test_self_pair():
+    print("[8] Self-pair behavior (why stage-2 self-join needs an id skip)")
+    exact_obj = set_token(0, 0, 1)
+    amb_obj = set_token(0, 0, 2) | 3   # atomic building matched only ambiguously
+    check("exact-token object cannot pair with itself", not new_allowed(exact_obj, exact_obj))
+    check("ambiguous-only object CAN pair with itself (mask does not prevent it)",
+          new_allowed(amb_obj, amb_obj))
+
+
+def main():
+    print("=" * 70)
+    print("OsmAnd PR #25534 mask algebra verification")
+    print("=" * 70)
+    test_forbidden_header_lookup()
+    test_legacy_fast_is_broken()
+    test_allowed_equivalence()
+    test_combine_equivalence()
+    test_count_covered()
+    test_duplicate_words_philadelphia()
+    test_contested_house_numbers()
+    test_self_pair()
+    print("=" * 70)
+    if FAILURES:
+        print(f"RESULT: {len(FAILURES)} FAILURES: {FAILURES}")
+        sys.exit(1)
+    print("RESULT: ALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/run-spatial-mask-tests.ps1
+++ b/run-spatial-mask-tests.ps1
@@ -1,0 +1,23 @@
+# Run SpatialTokenMask unit tests (OsmAnd PR #25535)
+# Requires: Eclipse Temurin JDK 17 (winget install EclipseAdoptium.Temurin.17.JDK)
+
+$jdk = "C:\Program Files\Eclipse Adoptium\jdk-17.0.20.8-hotspot"
+if (-not (Test-Path "$jdk\bin\java.exe")) {
+    Write-Error "JDK 17 not found at $jdk. Install: winget install EclipseAdoptium.Temurin.17.JDK"
+    exit 1
+}
+
+$env:JAVA_HOME = $jdk
+$env:Path = "$jdk\bin;" + $env:Path
+$env:JAVA_TOOL_OPTIONS = "-Dfile.encoding=UTF-8"
+$env:GRADLE_OPTS = "-Xmx4g"
+
+Set-Location $PSScriptRoot
+
+Write-Host "=== JUnit: SpatialTokenMaskTest ===" -ForegroundColor Cyan
+.\gradlew.bat ":OsmAnd-java:test" "--tests" "net.osmand.search.core.spatial.SpatialTokenMaskTest" --no-daemon
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host "`n=== Python: mask_verify.py ===" -ForegroundColor Cyan
+python OsmAnd-java\src\test\resources\spatial\mask_verify.py
+exit $LASTEXITCODE


### PR DESCRIPTION
## Summary

Fixes and completes the **token-mask layer** for the spatial pipeline ([PR #25534](https://github.com/osmandapp/OsmAnd/pull/25534)).

- **`SpatialTokenMask`** — pure 64-bit mask algebra: `allowed()`, loop-free `combine()`, duplicate-word variants, per-token contested ambiguous fork
- **`SpatialStagePipeline`** — wired into prepare/join; self-join identity skip; semantic filters restored; stats/debug fixes
- **Tests** — `SpatialTokenMaskTest` (JUnit) + `mask_verify.py` (standalone, no Java required)
- **Docs** — `SPATIAL_PIPELINE_MASK.md`

**Performance work** (incremental join, deferred common-word read) is in a **separate stacked PR**: #25536 — merge this PR first.

## Test plan (no maps required)

```bash
# Java (from repo root)
./gradlew :OsmAnd-java:test --tests net.osmand.search.core.spatial.SpatialTokenMaskTest

# Python cross-check (no JDK)
python OsmAnd-java/src/test/resources/spatial/mask_verify.py
```

Windows one-liner: `.\run-spatial-mask-tests.ps1` (JDK 17 + UTF-8).

Integration queries (`SpatialSearchTestAndDocs`, needs `.obf` maps): see `SPATIAL_PIPELINE_MASK.md` and **#25536** for Portugal benchmark.

## Target

Merge into **`spatialPipeline`**, not `master`.

Author: dmvkmusic@osmand.net