### PR TITLE
Fix Analyze on map position for tracks with time gaps

### DIFF
--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/other/TrackDetailsMenu.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/other/TrackDetailsMenu.java
@@ -347,21 +347,24 @@ public class TrackDetailsMenu {
 		GpxDisplayItem gpxItem = getGpxItem();
 		TrkSegment segment = getTrackSegment(chart);
 		boolean joinSegments = selectedGpxFile != null && selectedGpxFile.isJoinSegments();
+		boolean timeWithoutGaps = gpxItem != null && shouldCalculateWithoutGaps(gpxItem);
 
-		WptPt point = getPointAtChartPos(chart, gpxItem, segment, pos, joinSegments, true);
+		WptPt point = getPointAtChartPos(chart, gpxItem, segment, pos, joinSegments, true, timeWithoutGaps);
 		return point == null ? null : new LatLon(point.getLat(), point.getLon());
 	}
 
 	@Nullable
 	public static LatLon getLocationAtPos(@Nullable LineChart chart, @Nullable GpxDisplayItem gpxItem,
-			@Nullable TrkSegment segment, float pos, boolean joinSegments) {
-		WptPt point = getPointAtChartPos(chart, gpxItem, segment, pos, joinSegments, true);
+			@Nullable TrkSegment segment, float pos, boolean joinSegments, boolean timeWithoutGaps) {
+		WptPt point = getPointAtChartPos(chart, gpxItem, segment, pos,
+				joinSegments, true, timeWithoutGaps);
 		return point == null ? null : new LatLon(point.getLat(), point.getLon());
 	}
 
 	@Nullable
 	public static WptPt getPointAtChartPos(@Nullable LineChart chart, @Nullable GpxDisplayItem gpxItem,
-			@Nullable TrkSegment segment, float pos, boolean joinSegments, boolean preciseLocation) {
+			@Nullable TrkSegment segment, float pos, boolean joinSegments, boolean preciseLocation,
+			boolean timeWithoutGaps) {
 		LineData lineData = chart != null ? chart.getLineData() : null;
 		List<ILineDataSet> dataSets = lineData != null ? lineData.getDataSets() : null;
 
@@ -369,7 +372,7 @@ public class TrackDetailsMenu {
 			GpxFile gpxFile = gpxItem.group.getGpxFile();
 			if (gpxItem.chartAxisType == TIME || gpxItem.chartAxisType == TIME_OF_DAY) {
 				float time = pos * 1000;
-				return GpxUtils.getSegmentPointByTime(segment, gpxFile, time, preciseLocation, joinSegments);
+				return GpxUtils.getSegmentPointByTime(segment, gpxFile, time, preciseLocation, timeWithoutGaps);
 			} else {
 				OrderedLineDataSet dataSet = (OrderedLineDataSet) dataSets.get(0);
 				float distance = pos * dataSet.getDivX();

--- a/OsmAnd/src/net/osmand/plus/myplaces/tracks/dialogs/GPXItemPagerAdapter.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/tracks/dialogs/GPXItemPagerAdapter.java
@@ -229,6 +229,18 @@ public class GPXItemPagerAdapter extends PagerAdapter implements CustomTabProvid
 	private List<ILineDataSet> getDataSets(LineChart chart, GPXTabItemType tabType,
 	                                       GPXDataSetType firstType, GPXDataSetType secondType) {
 		List<ILineDataSet> dataSets = dataSetsMap.get(tabType);
+		boolean withoutGaps = shouldCalculateWithoutGaps();
+		if (chart != null && analysis != null) {
+			dataSets = ChartUtils.getDataSets(chart, app, analysis, firstType, secondType, selectedMainAxisType, withoutGaps);
+			if (!Algorithms.isEmpty(dataSets)) {
+				dataSetsMap.remove(tabType);
+			}
+			dataSetsMap.put(tabType, dataSets);
+		}
+		return dataSets;
+	}
+
+	private boolean shouldCalculateWithoutGaps() {
 		boolean withoutGaps = true;
 		if (isShowCurrentTrack()) {
 			GpxFile gpxFile = displayHelper.getGpx();
@@ -239,14 +251,7 @@ public class GPXItemPagerAdapter extends PagerAdapter implements CustomTabProvid
 			boolean joinSegments = item != null ? item.getParameter(JOIN_SEGMENTS) : false;
 			withoutGaps = gpxItem.isGeneralTrack() && joinSegments;
 		}
-		if (chart != null && analysis != null) {
-			dataSets = ChartUtils.getDataSets(chart, app, analysis, firstType, secondType, selectedMainAxisType, withoutGaps);
-			if (!Algorithms.isEmpty(dataSets)) {
-				dataSetsMap.remove(tabType);
-			}
-			dataSetsMap.put(tabType, dataSets);
-		}
-		return dataSets;
+		return withoutGaps;
 	}
 
 	@Nullable
@@ -265,7 +270,9 @@ public class GPXItemPagerAdapter extends PagerAdapter implements CustomTabProvid
 	private WptPt getPoint(LineChart chart, float pos) {
 		TrkSegment segment = getTrackSegment(chart);
 		boolean joinSegments = displayHelper.isJoinSegments();
-		return TrackDetailsMenu.getPointAtChartPos(chart, gpxItem, segment, pos, joinSegments, false);
+		boolean timeWithoutGaps = shouldCalculateWithoutGaps();
+		return TrackDetailsMenu.getPointAtChartPos(
+				chart, gpxItem, segment, pos, joinSegments, false, timeWithoutGaps);
 	}
 
 	@Override

--- a/OsmAnd/src/net/osmand/plus/track/helpers/GpxUtils.java
+++ b/OsmAnd/src/net/osmand/plus/track/helpers/GpxUtils.java
@@ -160,11 +160,18 @@ public class GpxUtils {
 
 	@Nullable
 	public static WptPt getSegmentPointByTime(@NonNull TrkSegment segment, @NonNull GpxFile gpxFile,
-	                                          float time, boolean preciseLocation, boolean joinSegments) {
-		if (!segment.getGeneralSegment() || joinSegments) {
+	                                          float time, boolean preciseLocation, boolean timeWithoutGaps) {
+		if (!segment.getGeneralSegment()) {
 			return getSegmentPointByTime(segment, time, 0, preciseLocation);
 		}
+		return timeWithoutGaps
+				? getSegmentPointByTimeWithoutGaps(gpxFile, time, preciseLocation)
+				: getSegmentPointByTimeIncludingGaps(gpxFile, time, preciseLocation);
+	}
 
+	@Nullable
+	private static WptPt getSegmentPointByTimeWithoutGaps(@NonNull GpxFile gpxFile, float time,
+	                                                      boolean preciseLocation) {
 		long passedSegmentsTime = 0;
 		for (Track track : gpxFile.getTracks()) {
 			if (track.isGeneralTrack()) {
@@ -181,6 +188,41 @@ public class GpxUtils {
 				long segmentEndTime = Algorithms.isEmpty(seg.getPoints()) ?
 						0 : seg.getPoints().get(seg.getPoints().size() - 1).getTime();
 				passedSegmentsTime += segmentEndTime - segmentStartTime;
+			}
+		}
+
+		return null;
+	}
+
+	@Nullable
+	private static WptPt getSegmentPointByTimeIncludingGaps(@NonNull GpxFile gpxFile, float time,
+	                                                        boolean preciseLocation) {
+		long firstSegmentStartTime = 0;
+		boolean hasFirstSegment = false;
+		WptPt previousSegmentEnd = null;
+		for (Track track : gpxFile.getTracks()) {
+			if (track.isGeneralTrack()) {
+				continue;
+			}
+
+			for (TrkSegment seg : track.getSegments()) {
+				if (Algorithms.isEmpty(seg.getPoints())) {
+					continue;
+				}
+				WptPt segmentStart = seg.getPoints().get(0);
+				if (!hasFirstSegment) {
+					firstSegmentStartTime = segmentStart.getTime();
+					hasFirstSegment = true;
+				}
+				long passedSegmentsTime = segmentStart.getTime() - firstSegmentStartTime;
+				if (time < passedSegmentsTime) {
+					return previousSegmentEnd;
+				}
+				WptPt point = getSegmentPointByTime(seg, time, passedSegmentsTime, preciseLocation);
+				if (point != null) {
+					return point;
+				}
+				previousSegmentEnd = seg.getPoints().get(seg.getPoints().size() - 1);
 			}
 		}
 

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/widgets/ElevationProfileWidget.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/widgets/ElevationProfileWidget.java
@@ -543,7 +543,10 @@ public class ElevationProfileWidget extends MapWidget {
 		Highlight highlight = getSelectedHighlight();
 		if (highlight != null) {
 			TrackChartPoints trackChartPoints = getTrackChartPoints();
-			LatLon location = TrackDetailsMenu.getLocationAtPos(chart, gpxItem, segment, highlight.getX(), true);
+			// This profile uses the distance axis; update this if a time axis is added.
+			boolean timeWithoutGaps = false;
+			LatLon location = TrackDetailsMenu.getLocationAtPos(
+					chart, gpxItem, segment, highlight.getX(), true, timeWithoutGaps);
 			if (location != null) {
 				trackChartPoints.setHighlightedPoint(location);
 			}

--- a/OsmAnd/test/java/net/osmand/plus/track/helpers/GpxUtilsTest.java
+++ b/OsmAnd/test/java/net/osmand/plus/track/helpers/GpxUtilsTest.java
@@ -1,0 +1,101 @@
+package net.osmand.plus.track.helpers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import net.osmand.shared.gpx.GpxFile;
+import net.osmand.shared.gpx.primitives.Track;
+import net.osmand.shared.gpx.primitives.TrkSegment;
+import net.osmand.shared.gpx.primitives.WptPt;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class GpxUtilsTest {
+	private static final boolean TIME_WITH_GAPS = false;
+	private static final boolean TIME_WITHOUT_GAPS = true;
+
+	@Test
+	public void testGetSegmentPointByTimeIncludesGapsBetweenSegments() {
+		GpxFile gpxFile = new GpxFile((String) null);
+		Track track = new Track();
+		track.getSegments().add(createSegment(1_000L, 10.0));
+		track.getSegments().add(createSegment(5_000L, 20.0));
+		track.getSegments().add(createSegment(11_000L, 30.0));
+		gpxFile.getTracks().add(track);
+
+		TrkSegment generalSegment = gpxFile.getGeneralSegment();
+		assertNotNull(generalSegment);
+
+		WptPt secondSegmentStart = GpxUtils.getSegmentPointByTime(
+				generalSegment, gpxFile, 4_000, false, TIME_WITH_GAPS);
+		WptPt thirdSegmentStart = GpxUtils.getSegmentPointByTime(
+				generalSegment, gpxFile, 10_000, false, TIME_WITH_GAPS);
+		WptPt previousSegmentEnd = GpxUtils.getSegmentPointByTime(
+				generalSegment, gpxFile, 2_000, false, TIME_WITH_GAPS);
+		WptPt pointInSecondSegment = GpxUtils.getSegmentPointByTime(
+				generalSegment, gpxFile, 4_500, true, TIME_WITH_GAPS);
+
+		assertPointLatitude(20.0, secondSegmentStart);
+		assertPointLatitude(30.0, thirdSegmentStart);
+		assertPointLatitude(10.1, previousSegmentEnd);
+		assertPointLatitude(20.05, pointInSecondSegment);
+	}
+
+	@Test
+	public void testGetSegmentPointByTimeExcludesGapsWhenRequested() {
+		GpxFile gpxFile = new GpxFile((String) null);
+		Track track = new Track();
+		track.getSegments().add(createSegment(1_000L, 10.0));
+		track.getSegments().add(createSegment(5_000L, 20.0));
+		gpxFile.getTracks().add(track);
+
+		TrkSegment generalSegment = gpxFile.getGeneralSegment();
+		assertNotNull(generalSegment);
+
+		WptPt pointInSecondSegment = GpxUtils.getSegmentPointByTime(
+				generalSegment, gpxFile, 1_500, true, TIME_WITHOUT_GAPS);
+
+		assertPointLatitude(20.05, pointInSecondSegment);
+	}
+
+	@Test
+	public void testGetSegmentPointByTimeUsesSameTimelineForSingleSegment() {
+		GpxFile gpxFile = new GpxFile((String) null);
+		Track track = new Track();
+		TrkSegment segment = createSegment(1_000L, 10.0);
+		track.getSegments().add(segment);
+		gpxFile.getTracks().add(track);
+
+		WptPt pointWithGaps = GpxUtils.getSegmentPointByTime(
+				segment, gpxFile, 500, true, TIME_WITH_GAPS);
+		WptPt pointWithoutGaps = GpxUtils.getSegmentPointByTime(
+				segment, gpxFile, 500, true, TIME_WITHOUT_GAPS);
+
+		assertPointLatitude(10.05, pointWithGaps);
+		assertPointLatitude(10.05, pointWithoutGaps);
+	}
+
+	private TrkSegment createSegment(long startTime, double latitude) {
+		TrkSegment segment = new TrkSegment();
+		segment.getPoints().add(createPoint(startTime, latitude));
+		segment.getPoints().add(createPoint(startTime + 1_000L, latitude + 0.1));
+		return segment;
+	}
+
+	private WptPt createPoint(long time, double latitude) {
+		WptPt point = new WptPt();
+		point.setTime(time);
+		point.setLat(latitude);
+		point.setLon(0.0);
+		return point;
+	}
+
+	private void assertPointLatitude(double expected, WptPt point) {
+		assertNotNull(point);
+		assertEquals(expected, point.getLat(), 0.000_001);
+	}
+}


### PR DESCRIPTION
Fixes #25282

The chart and map position resolver could use different time scales for tracks containing gaps between segments.

Changes:
- separated time-gap handling from `joinSegments`;
- made the map resolver use the same `timeWithoutGaps` mode as the chart;
- added point lookup with and without segment time gaps;
- added tests for multiple gaps, interpolation, gap boundaries, and single-segment tracks.

Distance-axis behavior is unchanged.