### PR TITLE
Fix Wikipedia details and online photos for favorites

### DIFF
--- a/OsmAnd/src/net/osmand/plus/helpers/AmenityExtensionsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/AmenityExtensionsHelper.java
@@ -46,12 +46,38 @@ public class AmenityExtensionsHelper {
 
 	@Nullable
 	public Amenity findAmenity(@NonNull String nameEn, double lat, double lon) {
-		List<String> names = Collections.singletonList(nameEn);
+		return findAmenity(nameEn, lat, lon, null);
+	}
+
+	/**
+	 * Resolves the source amenity using identity hints persisted with a favorite or waypoint.
+	 * Wikidata is matched first by {@link AmenitySearcher}; the origin name remains the fallback.
+	 */
+	@Nullable
+	public Amenity findAmenityByIdentity(@Nullable String originName, double lat, double lon,
+	                                     @NonNull Map<String, String> extensions) {
+		Map<String, String> normalizedExtensions = getUpdatedAmenityExtensions(extensions, null);
+		String wikidata = normalizedExtensions.get(WIKIDATA);
+		if (Algorithms.isEmpty(originName) && Algorithms.isEmpty(wikidata)) {
+			return null;
+		}
+		return findAmenity(originName, lat, lon, wikidata);
+	}
+
+	@Nullable
+	private Amenity findAmenity(@Nullable String nameEn, double lat, double lon,
+	                            @Nullable String wikidata) {
+		List<String> names = Algorithms.isEmpty(nameEn)
+				? Collections.emptyList()
+				: Collections.singletonList(nameEn);
 		AmenitySearcher searcher = app.getResourceManager().getAmenitySearcher();
 		AmenitySearcher.Settings settings = app.getResourceManager().getDefaultAmenitySearchSettings();
 
 		Amenity requestAmenity = new Amenity();
 		requestAmenity.setLocation(new LatLon(lat, lon));
+		if (!Algorithms.isEmpty(wikidata)) {
+			requestAmenity.setAdditionalInfo(WIKIDATA, wikidata);
+		}
 		AmenitySearcher.Request request = new AmenitySearcher.Request(requestAmenity, names, true);
 		return searcher.searchDetailedAmenity(request, settings);
 	}

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/AmenityDescriptionBuilder.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/AmenityDescriptionBuilder.java
@@ -1,0 +1,222 @@
+package net.osmand.plus.mapcontextmenu.builders;
+
+import static net.osmand.data.Amenity.DESCRIPTION;
+import static net.osmand.data.Amenity.SHORT_DESCRIPTION;
+import static net.osmand.data.Amenity.WIKIPEDIA;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.util.Pair;
+
+import net.osmand.data.AdditionalInfoBundle;
+import net.osmand.data.Amenity;
+import net.osmand.data.LatLon;
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.R;
+import net.osmand.plus.activities.MapActivity;
+import net.osmand.plus.mapcontextmenu.BuildRowAttrs;
+import net.osmand.plus.mapcontextmenu.MenuBuilder;
+import net.osmand.plus.settings.enums.ThemeUsageContext;
+import net.osmand.plus.utils.AndroidUtils;
+import net.osmand.plus.utils.ColorUtilities;
+import net.osmand.plus.utils.FontCache;
+import net.osmand.plus.utils.UiUtilities;
+import net.osmand.plus.widgets.TextViewEx;
+import net.osmand.plus.widgets.dialogbutton.DialogButton;
+import net.osmand.plus.wikipedia.WikiArticleHelper;
+import net.osmand.plus.wikipedia.WikipediaDialogFragment;
+import net.osmand.util.Algorithms;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.StringJoiner;
+
+final class AmenityDescriptionBuilder {
+
+	private static final String WIKIPEDIA_ORG_WIKI_URL_PART = ".wikipedia.org/wiki/";
+
+	private final MenuBuilder menuBuilder;
+	private final MapActivity mapActivity;
+	private final OsmandApplication app;
+	private final Amenity amenity;
+	private final AdditionalInfoBundle infoBundle;
+	private final boolean lightContent;
+
+	AmenityDescriptionBuilder(@NonNull MenuBuilder menuBuilder, @NonNull Amenity amenity,
+	                          @NonNull AdditionalInfoBundle infoBundle, boolean lightContent) {
+		this.menuBuilder = menuBuilder;
+		this.mapActivity = menuBuilder.getMapActivity();
+		this.app = menuBuilder.getApplication();
+		this.amenity = amenity;
+		this.infoBundle = infoBundle;
+		this.lightContent = lightContent;
+	}
+
+	/**
+	 * @return true when a short or regular amenity description was built
+	 * and the generic description row should be hidden.
+	 */
+	boolean buildDescription(@NonNull View view) {
+		Map<String, Object> filteredInfo = infoBundle.getFilteredLocalizedInfo();
+
+		if (buildShortWikiDescription(view, filteredInfo, true)) {
+			return true;
+		}
+
+		Pair<String, Locale> pair = AmenityUIHelper.getDescriptionWithPreferredLang(
+				app, amenity, DESCRIPTION, filteredInfo);
+		if (pair == null) {
+			return false;
+		}
+
+		menuBuilder.buildDescriptionRow(view, pair.first);
+		infoBundle.setCustomHiddenExtensions(Collections.singletonList(DESCRIPTION));
+		return true;
+	}
+
+	/**
+	 * @return true only when a short description was built. An online Wikipedia link does
+	 * not consume the regular description fallback.
+	 */
+	boolean buildShortWikiDescription(@NonNull View view,
+			@NonNull Map<String, Object> filteredInfo, boolean allowOnlineWiki) {
+		Pair<String, Locale> pair = AmenityUIHelper.getDescriptionWithPreferredLang(app, amenity, SHORT_DESCRIPTION, filteredInfo);
+		Locale locale = pair != null ? pair.second : null;
+		String description = pair != null ? pair.first : null;
+
+		boolean hasShortDescription = !Algorithms.isEmpty(description);
+		if (hasShortDescription) {
+			infoBundle.setCustomHiddenExtensions(Collections.singletonList(DESCRIPTION));
+		}
+		if (!hasShortDescription && allowOnlineWiki) {
+			description = createWikipediaArticleList(filteredInfo);
+		}
+		boolean[] descriptionCollapsed = {true};
+		if (!Algorithms.isEmpty(description)) {
+			View rowView = menuBuilder.buildRow(view,
+					new BuildRowAttrs.Builder().setText(description).setCollapsable(true).build());
+			TextViewEx textView = rowView.findViewById(R.id.text);
+			String descriptionToSet = description;
+			textView.setOnClickListener(v -> {
+				boolean collapsed = !descriptionCollapsed[0];
+				descriptionCollapsed[0] = collapsed;
+				updateDescriptionState(textView, descriptionToSet, collapsed);
+			});
+			updateDescriptionState(textView, descriptionToSet, descriptionCollapsed[0]);
+			buildReadFullWikiButton((ViewGroup) view, locale, hasShortDescription);
+		}
+		return hasShortDescription;
+	}
+
+	private void buildReadFullWikiButton(@NonNull ViewGroup container, @Nullable Locale locale,
+	                                     boolean hasShortDescription) {
+		Context context = container.getContext();
+		int activeColor = ColorUtilities.getActiveColor(context, !lightContent);
+
+		LayoutInflater themedInflater = UiUtilities.getInflater(mapActivity, !lightContent);
+		DialogButton button = (DialogButton) themedInflater.inflate(R.layout.context_menu_read_wiki_button, container, false);
+		if (hasShortDescription) {
+			String text = app.getString(R.string.context_menu_read_full_article);
+			button.setTitle(UiUtilities.createColorSpannable(text, activeColor, text));
+		} else {
+			String wikipedia = app.getString(R.string.shared_string_wikipedia);
+			String text = app.getString(R.string.read_on, wikipedia);
+			button.setTitle(UiUtilities.createColorSpannable(text, activeColor, wikipedia));
+		}
+
+		Resources resources = context.getResources();
+		int size = resources.getDimensionPixelSize(R.dimen.small_icon_size);
+		Drawable drawable = app.getUIUtilities().getIcon(R.drawable.ic_plugin_wikipedia, lightContent);
+		drawable = new BitmapDrawable(resources, AndroidUtils.drawableToBitmap(drawable, size, size, true));
+
+		TextViewEx textView = button.findViewById(R.id.button_text);
+		textView.setTypeface(FontCache.getNormalFont());
+		textView.setCompoundDrawablesWithIntrinsicBounds(drawable, null, null, null);
+
+		button.setOnClickListener(v -> {
+			if (hasShortDescription) {
+				WikipediaDialogFragment.showInstance(mapActivity, amenity, null);
+			} else {
+				String wikipediaUrl = amenity.getAdditionalInfo(WIKIPEDIA);
+				if (Algorithms.isEmpty(wikipediaUrl) && locale != null) {
+					String title = amenity.getName(locale.getLanguage());
+					if (!Algorithms.isEmpty(title)) {
+						wikipediaUrl = "https://" + locale.getLanguage()
+								+ WIKIPEDIA_ORG_WIKI_URL_PART + title.replace(' ', '_');
+					}
+				}
+				if (!Algorithms.isEmpty(wikipediaUrl)) {
+					LatLon location = amenity.getLocation() != null ? amenity.getLocation() : menuBuilder.getLatLon();
+					boolean nightMode = app.getDaynightHelper().isNightMode(app.getSettings().getApplicationMode(), ThemeUsageContext.MAP);
+					WikiArticleHelper.askShowArticle(mapActivity, nightMode, location, wikipediaUrl);
+				}
+			}
+		});
+		container.addView(button);
+	}
+
+	@Nullable
+	private String createWikipediaArticleList(@NonNull Map<String, Object> filteredInfo) {
+		Object value = filteredInfo.get(WIKIPEDIA);
+		if (value instanceof String url) {
+			if (url.contains(WIKIPEDIA_ORG_WIKI_URL_PART)) {
+				return url.substring(url.lastIndexOf(WIKIPEDIA_ORG_WIKI_URL_PART) + WIKIPEDIA_ORG_WIKI_URL_PART.length());
+			}
+		} else if (value instanceof Map<?, ?> map) {
+			Object localizationsValue = map.get("localizations");
+			if (!(localizationsValue instanceof Map<?, ?> localizations)
+					|| localizations.isEmpty()) {
+				return null;
+			}
+			List<String> localizationKeys = new ArrayList<>();
+			for (Object key : localizations.keySet()) {
+				if (key instanceof String stringKey) {
+					localizationKeys.add(stringKey);
+				}
+			}
+			Collection<String> availableLocales = AmenityUIHelper.collectAvailableLocalesFromTags(localizationKeys);
+			StringJoiner joiner = new StringJoiner(", ");
+			for (String key : availableLocales) {
+				String localizedKey = WIKIPEDIA + ":" + key;
+				Object localizedValue = localizations.get(localizedKey);
+				if (localizedValue instanceof String localizedString
+						&& !Algorithms.isEmpty(localizedString)) {
+					String name = app.getString(
+							R.string.wikipedia_names_pattern, localizedString, key);
+					joiner.add(name);
+				}
+			}
+			return joiner.toString();
+		}
+		return null;
+	}
+
+	private void updateDescriptionState(@NonNull TextView textView,
+	                                    @NonNull String description, boolean collapsed) {
+		String text = description;
+		if (collapsed) {
+			text = description.substring(0, Math.min(description.length(), 200));
+			if (description.length() > text.length()) {
+				int color = ColorUtilities.getActiveColor(app, !lightContent);
+				String ellipsis = app.getString(R.string.shared_string_ellipsis);
+				text += ellipsis;
+				textView.setText(UiUtilities.createColorSpannable(text, color, ellipsis));
+				return;
+			}
+		}
+		textView.setText(text);
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/AmenityMenuBuilder.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/AmenityMenuBuilder.java
@@ -1,27 +1,18 @@
 package net.osmand.plus.mapcontextmenu.builders;
 
-import static net.osmand.data.Amenity.DESCRIPTION;
-import static net.osmand.data.Amenity.SHORT_DESCRIPTION;
 import static net.osmand.data.Amenity.WIKIDATA;
-import static net.osmand.data.Amenity.WIKIPEDIA;
 import static net.osmand.plus.mapcontextmenu.builders.MenuRowBuilder.NEAREST_POI_KEY;
 import static net.osmand.plus.mapcontextmenu.builders.MenuRowBuilder.NEAREST_WIKI_KEY;
 import static net.osmand.plus.wikivoyage.data.TravelObfHelper.TAG_URL;
 import static net.osmand.plus.wikivoyage.data.TravelObfHelper.WPT_EXTRA_TAGS;
 
 import android.content.Context;
-import android.content.res.Resources;
-import android.graphics.drawable.BitmapDrawable;
-import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.LinearLayout;
-import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatImageView;
-import androidx.core.util.Pair;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -29,43 +20,26 @@ import com.google.gson.reflect.TypeToken;
 import net.osmand.PlatformUtil;
 import net.osmand.data.AdditionalInfoBundle;
 import net.osmand.data.Amenity;
-import net.osmand.data.LatLon;
 import net.osmand.osm.edit.OSMSettings;
 import net.osmand.plus.R;
 import net.osmand.plus.activities.MapActivity;
 import net.osmand.plus.helpers.AmenityExtensionsHelper;
-import net.osmand.plus.mapcontextmenu.BuildRowAttrs;
 import net.osmand.plus.mapcontextmenu.MenuBuilder;
 import net.osmand.plus.mapcontextmenu.builders.rows.AmenityInfoRow;
 import net.osmand.plus.mapcontextmenu.controllers.AmenityMenuController;
-import net.osmand.plus.settings.enums.ThemeUsageContext;
-import net.osmand.plus.utils.AndroidUtils;
-import net.osmand.plus.utils.ColorUtilities;
-import net.osmand.plus.utils.FontCache;
 import net.osmand.plus.utils.PicassoUtils;
-import net.osmand.plus.utils.UiUtilities;
-import net.osmand.plus.widgets.TextViewEx;
-import net.osmand.plus.widgets.dialogbutton.DialogButton;
-import net.osmand.plus.wikipedia.WikiArticleHelper;
-import net.osmand.plus.wikipedia.WikipediaDialogFragment;
 import net.osmand.util.Algorithms;
 
 import org.apache.commons.logging.Log;
 
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Type;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
-import java.util.StringJoiner;
 
 public class AmenityMenuBuilder extends MenuBuilder {
 
 	public static final Log LOG = PlatformUtil.getLog(AmenityMenuBuilder.class);
-	public static final String WIKIPEDIA_ORG_WIKI_URL_PART = ".wikipedia.org/wiki/";
-
 	protected AmenityUIHelper amenityUIHelper;
 	protected Map<String, String> extensions;
 	protected AdditionalInfoBundle infoBundle;
@@ -96,14 +70,7 @@ public class AmenityMenuBuilder extends MenuBuilder {
 
 	@Override
 	protected void buildDescription(View view) {
-		Map<String, Object> filteredInfo = infoBundle.getFilteredLocalizedInfo();
-		if (!buildShortWikiDescription(view, filteredInfo, true)) {
-			Pair<String, Locale> pair = AmenityUIHelper.getDescriptionWithPreferredLang(app, amenity, DESCRIPTION, filteredInfo);
-			if (pair != null) {
-				buildDescriptionRow(view, pair.first);
-				infoBundle.setCustomHiddenExtensions(Collections.singletonList(DESCRIPTION));
-			}
-		}
+		createAmenityDescriptionBuilder().buildDescription(view);
 		if (isCustomOnlinePhotosPosition()) {
 			buildPhotosRow((ViewGroup) view, amenity);
 		}
@@ -111,120 +78,13 @@ public class AmenityMenuBuilder extends MenuBuilder {
 
 	protected boolean buildShortWikiDescription(@NonNull View view,
 			@NonNull Map<String, Object> filteredInfo, boolean allowOnlineWiki) {
-		Pair<String, Locale> pair = AmenityUIHelper.getDescriptionWithPreferredLang(app, amenity, SHORT_DESCRIPTION, filteredInfo);
-		Locale locale = pair != null ? pair.second : null;
-		String description = pair != null ? pair.first : null;
-
-		boolean hasShortDescription = !Algorithms.isEmpty(description);
-		if (hasShortDescription) {
-			infoBundle.setCustomHiddenExtensions(Collections.singletonList(DESCRIPTION));
-		}
-		if (!hasShortDescription && allowOnlineWiki) {
-			description = createWikipediaArticleList(filteredInfo);
-		}
-		boolean[] descriptionCollapsed = {true};
-		if (!Algorithms.isEmpty(description)) {
-			View rowView = buildRow(view, new BuildRowAttrs.Builder().setText(description).setCollapsable(true).build());
-			TextViewEx textView = rowView.findViewById(R.id.text);
-			final String descriptionToSet = description;
-			textView.setOnClickListener(v -> {
-				boolean collapsed = !descriptionCollapsed[0];
-				descriptionCollapsed[0] = collapsed;
-				updateDescriptionState(textView, descriptionToSet, collapsed);
-			});
-			updateDescriptionState(textView, descriptionToSet, descriptionCollapsed[0]);
-			buildReadFullWikiButton((LinearLayout) view, locale, hasShortDescription);
-		}
-		return hasShortDescription;
+		return createAmenityDescriptionBuilder().buildShortWikiDescription(
+				view, filteredInfo, allowOnlineWiki);
 	}
 
-	protected void buildReadFullWikiButton(@NonNull ViewGroup container, @Nullable Locale locale,
-			boolean hasShortDescription) {
-		boolean light = isLightContent();
-		Context ctx = container.getContext();
-		int activeColor = ColorUtilities.getActiveColor(ctx, !light);
-
-		DialogButton button = (DialogButton) themedInflater.inflate(R.layout.context_menu_read_wiki_button, container, false);
-		if (hasShortDescription) {
-			String text = app.getString(R.string.context_menu_read_full_article);
-			button.setTitle(UiUtilities.createColorSpannable(text, activeColor, text));
-		} else {
-			String wikipedia = app.getString(R.string.shared_string_wikipedia);
-			String text = app.getString(R.string.read_on, wikipedia);
-			button.setTitle(UiUtilities.createColorSpannable(text, activeColor, wikipedia));
-		}
-
-		Resources resources = ctx.getResources();
-		int size = resources.getDimensionPixelSize(R.dimen.small_icon_size);
-		Drawable drawable = app.getUIUtilities().getIcon(R.drawable.ic_plugin_wikipedia, light);
-		drawable = new BitmapDrawable(resources, AndroidUtils.drawableToBitmap(drawable, size, size, true));
-
-		TextViewEx textView = button.findViewById(R.id.button_text);
-		textView.setTypeface(FontCache.getNormalFont());
-		textView.setCompoundDrawablesWithIntrinsicBounds(drawable, null, null, null);
-
-		button.setOnClickListener((v) -> {
-			if (hasShortDescription) {
-				WikipediaDialogFragment.showInstance(mapActivity, amenity, null);
-			} else {
-				String wikipediaUrl = amenity.getAdditionalInfo(WIKIPEDIA);
-				if (wikipediaUrl == null && locale != null) {
-					String title = amenity.getName(locale.getLanguage());
-					wikipediaUrl = "https://" + locale.getLanguage() + WIKIPEDIA_ORG_WIKI_URL_PART + title.replace(' ', '_');
-				}
-				if (mapActivity != null && !Algorithms.isEmpty(wikipediaUrl)) {
-					LatLon location = amenity != null ? amenity.getLocation() : getLatLon();
-					boolean nightMode = app.getDaynightHelper().isNightMode(app.getSettings().getApplicationMode(), ThemeUsageContext.MAP);
-					WikiArticleHelper.askShowArticle(mapActivity, nightMode, location, wikipediaUrl);
-				}
-			}
-		});
-		container.addView(button);
-	}
-
-	@Nullable
-	private String createWikipediaArticleList(Map<String, Object> filteredInfo) {
-		Object value = filteredInfo.get(WIKIPEDIA);
-		if (value != null) {
-			if (value instanceof String url) {
-				if (url.contains(WIKIPEDIA_ORG_WIKI_URL_PART)) {
-					return url.substring(url.lastIndexOf(WIKIPEDIA_ORG_WIKI_URL_PART) + WIKIPEDIA_ORG_WIKI_URL_PART.length());
-				}
-			} else {
-				Map<String, Object> map = (Map<String, Object>) value;
-				Map<String, String> localizations = (Map<String, String>) map.get("localizations");
-				if (Algorithms.isEmpty(localizations)) {
-					return null;
-				}
-				Collection<String> availableLocales = AmenityUIHelper.collectAvailableLocalesFromTags(localizations.keySet());
-				StringJoiner joiner = new StringJoiner(", ");
-				for (String key : availableLocales) {
-					String localizedKey = WIKIPEDIA + ":" + key;
-					String localizedValue = localizations.get(localizedKey);
-					if (!Algorithms.isEmpty(localizedValue)) {
-						String name = app.getString(R.string.wikipedia_names_pattern, localizedValue, key);
-						joiner.add(name);
-					}
-				}
-				return joiner.toString();
-			}
-		}
-		return null;
-	}
-
-	private void updateDescriptionState(TextView textView, String description, boolean collapsed) {
-		String text = description;
-		if (collapsed) {
-			text = description.substring(0, Math.min(description.length(), 200));
-			if (description.length() > text.length()) {
-				int color = ColorUtilities.getActiveColor(app, !isLightContent());
-				String ellipsis = app.getString(R.string.shared_string_ellipsis);
-				text += ellipsis;
-				textView.setText(UiUtilities.createColorSpannable(text, color, ellipsis));
-				return;
-			}
-		}
-		textView.setText(text);
+	@NonNull
+	private AmenityDescriptionBuilder createAmenityDescriptionBuilder() {
+		return new AmenityDescriptionBuilder(this, amenity, infoBundle, isLightContent());
 	}
 
 	@Override

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/FavouritePointMenuBuilder.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/FavouritePointMenuBuilder.java
@@ -1,5 +1,7 @@
 package net.osmand.plus.mapcontextmenu.builders;
 
+import static net.osmand.data.Amenity.DESCRIPTION;
+import static net.osmand.data.Amenity.WIKIDATA;
 import static net.osmand.plus.myplaces.MyPlacesActivity.FAV_TAB;
 import static net.osmand.plus.myplaces.MyPlacesActivity.TAB_ID;
 
@@ -8,6 +10,7 @@ import android.content.Intent;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.LinearLayout;
 
 import androidx.annotation.NonNull;
@@ -38,6 +41,7 @@ import net.osmand.util.Algorithms;
 
 import org.apache.commons.logging.Log;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,7 +51,9 @@ public class FavouritePointMenuBuilder extends MenuBuilder {
 	private static final Log LOG = PlatformUtil.getLog(FavouritePointMenuBuilder.class);
 
 	private final FavouritePoint point;
-	private Map<String, String> amenityExtensions = new HashMap<>();
+	private AdditionalInfoBundle mergedAmenityInfoBundle;
+	private Map<String, String> mergedAmenityExtensions = new HashMap<>();
+	private Map<String, String> sourceAmenityExtensions = Collections.emptyMap();
 
 	public FavouritePointMenuBuilder(@NonNull MapActivity activity, @NonNull FavouritePoint point, @Nullable Amenity amenity) {
 		super(activity);
@@ -58,14 +64,21 @@ public class FavouritePointMenuBuilder extends MenuBuilder {
 	}
 
 	private void acquireAmenityExtensions() {
+		String originName = point.getAmenityOriginName();
+		double lat = point.getLatitude();
+		double lon = point.getLongitude();
+		Map<String, String> storedExtensions = point.getAmenityExtensions();
+
 		AmenityExtensionsHelper helper = new AmenityExtensionsHelper(app);
 		if (amenity == null) {
-			String originName = point.getAmenityOriginName();
-			if (!Algorithms.isEmpty(originName)) {
-				setAmenity(helper.findAmenity(originName, point.getLatitude(), point.getLongitude()));
-			}
+			setAmenity(helper.findAmenityByIdentity(originName, lat, lon, storedExtensions));
 		}
-		amenityExtensions = helper.getUpdatedAmenityExtensions(point.getAmenityExtensions(), amenity);
+		mergedAmenityExtensions = helper.getUpdatedAmenityExtensions(storedExtensions, amenity);
+		mergedAmenityInfoBundle = new AdditionalInfoBundle(app.getPoiTypes(), mergedAmenityExtensions);
+		if (amenity != null) {
+			sourceAmenityExtensions = amenity.getAmenityExtensions(app.getPoiTypes(), false);
+			setCustomOnlinePhotosPosition(sourceAmenityExtensions.containsKey(WIKIDATA));
+		}
 	}
 
 	@Nullable
@@ -94,9 +107,8 @@ public class FavouritePointMenuBuilder extends MenuBuilder {
 		buildDateRow(view, app.getString(R.string.created_on), point.getTimestamp());
 		buildCommentRow(view, point.getComment());
 
-		if (!Algorithms.isEmpty(amenityExtensions)) {
-			AdditionalInfoBundle bundle = new AdditionalInfoBundle(app.getPoiTypes(), amenityExtensions);
-			AmenityUIHelper helper = new AmenityUIHelper(mapActivity, getPreferredMapAppLang(), bundle);
+		if (!Algorithms.isEmpty(mergedAmenityExtensions)) {
+			AmenityUIHelper helper = new AmenityUIHelper(mapActivity, getPreferredMapAppLang(), mergedAmenityInfoBundle);
 			helper.setLight(isLightContent());
 			helper.setLatLon(getLatLon());
 			helper.setCollapseExpandListener(getCollapseExpandListener());
@@ -106,10 +118,33 @@ public class FavouritePointMenuBuilder extends MenuBuilder {
 
 	@Override
 	protected void buildDescription(View view) {
-		String desc = point.getDescription();
-		if (!Algorithms.isEmpty(desc)) {
-			buildDescriptionRow(view, desc);
+		buildFavoriteDescription(view);
+		AmenityDescriptionBuilder descriptionBuilder = createSourceAmenityDescriptionBuilder();
+		if (descriptionBuilder == null) {
+			return;
 		}
+		if (descriptionBuilder.buildDescription(view)) {
+			mergedAmenityInfoBundle.setCustomHiddenExtensions(Collections.singletonList(DESCRIPTION));
+		}
+		if (isCustomOnlinePhotosPosition()) {
+			buildPhotosRow((ViewGroup) view, amenity);
+		}
+	}
+
+	private void buildFavoriteDescription(@NonNull View view) {
+		String description = point.getDescription();
+		if (!Algorithms.isEmpty(description)) {
+			buildDescriptionRow(view, description);
+		}
+	}
+
+	@Nullable
+	private AmenityDescriptionBuilder createSourceAmenityDescriptionBuilder() {
+		if (amenity != null) {
+			AdditionalInfoBundle bundle = new AdditionalInfoBundle(app.getPoiTypes(), sourceAmenityExtensions);
+			return new AmenityDescriptionBuilder(this, amenity, bundle, isLightContent());
+		}
+		return null;
 	}
 
 	@Override
@@ -173,5 +208,12 @@ public class FavouritePointMenuBuilder extends MenuBuilder {
 		bundle.putString(FragmentStateHolder.GROUP_NAME_TO_SHOW, groupName);
 		intent.putExtra(MapActivity.INTENT_PARAMS, bundle);
 		AndroidUtils.startActivityIfSafe(context, intent);
+	}
+
+	@Override
+	@NonNull
+	public Map<String, String> getAdditionalImageParams() {
+		Map<String, String> extensions = amenity != null ? sourceAmenityExtensions : mergedAmenityExtensions;
+		return AmenityExtensionsHelper.getImagesParams(extensions);
 	}
 }


### PR DESCRIPTION
Fixes #25090.

Restore Wikipedia details and online photos when a POI is added to Favorites.

The Favorite menu now resolves the source amenity using persisted identity data (Wikidata with origin-name fallback) and reuses the existing amenity description rendering. This restores the Wikipedia description, "Read full article" action, and online photos while keeping Favorite-specific menu behavior and without storing additional Wikipedia data in favorite.gpx.