### PR TITLE
Decouple widget updates from map redraw

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/layers/MapInfoLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/MapInfoLayer.java
@@ -125,14 +125,12 @@ public class MapInfoLayer extends OsmandMapLayer implements ICoveredScreenRectPr
 		widgetsUpdateScheduled = false;
 
 		MapActivity activity = getMapActivity();
-		OsmandSettings settings = activity != null ? activity.getSettings() : null;
-		if (activity != null && settings.MAP_ACTIVITY_ENABLED) {
+		if (activity != null && activity.getSettings().MAP_ACTIVITY_ENABLED) {
 			if (activity.isMapVisible()) {
 				long currentTime = SystemClock.uptimeMillis();
 				long elapsedTime = currentTime - lastWidgetsUpdateTime;
 				if (elapsedTime >= WIDGETS_UPDATE_INTERVAL_MS) {
 					updateWidgetsInternal(view.getCurrentRotatedTileBox(), drawSettings);
-					lastWidgetsUpdateTime = SystemClock.uptimeMillis();
 				}
 			}
 			scheduleWidgetsUpdate();
@@ -689,7 +687,6 @@ public class MapInfoLayer extends OsmandMapLayer implements ICoveredScreenRectPr
 		this.drawSettings = drawSettings;
 		if (getMapActivity() != null) {
 			updateWidgetsInternal(tileBox, drawSettings);
-			lastWidgetsUpdateTime = SystemClock.uptimeMillis();
 			scheduleWidgetsUpdate();
 		}
 	}
@@ -712,6 +709,7 @@ public class MapInfoLayer extends OsmandMapLayer implements ICoveredScreenRectPr
 		for (WidgetsContainer container : additionalWidgets) {
 			container.update(drawSettings);
 		}
+		lastWidgetsUpdateTime = SystemClock.uptimeMillis();
 	}
 
 	private void scheduleWidgetsUpdate() {

--- a/OsmAnd/src/net/osmand/plus/views/layers/MapInfoLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/MapInfoLayer.java
@@ -6,6 +6,7 @@ import static android.view.View.VISIBLE;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Rect;
+import android.os.SystemClock;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -65,6 +66,8 @@ import kotlin.Unit;
 
 public class MapInfoLayer extends OsmandMapLayer implements ICoveredScreenRectProvider {
 
+	private static final long WIDGETS_UPDATE_INTERVAL_MS = 500L;
+
 	private final RouteLayer routeLayer;
 	private final OsmandApplication app;
 	private final OsmandSettings settings;
@@ -114,6 +117,27 @@ public class MapInfoLayer extends OsmandMapLayer implements ICoveredScreenRectPr
 		appearanceRefreshScheduled = false;
 		refreshWidgetPanels();
 	};
+
+	private long lastWidgetsUpdateTime;
+	private boolean widgetsUpdateScheduled;
+
+	private final Runnable widgetsUpdateRunnable = () -> {
+		widgetsUpdateScheduled = false;
+
+		MapActivity activity = getMapActivity();
+		OsmandSettings settings = activity != null ? activity.getSettings() : null;
+		if (activity != null && settings.MAP_ACTIVITY_ENABLED) {
+			if (activity.isMapVisible()) {
+				long currentTime = SystemClock.uptimeMillis();
+				long elapsedTime = currentTime - lastWidgetsUpdateTime;
+				if (elapsedTime >= WIDGETS_UPDATE_INTERVAL_MS) {
+					updateWidgetsInternal(view.getCurrentRotatedTileBox(), drawSettings);
+					lastWidgetsUpdateTime = SystemClock.uptimeMillis();
+				}
+			}
+			scheduleWidgetsUpdate();
+		}
+	};
 	private final PanelAppearanceSettingsManager.Listener appearanceSettingsListener;
 
 	public MapInfoLayer(@NonNull Context context, @NonNull RouteLayer layer) {
@@ -133,6 +157,7 @@ public class MapInfoLayer extends OsmandMapLayer implements ICoveredScreenRectPr
 
 	@Override
 	public void setMapActivity(@Nullable MapActivity mapActivity) {
+		resetWidgetsUpdateState();
 		super.setMapActivity(mapActivity);
 		if (mapActivity != null) {
 			mapHudLayout = mapActivity.findViewById(R.id.map_hud_layout);
@@ -663,24 +688,54 @@ public class MapInfoLayer extends OsmandMapLayer implements ICoveredScreenRectPr
 	public void onDraw(Canvas canvas, RotatedTileBox tileBox, DrawSettings drawSettings) {
 		this.drawSettings = drawSettings;
 		if (getMapActivity() != null) {
-			updateColorShadowsOfText();
-			updateWidgetsInfo(drawSettings);
+			updateWidgetsInternal(tileBox, drawSettings);
+			lastWidgetsUpdateTime = SystemClock.uptimeMillis();
+			scheduleWidgetsUpdate();
+		}
+	}
 
-			updateMainWidgetPanels();
-			topToolbarView.updateInfo();
-			alarmWidget.updateInfo(drawSettings, false);
-			speedometerWidget.updateInfo(drawSettings);
+	private void updateWidgetsInternal(@NonNull RotatedTileBox tileBox, @Nullable DrawSettings drawSettings) {
+		updateColorShadowsOfText();
+		updateWidgetsInfo(drawSettings);
 
-			for (RulerWidget widget : rulerWidgets) {
-				widget.updateInfo(tileBox);
+		updateMainWidgetPanels();
+		topToolbarView.updateInfo();
+		alarmWidget.updateInfo(drawSettings, false);
+		speedometerWidget.updateInfo(drawSettings);
+
+		for (RulerWidget widget : rulerWidgets) {
+			widget.updateInfo(tileBox);
+		}
+		for (SideWidgetsPanel panel : sideWidgetsPanels) {
+			panel.update(drawSettings);
+		}
+		for (WidgetsContainer container : additionalWidgets) {
+			container.update(drawSettings);
+		}
+	}
+
+	private void scheduleWidgetsUpdate() {
+		MapHudLayout hudLayout = mapHudLayout;
+		if (hudLayout != null && !widgetsUpdateScheduled) {
+			MapActivity activity = getMapActivity();
+			long delay = WIDGETS_UPDATE_INTERVAL_MS;
+			if (activity != null && activity.isMapVisible()) {
+				long elapsedTime = SystemClock.uptimeMillis() - lastWidgetsUpdateTime;
+				delay = Math.max(0, WIDGETS_UPDATE_INTERVAL_MS - elapsedTime);
 			}
-			for (SideWidgetsPanel panel : sideWidgetsPanels) {
-				panel.update(drawSettings);
-			}
-			for (WidgetsContainer container : additionalWidgets) {
-				container.update(drawSettings);
+			widgetsUpdateScheduled = true;
+			if (!hudLayout.postDelayed(widgetsUpdateRunnable, delay)) {
+				widgetsUpdateScheduled = false;
 			}
 		}
+	}
+
+	private void resetWidgetsUpdateState() {
+		if (mapHudLayout != null) {
+			mapHudLayout.removeCallbacks(widgetsUpdateRunnable);
+		}
+		widgetsUpdateScheduled = false;
+		lastWidgetsUpdateTime = 0;
 	}
 
 	private void updateWidgetsInfo(@Nullable DrawSettings drawSettings) {


### PR DESCRIPTION
- extract the shared widget update pipeline
- schedule coalesced updates at 500 ms intervals
- skip periodic updates when map rendering already updated widgets
- cancel scheduled updates when the map activity changes