### PR TITLE
Fix excessive memory usage when loading Cloud file list

### DIFF
--- a/OsmAnd/src/net/osmand/plus/backup/BackupHelper.java
+++ b/OsmAnd/src/net/osmand/plus/backup/BackupHelper.java
@@ -37,13 +37,11 @@ import net.osmand.plus.settings.backend.backup.items.FileSettingsItem.FileSubtyp
 import net.osmand.plus.settings.backend.preferences.CommonPreference;
 import net.osmand.plus.utils.AndroidNetworkUtils;
 import net.osmand.plus.utils.AndroidNetworkUtils.NetworkResult;
-import net.osmand.plus.utils.AndroidUtils;
 import net.osmand.plus.utils.FileUtils;
 import net.osmand.util.Algorithms;
 import net.osmand.util.CollectionUtils;
 
 import org.apache.commons.logging.Log;
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -561,33 +559,34 @@ public class BackupHelper {
 		}
 		OperationLog operationLog = new OperationLog("downloadFileList", DEBUG);
 		operationLog.startOperation();
-		AndroidNetworkUtils.sendRequest(app, LIST_FILES_URL, params, "Download file list", false, false,
-				(resultJson, error, resultCode) -> {
+
+		AndroidNetworkUtils.<CloudFileListParseResult>sendRequestWithInputStream(
+				app, LIST_FILES_URL, params,
+				"Download file list", false, false,
+				inputStream -> StreamingCloudFileListParser.parse(inputStream, app),
+				(parseResult, error, resultCode) -> {
 					int status;
 					String message;
 					List<RemoteFile> remoteFiles = new ArrayList<>();
 					if (!Algorithms.isEmpty(error)) {
 						status = STATUS_SERVER_ERROR;
 						message = "Download file list error: " + new BackupError(error);
-					} else if (!Algorithms.isEmpty(resultJson)) {
-						try {
-							JSONObject res = new JSONObject(resultJson);
-							String totalZipSize = res.getString("totalZipSize");
-							String totalFiles = res.getString("totalFiles");
-							String totalFileVersions = res.getString("totalFileVersions");
-							maximumAccountSize = Algorithms.parseLongSilently(res.getString("maximumAccountSize"), 0);
-							JSONArray allFiles = res.getJSONArray("allFiles");
-							for (int i = 0; i < allFiles.length(); i++) {
-								remoteFiles.add(new RemoteFile(allFiles.getJSONObject(i)));
-							}
-							status = STATUS_SUCCESS;
-							message = "Total files: " + totalFiles + " " +
-									"Total zip size: " + AndroidUtils.formatSize(app, Long.parseLong(totalZipSize)) + " " +
-									"Total file versions: " + totalFileVersions;
-						} catch (JSONException e) {
-							status = STATUS_PARSE_JSON_ERROR;
-							message = "Download file list error: json parsing";
+					} else if (parseResult != null) {
+						Integer parseStatus = parseResult.getStatus();
+						Long parsedMaxAccountSize = parseResult.getMaximumAccountSize();
+						if (parsedMaxAccountSize != null) {
+							maximumAccountSize = parsedMaxAccountSize;
 						}
+						if (parseStatus == null) {
+							RuntimeException runtimeException = parseResult.getRuntimeException();
+							if (runtimeException != null) {
+								throw runtimeException;
+							}
+							throw new IllegalStateException(parseResult.getMessage());
+						}
+						status = parseStatus;
+						message = parseResult.getMessage();
+						remoteFiles.addAll(parseResult.getRemoteFiles());
 					} else {
 						status = STATUS_EMPTY_RESPONSE_ERROR;
 						message = "Download file list error: empty response";

--- a/OsmAnd/src/net/osmand/plus/backup/CloudFileListParseResult.kt
+++ b/OsmAnd/src/net/osmand/plus/backup/CloudFileListParseResult.kt
@@ -1,0 +1,19 @@
+package net.osmand.plus.backup
+
+import java.util.ArrayList
+import java.util.Collections
+
+/**
+ * Result of parsing a Cloud `/userdata/list-files` response.
+ */
+class CloudFileListParseResult internal constructor(
+	val status: Int?,
+	val message: String?,
+	val maximumAccountSize: Long?,
+	remoteFiles: List<RemoteFile>,
+	val runtimeException: RuntimeException? = null
+) {
+
+	val remoteFiles: List<RemoteFile> =
+		Collections.unmodifiableList(ArrayList(remoteFiles))
+}

--- a/OsmAnd/src/net/osmand/plus/backup/StreamingCloudFileListParser.kt
+++ b/OsmAnd/src/net/osmand/plus/backup/StreamingCloudFileListParser.kt
@@ -1,0 +1,359 @@
+package net.osmand.plus.backup
+
+import android.content.Context
+import android.util.JsonReader
+import android.util.JsonToken
+import android.util.MalformedJsonException
+import net.osmand.plus.utils.AndroidUtils
+import net.osmand.util.Algorithms
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+import org.json.JSONTokener
+import java.io.EOFException
+import java.io.FilterReader
+import java.io.IOException
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.io.Reader
+import java.nio.charset.StandardCharsets
+import java.util.ArrayList
+
+/**
+ * Streaming parser for the prepare/checking `/userdata/list-files` response.
+ *
+ * It retains at most one temporary file-entry JSONObject and skips `uniqueFiles`
+ * and unknown root fields without materializing them.
+ */
+object StreamingCloudFileListParser {
+	private const val JSON_ERROR_MESSAGE = "Download file list error: json parsing"
+	private const val EMPTY_ERROR_MESSAGE = "Download file list error: empty response"
+
+	@JvmStatic
+	@Throws(IOException::class)
+	fun parse(inputStream: InputStream, context: Context): CloudFileListParseResult {
+		val trackingReader = TrackingReader(
+			InputStreamReader(inputStream, StandardCharsets.UTF_8)
+		)
+		val reader = JsonReader(trackingReader)
+		reader.isLenient = true
+		try {
+			val firstToken = reader.peek()
+			if (firstToken == JsonToken.END_DOCUMENT) {
+				return if (trackingReader.hasContentAfterLineRemoval()) {
+					jsonError(null, emptyList())
+				} else {
+					emptyResponse()
+				}
+			}
+			if (firstToken != JsonToken.BEGIN_OBJECT) {
+				reader.skipValue()
+				requireEndOfDocument(reader)
+				return jsonError(null, emptyList())
+			}
+			val rootState = readRoot(reader)
+			requireEndOfDocument(reader)
+			return evaluateRoot(rootState, context)
+		} catch (e: InputSourceIOException) {
+			throw e.sourceException
+		} catch (_: EOFException) {
+			return if (trackingReader.hasContentAfterLineRemoval()) {
+				jsonError(null, emptyList())
+			} else {
+				emptyResponse()
+			}
+		} catch (_: MalformedJsonException) {
+			// Legacy JSONObject construction fails before exposing any allFiles records.
+			return jsonError(null, emptyList())
+		} catch (_: JSONException) {
+			// Legacy JSONObject construction fails before exposing any allFiles records.
+			return jsonError(null, emptyList())
+		} catch (_: IllegalStateException) {
+			// Legacy JSONObject construction fails before exposing any allFiles records.
+			return jsonError(null, emptyList())
+		} catch (e: IOException) {
+			throw e
+		} finally {
+			try {
+				reader.close()
+			} catch (_: Exception) {
+				// Matches the legacy body reader, which ignores close failures.
+			}
+		}
+	}
+
+	private fun readRoot(reader: JsonReader): RootState {
+		val rootState = RootState()
+		reader.beginObject()
+		while (reader.hasNext()) {
+			when (reader.nextName()) {
+				"totalZipSize" -> rootState.totalZipSize.set(readJsonValue(reader))
+				"totalFiles" -> rootState.totalFiles.set(readJsonValue(reader))
+				"totalFileVersions" -> rootState.totalFileVersions.set(readJsonValue(reader))
+				"maximumAccountSize" -> rootState.maximumAccountSize.set(readJsonValue(reader))
+				"allFiles" -> {
+					if (reader.peek() == JsonToken.BEGIN_ARRAY) {
+						rootState.allFilesOutcome = readAllFiles(reader)
+					} else {
+						rootState.allFilesOutcome = null
+						reader.skipValue()
+					}
+				}
+				"uniqueFiles" -> reader.skipValue()
+				else -> reader.skipValue()
+			}
+		}
+		reader.endObject()
+		return rootState
+	}
+
+	private fun readAllFiles(reader: JsonReader): AllFilesOutcome {
+		val outcome = AllFilesOutcome()
+		reader.beginArray()
+		while (reader.hasNext()) {
+			if (outcome.failureCategory != null) {
+				reader.skipValue()
+			} else if (reader.peek() != JsonToken.BEGIN_OBJECT) {
+				reader.skipValue()
+				outcome.failWithJson()
+			} else {
+				val fileJson = readJsonObject(reader)
+				try {
+					outcome.remoteFiles.add(RemoteFile(fileJson))
+				} catch (_: JSONException) {
+					outcome.failWithJson()
+				} catch (e: RuntimeException) {
+					outcome.failWithRuntime(e)
+				}
+			}
+		}
+		reader.endArray()
+		return outcome
+	}
+
+	private fun evaluateRoot(
+		rootState: RootState,
+		context: Context
+	): CloudFileListParseResult {
+		val totalZipSize: String
+		val totalFiles: String
+		val totalFileVersions: String
+		var maximumAccountSize: Long? = null
+
+		val outcome: AllFilesOutcome
+		try {
+			totalZipSize = rootState.totalZipSize.getRequiredString()
+			totalFiles = rootState.totalFiles.getRequiredString()
+			totalFileVersions = rootState.totalFileVersions.getRequiredString()
+			maximumAccountSize = Algorithms.parseLongSilently(
+				rootState.maximumAccountSize.getRequiredString(),
+				0
+			)
+			outcome = rootState.allFilesOutcome
+				?: throw JSONException("Value allFiles is not a JSONArray")
+		} catch (_: JSONException) {
+			return jsonError(maximumAccountSize, emptyList())
+		}
+
+		if (outcome.failureCategory == AllFilesFailure.JSON) {
+			return jsonError(
+				maximumAccountSize, outcome.remoteFiles
+			)
+		}
+		if (outcome.failureCategory == AllFilesFailure.RUNTIME) {
+			return runtimeError(
+				outcome.runtimeException,
+				maximumAccountSize, outcome.remoteFiles
+			)
+		}
+
+		try {
+			val message = "Total files: " + totalFiles + " " +
+					"Total zip size: " + AndroidUtils.formatSize(
+				context,
+				java.lang.Long.parseLong(totalZipSize)
+			) + " " +
+					"Total file versions: " + totalFileVersions
+			return CloudFileListParseResult(
+				BackupHelper.STATUS_SUCCESS, message,
+				maximumAccountSize, outcome.remoteFiles
+			)
+		} catch (e: RuntimeException) {
+			return runtimeError(
+				e,
+				maximumAccountSize, outcome.remoteFiles
+			)
+		}
+	}
+
+	private fun readJsonObject(reader: JsonReader): JSONObject {
+		val jsonObject = JSONObject()
+		reader.beginObject()
+		while (reader.hasNext()) {
+			val name = reader.nextName()
+			jsonObject.put(name, readJsonValue(reader))
+		}
+		reader.endObject()
+		return jsonObject
+	}
+
+	private fun readJsonArray(reader: JsonReader): JSONArray {
+		val array = JSONArray()
+		reader.beginArray()
+		while (reader.hasNext()) {
+			array.put(readJsonValue(reader))
+		}
+		reader.endArray()
+		return array
+	}
+
+	private fun readJsonValue(reader: JsonReader): Any {
+		return when (reader.peek()) {
+			JsonToken.BEGIN_OBJECT -> readJsonObject(reader)
+			JsonToken.BEGIN_ARRAY -> readJsonArray(reader)
+			JsonToken.STRING -> reader.nextString()
+			JsonToken.NUMBER -> JSONTokener(reader.nextString()).nextValue()
+			JsonToken.BOOLEAN -> reader.nextBoolean()
+			JsonToken.NULL -> {
+				reader.nextNull()
+				JSONObject.NULL
+			}
+			else -> throw JSONException("Unexpected JSON token " + reader.peek())
+		}
+	}
+
+	private fun requireEndOfDocument(reader: JsonReader) {
+		if (reader.peek() != JsonToken.END_DOCUMENT) {
+			throw MalformedJsonException("Unexpected trailing JSON value")
+		}
+	}
+
+	private fun emptyResponse(): CloudFileListParseResult {
+		return CloudFileListParseResult(
+			BackupHelper.STATUS_EMPTY_RESPONSE_ERROR, EMPTY_ERROR_MESSAGE,
+			null, emptyList()
+		)
+	}
+
+	private fun jsonError(
+		maximumAccountSize: Long?,
+		remoteFiles: List<RemoteFile>
+	): CloudFileListParseResult {
+		return CloudFileListParseResult(
+			BackupHelper.STATUS_PARSE_JSON_ERROR, JSON_ERROR_MESSAGE,
+			maximumAccountSize, remoteFiles
+		)
+	}
+
+	private fun runtimeError(
+		exception: RuntimeException?,
+		maximumAccountSize: Long?,
+		remoteFiles: List<RemoteFile>
+	): CloudFileListParseResult {
+		return CloudFileListParseResult(
+			null, exception?.message,
+			maximumAccountSize, remoteFiles, exception
+		)
+	}
+
+	private class RootState {
+		val totalZipSize = RootValue("totalZipSize")
+		val totalFiles = RootValue("totalFiles")
+		val totalFileVersions = RootValue("totalFileVersions")
+		val maximumAccountSize = RootValue("maximumAccountSize")
+		var allFilesOutcome: AllFilesOutcome? = null
+	}
+
+	private class RootValue(private val name: String) {
+		private var present = false
+		private var value: Any? = null
+
+		fun set(value: Any) {
+			present = true
+			this.value = value
+		}
+
+		fun getRequiredString(): String {
+			if (!present) {
+				throw JSONException("No value for $name")
+			}
+			return java.lang.String.valueOf(value)
+		}
+	}
+
+	private enum class AllFilesFailure {
+		JSON,
+		RUNTIME
+	}
+
+	private class AllFilesOutcome {
+		val remoteFiles: MutableList<RemoteFile> = ArrayList()
+		var failureCategory: AllFilesFailure? = null
+			private set
+		var runtimeException: RuntimeException? = null
+			private set
+
+		fun failWithJson() {
+			failureCategory = AllFilesFailure.JSON
+		}
+
+		fun failWithRuntime(exception: RuntimeException) {
+			failureCategory = AllFilesFailure.RUNTIME
+			runtimeException = exception
+		}
+	}
+
+	/** Tracks whether the legacy line reader would have produced a non-empty String. */
+	private class TrackingReader(reader: Reader) : FilterReader(reader) {
+		private var nonLineBreakContent = false
+		private var logicalLineBreakCount = 0
+		private var previousWasCarriageReturn = false
+
+		@Throws(IOException::class)
+		override fun read(): Int {
+			try {
+				val value = super.read()
+				track(value)
+				return value
+			} catch (e: IOException) {
+				throw InputSourceIOException(e)
+			}
+		}
+
+		@Throws(IOException::class)
+		override fun read(buffer: CharArray, offset: Int, length: Int): Int {
+			try {
+				val count = super.read(buffer, offset, length)
+				for (index in 0 until count) {
+					track(buffer[offset + index].code)
+				}
+				return count
+			} catch (e: IOException) {
+				throw InputSourceIOException(e)
+			}
+		}
+
+		private fun track(value: Int) {
+			if (value == '\r'.code) {
+				logicalLineBreakCount++
+				previousWasCarriageReturn = true
+			} else if (value == '\n'.code) {
+				if (!previousWasCarriageReturn) {
+					logicalLineBreakCount++
+				}
+				previousWasCarriageReturn = false
+			} else if (value >= 0) {
+				nonLineBreakContent = true
+				previousWasCarriageReturn = false
+			}
+		}
+
+		fun hasContentAfterLineRemoval(): Boolean {
+			return nonLineBreakContent || logicalLineBreakCount > 1
+		}
+	}
+
+	private class InputSourceIOException(
+		val sourceException: IOException
+	) : IOException(sourceException)
+}

--- a/OsmAnd/src/net/osmand/plus/utils/AndroidNetworkUtils.java
+++ b/OsmAnd/src/net/osmand/plus/utils/AndroidNetworkUtils.java
@@ -18,7 +18,6 @@ import net.osmand.plus.OsmAndTaskManager;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.R;
 import net.osmand.plus.Version;
-import net.osmand.shared.util.NetworkImageLoader;
 import net.osmand.util.Algorithms;
 
 import org.apache.commons.logging.Log;
@@ -42,7 +41,6 @@ import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.net.UnknownHostException;
 import java.text.MessageFormat;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -51,10 +49,6 @@ import java.util.Map.Entry;
 import java.util.concurrent.Executor;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
-
-import okhttp3.HttpUrl;
-import okhttp3.OkHttpClient;
-import okhttp3.Response;
 
 public class AndroidNetworkUtils {
 
@@ -66,6 +60,19 @@ public class AndroidNetworkUtils {
 
 	public interface OnRequestResultListener {
 		void onResult(@Nullable String result, @Nullable String error, @Nullable Integer resultCode);
+	}
+
+	/**
+	 * Consumes a successful HTTP response synchronously while its connection is open.
+	 * AndroidNetworkUtils owns the response stream and guarantees final cleanup.
+	 */
+	public interface InputStreamResponseHandler<T> {
+		@Nullable
+		T handle(@NonNull InputStream inputStream) throws IOException;
+	}
+
+	public interface OnInputStreamRequestResultListener<T> {
+		void onResult(@Nullable T result, @Nullable String error, @Nullable Integer resultCode);
 	}
 
 	public interface OnFileUploadCallback {
@@ -422,18 +429,61 @@ public class AndroidNetworkUtils {
 	                                 @Nullable Map<String, String> parameters,
 	                                 @Nullable String userOperation, boolean toastAllowed,
 	                                 boolean post, @Nullable OnRequestResultListener listener) {
+		return sendFormRequest(app, baseUrl, parameters, userOperation, toastAllowed, post,
+				AndroidNetworkUtils::streamToString, listener == null ? null : listener::onResult);
+	}
+
+	@Nullable
+	public static <T> T sendRequestWithInputStream(@Nullable OsmandApplication app,
+	                                              @NonNull String baseUrl,
+	                                              @Nullable Map<String, String> parameters,
+	                                              @Nullable String userOperation,
+	                                              boolean toastAllowed, boolean post,
+	                                              @NonNull InputStreamResponseHandler<T> responseHandler,
+	                                              @Nullable OnInputStreamRequestResultListener<T> listener) {
+		return sendFormRequest(app, baseUrl, parameters, userOperation, toastAllowed, post,
+				preserveHandlerNullPointerException(responseHandler), listener);
+	}
+
+	@Nullable
+	private static <T> T sendFormRequest(@Nullable OsmandApplication app,
+	                                    @NonNull String baseUrl,
+	                                    @Nullable Map<String, String> parameters,
+	                                    @Nullable String userOperation,
+	                                    boolean toastAllowed, boolean post,
+	                                    @NonNull InputStreamResponseHandler<T> responseHandler,
+	                                    @Nullable OnInputStreamRequestResultListener<T> listener) {
 		String paramsSeparator = baseUrl.indexOf('?') == -1 ? "?" : "&";
 		String contentType = "application/x-www-form-urlencoded;charset=UTF-8";
-		String params = getParameters(app, parameters, listener, userOperation, toastAllowed);
+
+		OnRequestResultListener parameterListener = listener == null ? null
+				: (result, error, resultCode) -> listener.onResult(null, error, resultCode);
+
+		String params = getParameters(app, parameters, parameterListener, userOperation, toastAllowed);
 		String url = params == null || post ? baseUrl : baseUrl + paramsSeparator + params;
-		return sendRequest(app, url, params, userOperation, contentType, toastAllowed, post, listener);
+
+		return executeRequest(app, url, params, userOperation, contentType,
+				toastAllowed, post, responseHandler, listener);
 	}
 
 	public static String sendRequest(@Nullable OsmandApplication app, @NonNull String url,
 	                                 @Nullable String body, @Nullable String userOperation,
 	                                 @Nullable String contentType, boolean toastAllowed,
 	                                 boolean post, @Nullable OnRequestResultListener listener) {
-		String result = null;
+		return executeRequest(app, url, body, userOperation, contentType, toastAllowed, post,
+				AndroidNetworkUtils::streamToString, listener == null ? null : listener::onResult);
+	}
+
+	@Nullable
+	private static <T> T executeRequest(@Nullable OsmandApplication app,
+	                                    @NonNull String url,
+	                                    @Nullable String body,
+	                                    @Nullable String userOperation,
+	                                    @Nullable String contentType,
+	                                    boolean toastAllowed, boolean post,
+	                                    @NonNull InputStreamResponseHandler<T> responseHandler,
+	                                    @Nullable OnInputStreamRequestResultListener<T> listener) {
+		T result = null;
 		String error = null;
 		Integer resultCode = null;
 		HttpURLConnection connection = null;
@@ -453,11 +503,22 @@ public class AndroidNetworkUtils {
 				}
 				InputStream errorStream = connection.getErrorStream();
 				if (errorStream != null) {
-					error = streamToString(errorStream);
+					try {
+						error = streamToString(errorStream);
+					} finally {
+						Algorithms.closeStream(errorStream);
+					}
 				}
 			} else {
-				result = streamToString(connection.getInputStream());
+				InputStream inputStream = connection.getInputStream();
+				try {
+					result = responseHandler.handle(inputStream);
+				} finally {
+					Algorithms.closeStream(inputStream);
+				}
 			}
+		} catch (ResponseHandlerNullPointerException e) {
+			throw e.getHandlerException();
 		} catch (NullPointerException e) {
 			// that's tricky case why NPE is thrown to fix that problem httpClient could be used
 			if (app != null) {
@@ -489,6 +550,35 @@ public class AndroidNetworkUtils {
 			listener.onResult(result, error, resultCode);
 		}
 		return result;
+	}
+
+	@NonNull
+	private static <T> InputStreamResponseHandler<T> preserveHandlerNullPointerException(
+			@NonNull InputStreamResponseHandler<T> responseHandler) {
+		return inputStream -> {
+			try {
+				return responseHandler.handle(inputStream);
+			} catch (NullPointerException e) {
+				// Raw NPEs are historically mapped to authorization failure by the legacy String path.
+				throw new ResponseHandlerNullPointerException(e);
+			}
+		};
+	}
+
+	private static class ResponseHandlerNullPointerException extends RuntimeException {
+
+		@NonNull
+		private final NullPointerException handlerException;
+
+		ResponseHandlerNullPointerException(@NonNull NullPointerException handlerException) {
+			super(handlerException);
+			this.handlerException = handlerException;
+		}
+
+		@NonNull
+		NullPointerException getHandlerException() {
+			return handlerException;
+		}
 	}
 
 	@NonNull


### PR DESCRIPTION
## Summary

Fixes excessive memory usage during OsmAnd Cloud backup checking by parsing the `/userdata/list-files` response directly from the HTTP `InputStream`.

Previously, a successful response was first converted into a complete `String` and then into a full `JSONObject` tree containing the `allFiles` and `uniqueFiles` arrays. For large Cloud accounts, these temporary representations significantly increased peak memory usage and could contribute to `OutOfMemoryError`.

The new implementation processes `allFiles` sequentially with `JsonReader`, keeping only the current file entry in its temporary JSON representation.

## Changes

- Added `StreamingCloudFileListParser` for the Cloud file-list response.
- Added a compact `CloudFileListParseResult` model.
- Integrated streaming parsing into `BackupHelper.downloadFileList()`.
- Added generic `InputStream` response handling to `AndroidNetworkUtils`.
- Refactored the existing String-based `sendRequest()` to reuse the shared HTTP request implementation.
- Skipped the unused `uniqueFiles` array without materializing it.
- Preserved the existing success, error, callback and exception behavior.
- Ensured success streams, error streams and HTTP connections are always closed.
- Kept non-200 response bodies String-based for compatibility with the existing error-handling flow.
- Did not add a legacy parser fallback, since it could reproduce the original memory problem.

## Resulting flow

```text
HTTP InputStream
→ JsonReader
→ one temporary JSONObject per file entry
→ RemoteFile
→ List<RemoteFile>
````

Instead of:

```text
HTTP InputStream
→ complete response String
→ root JSONObject
→ allFiles and uniqueFiles JSON arrays
→ List<RemoteFile>
```

## Validation

The streaming parser was compared with the legacy parser using the same real Cloud response:

```text
Response size:          1,600,574 bytes
allFiles records:       3,318

Legacy parser files:    3,318
Streaming parser files: 3,318

Root differences:       0
RemoteFile differences: 0
Total differences:      0
Equivalent:             true
```

Three independent memory measurements were performed for both implementations.

Median results:

| Metric                               |    Legacy | Streaming |              Difference |
| ------------------------------------ | --------: | --------: | ----------------------: |
| Maximum Java heap                    |  79.7 MiB |  69.0 MiB |  **−10.7 MiB / −13.4%** |
| Maximum total memory                 | 548.1 MiB | 523.6 MiB |   **−24.5 MiB / −4.5%** |
| Java growth from the pre-Cloud level | +27.6 MiB | +27.5 MiB | approximately unchanged |

The implementation produces the same Cloud file list while reducing the typical memory peak.

## Scope

This change specifically removes the full-response memory amplification during
Cloud file-list loading while preserving the existing downstream backup
processing behavior.