### PR TITLE
Fix #24916 split interval analysis corruption

### DIFF
--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxTrackAnalysis.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxTrackAnalysis.kt
@@ -504,8 +504,10 @@ class GpxTrackAnalysis {
 
 		for (s in splitSegments) {
 			val numberOfPoints = s.getNumberOfPoints()
+			val isWholeSegment = s.startPointInd == 0 && s.startCoeff == 0.0
+					&& s.endPointInd == s.segment.points.size - 2 && s.endCoeff == 1.0
 			var segmentDistance = 0f
-			var detachedStartAttributes: PointAttributes? = null
+			val segmentAttributes = ArrayList<PointAttributes>(numberOfPoints)
 			metricEnd += s.metricEnd
 			secondaryMetricEnd += s.secondaryMetricEnd
 			_points += numberOfPoints
@@ -550,7 +552,6 @@ class GpxTrackAnalysis {
 
 				val hasPartialStart = j == 1 && s.startCoeff > 0
 				val hasExactSubsegmentStart = j == 0 && s.startPointInd > 0 && s.startCoeff == 0.0
-				val needsDetachedAttributes = hasPartialStart || hasExactSubsegmentStart
 				var distance = point.attributes?.distance ?: -1f
 				if (hasPartialStart) {
 					distance = -1f
@@ -565,7 +566,10 @@ class GpxTrackAnalysis {
 					}
 					_totalDistance += distance
 					segmentDistance += distance
-					point.distance = segmentDistance.toDouble()
+					val isSyntheticEnd = j == numberOfPoints - 1 && s.endCoeff != 1.0
+					if (isWholeSegment || isSyntheticEnd) {
+						point.distance = segmentDistance.toDouble()
+					}
 
 					timeDiffMillis = maxOf(0, point.time - prev.time)
 					timeDiff = timeDiffMillis.toDouble() / 1000
@@ -622,8 +626,13 @@ class GpxTrackAnalysis {
 					}
 				}
 
-				// Reuse existing PointAttributes to avoid per-point allocation. Points affected by
-				// an interval start have interval-specific values, so keep their attributes detached.
+				val hasExactPartialEnd = !isWholeSegment
+						&& j == numberOfPoints - 1 && s.endCoeff == 1.0
+				val needsDetachedAttributes = hasPartialStart || hasExactSubsegmentStart || hasExactPartialEnd
+
+				// Reuse existing PointAttributes to avoid per-point allocation. Source points at
+				// partial interval boundaries have interval-specific values, so detach their attributes.
+				// Whole segment endpoints stay attached to populate the per-point cache.
 				val attributes = if (needsDetachedAttributes) {
 					point.attributes?.copy() ?: PointAttributes(0f, 0f, false, false)
 				} else {
@@ -641,11 +650,9 @@ class GpxTrackAnalysis {
 				attributes.lastPoint = lastPoint
 				attributes.speed = speed
 				attributes.elevation = elevation
-				if (needsDetachedAttributes) {
-					detachedStartAttributes = attributes
-				}
 
 				addWptAttribute(point, attributes, pointsAnalyser)
+				segmentAttributes.add(attributes)
 				if (attributes.sensorSpeed > 0 && !attributes.sensorSpeed.isInfinite()) {
 					_maxSensorSpeed = maxOf(attributes.sensorSpeed, _maxSensorSpeed)
 					sensorSpeedCount++
@@ -779,7 +786,7 @@ class GpxTrackAnalysis {
 				}
 
 			}
-			processElevationDiff(s, detachedStartAttributes)
+			processElevationDiff(s, segmentAttributes)
 		}
 
 		if (!joinSegments && totalDistanceWithoutGaps > 0) {
@@ -950,7 +957,7 @@ class GpxTrackAnalysis {
 
 	private fun processElevationDiff(
 		segment: SplitSegment,
-		detachedStartAttributes: PointAttributes?
+		segmentAttributes: List<PointAttributes>
 	) {
 		val approximator = getElevationApproximator(segment)
 		approximator.approximate()
@@ -968,14 +975,14 @@ class GpxTrackAnalysis {
 
 			if (segLastUp != null) {
 				val upDist = calculateTotalDistanceForSlope(segLastUp, indexes, distances)
-				val upMaxSpeed = calculateMaxSpeedForSlope(segLastUp, segment, detachedStartAttributes)
-				val upMovingTime = calculateMovingTimeForSlope(segLastUp, segment, detachedStartAttributes)
+				val upMaxSpeed = calculateMaxSpeedForSlope(segLastUp, segment, segmentAttributes)
+				val upMovingTime = calculateMovingTimeForSlope(segLastUp, segment, segmentAttributes)
 				this.lastUphill = segLastUp.copy(distance = upDist, maxSpeed = upMaxSpeed, movingTime = upMovingTime)
 			}
 			if (segLastDown != null) {
 				val downDist = calculateTotalDistanceForSlope(segLastDown, indexes, distances)
-				val downMaxSpeed = calculateMaxSpeedForSlope(segLastDown, segment, detachedStartAttributes)
-				val downMovingTime = calculateMovingTimeForSlope(segLastDown, segment, detachedStartAttributes)
+				val downMaxSpeed = calculateMaxSpeedForSlope(segLastDown, segment, segmentAttributes)
+				val downMovingTime = calculateMovingTimeForSlope(segLastDown, segment, segmentAttributes)
 				this.lastDownhill = segLastDown.copy(distance = downDist, maxSpeed = downMaxSpeed, movingTime = downMovingTime)
 			}
 		}
@@ -1001,18 +1008,17 @@ class GpxTrackAnalysis {
 	private fun calculateMaxSpeedForSlope(
 		slope: ElevationDiffsCalculator.SlopeInfo?,
 		segment: SplitSegment,
-		detachedStartAttributes: PointAttributes?
+		segmentAttributes: List<PointAttributes>
 	): Float {
 		if (slope == null) return 0.0f
 		val startIdx = slope.startPointIndex
 		val endIdx = slope.endPointIndex
 		if (startIdx > endIdx) return 0.0f
-		val detachedStartIndex = if (segment.startCoeff > 0) 1 else 0
 		var maxSpeed = 0.0f
 		for (i in startIdx..endIdx) {
 			val pt = segment[i]
-			val attributes = detachedStartAttributes?.takeIf { i == detachedStartIndex } ?: pt.attributes
-			val speed = if (attributes != null && !attributes.speed.isNaN()) attributes.speed else pt.speed
+			val attributes = segmentAttributes[i]
+			val speed = if (!attributes.speed.isNaN()) attributes.speed else pt.speed
 
 			if (speed > maxSpeed) {
 				maxSpeed = speed
@@ -1024,13 +1030,12 @@ class GpxTrackAnalysis {
     private fun calculateMovingTimeForSlope(
         slope: ElevationDiffsCalculator.SlopeInfo?,
         segment: SplitSegment,
-        detachedStartAttributes: PointAttributes?
+        segmentAttributes: List<PointAttributes>
     ): Long {
         if (slope == null) return 0L
         val startIdx = slope.startPointIndex
         val endIdx = slope.endPointIndex
         if (startIdx >= endIdx) return 0L
-        val detachedStartIndex = if (segment.startCoeff > 0) 1 else 0
         var movingTime = 0L
         for (i in (startIdx + 1)..endIdx) {
             val prev = segment[i - 1]
@@ -1041,12 +1046,12 @@ class GpxTrackAnalysis {
             val timeDiffSec = (timeDiffMillis / 1000).toInt()
             if (timeDiffSec <= 0) continue
 
-            val attributes = detachedStartAttributes?.takeIf { i == detachedStartIndex } ?: pt.attributes
-            var distance = attributes?.distance ?: -1f
+            val attributes = segmentAttributes[i]
+            var distance = attributes.distance
             if (distance < 0f) {
                 distance = KMapUtils.getEllipsoidDistance(prev.lat, prev.lon, pt.lat, pt.lon).toFloat()
             }
-            var speed = if (attributes != null && !attributes.speed.isNaN()) attributes.speed else pt.speed
+            var speed = if (!attributes.speed.isNaN()) attributes.speed else pt.speed
             if (speed == 0.0f) {
                 speed = distance / timeDiffSec.toFloat()
             }

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxTrackAnalysis.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxTrackAnalysis.kt
@@ -505,6 +505,7 @@ class GpxTrackAnalysis {
 		for (s in splitSegments) {
 			val numberOfPoints = s.getNumberOfPoints()
 			var segmentDistance = 0f
+			var partialStartAttributes: PointAttributes? = null
 			metricEnd += s.metricEnd
 			secondaryMetricEnd += s.secondaryMetricEnd
 			_points += numberOfPoints
@@ -619,11 +620,16 @@ class GpxTrackAnalysis {
 					}
 				}
 
-				// Reuse existing PointAttributes to avoid per‑point allocation
-				val attributes = point.attributes ?: run {
-					val a = PointAttributes(0f, 0f, false, false)
-					point.attributes = a
-					a
+				// Reuse existing PointAttributes to avoid per-point allocation. The point right after
+				// an interpolated split boundary has interval-specific values, so keep them detached.
+				val attributes = if (hasPartialStart) {
+					point.attributes?.copy() ?: PointAttributes(0f, 0f, false, false)
+				} else {
+					point.attributes ?: run {
+						val a = PointAttributes(0f, 0f, false, false)
+						point.attributes = a
+						a
+					}
 				}
 
 				// Update fields
@@ -633,6 +639,9 @@ class GpxTrackAnalysis {
 				attributes.lastPoint = lastPoint
 				attributes.speed = speed
 				attributes.elevation = elevation
+				if (hasPartialStart) {
+					partialStartAttributes = attributes
+				}
 
 				addWptAttribute(point, attributes, pointsAnalyser)
 				if (attributes.sensorSpeed > 0 && !attributes.sensorSpeed.isInfinite()) {
@@ -768,7 +777,7 @@ class GpxTrackAnalysis {
 				}
 
 			}
-			processElevationDiff(s)
+			processElevationDiff(s, partialStartAttributes)
 		}
 
 		if (!joinSegments && totalDistanceWithoutGaps > 0) {
@@ -937,7 +946,10 @@ class GpxTrackAnalysis {
 		return if (valuesCount > 0) (totalSum.toDouble() / valuesCount).toInt() else 0
 	}
 
-	private fun processElevationDiff(segment: SplitSegment) {
+	private fun processElevationDiff(
+		segment: SplitSegment,
+		partialStartAttributes: PointAttributes?
+	) {
 		val approximator = getElevationApproximator(segment)
 		approximator.approximate()
 		val distances = approximator.getDistances()
@@ -954,14 +966,14 @@ class GpxTrackAnalysis {
 
 			if (segLastUp != null) {
 				val upDist = calculateTotalDistanceForSlope(segLastUp, indexes, distances)
-				val upMaxSpeed = calculateMaxSpeedForSlope(segLastUp, segment)
-                val upMovingTime = calculateMovingTimeForSlope(segLastUp, segment)
+				val upMaxSpeed = calculateMaxSpeedForSlope(segLastUp, segment, partialStartAttributes)
+				val upMovingTime = calculateMovingTimeForSlope(segLastUp, segment, partialStartAttributes)
 				this.lastUphill = segLastUp.copy(distance = upDist, maxSpeed = upMaxSpeed, movingTime = upMovingTime)
 			}
 			if (segLastDown != null) {
 				val downDist = calculateTotalDistanceForSlope(segLastDown, indexes, distances)
-				val downMaxSpeed = calculateMaxSpeedForSlope(segLastDown, segment)
-                val downMovingTime = calculateMovingTimeForSlope(segLastDown, segment)
+				val downMaxSpeed = calculateMaxSpeedForSlope(segLastDown, segment, partialStartAttributes)
+				val downMovingTime = calculateMovingTimeForSlope(segLastDown, segment, partialStartAttributes)
 				this.lastDownhill = segLastDown.copy(distance = downDist, maxSpeed = downMaxSpeed, movingTime = downMovingTime)
 			}
 		}
@@ -986,7 +998,8 @@ class GpxTrackAnalysis {
 
 	private fun calculateMaxSpeedForSlope(
 		slope: ElevationDiffsCalculator.SlopeInfo?,
-		segment: SplitSegment
+		segment: SplitSegment,
+		partialStartAttributes: PointAttributes?
 	): Float {
 		if (slope == null) return 0.0f
 		val startIdx = slope.startPointIndex
@@ -995,7 +1008,7 @@ class GpxTrackAnalysis {
 		var maxSpeed = 0.0f
 		for (i in startIdx..endIdx) {
 			val pt = segment[i]
-			val attributes = pt.attributes
+			val attributes = partialStartAttributes?.takeIf { i == 1 } ?: pt.attributes
 			val speed = if (attributes != null && !attributes.speed.isNaN()) attributes.speed else pt.speed
 
 			if (speed > maxSpeed) {
@@ -1007,7 +1020,8 @@ class GpxTrackAnalysis {
  
     private fun calculateMovingTimeForSlope(
         slope: ElevationDiffsCalculator.SlopeInfo?,
-        segment: SplitSegment
+        segment: SplitSegment,
+        partialStartAttributes: PointAttributes?
     ): Long {
         if (slope == null) return 0L
         val startIdx = slope.startPointIndex
@@ -1023,7 +1037,7 @@ class GpxTrackAnalysis {
             val timeDiffSec = (timeDiffMillis / 1000).toInt()
             if (timeDiffSec <= 0) continue
 
-            val attributes = pt.attributes
+            val attributes = partialStartAttributes?.takeIf { i == 1 } ?: pt.attributes
             var distance = attributes?.distance ?: -1f
             if (distance < 0f) {
                 distance = KMapUtils.getEllipsoidDistance(prev.lat, prev.lon, pt.lat, pt.lon).toFloat()

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxTrackAnalysis.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxTrackAnalysis.kt
@@ -547,8 +547,9 @@ class GpxTrackAnalysis {
 				}
 				updateHdop(point)
 
+				val hasPartialStart = j == 1 && s.startCoeff > 0
 				var distance = point.attributes?.distance ?: -1f
-				if (j == 1 && s.startCoeff > 0) {
+				if (hasPartialStart) {
 					distance = -1f
 				}
 				if (j > 0) {
@@ -625,7 +626,7 @@ class GpxTrackAnalysis {
 					a
 				}
 
-				// Update fields (no new object created)
+				// Update fields
 				attributes.distance = distance
 				attributes.timeDiff = timeDiff.toFloat()
 				attributes.firstPoint = firstPoint
@@ -842,9 +843,6 @@ class GpxTrackAnalysis {
 		}
 		if (!hasElevationData() && !attributes.elevation.isNaN()) {
 			setHasData(POINT_ELEVATION, true)
-		}
-		if (point.attributes != attributes) {
-			point.attributes = attributes
 		}
 		pointsAnalyser?.onAnalysePoint(this, point, attributes)
 		if (collectPointData) {
@@ -1095,6 +1093,10 @@ class GpxTrackAnalysis {
 	}
 
 	fun interface TrackPointsAnalyser {
+		/**
+		 * The supplied attribute may be detached from `point.attributes` for interval-specific
+		 * boundary calculations. Implementations should read and update the supplied attribute.
+		 */
 		fun onAnalysePoint(analysis: GpxTrackAnalysis, point: WptPt, attribute: PointAttributes)
 	}
 }

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxTrackAnalysis.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxTrackAnalysis.kt
@@ -505,7 +505,7 @@ class GpxTrackAnalysis {
 		for (s in splitSegments) {
 			val numberOfPoints = s.getNumberOfPoints()
 			var segmentDistance = 0f
-			var partialStartAttributes: PointAttributes? = null
+			var detachedStartAttributes: PointAttributes? = null
 			metricEnd += s.metricEnd
 			secondaryMetricEnd += s.secondaryMetricEnd
 			_points += numberOfPoints
@@ -549,6 +549,8 @@ class GpxTrackAnalysis {
 				updateHdop(point)
 
 				val hasPartialStart = j == 1 && s.startCoeff > 0
+				val hasExactSubsegmentStart = j == 0 && s.startPointInd > 0 && s.startCoeff == 0.0
+				val needsDetachedAttributes = hasPartialStart || hasExactSubsegmentStart
 				var distance = point.attributes?.distance ?: -1f
 				if (hasPartialStart) {
 					distance = -1f
@@ -620,9 +622,9 @@ class GpxTrackAnalysis {
 					}
 				}
 
-				// Reuse existing PointAttributes to avoid per-point allocation. The point right after
-				// an interpolated split boundary has interval-specific values, so keep them detached.
-				val attributes = if (hasPartialStart) {
+				// Reuse existing PointAttributes to avoid per-point allocation. Points affected by
+				// an interval start have interval-specific values, so keep their attributes detached.
+				val attributes = if (needsDetachedAttributes) {
 					point.attributes?.copy() ?: PointAttributes(0f, 0f, false, false)
 				} else {
 					point.attributes ?: run {
@@ -639,8 +641,8 @@ class GpxTrackAnalysis {
 				attributes.lastPoint = lastPoint
 				attributes.speed = speed
 				attributes.elevation = elevation
-				if (hasPartialStart) {
-					partialStartAttributes = attributes
+				if (needsDetachedAttributes) {
+					detachedStartAttributes = attributes
 				}
 
 				addWptAttribute(point, attributes, pointsAnalyser)
@@ -777,7 +779,7 @@ class GpxTrackAnalysis {
 				}
 
 			}
-			processElevationDiff(s, partialStartAttributes)
+			processElevationDiff(s, detachedStartAttributes)
 		}
 
 		if (!joinSegments && totalDistanceWithoutGaps > 0) {
@@ -948,7 +950,7 @@ class GpxTrackAnalysis {
 
 	private fun processElevationDiff(
 		segment: SplitSegment,
-		partialStartAttributes: PointAttributes?
+		detachedStartAttributes: PointAttributes?
 	) {
 		val approximator = getElevationApproximator(segment)
 		approximator.approximate()
@@ -966,14 +968,14 @@ class GpxTrackAnalysis {
 
 			if (segLastUp != null) {
 				val upDist = calculateTotalDistanceForSlope(segLastUp, indexes, distances)
-				val upMaxSpeed = calculateMaxSpeedForSlope(segLastUp, segment, partialStartAttributes)
-				val upMovingTime = calculateMovingTimeForSlope(segLastUp, segment, partialStartAttributes)
+				val upMaxSpeed = calculateMaxSpeedForSlope(segLastUp, segment, detachedStartAttributes)
+				val upMovingTime = calculateMovingTimeForSlope(segLastUp, segment, detachedStartAttributes)
 				this.lastUphill = segLastUp.copy(distance = upDist, maxSpeed = upMaxSpeed, movingTime = upMovingTime)
 			}
 			if (segLastDown != null) {
 				val downDist = calculateTotalDistanceForSlope(segLastDown, indexes, distances)
-				val downMaxSpeed = calculateMaxSpeedForSlope(segLastDown, segment, partialStartAttributes)
-				val downMovingTime = calculateMovingTimeForSlope(segLastDown, segment, partialStartAttributes)
+				val downMaxSpeed = calculateMaxSpeedForSlope(segLastDown, segment, detachedStartAttributes)
+				val downMovingTime = calculateMovingTimeForSlope(segLastDown, segment, detachedStartAttributes)
 				this.lastDownhill = segLastDown.copy(distance = downDist, maxSpeed = downMaxSpeed, movingTime = downMovingTime)
 			}
 		}
@@ -999,16 +1001,17 @@ class GpxTrackAnalysis {
 	private fun calculateMaxSpeedForSlope(
 		slope: ElevationDiffsCalculator.SlopeInfo?,
 		segment: SplitSegment,
-		partialStartAttributes: PointAttributes?
+		detachedStartAttributes: PointAttributes?
 	): Float {
 		if (slope == null) return 0.0f
 		val startIdx = slope.startPointIndex
 		val endIdx = slope.endPointIndex
 		if (startIdx > endIdx) return 0.0f
+		val detachedStartIndex = if (segment.startCoeff > 0) 1 else 0
 		var maxSpeed = 0.0f
 		for (i in startIdx..endIdx) {
 			val pt = segment[i]
-			val attributes = partialStartAttributes?.takeIf { i == 1 } ?: pt.attributes
+			val attributes = detachedStartAttributes?.takeIf { i == detachedStartIndex } ?: pt.attributes
 			val speed = if (attributes != null && !attributes.speed.isNaN()) attributes.speed else pt.speed
 
 			if (speed > maxSpeed) {
@@ -1021,12 +1024,13 @@ class GpxTrackAnalysis {
     private fun calculateMovingTimeForSlope(
         slope: ElevationDiffsCalculator.SlopeInfo?,
         segment: SplitSegment,
-        partialStartAttributes: PointAttributes?
+        detachedStartAttributes: PointAttributes?
     ): Long {
         if (slope == null) return 0L
         val startIdx = slope.startPointIndex
         val endIdx = slope.endPointIndex
         if (startIdx >= endIdx) return 0L
+        val detachedStartIndex = if (segment.startCoeff > 0) 1 else 0
         var movingTime = 0L
         for (i in (startIdx + 1)..endIdx) {
             val prev = segment[i - 1]
@@ -1037,7 +1041,7 @@ class GpxTrackAnalysis {
             val timeDiffSec = (timeDiffMillis / 1000).toInt()
             if (timeDiffSec <= 0) continue
 
-            val attributes = partialStartAttributes?.takeIf { i == 1 } ?: pt.attributes
+            val attributes = detachedStartAttributes?.takeIf { i == detachedStartIndex } ?: pt.attributes
             var distance = attributes?.distance ?: -1f
             if (distance < 0f) {
                 distance = KMapUtils.getEllipsoidDistance(prev.lat, prev.lon, pt.lat, pt.lon).toFloat()

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/PointAttributes.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/PointAttributes.kt
@@ -134,6 +134,16 @@ class PointAttributes(
 		get() = vehicleData?.throttlePosition ?: Float.NaN
 		set(value) = setVehicleValue(value) { throttlePosition = it }
 
+	internal fun copy(): PointAttributes {
+		return PointAttributes(distance, timeDiff, firstPoint, lastPoint).also { copy ->
+			copy.speed = speed
+			copy.elevation = elevation
+			copy.sensorData = sensorData?.copy()
+			copy.devData = devData?.copy()
+			copy.vehicleData = vehicleData?.copy()
+		}
+	}
+
 	fun hasAnyValueSet(): Boolean = !speed.isNaN() || !elevation.isNaN() ||
 			hasAnySensorValueSet() || hasAnyDevValueSet() || hasAnyVehicleValueSet()
 
@@ -275,6 +285,15 @@ class PointAttributes(
 					!bikePower.isNaN() ||
 					!waterTemperature.isNaN() ||
 					!airTemperature.isNaN()
+
+		fun copy() = SensorData().also { copy ->
+			copy.heartRate = heartRate
+			copy.sensorSpeed = sensorSpeed
+			copy.bikeCadence = bikeCadence
+			copy.bikePower = bikePower
+			copy.waterTemperature = waterTemperature
+			copy.airTemperature = airTemperature
+		}
 	}
 
 	private class DevData {
@@ -283,6 +302,12 @@ class PointAttributes(
 		var interpolationOffsetN: Float = Float.NaN
 
 		fun hasAnyValueSet(): Boolean = !rawZoom.isNaN() || !animatedZoom.isNaN() || !interpolationOffsetN.isNaN()
+
+		fun copy() = DevData().also { copy ->
+			copy.rawZoom = rawZoom
+			copy.animatedZoom = animatedZoom
+			copy.interpolationOffsetN = interpolationOffsetN
+		}
 	}
 
 	private class VehicleData {
@@ -314,5 +339,21 @@ class PointAttributes(
 					!batteryVoltage.isNaN() ||
 					!vehicleSpeed.isNaN() ||
 					!throttlePosition.isNaN()
+
+		fun copy() = VehicleData().also { copy ->
+			copy.intakeTemp = intakeTemp
+			copy.ambientTemp = ambientTemp
+			copy.coolantTemp = coolantTemp
+			copy.engineOilTemp = engineOilTemp
+			copy.rpmSpeed = rpmSpeed
+			copy.runtimeEngine = runtimeEngine
+			copy.engineLoad = engineLoad
+			copy.fuelPressure = fuelPressure
+			copy.fuelConsumption = fuelConsumption
+			copy.fuelRemaining = fuelRemaining
+			copy.batteryVoltage = batteryVoltage
+			copy.vehicleSpeed = vehicleSpeed
+			copy.throttlePosition = throttlePosition
+		}
 	}
 }

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/GpxTrackAnalysisTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/GpxTrackAnalysisTest.kt
@@ -1,11 +1,13 @@
 package net.osmand.shared
 
+import net.osmand.shared.gpx.GpxFile
 import net.osmand.shared.gpx.GpxTrackAnalysis
 import net.osmand.shared.gpx.SplitSegment
 import net.osmand.shared.gpx.primitives.TrkSegment
 import net.osmand.shared.gpx.primitives.WptPt
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
@@ -15,6 +17,9 @@ class GpxTrackAnalysisTest {
 	fun splitByDistanceKeepsWholeTrackAttributesIntact() {
 		val segment = createSparseSegment()
 		val totalDistanceBefore = analyze(segment).totalDistance
+		val pointDistancesBefore = segment.points.map { it.distance }
+		val pointIndexBefore = GpxFile(null)
+			.getPointIndexByDistance(segment.points, pointDistancesBefore[2])
 		val sourceAttributes = requireNotNull(segment.points[1].attributes)
 		sourceAttributes.heartRate = 5f
 		sourceAttributes.rawZoom = 6f
@@ -52,6 +57,9 @@ class GpxTrackAnalysisTest {
 			assertEquals(5f, sourceAttributes.heartRate)
 			assertEquals(6f, sourceAttributes.rawZoom)
 			assertEquals(7f, sourceAttributes.engineLoad)
+			assertEquals(pointDistancesBefore, segment.points.map { point -> point.distance })
+			assertEquals(pointIndexBefore, GpxFile(null)
+				.getPointIndexByDistance(segment.points, pointDistancesBefore[2]))
 			assertEquals(totalDistanceBefore, analyze(segment).totalDistance, 0.001f)
 		}
 	}
@@ -60,9 +68,14 @@ class GpxTrackAnalysisTest {
 	fun exactSubsegmentStartKeepsWholeTrackAttributesIntact() {
 		val segment = createSparseSegment()
 		val totalDistanceBefore = analyze(segment).totalDistance
+		val pointDistancesBefore = segment.points.map { it.distance }
 		val sourceAttributes = requireNotNull(segment.points[1].attributes)
+		sourceAttributes.heartRate = 5f
+		sourceAttributes.rawZoom = 6f
+		sourceAttributes.engineLoad = 7f
 		val sourceDistance = sourceAttributes.distance
 		val sourceTimeDiff = sourceAttributes.timeDiff
+		val sourceSpeed = sourceAttributes.speed
 		// Uphill/downhill intervals start at existing extremum points.
 		val subsegment = SplitSegment(1, segment.points.size, segment)
 
@@ -73,9 +86,14 @@ class GpxTrackAnalysisTest {
 		assertTrue(startAttributes !== sourceAttributes)
 		assertEquals(0f, startAttributes.distance)
 		assertEquals(0f, startAttributes.timeDiff)
+		assertEquals(5f, startAttributes.heartRate)
+		assertEquals(6f, startAttributes.rawZoom)
+		assertEquals(7f, startAttributes.engineLoad)
 		assertSame(sourceAttributes, segment.points[1].attributes)
 		assertEquals(sourceDistance, sourceAttributes.distance)
 		assertEquals(sourceTimeDiff, sourceAttributes.timeDiff)
+		assertEquals(sourceSpeed, sourceAttributes.speed)
+		assertEquals(pointDistancesBefore, segment.points.map { it.distance })
 		assertEquals(totalDistanceBefore, analyze(segment).totalDistance, 0.001f)
 	}
 
@@ -83,6 +101,7 @@ class GpxTrackAnalysisTest {
 	fun splitSlopeUsesPartialBoundaryAttributes() {
 		val segment = createSlowUphillSegment()
 		analyze(segment)
+		val pointDistancesBefore = segment.points.map { it.distance }
 		val sourceAttributes = requireNotNull(segment.points[1].attributes)
 		val partialSegment = SplitSegment(segment, 0, 0.9).apply {
 			setLastPoint(2, 1.0)
@@ -94,6 +113,51 @@ class GpxTrackAnalysisTest {
 		assertTrue(boundaryAttributes.distance < sourceAttributes.distance)
 		assertTrue(boundaryAttributes.timeDiff < sourceAttributes.timeDiff)
 		assertEquals(0L, requireNotNull(analysis.lastUphill).movingTime)
+		assertEquals(pointDistancesBefore, segment.points.map { it.distance })
+	}
+
+	@Test
+	fun coldExactPartialEndDoesNotAttachIntervalAttributes() {
+		val segment = createGeneralSegment()
+		val sourceEndPoint = segment.points[1]
+		val partialSegment = SplitSegment(0, 2, segment)
+
+		val partialAnalysis = GpxTrackAnalysis()
+			.prepareInformation(0, null, partialSegment)
+
+		assertNull(sourceEndPoint.attributes)
+		assertEquals(false, partialAnalysis.pointAttributes.last().lastPoint)
+
+		val wholeAnalysis = analyze(segment)
+		val wholeEndAttributes = wholeAnalysis.pointAttributes[1]
+		assertSame(wholeEndAttributes, sourceEndPoint.attributes)
+		assertTrue(wholeEndAttributes.lastPoint)
+	}
+
+	@Test
+	fun exactPartialEndSlopeUsesCurrentAnalysisAttributes() {
+		val segment = createMixedSpeedUphillSegment()
+		analyze(segment)
+		val pointDistancesBefore = segment.points.map { it.distance }
+		val sourceEndAttributes = requireNotNull(segment.points.last().attributes)
+		assertEquals(0f, sourceEndAttributes.speed)
+		val partialSegment = SplitSegment(1, segment.points.size, segment)
+
+		val analysis = GpxTrackAnalysis().prepareInformation(0, null, partialSegment)
+		val partialEndAttributes = analysis.pointAttributes.last()
+		val lastUphill = requireNotNull(analysis.lastUphill)
+
+		assertTrue(partialEndAttributes !== sourceEndAttributes)
+		assertTrue(partialEndAttributes.speed > 0f)
+		assertEquals(partialEndAttributes.speed, lastUphill.maxSpeed, 0.001f)
+		assertEquals(0f, sourceEndAttributes.speed)
+		assertEquals(pointDistancesBefore, segment.points.map { it.distance })
+
+		val compactAnalysis = GpxTrackAnalysis().apply { collectPointData = false }
+			.prepareInformation(0, null, partialSegment)
+		assertTrue(compactAnalysis.pointAttributes.isEmpty())
+		assertEquals(partialEndAttributes.speed,
+			requireNotNull(compactAnalysis.lastUphill).maxSpeed, 0.001f)
 	}
 
 	private fun createSparseSegment() = TrkSegment().apply {
@@ -104,10 +168,23 @@ class GpxTrackAnalysisTest {
 	}
 
 	private fun createSlowUphillSegment() = TrkSegment().apply {
-		points.add(WptPt(0.0, 0.0, 1_000_000L, 0.0, 0f, Float.NaN))
-		points.add(WptPt(0.0, 0.01, 21_000_000L, 10.0, 0f, Float.NaN))
-		points.add(WptPt(0.0, 0.02, 41_000_000L, 20.0, 0f, Float.NaN))
-		points.add(WptPt(0.0, 0.03, 61_000_000L, 30.0, 0f, Float.NaN))
+		points.add(WptPt(0.0, 0.0, 1_000_000L, 100.0, 0f, Float.NaN))
+		points.add(WptPt(0.0, 0.01, 21_000_000L, 110.0, 0f, Float.NaN))
+		points.add(WptPt(0.0, 0.02, 41_000_000L, 120.0, 0f, Float.NaN))
+		points.add(WptPt(0.0, 0.03, 61_000_000L, 130.0, 0f, Float.NaN))
+	}
+
+	private fun createGeneralSegment() = createSparseSegment().apply {
+		generalSegment = true
+		points[1].lastPoint = true
+	}
+
+	private fun createMixedSpeedUphillSegment() = TrkSegment().apply {
+		points.add(WptPt(0.0, 0.00, 1_000_000L, -10.0, 5f, Float.NaN))
+		points.add(WptPt(0.0, 0.01, 1_100_000L, 0.0, 0f, Float.NaN))
+		points.add(WptPt(0.0, 0.02, 1_100_000L, 10.0, 0f, Float.NaN))
+		points.add(WptPt(0.0, 0.03, 1_100_000L, 20.0, 0f, Float.NaN))
+		points.add(WptPt(0.0, 0.04, 2_300_000L, 30.0, 0f, Float.NaN))
 	}
 
 	private fun analyze(segment: TrkSegment): GpxTrackAnalysis {

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/GpxTrackAnalysisTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/GpxTrackAnalysisTest.kt
@@ -57,6 +57,29 @@ class GpxTrackAnalysisTest {
 	}
 
 	@Test
+	fun exactSubsegmentStartKeepsWholeTrackAttributesIntact() {
+		val segment = createSparseSegment()
+		val totalDistanceBefore = analyze(segment).totalDistance
+		val sourceAttributes = requireNotNull(segment.points[1].attributes)
+		val sourceDistance = sourceAttributes.distance
+		val sourceTimeDiff = sourceAttributes.timeDiff
+		// Uphill/downhill intervals start at existing extremum points.
+		val subsegment = SplitSegment(1, segment.points.size, segment)
+
+		val startAttributes = GpxTrackAnalysis()
+			.prepareInformation(0, null, subsegment)
+			.pointAttributes[0]
+
+		assertTrue(startAttributes !== sourceAttributes)
+		assertEquals(0f, startAttributes.distance)
+		assertEquals(0f, startAttributes.timeDiff)
+		assertSame(sourceAttributes, segment.points[1].attributes)
+		assertEquals(sourceDistance, sourceAttributes.distance)
+		assertEquals(sourceTimeDiff, sourceAttributes.timeDiff)
+		assertEquals(totalDistanceBefore, analyze(segment).totalDistance, 0.001f)
+	}
+
+	@Test
 	fun splitSlopeUsesPartialBoundaryAttributes() {
 		val segment = createSlowUphillSegment()
 		analyze(segment)

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/GpxTrackAnalysisTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/GpxTrackAnalysisTest.kt
@@ -1,0 +1,93 @@
+package net.osmand.shared
+
+import net.osmand.shared.gpx.GpxTrackAnalysis
+import net.osmand.shared.gpx.SplitSegment
+import net.osmand.shared.gpx.primitives.TrkSegment
+import net.osmand.shared.gpx.primitives.WptPt
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class GpxTrackAnalysisTest {
+
+	@Test
+	fun splitByDistanceKeepsWholeTrackAttributesIntact() {
+		val segment = createSparseSegment()
+		val totalDistanceBefore = analyze(segment).totalDistance
+		val sourceAttributes = requireNotNull(segment.points[1].attributes)
+		sourceAttributes.heartRate = 5f
+		sourceAttributes.rawZoom = 6f
+		sourceAttributes.engineLoad = 7f
+		val sourceDistance = sourceAttributes.distance
+		val sourceTimeDiff = sourceAttributes.timeDiff
+		val sourceSpeed = sourceAttributes.speed
+		val sourceFirstPoint = sourceAttributes.firstPoint
+		val sourceLastPoint = sourceAttributes.lastPoint
+
+		val analyser = GpxTrackAnalysis.TrackPointsAnalyser { _, point, attributes ->
+			if (point.attributes !== attributes) {
+				attributes.heartRate = 15f
+				attributes.rawZoom = 16f
+				attributes.engineLoad = 17f
+			}
+		}
+		repeat(2) {
+			val boundaryAttributes = segment.splitByDistance(1_000.0, false, analyser)[1].pointAttributes[1]
+
+			assertTrue(boundaryAttributes !== sourceAttributes)
+			assertTrue(boundaryAttributes.distance > 0f)
+			assertTrue(boundaryAttributes.distance < sourceDistance)
+			assertTrue(boundaryAttributes.timeDiff > 0f)
+			assertTrue(boundaryAttributes.timeDiff < sourceTimeDiff)
+			assertEquals(15f, boundaryAttributes.heartRate)
+			assertEquals(16f, boundaryAttributes.rawZoom)
+			assertEquals(17f, boundaryAttributes.engineLoad)
+			assertSame(sourceAttributes, segment.points[1].attributes)
+			assertEquals(sourceDistance, sourceAttributes.distance)
+			assertEquals(sourceTimeDiff, sourceAttributes.timeDiff)
+			assertEquals(sourceSpeed, sourceAttributes.speed)
+			assertEquals(sourceFirstPoint, sourceAttributes.firstPoint)
+			assertEquals(sourceLastPoint, sourceAttributes.lastPoint)
+			assertEquals(5f, sourceAttributes.heartRate)
+			assertEquals(6f, sourceAttributes.rawZoom)
+			assertEquals(7f, sourceAttributes.engineLoad)
+			assertEquals(totalDistanceBefore, analyze(segment).totalDistance, 0.001f)
+		}
+	}
+
+	@Test
+	fun splitSlopeUsesPartialBoundaryAttributes() {
+		val segment = createSlowUphillSegment()
+		analyze(segment)
+		val sourceAttributes = requireNotNull(segment.points[1].attributes)
+		val partialSegment = SplitSegment(segment, 0, 0.9).apply {
+			setLastPoint(2, 1.0)
+		}
+
+		val analysis = GpxTrackAnalysis().prepareInformation(0, null, partialSegment)
+		val boundaryAttributes = analysis.pointAttributes[1]
+
+		assertTrue(boundaryAttributes.distance < sourceAttributes.distance)
+		assertTrue(boundaryAttributes.timeDiff < sourceAttributes.timeDiff)
+		assertEquals(0L, requireNotNull(analysis.lastUphill).movingTime)
+	}
+
+	private fun createSparseSegment() = TrkSegment().apply {
+		points.add(WptPt(0.0, 0.0, 1_000_000L, Double.NaN, 0f, Float.NaN))
+		points.add(WptPt(0.0, 0.01, 1_100_000L, Double.NaN, 0f, Float.NaN))
+		points.add(WptPt(0.0, 0.02, 1_200_000L, Double.NaN, 0f, Float.NaN))
+		points.add(WptPt(0.0, 0.03, 1_300_000L, Double.NaN, 0f, Float.NaN))
+	}
+
+	private fun createSlowUphillSegment() = TrkSegment().apply {
+		points.add(WptPt(0.0, 0.0, 1_000_000L, 0.0, 0f, Float.NaN))
+		points.add(WptPt(0.0, 0.01, 21_000_000L, 10.0, 0f, Float.NaN))
+		points.add(WptPt(0.0, 0.02, 41_000_000L, 20.0, 0f, Float.NaN))
+		points.add(WptPt(0.0, 0.03, 61_000_000L, 30.0, 0f, Float.NaN))
+	}
+
+	private fun analyze(segment: TrkSegment): GpxTrackAnalysis {
+		return GpxTrackAnalysis().prepareInformation(0, null, SplitSegment(segment))
+	}
+}


### PR DESCRIPTION
Fixes #24916.

Split interval analysis reused `PointAttributes` stored in the source `WptPt` and overwrote whole-track values with interval-specific data. As a result, the displayed total track distance decreased after using interval analysis and remained incorrect until the app was restarted.

The fix keeps attributes detached for both types of interval starts:

- interpolated boundaries used by distance/time splits;
- existing extremum points used by uphill/downhill splits.

Nested sensor, dev, and vehicle data is deep-copied to avoid shared mutable state. Slope calculations also use the detached start attributes for interval-specific max speed and moving time.

`TrackPointsAnalyser` now explicitly documents that the supplied attributes may differ from `point.attributes`.

Regression tests cover:

- repeated split/full-track analysis without changing total distance;
- exact subsegment starts used by uphill/downhill intervals;
- partial boundary attributes used by slope calculations.

The fix does not copy `WptPt` objects or the entire track. Additional `PointAttributes` are created only for affected interval boundaries.