### PR TITLE
Fix divider end inset

### DIFF
--- a/OsmAnd/res/layout/divider_half_item_with_background.xml
+++ b/OsmAnd/res/layout/divider_half_item_with_background.xml
@@ -9,7 +9,6 @@
 		android:layout_width="match_parent"
 		android:layout_height="match_parent"
 		android:layout_marginStart="@dimen/divider_color_light_margin_start"
-		android:layout_marginEnd="@dimen/divider_color_light_margin_start"
 		android:background="?attr/divider_color_basic" />
 
 </FrameLayout>


### PR DESCRIPTION
Restore the standard one-sided inset for the shared half-divider layout, so dividers align with list content across Settings and Cloud Changes.