### PR TITLE
Refactor search result ownership using immutable snapshots

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/search/SearchUICore.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/SearchUICore.java
@@ -1369,14 +1369,14 @@ public class SearchUICore {
 			}
 			object.parentSearchResult = parentSearchResult;
 			if (matcher == null || matcher.publish(object)) {
-				if (object.objectType == ObjectType.PARTIAL_LOCATION) {
+				boolean partialLocation = object.objectType == ObjectType.PARTIAL_LOCATION;
+				if (partialLocation) {
 					if (progressListener != null) {
 						progressListener.onPartialLocation(request, object.requiredSearchPhrase);
 					}
-					return true;
 				}
 				count++;
-				if (progressListener != null) {
+				if (progressListener != null && !partialLocation) {
 					apiResults.add(object);
 				}
 				if (totalLimit == -1 || count < totalLimit) {

--- a/OsmAnd-java/src/main/java/net/osmand/search/SearchUICore.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/SearchUICore.java
@@ -162,6 +162,15 @@ public class SearchUICore {
 			return collection;
 		}
 
+		public static SearchResultCollection fromSnapshot(SearchResultCollectionSnapshot snapshot, SearchPhrase phrase) {
+			SearchResultCollection collection = new SearchResultCollection(phrase, snapshot.isSkipSorting(),
+					snapshot.getSpatialSearchVisibleLevel());
+			collection.searchResults.addAll(SearchResultSnapshot.toSearchResults(
+					snapshot.getCurrentSearchResults(), phrase));
+			collection.useLimit = snapshot.getUseLimit();
+			return collection;
+		}
+
 		public SearchResultCollection combineWithCollection(SearchResultCollection collection, boolean resort, boolean removeDuplicates) {
 			SearchResultCollection src = new SearchResultCollection(phrase, skipSorting || collection.skipSorting,
 					Math.max(spatialSearchVisibleLevel, collection.spatialSearchVisibleLevel));
@@ -803,21 +812,26 @@ public class SearchUICore {
 	}
 
 	public void search(final String text, final boolean delayedExecution, final ResultMatcher<SearchResult> matcher) {
-		search(text, delayedExecution, matcher, null, null);
+		search(text, delayedExecution, matcher, null, null, null);
 	}
 	public void search(final String text, final boolean delayedExecution, final ResultMatcher<SearchResult> matcher, 
 			SearchSettings overrideSettings) {
-		search(text, delayedExecution, matcher, null, overrideSettings);
+		search(text, delayedExecution, matcher, null, overrideSettings, null);
 	}
 
 	public void searchWithProgress(final String text, final boolean delayedExecution,
 			SearchProgressListener progressListener) {
-		search(text, delayedExecution, null, progressListener, null);
+		searchWithProgress(text, delayedExecution, progressListener, null);
+	}
+
+	public void searchWithProgress(final String text, final boolean delayedExecution,
+			SearchProgressListener progressListener, SearchResultCollectionSnapshot initialResults) {
+		search(text, delayedExecution, null, progressListener, null, initialResults);
 	}
 
 	private void search(final String text, final boolean delayedExecution,
 			ResultMatcher<SearchResult> matcher, SearchProgressListener progressListener,
-			SearchSettings overrideSettings) {
+			SearchSettings overrideSettings, SearchResultCollectionSnapshot initialResults) {
 		if (overrideSettings != null) {
 			this.searchSettings = overrideSettings;
 		}
@@ -838,7 +852,7 @@ public class SearchUICore {
 					}
 					final SearchPerformanceStats performanceStats = new SearchPerformanceStats(isSpatialSearch() ? "spatial" : "general");
 					final SearchResultMatcher rm = new SearchResultMatcher(matcher, progressListener, phrase, request,
-							requestNumber, totalLimit, performanceStats);
+							requestNumber, totalLimit, performanceStats, initialResults);
 					if (debugMode) {
 						LOG.info("Starting search <" + phrase.toString() + ">");
 					}
@@ -1174,17 +1188,23 @@ public class SearchUICore {
 
 			public SearchResultMatcher(ResultMatcher<SearchResult> matcher, SearchPhrase phrase, int request,
 									   AtomicInteger requestNumber, int totalLimit) {
-				this(matcher, null, phrase, request, requestNumber, totalLimit, null);
+				this(matcher, null, phrase, request, requestNumber, totalLimit, null, null);
 			}
 
 			SearchResultMatcher(ResultMatcher<SearchResult> matcher, SearchProgressListener progressListener,
 					SearchPhrase phrase, int request, AtomicInteger requestNumber, int totalLimit) {
-				this(matcher, progressListener, phrase, request, requestNumber, totalLimit, null);
+				this(matcher, progressListener, phrase, request, requestNumber, totalLimit, null, null);
+			}
+
+			SearchResultMatcher(ResultMatcher<SearchResult> matcher, SearchProgressListener progressListener,
+					SearchPhrase phrase, int request, AtomicInteger requestNumber, int totalLimit,
+					SearchResultCollectionSnapshot initialResults) {
+				this(matcher, progressListener, phrase, request, requestNumber, totalLimit, null, initialResults);
 			}
 
 			private SearchResultMatcher(ResultMatcher<SearchResult> matcher, SearchProgressListener progressListener,
 					SearchPhrase phrase, int request, AtomicInteger requestNumber, int totalLimit,
-					SearchPerformanceStats performanceStats) {
+					SearchPerformanceStats performanceStats, SearchResultCollectionSnapshot initialResults) {
 				this.matcher = matcher;
 				this.progressListener = progressListener;
 				this.phrase = phrase;
@@ -1192,6 +1212,9 @@ public class SearchUICore {
 				this.requestNumber = requestNumber;
 				this.totalLimit = totalLimit;
 				this.performanceStats = performanceStats;
+				this.aggregatedResults = initialResults != null
+						? SearchResultCollection.fromSnapshot(initialResults, phrase)
+						: null;
 			}
 
 		public SearchResult setParentSearchResult(SearchResult parentSearchResult) {

--- a/OsmAnd-java/src/main/java/net/osmand/search/SearchUICore.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/SearchUICore.java
@@ -34,6 +34,8 @@ import net.osmand.search.core.SearchPhrase;
 import net.osmand.search.core.SearchPhrase.NameStringMatcher;
 import net.osmand.search.core.SearchResult;
 import net.osmand.search.core.SearchResultCollectionSnapshot;
+import net.osmand.search.core.SearchResultProgressSnapshot;
+import net.osmand.search.core.SearchResultProgressSnapshot.Stage;
 import net.osmand.search.core.SearchSettings;
 import net.osmand.search.core.SearchSettings.SortType;
 import net.osmand.search.core.SearchWord;
@@ -860,7 +862,7 @@ public class SearchUICore {
 								}
 								if (!rm.isCancelled()) {
 									currentSearchResult = quickRes;
-									rm.filterFinished(phrase);
+									rm.filterFinished(phrase, quickRes);
 								}
 								filtered = true;
 							}
@@ -894,7 +896,7 @@ public class SearchUICore {
 						if (phrase.getSettings().isExportObjects()) {
 							rm.createTestJSON(collection);
 						}
-						rm.searchFinished(phrase);
+						rm.searchFinished(phrase, collection);
 						if (onResultsComplete != null) {
 							onResultsComplete.run();
 						}
@@ -1139,6 +1141,10 @@ public class SearchUICore {
 		private SearchPhrase phrase;
 		private List<MapObject> exportedObjects;
 		private List<City> exportedCities;
+		private List<SearchResult> apiResults = new ArrayList<>();
+		private SearchResultCollection aggregatedResults;
+		private SearchResultCollection lastRegionResults;
+		private SearchCoreAPI lastRegionApi;
 
 			public SearchResultMatcher(ResultMatcher<SearchResult> matcher, SearchPhrase phrase, int request,
 									   AtomicInteger requestNumber, int totalLimit) {
@@ -1187,44 +1193,84 @@ public class SearchUICore {
 			}
 		}
 
-		public void filterFinished(SearchPhrase phrase) {
+		public void filterFinished(SearchPhrase phrase, SearchResultCollection collection) {
 			if (matcher != null) {
 				SearchResult sr = new SearchResult(phrase);
 				sr.objectType = ObjectType.FILTER_FINISHED;
+				sr.progressSnapshot = new SearchResultProgressSnapshot(Stage.FILTER_FINISHED, null, null,
+						collection.toSnapshot(request), false, false);
 				matcher.publish(sr);
 			}
 		}
 
-		public void searchFinished(SearchPhrase phrase) {
+		public void searchFinished(SearchPhrase phrase, SearchResultCollection collection) {
 			if (matcher != null) {
 				SearchResult sr = new SearchResult(phrase);
 				sr.objectType = ObjectType.SEARCH_FINISHED;
+				sr.progressSnapshot = new SearchResultProgressSnapshot(Stage.SEARCH_FINISHED, null, null,
+						collection.toSnapshot(request), false, false);
 				matcher.publish(sr);
 			}
 		}
 
 		public void apiSearchFinished(SearchCoreAPI api, SearchPhrase phrase) {
 			if (matcher != null) {
+				boolean spatialSearchApi = api instanceof SpatialTextSearchAPI;
+				SearchResultCollection apiCollection = api == lastRegionApi && lastRegionResults != null
+						? lastRegionResults
+						: createApiResultCollection(phrase, spatialSearchApi);
+				boolean append = aggregatedResults != null;
+				aggregatedResults = append
+						? aggregatedResults.combineWithCollection(apiCollection, !spatialSearchApi, true)
+						: apiCollection;
 				SearchResult sr = new SearchResult(phrase);
 				sr.objectType = ObjectType.SEARCH_API_FINISHED;
 				sr.object = api;
 				sr.parentSearchResult = parentSearchResult;
+				sr.progressSnapshot = new SearchResultProgressSnapshot(Stage.API_FINISHED, api, null,
+						aggregatedResults.toSnapshot(request), append, hasImpreciseResults());
 				matcher.publish(sr);
+				apiResults = new ArrayList<>();
+				lastRegionResults = null;
+				lastRegionApi = null;
 			}
 		}
 
 		public void apiSearchRegionFinished(SearchCoreAPI api, BinaryMapIndexReader region, SearchPhrase phrase) {
 			if (matcher != null) {
+				boolean spatialSearchApi = api instanceof SpatialTextSearchAPI;
+				lastRegionResults = createApiResultCollection(phrase, spatialSearchApi);
+				lastRegionApi = api;
+				boolean append = aggregatedResults != null;
+				SearchResultCollection visibleResults = append
+						? aggregatedResults.combineWithCollection(lastRegionResults, true, true)
+						: lastRegionResults;
 				SearchResult sr = new SearchResult(phrase);
 				sr.objectType = ObjectType.SEARCH_API_REGION_FINISHED;
 				sr.object = api;
 				sr.parentSearchResult = parentSearchResult;
 				sr.file = region;
+				sr.progressSnapshot = new SearchResultProgressSnapshot(Stage.REGION_FINISHED, api, region,
+						visibleResults.toSnapshot(request), append, false);
 				matcher.publish(sr);
 				if (debugMode) {
 					LOG.info("API region search done <" + phrase + "> API=<" + api + "> Region=<" + region.getFile().getName() + ">");
 				}
 			}
+		}
+
+		private SearchResultCollection createApiResultCollection(SearchPhrase phrase, boolean spatialSearchApi) {
+			return new SearchResultCollection(phrase, spatialSearchApi)
+					.addSearchResults(apiResults, !spatialSearchApi, true);
+		}
+
+		private boolean hasImpreciseResults() {
+			for (SearchResult result : apiResults) {
+				if (result.hasImpreciseCoordinates()) {
+					return true;
+				}
+			}
+			return false;
 		}
 
 		@Override
@@ -1270,6 +1316,9 @@ public class SearchUICore {
 			object.parentSearchResult = parentSearchResult;
 			if (matcher == null || matcher.publish(object)) {
 				count++;
+				if (matcher != null) {
+					apiResults.add(object);
+				}
 				if (totalLimit == -1 || count < totalLimit) {
 					requestResults.add(object);
 				}

--- a/OsmAnd-java/src/main/java/net/osmand/search/SearchUICore.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/SearchUICore.java
@@ -1230,41 +1230,33 @@ public class SearchUICore {
 		}
 
 		public void filterFinished(SearchPhrase phrase, SearchResultCollection collection) {
-			if (hasProgressConsumer()) {
+			if (progressListener != null) {
 				SearchResultProgressSnapshot progress = new SearchResultProgressSnapshot(Stage.FILTER_FINISHED,
 						null, null, collection.toSnapshot(request), false, false, false);
-				if (progressListener != null) {
-					progressListener.onProgress(progress);
-				}
-				if (matcher == null) {
-					return;
-				}
+				progressListener.onProgress(progress);
+			}
+			if (matcher != null) {
 				SearchResult sr = new SearchResult(phrase);
 				sr.objectType = ObjectType.FILTER_FINISHED;
-				sr.progressSnapshot = progress;
 				matcher.publish(sr);
 			}
 		}
 
 		public void searchFinished(SearchPhrase phrase, SearchResultCollection collection) {
-			if (hasProgressConsumer()) {
+			if (progressListener != null) {
 				SearchResultProgressSnapshot progress = new SearchResultProgressSnapshot(Stage.SEARCH_FINISHED,
 						null, null, collection.toSnapshot(request), false, false, false);
-				if (progressListener != null) {
-					progressListener.onProgress(progress);
-				}
-				if (matcher == null) {
-					return;
-				}
+				progressListener.onProgress(progress);
+			}
+			if (matcher != null) {
 				SearchResult sr = new SearchResult(phrase);
 				sr.objectType = ObjectType.SEARCH_FINISHED;
-				sr.progressSnapshot = progress;
 				matcher.publish(sr);
 			}
 		}
 
 		public void apiSearchFinished(SearchCoreAPI api, SearchPhrase phrase) {
-			if (hasProgressConsumer()) {
+			if (progressListener != null) {
 				boolean spatialSearchApi = api instanceof SpatialTextSearchAPI;
 				boolean hasRegionResults = api == lastRegionApi && lastRegionResults != null;
 				SearchResultCollection apiCollection = hasRegionResults
@@ -1276,25 +1268,22 @@ public class SearchUICore {
 						: apiCollection;
 				SearchResultProgressSnapshot progress = new SearchResultProgressSnapshot(Stage.API_FINISHED, api, null,
 						aggregatedResults.toSnapshot(request), append, hasImpreciseResults(), hasRegionResults);
-				if (progressListener != null) {
-					progressListener.onProgress(progress);
-				}
-				if (matcher != null) {
-					SearchResult sr = new SearchResult(phrase);
-					sr.objectType = ObjectType.SEARCH_API_FINISHED;
-					sr.object = api;
-					sr.parentSearchResult = parentSearchResult;
-					sr.progressSnapshot = progress;
-					matcher.publish(sr);
-				}
+				progressListener.onProgress(progress);
 				apiResults = new ArrayList<>();
 				lastRegionResults = null;
 				lastRegionApi = null;
 			}
+			if (matcher != null) {
+				SearchResult sr = new SearchResult(phrase);
+				sr.objectType = ObjectType.SEARCH_API_FINISHED;
+				sr.object = api;
+				sr.parentSearchResult = parentSearchResult;
+				matcher.publish(sr);
+			}
 		}
 
 		public void apiSearchRegionFinished(SearchCoreAPI api, BinaryMapIndexReader region, SearchPhrase phrase) {
-			if (hasProgressConsumer()) {
+			if (progressListener != null) {
 				boolean spatialSearchApi = api instanceof SpatialTextSearchAPI;
 				lastRegionResults = createApiResultCollection(phrase, spatialSearchApi);
 				lastRegionApi = api;
@@ -1304,18 +1293,17 @@ public class SearchUICore {
 						: lastRegionResults;
 				SearchResultProgressSnapshot progress = new SearchResultProgressSnapshot(Stage.REGION_FINISHED, api, region,
 						visibleResults.toSnapshot(request), append, false, true);
-				if (progressListener != null) {
-					progressListener.onProgress(progress);
-				}
-				if (matcher != null) {
-					SearchResult sr = new SearchResult(phrase);
-					sr.objectType = ObjectType.SEARCH_API_REGION_FINISHED;
-					sr.object = api;
-					sr.parentSearchResult = parentSearchResult;
-					sr.file = region;
-					sr.progressSnapshot = progress;
-					matcher.publish(sr);
-				}
+				progressListener.onProgress(progress);
+			}
+			if (matcher != null) {
+				SearchResult sr = new SearchResult(phrase);
+				sr.objectType = ObjectType.SEARCH_API_REGION_FINISHED;
+				sr.object = api;
+				sr.parentSearchResult = parentSearchResult;
+				sr.file = region;
+				matcher.publish(sr);
+			}
+			if (progressListener != null || matcher != null) {
 				if (debugMode) {
 					LOG.info("API region search done <" + phrase + "> API=<" + api + "> Region=<" + region.getFile().getName() + ">");
 				}
@@ -1325,10 +1313,6 @@ public class SearchUICore {
 		private SearchResultCollection createApiResultCollection(SearchPhrase phrase, boolean spatialSearchApi) {
 			return new SearchResultCollection(phrase, spatialSearchApi)
 					.addSearchResults(apiResults, !spatialSearchApi, true);
-		}
-
-		private boolean hasProgressConsumer() {
-			return matcher != null || progressListener != null;
 		}
 
 		private boolean hasImpreciseResults() {
@@ -1392,7 +1376,7 @@ public class SearchUICore {
 					return true;
 				}
 				count++;
-				if (hasProgressConsumer()) {
+				if (progressListener != null) {
 					apiResults.add(object);
 				}
 				if (totalLimit == -1 || count < totalLimit) {

--- a/OsmAnd-java/src/main/java/net/osmand/search/SearchUICore.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/SearchUICore.java
@@ -36,6 +36,7 @@ import net.osmand.search.core.SearchResult;
 import net.osmand.search.core.SearchResultCollectionSnapshot;
 import net.osmand.search.core.SearchResultProgressSnapshot;
 import net.osmand.search.core.SearchResultProgressSnapshot.Stage;
+import net.osmand.search.core.SearchResultSnapshot;
 import net.osmand.search.core.SearchSettings;
 import net.osmand.search.core.SearchSettings.SortType;
 import net.osmand.search.core.SearchWord;
@@ -150,6 +151,14 @@ public class SearchUICore {
 		public SearchResultCollectionSnapshot toSnapshot(long requestId) {
 			return SearchResultCollectionSnapshot.from(requestId, phrase, searchResults, skipSorting,
 					spatialSearchVisibleLevel, useLimit);
+		}
+
+		public static SearchResultCollection fromSnapshot(SearchResultCollectionSnapshot snapshot) {
+			SearchResultCollection collection = new SearchResultCollection(snapshot.getPhrase(), snapshot.isSkipSorting(),
+					snapshot.getSpatialSearchVisibleLevel());
+			collection.searchResults.addAll(SearchResultSnapshot.toSearchResults(snapshot.getCurrentSearchResults()));
+			collection.useLimit = snapshot.getUseLimit();
+			return collection;
 		}
 
 		public SearchResultCollection combineWithCollection(SearchResultCollection collection, boolean resort, boolean removeDuplicates) {
@@ -701,6 +710,10 @@ public class SearchUICore {
 		return currentSearchResult;
 	}
 
+	public boolean isCurrentSearchRequest(long requestId) {
+		return requestNumber.get() == requestId;
+	}
+
 	public SearchPhrase getPhrase() {
 		return phrase;
 	}
@@ -1198,7 +1211,7 @@ public class SearchUICore {
 				SearchResult sr = new SearchResult(phrase);
 				sr.objectType = ObjectType.FILTER_FINISHED;
 				sr.progressSnapshot = new SearchResultProgressSnapshot(Stage.FILTER_FINISHED, null, null,
-						collection.toSnapshot(request), false, false);
+						collection.toSnapshot(request), false, false, false);
 				matcher.publish(sr);
 			}
 		}
@@ -1208,7 +1221,7 @@ public class SearchUICore {
 				SearchResult sr = new SearchResult(phrase);
 				sr.objectType = ObjectType.SEARCH_FINISHED;
 				sr.progressSnapshot = new SearchResultProgressSnapshot(Stage.SEARCH_FINISHED, null, null,
-						collection.toSnapshot(request), false, false);
+						collection.toSnapshot(request), false, false, false);
 				matcher.publish(sr);
 			}
 		}
@@ -1216,7 +1229,8 @@ public class SearchUICore {
 		public void apiSearchFinished(SearchCoreAPI api, SearchPhrase phrase) {
 			if (matcher != null) {
 				boolean spatialSearchApi = api instanceof SpatialTextSearchAPI;
-				SearchResultCollection apiCollection = api == lastRegionApi && lastRegionResults != null
+				boolean hasRegionResults = api == lastRegionApi && lastRegionResults != null;
+				SearchResultCollection apiCollection = hasRegionResults
 						? lastRegionResults
 						: createApiResultCollection(phrase, spatialSearchApi);
 				boolean append = aggregatedResults != null;
@@ -1228,7 +1242,7 @@ public class SearchUICore {
 				sr.object = api;
 				sr.parentSearchResult = parentSearchResult;
 				sr.progressSnapshot = new SearchResultProgressSnapshot(Stage.API_FINISHED, api, null,
-						aggregatedResults.toSnapshot(request), append, hasImpreciseResults());
+						aggregatedResults.toSnapshot(request), append, hasImpreciseResults(), hasRegionResults);
 				matcher.publish(sr);
 				apiResults = new ArrayList<>();
 				lastRegionResults = null;
@@ -1251,7 +1265,7 @@ public class SearchUICore {
 				sr.parentSearchResult = parentSearchResult;
 				sr.file = region;
 				sr.progressSnapshot = new SearchResultProgressSnapshot(Stage.REGION_FINISHED, api, region,
-						visibleResults.toSnapshot(request), append, false);
+						visibleResults.toSnapshot(request), append, false, true);
 				matcher.publish(sr);
 				if (debugMode) {
 					LOG.info("API region search done <" + phrase + "> API=<" + api + "> Region=<" + region.getFile().getName() + ">");
@@ -1315,6 +1329,9 @@ public class SearchUICore {
 			}
 			object.parentSearchResult = parentSearchResult;
 			if (matcher == null || matcher.publish(object)) {
+				if (object.objectType == ObjectType.PARTIAL_LOCATION) {
+					return true;
+				}
 				count++;
 				if (matcher != null) {
 					apiResults.add(object);

--- a/OsmAnd-java/src/main/java/net/osmand/search/SearchUICore.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/SearchUICore.java
@@ -32,6 +32,7 @@ import net.osmand.search.core.SearchCoreFactory.SearchStreetByCityAPI;
 import net.osmand.search.core.SearchExportSettings;
 import net.osmand.search.core.SearchPhrase;
 import net.osmand.search.core.SearchPhrase.NameStringMatcher;
+import net.osmand.search.core.SearchProgressListener;
 import net.osmand.search.core.SearchResult;
 import net.osmand.search.core.SearchResultCollectionSnapshot;
 import net.osmand.search.core.SearchResultProgressSnapshot;
@@ -802,9 +803,20 @@ public class SearchUICore {
 	}
 
 	public void search(final String text, final boolean delayedExecution, final ResultMatcher<SearchResult> matcher) {
-		search(text, delayedExecution, matcher, null);
+		search(text, delayedExecution, matcher, null, null);
 	}
 	public void search(final String text, final boolean delayedExecution, final ResultMatcher<SearchResult> matcher, 
+			SearchSettings overrideSettings) {
+		search(text, delayedExecution, matcher, null, overrideSettings);
+	}
+
+	public void searchWithProgress(final String text, final boolean delayedExecution,
+			SearchProgressListener progressListener) {
+		search(text, delayedExecution, null, progressListener, null);
+	}
+
+	private void search(final String text, final boolean delayedExecution,
+			ResultMatcher<SearchResult> matcher, SearchProgressListener progressListener,
 			SearchSettings overrideSettings) {
 		if (overrideSettings != null) {
 			this.searchSettings = overrideSettings;
@@ -825,8 +837,8 @@ public class SearchUICore {
 						onSearchStart.run();
 					}
 					final SearchPerformanceStats performanceStats = new SearchPerformanceStats(isSpatialSearch() ? "spatial" : "general");
-					final SearchResultMatcher rm = new SearchResultMatcher(matcher, phrase, request, requestNumber, totalLimit,
-							performanceStats);
+					final SearchResultMatcher rm = new SearchResultMatcher(matcher, progressListener, phrase, request,
+							requestNumber, totalLimit, performanceStats);
 					if (debugMode) {
 						LOG.info("Starting search <" + phrase.toString() + ">");
 					}
@@ -1145,6 +1157,7 @@ public class SearchUICore {
 		public static class SearchResultMatcher implements ResultMatcher<SearchResult> {
 			private final List<SearchResult> requestResults = new ArrayList<>();
 			private final ResultMatcher<SearchResult> matcher;
+			private final SearchProgressListener progressListener;
 			private final int request;
 			private final SearchPerformanceStats performanceStats;
 			int totalLimit;
@@ -1161,12 +1174,19 @@ public class SearchUICore {
 
 			public SearchResultMatcher(ResultMatcher<SearchResult> matcher, SearchPhrase phrase, int request,
 									   AtomicInteger requestNumber, int totalLimit) {
-				this(matcher, phrase, request, requestNumber, totalLimit, null);
+				this(matcher, null, phrase, request, requestNumber, totalLimit, null);
 			}
 
-			private SearchResultMatcher(ResultMatcher<SearchResult> matcher, SearchPhrase phrase, int request,
-										AtomicInteger requestNumber, int totalLimit, SearchPerformanceStats performanceStats) {
+			SearchResultMatcher(ResultMatcher<SearchResult> matcher, SearchProgressListener progressListener,
+					SearchPhrase phrase, int request, AtomicInteger requestNumber, int totalLimit) {
+				this(matcher, progressListener, phrase, request, requestNumber, totalLimit, null);
+			}
+
+			private SearchResultMatcher(ResultMatcher<SearchResult> matcher, SearchProgressListener progressListener,
+					SearchPhrase phrase, int request, AtomicInteger requestNumber, int totalLimit,
+					SearchPerformanceStats performanceStats) {
 				this.matcher = matcher;
+				this.progressListener = progressListener;
 				this.phrase = phrase;
 				this.request = request;
 				this.requestNumber = requestNumber;
@@ -1199,6 +1219,9 @@ public class SearchUICore {
 		}
 
 		public void searchStarted(SearchPhrase phrase) {
+			if (progressListener != null) {
+				progressListener.onSearchStarted(request, phrase);
+			}
 			if (matcher != null) {
 				SearchResult sr = new SearchResult(phrase);
 				sr.objectType = ObjectType.SEARCH_STARTED;
@@ -1207,27 +1230,41 @@ public class SearchUICore {
 		}
 
 		public void filterFinished(SearchPhrase phrase, SearchResultCollection collection) {
-			if (matcher != null) {
+			if (hasProgressConsumer()) {
+				SearchResultProgressSnapshot progress = new SearchResultProgressSnapshot(Stage.FILTER_FINISHED,
+						null, null, collection.toSnapshot(request), false, false, false);
+				if (progressListener != null) {
+					progressListener.onProgress(progress);
+				}
+				if (matcher == null) {
+					return;
+				}
 				SearchResult sr = new SearchResult(phrase);
 				sr.objectType = ObjectType.FILTER_FINISHED;
-				sr.progressSnapshot = new SearchResultProgressSnapshot(Stage.FILTER_FINISHED, null, null,
-						collection.toSnapshot(request), false, false, false);
+				sr.progressSnapshot = progress;
 				matcher.publish(sr);
 			}
 		}
 
 		public void searchFinished(SearchPhrase phrase, SearchResultCollection collection) {
-			if (matcher != null) {
+			if (hasProgressConsumer()) {
+				SearchResultProgressSnapshot progress = new SearchResultProgressSnapshot(Stage.SEARCH_FINISHED,
+						null, null, collection.toSnapshot(request), false, false, false);
+				if (progressListener != null) {
+					progressListener.onProgress(progress);
+				}
+				if (matcher == null) {
+					return;
+				}
 				SearchResult sr = new SearchResult(phrase);
 				sr.objectType = ObjectType.SEARCH_FINISHED;
-				sr.progressSnapshot = new SearchResultProgressSnapshot(Stage.SEARCH_FINISHED, null, null,
-						collection.toSnapshot(request), false, false, false);
+				sr.progressSnapshot = progress;
 				matcher.publish(sr);
 			}
 		}
 
 		public void apiSearchFinished(SearchCoreAPI api, SearchPhrase phrase) {
-			if (matcher != null) {
+			if (hasProgressConsumer()) {
 				boolean spatialSearchApi = api instanceof SpatialTextSearchAPI;
 				boolean hasRegionResults = api == lastRegionApi && lastRegionResults != null;
 				SearchResultCollection apiCollection = hasRegionResults
@@ -1237,13 +1274,19 @@ public class SearchUICore {
 				aggregatedResults = append
 						? aggregatedResults.combineWithCollection(apiCollection, !spatialSearchApi, true)
 						: apiCollection;
-				SearchResult sr = new SearchResult(phrase);
-				sr.objectType = ObjectType.SEARCH_API_FINISHED;
-				sr.object = api;
-				sr.parentSearchResult = parentSearchResult;
-				sr.progressSnapshot = new SearchResultProgressSnapshot(Stage.API_FINISHED, api, null,
+				SearchResultProgressSnapshot progress = new SearchResultProgressSnapshot(Stage.API_FINISHED, api, null,
 						aggregatedResults.toSnapshot(request), append, hasImpreciseResults(), hasRegionResults);
-				matcher.publish(sr);
+				if (progressListener != null) {
+					progressListener.onProgress(progress);
+				}
+				if (matcher != null) {
+					SearchResult sr = new SearchResult(phrase);
+					sr.objectType = ObjectType.SEARCH_API_FINISHED;
+					sr.object = api;
+					sr.parentSearchResult = parentSearchResult;
+					sr.progressSnapshot = progress;
+					matcher.publish(sr);
+				}
 				apiResults = new ArrayList<>();
 				lastRegionResults = null;
 				lastRegionApi = null;
@@ -1251,7 +1294,7 @@ public class SearchUICore {
 		}
 
 		public void apiSearchRegionFinished(SearchCoreAPI api, BinaryMapIndexReader region, SearchPhrase phrase) {
-			if (matcher != null) {
+			if (hasProgressConsumer()) {
 				boolean spatialSearchApi = api instanceof SpatialTextSearchAPI;
 				lastRegionResults = createApiResultCollection(phrase, spatialSearchApi);
 				lastRegionApi = api;
@@ -1259,14 +1302,20 @@ public class SearchUICore {
 				SearchResultCollection visibleResults = append
 						? aggregatedResults.combineWithCollection(lastRegionResults, true, true)
 						: lastRegionResults;
-				SearchResult sr = new SearchResult(phrase);
-				sr.objectType = ObjectType.SEARCH_API_REGION_FINISHED;
-				sr.object = api;
-				sr.parentSearchResult = parentSearchResult;
-				sr.file = region;
-				sr.progressSnapshot = new SearchResultProgressSnapshot(Stage.REGION_FINISHED, api, region,
+				SearchResultProgressSnapshot progress = new SearchResultProgressSnapshot(Stage.REGION_FINISHED, api, region,
 						visibleResults.toSnapshot(request), append, false, true);
-				matcher.publish(sr);
+				if (progressListener != null) {
+					progressListener.onProgress(progress);
+				}
+				if (matcher != null) {
+					SearchResult sr = new SearchResult(phrase);
+					sr.objectType = ObjectType.SEARCH_API_REGION_FINISHED;
+					sr.object = api;
+					sr.parentSearchResult = parentSearchResult;
+					sr.file = region;
+					sr.progressSnapshot = progress;
+					matcher.publish(sr);
+				}
 				if (debugMode) {
 					LOG.info("API region search done <" + phrase + "> API=<" + api + "> Region=<" + region.getFile().getName() + ">");
 				}
@@ -1276,6 +1325,10 @@ public class SearchUICore {
 		private SearchResultCollection createApiResultCollection(SearchPhrase phrase, boolean spatialSearchApi) {
 			return new SearchResultCollection(phrase, spatialSearchApi)
 					.addSearchResults(apiResults, !spatialSearchApi, true);
+		}
+
+		private boolean hasProgressConsumer() {
+			return matcher != null || progressListener != null;
 		}
 
 		private boolean hasImpreciseResults() {
@@ -1290,6 +1343,9 @@ public class SearchUICore {
 		@Override
 		public boolean publish(SearchResult object) {
 			sampleMemory();
+			if (progressListener != null && isCancelled()) {
+				return false;
+			}
 			// disable boundary for end results
 			if (object.objectType == ObjectType.BOUNDARY) {
 				return false;
@@ -1330,10 +1386,13 @@ public class SearchUICore {
 			object.parentSearchResult = parentSearchResult;
 			if (matcher == null || matcher.publish(object)) {
 				if (object.objectType == ObjectType.PARTIAL_LOCATION) {
+					if (progressListener != null) {
+						progressListener.onPartialLocation(request, object.requiredSearchPhrase);
+					}
 					return true;
 				}
 				count++;
-				if (matcher != null) {
+				if (hasProgressConsumer()) {
 					apiResults.add(object);
 				}
 				if (totalLimit == -1 || count < totalLimit) {
@@ -1347,7 +1406,9 @@ public class SearchUICore {
 		@Override
 		public boolean isCancelled() {
 			boolean cancelled = request != requestNumber.get();
-			return cancelled || (matcher != null && matcher.isCancelled());
+			return cancelled
+					|| (matcher != null && matcher.isCancelled())
+					|| (progressListener != null && progressListener.isCancelled());
 		}
 
 		public List<MapObject> getExportedObjects() {

--- a/OsmAnd-java/src/main/java/net/osmand/search/SearchUICore.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/SearchUICore.java
@@ -33,6 +33,7 @@ import net.osmand.search.core.SearchExportSettings;
 import net.osmand.search.core.SearchPhrase;
 import net.osmand.search.core.SearchPhrase.NameStringMatcher;
 import net.osmand.search.core.SearchResult;
+import net.osmand.search.core.SearchResultCollectionSnapshot;
 import net.osmand.search.core.SearchSettings;
 import net.osmand.search.core.SearchSettings.SortType;
 import net.osmand.search.core.SearchWord;
@@ -138,6 +139,15 @@ public class SearchUICore {
 			this.phrase = phrase;
 			this.skipSorting = skipSorting;
 			this.spatialSearchVisibleLevel = spatialSearchVisibleLevel;
+		}
+
+		public SearchResultCollectionSnapshot toSnapshot() {
+			return toSnapshot(SearchResultCollectionSnapshot.NO_REQUEST_ID);
+		}
+
+		public SearchResultCollectionSnapshot toSnapshot(long requestId) {
+			return SearchResultCollectionSnapshot.from(requestId, phrase, searchResults, skipSorting,
+					spatialSearchVisibleLevel, useLimit);
 		}
 
 		public SearchResultCollection combineWithCollection(SearchResultCollection collection, boolean resort, boolean removeDuplicates) {

--- a/OsmAnd-java/src/main/java/net/osmand/search/core/SearchProgressListener.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/core/SearchProgressListener.java
@@ -1,0 +1,13 @@
+package net.osmand.search.core;
+
+/** Receives request-scoped search lifecycle events without exposing mutable search results. */
+public interface SearchProgressListener {
+
+	void onSearchStarted(long requestId, SearchPhrase phrase);
+
+	void onProgress(SearchResultProgressSnapshot progress);
+
+	void onPartialLocation(long requestId, SearchPhrase phrase);
+
+	boolean isCancelled();
+}

--- a/OsmAnd-java/src/main/java/net/osmand/search/core/SearchResult.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/core/SearchResult.java
@@ -55,7 +55,6 @@ public class SearchResult {
 
 	public Object object;
 	public SpatialSearchResult spatialResult;
-	public SearchResultProgressSnapshot progressSnapshot;
 	public ObjectType objectType;
 	public BinaryMapIndexReader file;
 

--- a/OsmAnd-java/src/main/java/net/osmand/search/core/SearchResult.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/core/SearchResult.java
@@ -50,6 +50,7 @@ public class SearchResult {
 
 	public Object object;
 	public SpatialSearchResult spatialResult;
+	public SearchResultProgressSnapshot progressSnapshot;
 	public ObjectType objectType;
 	public BinaryMapIndexReader file;
 

--- a/OsmAnd-java/src/main/java/net/osmand/search/core/SearchResult.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/core/SearchResult.java
@@ -27,6 +27,11 @@ import net.osmand.util.SearchAlgorithms;
 
 public class SearchResult {
 
+	@FunctionalInterface
+	public interface SearchResultFactory {
+		SearchResult create(SearchPhrase phrase);
+	}
+
 	public static final String DELIMITER = " ";
 	private static final String HYPHEN = "-";
 	static final int NEAREST_METERS_LIMIT = 30000;
@@ -100,6 +105,11 @@ public class SearchResult {
 
 	public SearchResult(SearchPhrase sp) {
 		this.requiredSearchPhrase = sp;
+	}
+
+	/** Returns a factory that recreates this result subtype without retaining this mutable instance. */
+	public SearchResultFactory getSnapshotResultFactory() {
+		return SearchResult::new;
 	}
 
 	public boolean hasImpreciseCoordinates() {

--- a/OsmAnd-java/src/main/java/net/osmand/search/core/SearchResultCollectionSnapshot.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/core/SearchResultCollectionSnapshot.java
@@ -1,0 +1,100 @@
+package net.osmand.search.core;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Immutable, request-scoped snapshot of an aggregated search result collection. */
+public final class SearchResultCollectionSnapshot {
+
+	public static final long NO_REQUEST_ID = -1;
+
+	private final long requestId;
+	private final SearchPhrase phrase;
+	private final List<SearchResultSnapshot> searchResults;
+	private final boolean skipSorting;
+	private final int spatialSearchVisibleLevel;
+	private final boolean useLimit;
+
+	private SearchResultCollectionSnapshot(long requestId, SearchPhrase phrase,
+	                                       List<SearchResultSnapshot> searchResults, boolean skipSorting,
+	                                       int spatialSearchVisibleLevel, boolean useLimit) {
+		this.requestId = requestId;
+		this.phrase = Objects.requireNonNull(phrase);
+		this.searchResults = Collections.unmodifiableList(new ArrayList<>(searchResults));
+		this.skipSorting = skipSorting;
+		this.spatialSearchVisibleLevel = spatialSearchVisibleLevel;
+		this.useLimit = useLimit;
+	}
+
+	public static SearchResultCollectionSnapshot from(long requestId, SearchPhrase phrase,
+	                                                  List<SearchResult> searchResults, boolean skipSorting,
+	                                                  int spatialSearchVisibleLevel, boolean useLimit) {
+		return new SearchResultCollectionSnapshot(requestId, phrase, SearchResultSnapshot.fromAll(searchResults),
+				skipSorting, spatialSearchVisibleLevel, useLimit);
+	}
+
+	public long getRequestId() {
+		return requestId;
+	}
+
+	public SearchPhrase getPhrase() {
+		return phrase;
+	}
+
+	public List<SearchResultSnapshot> getCurrentSearchResults() {
+		return searchResults;
+	}
+
+	public List<SearchResultSnapshot> getVisibleSpatialSearchResults() {
+		if (!skipSorting) {
+			return searchResults;
+		}
+		List<SearchResultSnapshot> visibleResults = new ArrayList<>();
+		for (int level = 0; level <= spatialSearchVisibleLevel; level++) {
+			for (SearchResultSnapshot result : searchResults) {
+				if (result.getSpatialSearchVisibleLevel() == level) {
+					visibleResults.add(result);
+				}
+			}
+		}
+		return Collections.unmodifiableList(visibleResults);
+	}
+
+	public boolean hasSearchResults() {
+		return !searchResults.isEmpty();
+	}
+
+	public boolean isSkipSorting() {
+		return skipSorting;
+	}
+
+	public int getSpatialSearchVisibleLevel() {
+		return spatialSearchVisibleLevel;
+	}
+
+	public boolean getUseLimit() {
+		return useLimit;
+	}
+
+	public boolean hasMoreSpatialSearchResults() {
+		if (!skipSorting) {
+			return false;
+		}
+		for (SearchResultSnapshot result : searchResults) {
+			if (result.getSpatialSearchVisibleLevel() > spatialSearchVisibleLevel) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public SearchResultCollectionSnapshot withMoreSpatialSearchResults() {
+		if (!hasMoreSpatialSearchResults()) {
+			return this;
+		}
+		return new SearchResultCollectionSnapshot(requestId, phrase, searchResults, skipSorting,
+				spatialSearchVisibleLevel + 1, useLimit);
+	}
+}

--- a/OsmAnd-java/src/main/java/net/osmand/search/core/SearchResultProgressSnapshot.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/core/SearchResultProgressSnapshot.java
@@ -1,0 +1,58 @@
+package net.osmand.search.core;
+
+import java.util.Objects;
+
+import net.osmand.binary.BinaryMapIndexReader;
+
+/** Immutable result state produced by the search worker at a progress boundary. */
+public final class SearchResultProgressSnapshot {
+
+	public enum Stage {
+		FILTER_FINISHED,
+		API_FINISHED,
+		REGION_FINISHED,
+		SEARCH_FINISHED
+	}
+
+	private final Stage stage;
+	private final SearchCoreAPI searchApi;
+	private final BinaryMapIndexReader region;
+	private final SearchResultCollectionSnapshot resultCollection;
+	private final boolean append;
+	private final boolean impreciseResults;
+
+	public SearchResultProgressSnapshot(Stage stage, SearchCoreAPI searchApi, BinaryMapIndexReader region,
+	                                    SearchResultCollectionSnapshot resultCollection, boolean append,
+	                                    boolean impreciseResults) {
+		this.stage = Objects.requireNonNull(stage);
+		this.searchApi = searchApi;
+		this.region = region;
+		this.resultCollection = Objects.requireNonNull(resultCollection);
+		this.append = append;
+		this.impreciseResults = impreciseResults;
+	}
+
+	public Stage getStage() {
+		return stage;
+	}
+
+	public SearchCoreAPI getSearchApi() {
+		return searchApi;
+	}
+
+	public BinaryMapIndexReader getRegion() {
+		return region;
+	}
+
+	public SearchResultCollectionSnapshot getResultCollection() {
+		return resultCollection;
+	}
+
+	public boolean shouldAppend() {
+		return append;
+	}
+
+	public boolean hasImpreciseResults() {
+		return impreciseResults;
+	}
+}

--- a/OsmAnd-java/src/main/java/net/osmand/search/core/SearchResultProgressSnapshot.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/core/SearchResultProgressSnapshot.java
@@ -20,20 +20,26 @@ public final class SearchResultProgressSnapshot {
 	private final SearchResultCollectionSnapshot resultCollection;
 	private final boolean append;
 	private final boolean impreciseResults;
+	private final boolean regionResultsPublished;
 
 	public SearchResultProgressSnapshot(Stage stage, SearchCoreAPI searchApi, BinaryMapIndexReader region,
 	                                    SearchResultCollectionSnapshot resultCollection, boolean append,
-	                                    boolean impreciseResults) {
+	                                    boolean impreciseResults, boolean regionResultsPublished) {
 		this.stage = Objects.requireNonNull(stage);
 		this.searchApi = searchApi;
 		this.region = region;
 		this.resultCollection = Objects.requireNonNull(resultCollection);
 		this.append = append;
 		this.impreciseResults = impreciseResults;
+		this.regionResultsPublished = regionResultsPublished;
 	}
 
 	public Stage getStage() {
 		return stage;
+	}
+
+	public long getRequestId() {
+		return resultCollection.getRequestId();
 	}
 
 	public SearchCoreAPI getSearchApi() {
@@ -54,5 +60,9 @@ public final class SearchResultProgressSnapshot {
 
 	public boolean hasImpreciseResults() {
 		return impreciseResults;
+	}
+
+	public boolean hasPublishedRegionResults() {
+		return regionResultsPublished;
 	}
 }

--- a/OsmAnd-java/src/main/java/net/osmand/search/core/SearchResultSnapshot.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/core/SearchResultSnapshot.java
@@ -98,14 +98,19 @@ public final class SearchResultSnapshot {
 	}
 
 	public SearchResult toSearchResult() {
-		return toSearchResult(new IdentityHashMap<>());
+		return toSearchResult(new IdentityHashMap<>(), null);
 	}
 
 	public static List<SearchResult> toSearchResults(List<SearchResultSnapshot> snapshots) {
+		return toSearchResults(snapshots, null);
+	}
+
+	public static List<SearchResult> toSearchResults(List<SearchResultSnapshot> snapshots,
+	                                                 SearchPhrase requiredSearchPhrase) {
 		Map<SearchResultSnapshot, SearchResult> results = new IdentityHashMap<>();
 		List<SearchResult> result = new ArrayList<>(snapshots.size());
 		for (SearchResultSnapshot snapshot : snapshots) {
-			result.add(Objects.requireNonNull(snapshot).toSearchResult(results));
+			result.add(Objects.requireNonNull(snapshot).toSearchResult(results, requiredSearchPhrase));
 		}
 		return result;
 	}
@@ -137,13 +142,17 @@ public final class SearchResultSnapshot {
 		return source == null ? null : Collections.unmodifiableList(new ArrayList<>(source));
 	}
 
-	private SearchResult toSearchResult(Map<SearchResultSnapshot, SearchResult> results) {
+	private SearchResult toSearchResult(Map<SearchResultSnapshot, SearchResult> results,
+	                                    SearchPhrase requiredSearchPhrase) {
 		SearchResult result = results.get(this);
 		if (result != null) {
 			return result;
 		}
-		SearchResult parent = parentSearchResult != null ? parentSearchResult.toSearchResult(results) : null;
-		result = Objects.requireNonNull(resultFactory.create(requiredSearchPhrase));
+		SearchResult parent = parentSearchResult != null
+				? parentSearchResult.toSearchResult(results, requiredSearchPhrase)
+				: null;
+		SearchPhrase resultPhrase = requiredSearchPhrase != null ? requiredSearchPhrase : this.requiredSearchPhrase;
+		result = Objects.requireNonNull(resultFactory.create(resultPhrase));
 		result.parentSearchResult = parent;
 		result.wordsSpan = wordsSpan;
 		result.object = object;

--- a/OsmAnd-java/src/main/java/net/osmand/search/core/SearchResultSnapshot.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/core/SearchResultSnapshot.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 
 import net.osmand.binary.BinaryMapIndexReader;
 import net.osmand.data.LatLon;
+import net.osmand.search.core.SearchResult.SearchResultFactory;
 import net.osmand.search.core.SearchResult.SearchResultResource;
 import net.osmand.search.core.spatial.SpatialSearchResult;
 import net.osmand.util.MapUtils;
@@ -24,7 +25,9 @@ import net.osmand.util.MapUtils;
 public final class SearchResultSnapshot {
 
 	private final SearchPhrase requiredSearchPhrase;
+	private final SearchResultFactory resultFactory;
 	private final SearchResultSnapshot parentSearchResult;
+	private final String wordsSpan;
 	private final Object object;
 	private final SpatialSearchResult spatialResult;
 	private final ObjectType objectType;
@@ -43,6 +46,7 @@ public final class SearchResultSnapshot {
 	private final Object relatedObject;
 	private final double distRelatedObjectName;
 	private final boolean impreciseCoordinates;
+	private final boolean firstUnknownWordMatches;
 	private final double unknownPhraseMatchWeight;
 	private final int foundWordCount;
 	private final int depth;
@@ -55,7 +59,9 @@ public final class SearchResultSnapshot {
 
 	private SearchResultSnapshot(SearchResult result, SearchResultSnapshot parentSearchResult) {
 		requiredSearchPhrase = result.requiredSearchPhrase;
+		resultFactory = result.getSnapshotResultFactory();
 		this.parentSearchResult = parentSearchResult;
+		wordsSpan = result.wordsSpan;
 		object = result.object;
 		spatialResult = result.spatialResult;
 		objectType = result.objectType;
@@ -74,6 +80,7 @@ public final class SearchResultSnapshot {
 		relatedObject = result.relatedObject;
 		distRelatedObjectName = result.distRelatedObjectName;
 		impreciseCoordinates = result.hasImpreciseCoordinates();
+		firstUnknownWordMatches = result.firstUnknownWordMatches;
 		unknownPhraseMatchWeight = result.getUnknownPhraseMatchWeight();
 		foundWordCount = result.getFoundWordCount();
 		depth = result.getDepth();
@@ -88,6 +95,19 @@ public final class SearchResultSnapshot {
 
 	public static SearchResultSnapshot from(SearchResult result) {
 		return from(Objects.requireNonNull(result), new IdentityHashMap<>());
+	}
+
+	public SearchResult toSearchResult() {
+		return toSearchResult(new IdentityHashMap<>());
+	}
+
+	public static List<SearchResult> toSearchResults(List<SearchResultSnapshot> snapshots) {
+		Map<SearchResultSnapshot, SearchResult> results = new IdentityHashMap<>();
+		List<SearchResult> result = new ArrayList<>(snapshots.size());
+		for (SearchResultSnapshot snapshot : snapshots) {
+			result.add(Objects.requireNonNull(snapshot).toSearchResult(results));
+		}
+		return result;
 	}
 
 	static List<SearchResultSnapshot> fromAll(List<SearchResult> results) {
@@ -115,6 +135,40 @@ public final class SearchResultSnapshot {
 
 	private static List<String> copyStrings(Collection<String> source) {
 		return source == null ? null : Collections.unmodifiableList(new ArrayList<>(source));
+	}
+
+	private SearchResult toSearchResult(Map<SearchResultSnapshot, SearchResult> results) {
+		SearchResult result = results.get(this);
+		if (result != null) {
+			return result;
+		}
+		SearchResult parent = parentSearchResult != null ? parentSearchResult.toSearchResult(results) : null;
+		result = Objects.requireNonNull(resultFactory.create(requiredSearchPhrase));
+		result.parentSearchResult = parent;
+		result.wordsSpan = wordsSpan;
+		result.object = object;
+		result.spatialResult = spatialResult;
+		result.objectType = objectType;
+		result.file = file;
+		result.priority = priority;
+		result.priorityDistance = priorityDistance;
+		result.spatialSearchVisibleLevel = spatialSearchVisibleLevel;
+		result.location = location;
+		result.preferredZoom = preferredZoom;
+		result.localeName = localeName;
+		result.alternateName = alternateName;
+		result.addressName = addressName;
+		result.cityName = cityName;
+		result.otherNames = otherNames != null ? new ArrayList<>(otherNames) : null;
+		result.localeRelatedObjectName = localeRelatedObjectName;
+		result.relatedObject = relatedObject;
+		result.distRelatedObjectName = distRelatedObjectName;
+		result.setImpreciseCoordinates(impreciseCoordinates);
+		result.setFirstUnknownWordMatches(firstUnknownWordMatches);
+		result.setUnknownPhraseMatchWeight(unknownPhraseMatchWeight);
+		result.setOtherWordsMatch(otherWordsMatch != null ? new ArrayList<>(otherWordsMatch) : null);
+		results.put(this, result);
+		return result;
 	}
 
 	public SearchPhrase getRequiredSearchPhrase() {

--- a/OsmAnd-java/src/main/java/net/osmand/search/core/SearchResultSnapshot.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/core/SearchResultSnapshot.java
@@ -1,0 +1,246 @@
+package net.osmand.search.core;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import net.osmand.binary.BinaryMapIndexReader;
+import net.osmand.data.LatLon;
+import net.osmand.search.core.SearchResult.SearchResultResource;
+import net.osmand.search.core.spatial.SpatialSearchResult;
+import net.osmand.util.MapUtils;
+
+/**
+ * Immutable search metadata published outside of the search worker.
+ *
+ * Domain objects referenced by {@link #getObject()} and {@link #getRelatedObject()} are intentionally
+ * not cloned. Consumers must treat those objects as read-only. Mutable collections owned by
+ * {@link SearchResult} are defensively copied.
+ */
+public final class SearchResultSnapshot {
+
+	private final SearchPhrase requiredSearchPhrase;
+	private final SearchResultSnapshot parentSearchResult;
+	private final Object object;
+	private final SpatialSearchResult spatialResult;
+	private final ObjectType objectType;
+	private final BinaryMapIndexReader file;
+	private final double priority;
+	private final double priorityDistance;
+	private final int spatialSearchVisibleLevel;
+	private final LatLon location;
+	private final int preferredZoom;
+	private final String localeName;
+	private final String alternateName;
+	private final String addressName;
+	private final String cityName;
+	private final List<String> otherNames;
+	private final String localeRelatedObjectName;
+	private final Object relatedObject;
+	private final double distRelatedObjectName;
+	private final boolean impreciseCoordinates;
+	private final double unknownPhraseMatchWeight;
+	private final int foundWordCount;
+	private final int depth;
+	private final boolean allWordsEqual;
+	private final boolean allWordsInPhraseAreInResult;
+	private final List<String> otherWordsMatch;
+	private final SearchResultResource resourceType;
+	private final boolean fullPhraseEqualLocaleName;
+	private final String displayText;
+
+	private SearchResultSnapshot(SearchResult result, SearchResultSnapshot parentSearchResult) {
+		requiredSearchPhrase = result.requiredSearchPhrase;
+		this.parentSearchResult = parentSearchResult;
+		object = result.object;
+		spatialResult = result.spatialResult;
+		objectType = result.objectType;
+		file = result.file;
+		priority = result.priority;
+		priorityDistance = result.priorityDistance;
+		spatialSearchVisibleLevel = result.spatialSearchVisibleLevel;
+		location = result.location;
+		preferredZoom = result.preferredZoom;
+		localeName = result.localeName;
+		alternateName = result.alternateName;
+		addressName = result.addressName;
+		cityName = result.cityName;
+		otherNames = copyStrings(result.otherNames);
+		localeRelatedObjectName = result.localeRelatedObjectName;
+		relatedObject = result.relatedObject;
+		distRelatedObjectName = result.distRelatedObjectName;
+		impreciseCoordinates = result.hasImpreciseCoordinates();
+		unknownPhraseMatchWeight = result.getUnknownPhraseMatchWeight();
+		foundWordCount = result.getFoundWordCount();
+		depth = result.getDepth();
+		SearchResult.CheckWordsMatchCount completeMatch = result.getCompleteMatchRes();
+		allWordsEqual = completeMatch != null && completeMatch.allWordsEqual;
+		allWordsInPhraseAreInResult = completeMatch != null && completeMatch.allWordsInPhraseAreInResult;
+		otherWordsMatch = copyStrings(result.getOtherWordsMatch());
+		resourceType = result.getResourceType();
+		fullPhraseEqualLocaleName = result.isFullPhraseEqualLocaleName();
+		displayText = result.toString();
+	}
+
+	public static SearchResultSnapshot from(SearchResult result) {
+		return from(Objects.requireNonNull(result), new IdentityHashMap<>());
+	}
+
+	static List<SearchResultSnapshot> fromAll(List<SearchResult> results) {
+		Map<SearchResult, SearchResultSnapshot> snapshots = new IdentityHashMap<>();
+		List<SearchResultSnapshot> result = new ArrayList<>(results.size());
+		for (SearchResult searchResult : results) {
+			result.add(from(Objects.requireNonNull(searchResult), snapshots));
+		}
+		return result;
+	}
+
+	private static SearchResultSnapshot from(SearchResult result,
+	                                         Map<SearchResult, SearchResultSnapshot> snapshots) {
+		SearchResultSnapshot snapshot = snapshots.get(result);
+		if (snapshot != null) {
+			return snapshot;
+		}
+		SearchResultSnapshot parent = result.parentSearchResult != null
+				? from(result.parentSearchResult, snapshots)
+				: null;
+		snapshot = new SearchResultSnapshot(result, parent);
+		snapshots.put(result, snapshot);
+		return snapshot;
+	}
+
+	private static List<String> copyStrings(Collection<String> source) {
+		return source == null ? null : Collections.unmodifiableList(new ArrayList<>(source));
+	}
+
+	public SearchPhrase getRequiredSearchPhrase() {
+		return requiredSearchPhrase;
+	}
+
+	public SearchResultSnapshot getParentSearchResult() {
+		return parentSearchResult;
+	}
+
+	public Object getObject() {
+		return object;
+	}
+
+	public SpatialSearchResult getSpatialResult() {
+		return spatialResult;
+	}
+
+	public ObjectType getObjectType() {
+		return objectType;
+	}
+
+	public BinaryMapIndexReader getFile() {
+		return file;
+	}
+
+	public double getPriority() {
+		return priority;
+	}
+
+	public double getPriorityDistance() {
+		return priorityDistance;
+	}
+
+	public int getSpatialSearchVisibleLevel() {
+		return spatialSearchVisibleLevel;
+	}
+
+	public LatLon getLocation() {
+		return location;
+	}
+
+	public int getPreferredZoom() {
+		return preferredZoom;
+	}
+
+	public String getLocaleName() {
+		return localeName;
+	}
+
+	public String getAlternateName() {
+		return alternateName;
+	}
+
+	public String getAddressName() {
+		return addressName;
+	}
+
+	public String getCityName() {
+		return cityName;
+	}
+
+	public List<String> getOtherNames() {
+		return otherNames;
+	}
+
+	public String getLocaleRelatedObjectName() {
+		return localeRelatedObjectName;
+	}
+
+	public Object getRelatedObject() {
+		return relatedObject;
+	}
+
+	public double getDistRelatedObjectName() {
+		return distRelatedObjectName;
+	}
+
+	public boolean hasImpreciseCoordinates() {
+		return impreciseCoordinates;
+	}
+
+	public double getUnknownPhraseMatchWeight() {
+		return unknownPhraseMatchWeight;
+	}
+
+	public int getFoundWordCount() {
+		return foundWordCount;
+	}
+
+	public int getDepth() {
+		return depth;
+	}
+
+	public boolean isAllWordsEqual() {
+		return allWordsEqual;
+	}
+
+	public boolean isAllWordsInPhraseAreInResult() {
+		return allWordsInPhraseAreInResult;
+	}
+
+	public List<String> getOtherWordsMatch() {
+		return otherWordsMatch;
+	}
+
+	public SearchResultResource getResourceType() {
+		return resourceType;
+	}
+
+	public boolean isFullPhraseEqualLocaleName() {
+		return fullPhraseEqualLocaleName;
+	}
+
+	public double getSearchDistance(LatLon origin) {
+		double distance = origin != null && location != null ? MapUtils.getDistance(origin, location) : 0;
+		return priority - 1 / (1 + priorityDistance * distance);
+	}
+
+	public double getSearchDistance(LatLon origin, double priorityDistance) {
+		double distance = origin != null && location != null ? MapUtils.getDistance(origin, location) : 0;
+		return priority - 1 / (1 + priorityDistance * distance);
+	}
+
+	@Override
+	public String toString() {
+		return displayText;
+	}
+}

--- a/OsmAnd-java/src/test/java/net/osmand/search/SearchResultSnapshotTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/search/SearchResultSnapshotTest.java
@@ -1,18 +1,13 @@
 package net.osmand.search;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import net.osmand.data.LatLon;
 import net.osmand.search.SearchUICore.SearchResultCollection;
 import net.osmand.search.SearchUICore.SearchResultMatcher;
 import net.osmand.search.core.ObjectType;
 import net.osmand.search.core.SearchCoreFactory.SearchBaseAPI;
 import net.osmand.search.core.SearchPhrase;
+import net.osmand.search.core.SearchProgressListener;
 import net.osmand.search.core.SearchResult;
-import net.osmand.search.core.SearchResult.SearchResultFactory;
 import net.osmand.search.core.SearchResultCollectionSnapshot;
 import net.osmand.search.core.SearchResultProgressSnapshot;
 import net.osmand.search.core.SearchResultProgressSnapshot.Stage;
@@ -21,6 +16,11 @@ import net.osmand.search.core.SearchSettings;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class SearchResultSnapshotTest {
 

--- a/OsmAnd-java/src/test/java/net/osmand/search/SearchResultSnapshotTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/search/SearchResultSnapshotTest.java
@@ -3,13 +3,19 @@ package net.osmand.search;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import net.osmand.ResultMatcher;
 import net.osmand.data.LatLon;
 import net.osmand.search.SearchUICore.SearchResultCollection;
+import net.osmand.search.SearchUICore.SearchResultMatcher;
 import net.osmand.search.core.ObjectType;
+import net.osmand.search.core.SearchCoreFactory.SearchBaseAPI;
 import net.osmand.search.core.SearchPhrase;
 import net.osmand.search.core.SearchResult;
 import net.osmand.search.core.SearchResultCollectionSnapshot;
+import net.osmand.search.core.SearchResultProgressSnapshot;
+import net.osmand.search.core.SearchResultProgressSnapshot.Stage;
 import net.osmand.search.core.SearchResultSnapshot;
 import net.osmand.search.core.SearchSettings;
 
@@ -79,6 +85,45 @@ public class SearchResultSnapshotTest {
 		Assert.assertEquals(1, expanded.getSpatialSearchVisibleLevel());
 	}
 
+	@Test
+	public void testMatcherAggregatesApiProgressInCore() {
+		SearchPhrase phrase = createPhrase();
+		AtomicInteger requestNumber = new AtomicInteger(7);
+		List<SearchResult> published = new ArrayList<>();
+		SearchResultMatcher matcher = new SearchResultMatcher(new ResultMatcher<SearchResult>() {
+			@Override
+			public boolean publish(SearchResult object) {
+				published.add(object);
+				return true;
+			}
+
+			@Override
+			public boolean isCancelled() {
+				return false;
+			}
+		}, phrase, requestNumber.get(), requestNumber, -1);
+
+		TestSearchApi firstApi = new TestSearchApi();
+		matcher.publish(createResult(phrase, "First", 0));
+		matcher.apiSearchFinished(firstApi, phrase);
+		SearchResultProgressSnapshot firstProgress = published.get(published.size() - 1).progressSnapshot;
+
+		Assert.assertEquals(Stage.API_FINISHED, firstProgress.getStage());
+		Assert.assertSame(firstApi, firstProgress.getSearchApi());
+		Assert.assertFalse(firstProgress.shouldAppend());
+		Assert.assertEquals(7, firstProgress.getResultCollection().getRequestId());
+		Assert.assertEquals(1, firstProgress.getResultCollection().getCurrentSearchResults().size());
+		Assert.assertEquals("First", firstProgress.getResultCollection().getCurrentSearchResults().get(0).getLocaleName());
+
+		TestSearchApi secondApi = new TestSearchApi();
+		matcher.publish(createResult(phrase, "Second", 0));
+		matcher.apiSearchFinished(secondApi, phrase);
+		SearchResultProgressSnapshot secondProgress = published.get(published.size() - 1).progressSnapshot;
+
+		Assert.assertTrue(secondProgress.shouldAppend());
+		Assert.assertEquals(2, secondProgress.getResultCollection().getCurrentSearchResults().size());
+	}
+
 	private SearchPhrase createPhrase() {
 		SearchSettings settings = new SearchSettings((SearchSettings) null);
 		settings = settings.setOriginalLocation(new LatLon(0, 0));
@@ -92,5 +137,11 @@ public class SearchResultSnapshotTest {
 		result.location = new LatLon(0, 0);
 		result.spatialSearchVisibleLevel = visibleLevel;
 		return result;
+	}
+
+	private static class TestSearchApi extends SearchBaseAPI {
+		TestSearchApi() {
+			super(ObjectType.LOCATION);
+		}
 	}
 }

--- a/OsmAnd-java/src/test/java/net/osmand/search/SearchResultSnapshotTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/search/SearchResultSnapshotTest.java
@@ -1,0 +1,96 @@
+package net.osmand.search;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import net.osmand.data.LatLon;
+import net.osmand.search.SearchUICore.SearchResultCollection;
+import net.osmand.search.core.ObjectType;
+import net.osmand.search.core.SearchPhrase;
+import net.osmand.search.core.SearchResult;
+import net.osmand.search.core.SearchResultCollectionSnapshot;
+import net.osmand.search.core.SearchResultSnapshot;
+import net.osmand.search.core.SearchSettings;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SearchResultSnapshotTest {
+
+	@Test
+	public void testResultSnapshotDoesNotReflectMutableSearchMetadataChanges() {
+		SearchPhrase phrase = createPhrase();
+		SearchResult parent = createResult(phrase, "Parent", 0);
+		SearchResult result = createResult(phrase, "Original", 0);
+		result.parentSearchResult = parent;
+		List<String> otherNames = new ArrayList<>(Arrays.asList("First", "Second"));
+		result.otherNames = otherNames;
+
+		SearchResultSnapshot snapshot = SearchResultSnapshot.from(result);
+		result.localeName = "Changed";
+		parent.localeName = "Changed parent";
+		otherNames.add("Third");
+
+		Assert.assertEquals("Original", snapshot.getLocaleName());
+		Assert.assertEquals("Parent", snapshot.getParentSearchResult().getLocaleName());
+		Assert.assertEquals(Arrays.asList("First", "Second"), snapshot.getOtherNames());
+		try {
+			snapshot.getOtherNames().add("Third");
+			Assert.fail("Snapshot metadata must be immutable");
+		} catch (UnsupportedOperationException expected) {
+			// Expected.
+		}
+	}
+
+	@Test
+	public void testCollectionSnapshotIsImmutableAndKeepsRequestId() {
+		SearchPhrase phrase = createPhrase();
+		SearchResultCollection collection = new SearchResultCollection(phrase);
+		collection.addSearchResults(Arrays.asList(createResult(phrase, "Result", 0)), false, false);
+
+		SearchResultCollectionSnapshot snapshot = collection.toSnapshot(42);
+
+		Assert.assertEquals(42, snapshot.getRequestId());
+		Assert.assertEquals(1, snapshot.getCurrentSearchResults().size());
+		try {
+			snapshot.getCurrentSearchResults().clear();
+			Assert.fail("Snapshot results must be immutable");
+		} catch (UnsupportedOperationException expected) {
+			// Expected.
+		}
+	}
+
+	@Test
+	public void testSpatialVisibilityCreatesANewSnapshot() {
+		SearchPhrase phrase = createPhrase();
+		SearchResult first = createResult(phrase, "First", 0);
+		SearchResult second = createResult(phrase, "Second", 1);
+		SearchResultCollection collection = new SearchResultCollection(phrase, true);
+		collection.addSearchResults(Arrays.asList(first, second), false, false);
+
+		SearchResultCollectionSnapshot initial = collection.toSnapshot();
+		SearchResultCollectionSnapshot expanded = initial.withMoreSpatialSearchResults();
+
+		Assert.assertNotSame(initial, expanded);
+		Assert.assertEquals(1, initial.getVisibleSpatialSearchResults().size());
+		Assert.assertEquals(2, expanded.getVisibleSpatialSearchResults().size());
+		Assert.assertEquals(0, initial.getSpatialSearchVisibleLevel());
+		Assert.assertEquals(1, expanded.getSpatialSearchVisibleLevel());
+	}
+
+	private SearchPhrase createPhrase() {
+		SearchSettings settings = new SearchSettings((SearchSettings) null);
+		settings = settings.setOriginalLocation(new LatLon(0, 0));
+		return SearchPhrase.emptyPhrase(settings);
+	}
+
+	private SearchResult createResult(SearchPhrase phrase, String name, int visibleLevel) {
+		SearchResult result = new SearchResult(phrase);
+		result.objectType = ObjectType.LOCATION;
+		result.localeName = name;
+		result.location = new LatLon(0, 0);
+		result.spatialSearchVisibleLevel = visibleLevel;
+		return result;
+	}
+}

--- a/OsmAnd-java/src/test/java/net/osmand/search/SearchResultSnapshotTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/search/SearchResultSnapshotTest.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import net.osmand.ResultMatcher;
 import net.osmand.data.LatLon;
 import net.osmand.search.SearchUICore.SearchResultCollection;
 import net.osmand.search.SearchUICore.SearchResultMatcher;
@@ -111,19 +110,28 @@ public class SearchResultSnapshotTest {
 	public void testMatcherAggregatesApiProgressInCore() {
 		SearchPhrase phrase = createPhrase();
 		AtomicInteger requestNumber = new AtomicInteger(7);
-		List<SearchResult> published = new ArrayList<>();
-		SearchResultMatcher matcher = new SearchResultMatcher(new ResultMatcher<SearchResult>() {
+		List<SearchResultProgressSnapshot> published = new ArrayList<>();
+		SearchProgressListener progressListener = new SearchProgressListener() {
 			@Override
-			public boolean publish(SearchResult object) {
-				published.add(object);
-				return true;
+			public void onSearchStarted(long requestId, SearchPhrase phrase) {
+			}
+
+			@Override
+			public void onProgress(SearchResultProgressSnapshot progress) {
+				published.add(progress);
+			}
+
+			@Override
+			public void onPartialLocation(long requestId, SearchPhrase phrase) {
 			}
 
 			@Override
 			public boolean isCancelled() {
 				return false;
 			}
-		}, phrase, requestNumber.get(), requestNumber, -1);
+		};
+		SearchResultMatcher matcher = new SearchResultMatcher(null, progressListener, phrase,
+				requestNumber.get(), requestNumber, -1);
 
 		TestSearchApi firstApi = new TestSearchApi();
 		SearchResult partialLocation = createResult(phrase, "Partial", 0);
@@ -131,7 +139,7 @@ public class SearchResultSnapshotTest {
 		matcher.publish(partialLocation);
 		matcher.publish(createResult(phrase, "First", 0));
 		matcher.apiSearchFinished(firstApi, phrase);
-		SearchResultProgressSnapshot firstProgress = published.get(published.size() - 1).progressSnapshot;
+		SearchResultProgressSnapshot firstProgress = published.get(published.size() - 1);
 
 		Assert.assertEquals(Stage.API_FINISHED, firstProgress.getStage());
 		Assert.assertSame(firstApi, firstProgress.getSearchApi());
@@ -144,7 +152,7 @@ public class SearchResultSnapshotTest {
 		TestSearchApi secondApi = new TestSearchApi();
 		matcher.publish(createResult(phrase, "Second", 0));
 		matcher.apiSearchFinished(secondApi, phrase);
-		SearchResultProgressSnapshot secondProgress = published.get(published.size() - 1).progressSnapshot;
+		SearchResultProgressSnapshot secondProgress = published.get(published.size() - 1);
 
 		Assert.assertTrue(secondProgress.shouldAppend());
 		Assert.assertEquals(2, secondProgress.getResultCollection().getCurrentSearchResults().size());

--- a/OsmAnd-java/src/test/java/net/osmand/search/SearchResultSnapshotTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/search/SearchResultSnapshotTest.java
@@ -150,6 +150,57 @@ public class SearchResultSnapshotTest {
 		Assert.assertEquals(2, secondProgress.getResultCollection().getCurrentSearchResults().size());
 	}
 
+	@Test
+	public void testProgressListenerReceivesSnapshotsWithoutMutableResults() {
+		SearchPhrase phrase = createPhrase();
+		AtomicInteger requestNumber = new AtomicInteger(11);
+		List<Long> startedRequests = new ArrayList<>();
+		List<Long> partialLocationRequests = new ArrayList<>();
+		List<SearchResultProgressSnapshot> progressSnapshots = new ArrayList<>();
+		SearchProgressListener progressListener = new SearchProgressListener() {
+			@Override
+			public void onSearchStarted(long requestId, SearchPhrase phrase) {
+				startedRequests.add(requestId);
+			}
+
+			@Override
+			public void onProgress(SearchResultProgressSnapshot progress) {
+				progressSnapshots.add(progress);
+			}
+
+			@Override
+			public void onPartialLocation(long requestId, SearchPhrase phrase) {
+				partialLocationRequests.add(requestId);
+			}
+
+			@Override
+			public boolean isCancelled() {
+				return false;
+			}
+		};
+		SearchResultMatcher matcher = new SearchResultMatcher(null, progressListener, phrase,
+				requestNumber.get(), requestNumber, -1);
+
+		matcher.searchStarted(phrase);
+		SearchResult partialLocation = createResult(phrase, "Partial", 0);
+		partialLocation.objectType = ObjectType.PARTIAL_LOCATION;
+		matcher.publish(partialLocation);
+		SearchResult sourceResult = createResult(phrase, "Result", 0);
+		matcher.publish(sourceResult);
+		matcher.apiSearchFinished(new TestSearchApi(), phrase);
+		sourceResult.localeName = "Changed";
+
+		Assert.assertEquals(Arrays.asList(11L), startedRequests);
+		Assert.assertEquals(Arrays.asList(11L), partialLocationRequests);
+		Assert.assertEquals(1, matcher.getRequestResults().size());
+		Assert.assertEquals(1, progressSnapshots.size());
+		SearchResultProgressSnapshot progress = progressSnapshots.get(0);
+		Assert.assertEquals(Stage.API_FINISHED, progress.getStage());
+		Assert.assertEquals(11, progress.getRequestId());
+		Assert.assertEquals("Result",
+				progress.getResultCollection().getCurrentSearchResults().get(0).getLocaleName());
+	}
+
 	private SearchPhrase createPhrase() {
 		SearchSettings settings = new SearchSettings((SearchSettings) null);
 		settings = settings.setOriginalLocation(new LatLon(0, 0));

--- a/OsmAnd-java/src/test/java/net/osmand/search/SearchResultSnapshotTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/search/SearchResultSnapshotTest.java
@@ -146,7 +146,7 @@ public class SearchResultSnapshotTest {
 		Assert.assertFalse(firstProgress.shouldAppend());
 		Assert.assertEquals(7, firstProgress.getResultCollection().getRequestId());
 		Assert.assertEquals(1, firstProgress.getResultCollection().getCurrentSearchResults().size());
-		Assert.assertEquals(1, matcher.getRequestResults().size());
+		Assert.assertEquals(2, matcher.getRequestResults().size());
 		Assert.assertEquals("First", firstProgress.getResultCollection().getCurrentSearchResults().get(0).getLocaleName());
 
 		TestSearchApi secondApi = new TestSearchApi();
@@ -200,7 +200,7 @@ public class SearchResultSnapshotTest {
 
 		Assert.assertEquals(Arrays.asList(11L), startedRequests);
 		Assert.assertEquals(Arrays.asList(11L), partialLocationRequests);
-		Assert.assertEquals(1, matcher.getRequestResults().size());
+		Assert.assertEquals(2, matcher.getRequestResults().size());
 		Assert.assertEquals(1, progressSnapshots.size());
 		SearchResultProgressSnapshot progress = progressSnapshots.get(0);
 		Assert.assertEquals(Stage.API_FINISHED, progress.getStage());

--- a/OsmAnd-java/src/test/java/net/osmand/search/SearchResultSnapshotTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/search/SearchResultSnapshotTest.java
@@ -159,6 +159,58 @@ public class SearchResultSnapshotTest {
 	}
 
 	@Test
+	public void testMatcherStartsAggregationFromIndependentSnapshot() {
+		SearchPhrase previousPhrase = createPhrase();
+		SearchResult previousResult = createResult(previousPhrase, "Existing", 0);
+		SearchResultCollection previousCollection = new SearchResultCollection(previousPhrase);
+		previousCollection.addSearchResults(Arrays.asList(previousResult), false, false);
+		SearchResultCollectionSnapshot initialResults = previousCollection.toSnapshot();
+
+		SearchPhrase currentPhrase = createPhrase();
+		AtomicInteger requestNumber = new AtomicInteger(13);
+		List<SearchResultProgressSnapshot> published = new ArrayList<>();
+		SearchProgressListener progressListener = new SearchProgressListener() {
+			@Override
+			public void onSearchStarted(long requestId, SearchPhrase phrase) {
+			}
+
+			@Override
+			public void onProgress(SearchResultProgressSnapshot progress) {
+				published.add(progress);
+			}
+
+			@Override
+			public void onPartialLocation(long requestId, SearchPhrase phrase) {
+			}
+
+			@Override
+			public boolean isCancelled() {
+				return false;
+			}
+		};
+		SearchResultMatcher matcher = new SearchResultMatcher(null, progressListener, currentPhrase,
+				requestNumber.get(), requestNumber, -1, initialResults);
+
+		matcher.publish(createResult(currentPhrase, "New", 0));
+		matcher.apiSearchFinished(new TestSearchApi(), currentPhrase);
+
+		Assert.assertEquals(1, published.size());
+		SearchResultProgressSnapshot progress = published.get(0);
+		Assert.assertTrue(progress.shouldAppend());
+		Assert.assertEquals(2, progress.getResultCollection().getCurrentSearchResults().size());
+		Assert.assertSame(currentPhrase, progress.getResultCollection().getPhrase());
+		Assert.assertSame(previousPhrase, initialResults.getPhrase());
+		Assert.assertSame(previousPhrase,
+				initialResults.getCurrentSearchResults().get(0).getRequiredSearchPhrase());
+
+		SearchResultCollection aggregated = SearchResultCollection.fromSnapshot(progress.getResultCollection());
+		for (SearchResult result : aggregated.getCurrentSearchResults()) {
+			Assert.assertSame(currentPhrase, result.requiredSearchPhrase);
+			Assert.assertNotSame(previousResult, result);
+		}
+	}
+
+	@Test
 	public void testProgressListenerReceivesSnapshotsWithoutMutableResults() {
 		SearchPhrase phrase = createPhrase();
 		AtomicInteger requestNumber = new AtomicInteger(11);

--- a/OsmAnd-java/src/test/java/net/osmand/search/SearchResultSnapshotTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/search/SearchResultSnapshotTest.java
@@ -13,6 +13,7 @@ import net.osmand.search.core.ObjectType;
 import net.osmand.search.core.SearchCoreFactory.SearchBaseAPI;
 import net.osmand.search.core.SearchPhrase;
 import net.osmand.search.core.SearchResult;
+import net.osmand.search.core.SearchResult.SearchResultFactory;
 import net.osmand.search.core.SearchResultCollectionSnapshot;
 import net.osmand.search.core.SearchResultProgressSnapshot;
 import net.osmand.search.core.SearchResultProgressSnapshot.Stage;
@@ -53,12 +54,19 @@ public class SearchResultSnapshotTest {
 	public void testCollectionSnapshotIsImmutableAndKeepsRequestId() {
 		SearchPhrase phrase = createPhrase();
 		SearchResultCollection collection = new SearchResultCollection(phrase);
-		collection.addSearchResults(Arrays.asList(createResult(phrase, "Result", 0)), false, false);
+		SearchResult sourceResult = createResult(phrase, "Result", 0);
+		collection.addSearchResults(Arrays.asList(sourceResult), false, false);
 
 		SearchResultCollectionSnapshot snapshot = collection.toSnapshot(42);
+		SearchResultCollection uiCollection = SearchResultCollection.fromSnapshot(snapshot);
+		SearchResult uiResult = uiCollection.getCurrentSearchResults().get(0);
 
 		Assert.assertEquals(42, snapshot.getRequestId());
 		Assert.assertEquals(1, snapshot.getCurrentSearchResults().size());
+		Assert.assertNotSame(sourceResult, uiResult);
+		uiResult.localeName = "UI change";
+		Assert.assertEquals("Result", sourceResult.localeName);
+		Assert.assertEquals("Result", snapshot.getCurrentSearchResults().get(0).getLocaleName());
 		try {
 			snapshot.getCurrentSearchResults().clear();
 			Assert.fail("Snapshot results must be immutable");
@@ -86,6 +94,20 @@ public class SearchResultSnapshotTest {
 	}
 
 	@Test
+	public void testSnapshotCopyPreservesSearchResultSubtype() {
+		SearchPhrase phrase = createPhrase();
+		TestSearchResult source = new TestSearchResult(phrase, "extra");
+		source.objectType = ObjectType.LOCATION;
+		source.localeName = "Result";
+
+		SearchResult copy = SearchResultSnapshot.from(source).toSearchResult();
+
+		Assert.assertTrue(copy instanceof TestSearchResult);
+		Assert.assertEquals("extra", ((TestSearchResult) copy).getExtraData());
+		Assert.assertNotSame(source, copy);
+	}
+
+	@Test
 	public void testMatcherAggregatesApiProgressInCore() {
 		SearchPhrase phrase = createPhrase();
 		AtomicInteger requestNumber = new AtomicInteger(7);
@@ -104,6 +126,9 @@ public class SearchResultSnapshotTest {
 		}, phrase, requestNumber.get(), requestNumber, -1);
 
 		TestSearchApi firstApi = new TestSearchApi();
+		SearchResult partialLocation = createResult(phrase, "Partial", 0);
+		partialLocation.objectType = ObjectType.PARTIAL_LOCATION;
+		matcher.publish(partialLocation);
 		matcher.publish(createResult(phrase, "First", 0));
 		matcher.apiSearchFinished(firstApi, phrase);
 		SearchResultProgressSnapshot firstProgress = published.get(published.size() - 1).progressSnapshot;
@@ -113,6 +138,7 @@ public class SearchResultSnapshotTest {
 		Assert.assertFalse(firstProgress.shouldAppend());
 		Assert.assertEquals(7, firstProgress.getResultCollection().getRequestId());
 		Assert.assertEquals(1, firstProgress.getResultCollection().getCurrentSearchResults().size());
+		Assert.assertEquals(1, matcher.getRequestResults().size());
 		Assert.assertEquals("First", firstProgress.getResultCollection().getCurrentSearchResults().get(0).getLocaleName());
 
 		TestSearchApi secondApi = new TestSearchApi();
@@ -142,6 +168,25 @@ public class SearchResultSnapshotTest {
 	private static class TestSearchApi extends SearchBaseAPI {
 		TestSearchApi() {
 			super(ObjectType.LOCATION);
+		}
+	}
+
+	private static class TestSearchResult extends SearchResult {
+		private final String extraData;
+
+		TestSearchResult(SearchPhrase phrase, String extraData) {
+			super(phrase);
+			this.extraData = extraData;
+		}
+
+		String getExtraData() {
+			return extraData;
+		}
+
+		@Override
+		public SearchResultFactory getSnapshotResultFactory() {
+			String data = extraData;
+			return phrase -> new TestSearchResult(phrase, data);
 		}
 	}
 }

--- a/OsmAnd/src/net/osmand/plus/search/QuickSearchHelper.java
+++ b/OsmAnd/src/net/osmand/plus/search/QuickSearchHelper.java
@@ -59,6 +59,7 @@ import net.osmand.search.core.SearchCoreFactory.SearchBaseAPI;
 import net.osmand.search.core.SearchPhrase;
 import net.osmand.search.core.SearchPhrase.NameStringMatcher;
 import net.osmand.search.core.SearchResult;
+import net.osmand.search.core.SearchResult.SearchResultFactory;
 import net.osmand.search.core.SearchSettings;
 import net.osmand.search.core.spatial.SpatialTextSearchAPI;
 import net.osmand.shared.gpx.primitives.WptPt;
@@ -481,6 +482,12 @@ public class QuickSearchHelper implements ResourceListener {
 			@NonNull
 			public HistoryEntry getHistoryEntry() {
 				return historyEntry;
+			}
+
+			@Override
+			public SearchResultFactory getSnapshotResultFactory() {
+				HistoryEntry entry = historyEntry;
+				return phrase -> new HistorySearchResult(phrase, entry);
 			}
 		}
 

--- a/OsmAnd/src/net/osmand/plus/search/dialogs/QuickSearchDialogFragment.java
+++ b/OsmAnd/src/net/osmand/plus/search/dialogs/QuickSearchDialogFragment.java
@@ -2457,6 +2457,9 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 
 	private void runCoreSearchInternal(String text, boolean showQuickResult, boolean searchMore,
 	                                   SearchResultListener resultListener, boolean preserveSelectedPoiTypeNames) {
+		SearchResultCollection previousResults = searchMore ? getResultCollection() : null;
+		// The worker reconstructs its own SearchResult instances and rebases them to the new phrase.
+		SearchResultCollectionSnapshot initialResults = previousResults != null ? previousResults.toSnapshot() : null;
 		searchUICore.searchWithProgress(text, showQuickResult, new SearchProgressListener() {
 			@Override
 			public void onSearchStarted(long requestId, SearchPhrase phrase) {
@@ -2484,10 +2487,8 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 							if (paused || cancelPrev || !isCurrentProgressSnapshot(progress)) {
 								return;
 							}
-							SearchResultCollection finalResults = SearchResultCollection.fromSnapshot(
-									progress.getResultCollection());
-							SearchPhrase phrase = finalResults.getPhrase();
-							setResultCollection(finalResults);
+							// API snapshots own the visible results; the final core snapshot also contains PARTIAL_LOCATION.
+							SearchPhrase phrase = progress.getResultCollection().getPhrase();
 							searching = false;
 							if (resultListener == null || resultListener.searchFinished(phrase)) {
 								hideProgressBar();
@@ -2543,7 +2544,7 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 			public boolean isCancelled() {
 				return paused || cancelPrev;
 			}
-		});
+		}, initialResults);
 
 		if (!searchMore) {
 			setResultCollection(null, preserveSelectedPoiTypeNames);

--- a/OsmAnd/src/net/osmand/plus/search/dialogs/QuickSearchDialogFragment.java
+++ b/OsmAnd/src/net/osmand/plus/search/dialogs/QuickSearchDialogFragment.java
@@ -2460,10 +2460,6 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 	private void runCoreSearchInternal(String text, boolean showQuickResult, boolean searchMore,
 	                                   SearchResultListener resultListener, boolean preserveSelectedPoiTypeNames) {
 		searchUICore.search(text, showQuickResult, new ResultMatcher<SearchResult>() {
-			SearchResultCollection regionResultCollection;
-			SearchCoreAPI regionResultApi;
-			List<SearchResult> results = new ArrayList<>();
-
 			@Override
 			public boolean publish(SearchResult object) {
 				if (object.objectType == SEARCH_STARTED) {
@@ -2479,9 +2475,13 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 						}
 						break;
 					case SEARCH_FINISHED:
+						SearchResultCollection finalResults = getProgressResultCollection(object);
 						app.runInUIThread(() -> {
-							if (paused) {
+							if (paused || !isCurrentProgressSnapshot(object.progressSnapshot)) {
 								return;
+							}
+							if (finalResults != null) {
+								setResultCollection(finalResults);
 							}
 							searching = false;
 							if (resultListener == null || resultListener.searchFinished(object.requiredSearchPhrase)) {
@@ -2492,49 +2492,39 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 						});
 						break;
 					case FILTER_FINISHED:
-						if (resultListener != null) {
-							app.runInUIThread(() -> resultListener.publish(searchUICore.getCurrentSearchResult(), false));
+						SearchResultCollection filteredResults = getProgressResultCollection(object);
+						if (resultListener != null && filteredResults != null) {
+							app.runInUIThread(() -> {
+								if (isCurrentProgressSnapshot(object.progressSnapshot)) {
+									resultListener.publish(filteredResults, false);
+								}
+							});
 						}
 						break;
 					case SEARCH_API_FINISHED:
-						SearchCoreAPI searchApi = (SearchCoreAPI) object.object;
-						List<SearchResult> apiResults;
-						SearchPhrase phrase = object.requiredSearchPhrase;
-						SearchCoreAPI regionApi = regionResultApi;
-						SearchResultCollection regionCollection = regionResultCollection;
-						boolean hasRegionCollection = (searchApi == regionApi && regionCollection != null);
-						if (hasRegionCollection) {
-							apiResults = regionCollection.getCurrentSearchResults();
-						} else {
-							apiResults = results;
+						if (isCurrentProgressSnapshot(object.progressSnapshot)) {
+							showApiResults(object.progressSnapshot, resultListener);
+							switch (processTopIndexAfterLoad) {
+								case FILTER:
+									app.runInUIThread(() -> onFilterChipClick());
+									break;
+								case MAP:
+									app.runInUIThread(() -> onShowOnMapButtonClick());
+									break;
+							}
+							processTopIndexAfterLoad = ProcessTopIndex.NO;
 						}
-						regionResultApi = null;
-						regionResultCollection = null;
-						results = new ArrayList<>();
-						showApiResults(searchApi, apiResults, phrase, hasRegionCollection, resultListener);
-						switch (processTopIndexAfterLoad) {
-							case FILTER:
-								app.runInUIThread(() -> onFilterChipClick());
-								break;
-							case MAP:
-								app.runInUIThread(() -> onShowOnMapButtonClick());
-								break;
-						}
-						processTopIndexAfterLoad = ProcessTopIndex.NO;
 						break;
 					case SEARCH_API_REGION_FINISHED:
-						regionResultApi = (SearchCoreAPI) object.object;
-						SearchPhrase regionPhrase = object.requiredSearchPhrase;
-						boolean spatialSearchApi = isSpatialSearchApi(regionResultApi);
-						regionResultCollection = new SearchResultCollection(regionPhrase, spatialSearchApi)
-								.addSearchResults(results, !spatialSearchApi, true);
-						showRegionResults(object.file, regionPhrase, regionResultCollection, resultListener);
+						if (isCurrentProgressSnapshot(object.progressSnapshot)) {
+							showRegionResults(object.progressSnapshot, resultListener);
+						}
 						break;
 					case PARTIAL_LOCATION:
 						showLocationToolbar();
 						break;
 					default:
-						results.add(object);
+						break;
 				}
 
 				return true;
@@ -2555,6 +2545,18 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 		}
 	}
 
+	@Nullable
+	private SearchResultCollection getProgressResultCollection(@NonNull SearchResult event) {
+		SearchResultProgressSnapshot progress = event.progressSnapshot;
+		return isCurrentProgressSnapshot(progress)
+				? SearchResultCollection.fromSnapshot(progress.getResultCollection())
+				: null;
+	}
+
+	private boolean isCurrentProgressSnapshot(@Nullable SearchResultProgressSnapshot progress) {
+		return progress != null && searchUICore.isCurrentSearchRequest(progress.getRequestId());
+	}
+
 	private void showLocationToolbar() {
 		app.runInUIThread(() -> {
 			foundPartialLocation = true;
@@ -2564,90 +2566,49 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 		});
 	}
 
-	private void showApiResults(SearchCoreAPI searchApi,
-	                            List<SearchResult> apiResults,
-	                            SearchPhrase phrase,
-	                            boolean hasRegionCollection,
-	                            SearchResultListener resultListener) {
+	private void showApiResults(@NonNull SearchResultProgressSnapshot progress,
+	                            @Nullable SearchResultListener resultListener) {
+		SearchCoreAPI searchApi = progress.getSearchApi();
+		SearchResultCollection resultCollection = SearchResultCollection.fromSnapshot(progress.getResultCollection());
+		SearchPhrase phrase = resultCollection.getPhrase();
 		CompletableFuture.runAsync(() -> {
-			if (!paused && !cancelPrev) {
+			if (!paused && !cancelPrev && isCurrentProgressSnapshot(progress)) {
 				if (isDebugMode) {
-					LOG.info("UI >> Showing API results <" + phrase + "> API=<" + searchApi + "> Results=" + apiResults.size());
+					LOG.info("UI >> Showing API results <" + phrase + "> API=<" + searchApi + "> Results="
+							+ getSearchResultCollectionFormattedSize(resultCollection));
 				}
-				boolean spatialSearchApi = isSpatialSearchApi(searchApi);
-				SearchResultCollection apiCollection = new SearchResultCollection(phrase, spatialSearchApi);
-				apiCollection.addSearchResults(apiResults, !spatialSearchApi, true);
-				boolean append = getResultCollection() != null;
-				if (append) {
-					if (isDebugMode) {
-						LOG.info("UI >> Appending API results <" + phrase + "> API=<" + searchApi + "> Result collection=" + getSearchResultCollectionFormattedSize(getResultCollection()));
-					}
-					setResultCollection(getResultCollection().combineWithCollection(apiCollection,
-							!spatialSearchApi, true));
-					if (isDebugMode) {
-						LOG.info("UI >> API results appended <" + phrase + "> API=<" + searchApi + "> Result collection=" + getSearchResultCollectionFormattedSize(getResultCollection()));
-					}
-				} else {
-					if (isDebugMode) {
-						LOG.info("UI >> Assign API results <" + phrase + "> API=<" + searchApi + ">");
-					}
-					setResultCollection(apiCollection);
-					if (isDebugMode) {
-						LOG.info("UI >> API results assigned <" + phrase + "> API=<" + searchApi + "> Result collection=" + getSearchResultCollectionFormattedSize(getResultCollection()));
-					}
-				}
-				if (!hasRegionCollection && resultListener != null) {
-					resultListener.publish(getResultCollection(), append);
+				setResultCollection(resultCollection);
+				if (!progress.hasPublishedRegionResults() && resultListener != null) {
+					resultListener.publish(resultCollection, progress.shouldAppend());
 				}
 				if (isDebugMode) {
-					LOG.info("UI >> API results shown <" + phrase + "> API=<" + searchApi + "> Results=" + getSearchResultCollectionFormattedSize(getResultCollection()));
+					LOG.info("UI >> API results shown <" + phrase + "> API=<" + searchApi + "> Results="
+							+ getSearchResultCollectionFormattedSize(resultCollection));
 				}
-				displayToastIfAnyImpreciseResults(apiResults);
+				if (progress.hasImpreciseResults()) {
+					app.showToastMessage(R.string.imprecise_coordinates);
+				}
 			}
 		}, app::runInUIThread).join();
 	}
 
-	private boolean isSpatialSearchApi(SearchCoreAPI searchApi) {
-		return searchApi instanceof SpatialTextSearchAPI;
-	}
-
-	private void displayToastIfAnyImpreciseResults(List<SearchResult> apiResults) {
-		for (SearchResult apiResult : apiResults) {
-			if (apiResult.hasImpreciseCoordinates()) {
-				app.showToastMessage(R.string.imprecise_coordinates);
-				break;
-			}
-		}
-	}
-
-	private void showRegionResults(BinaryMapIndexReader region,
-	                               SearchPhrase phrase,
-	                               SearchResultCollection regionResultCollection,
-	                               SearchResultListener resultListener) {
+	private void showRegionResults(@NonNull SearchResultProgressSnapshot progress,
+	                               @Nullable SearchResultListener resultListener) {
+		BinaryMapIndexReader region = progress.getRegion();
+		SearchResultCollection resultCollection = SearchResultCollection.fromSnapshot(progress.getResultCollection());
+		SearchPhrase phrase = resultCollection.getPhrase();
 		CompletableFuture.runAsync(() -> {
-			if (!paused && !cancelPrev) {
+			if (!paused && !cancelPrev && isCurrentProgressSnapshot(progress)) {
 				if (isDebugMode) {
-					LOG.info("UI >> Showing region results <" + phrase + "> Region=<" + region.getFile().getName() + "> Results=" + getSearchResultCollectionFormattedSize(regionResultCollection));
+					LOG.info("UI >> Showing region results <" + phrase + "> Region=<" + region.getFile().getName()
+							+ "> Results=" + getSearchResultCollectionFormattedSize(resultCollection));
 				}
-				if (getResultCollection() != null) {
-					if (isDebugMode) {
-						LOG.info("UI >> Combining region results <" + phrase + "> Region=<" + region.getFile().getName() + "> Result collection=" + getSearchResultCollectionFormattedSize(getResultCollection()));
-					}
-					SearchResultCollection resCollection = getResultCollection().combineWithCollection(regionResultCollection, true, true);
-					if (isDebugMode) {
-						LOG.info("UI >> Region results combined <" + phrase + "> Region=<" + region.getFile().getName() + "> Result collection=" + getSearchResultCollectionFormattedSize(resCollection));
-					}
-					if (resultListener != null) {
-						resultListener.publish(resCollection, true);
-					}
-					if (isDebugMode) {
-						LOG.info("UI >> Region results shown <" + phrase + "> Region=<" + region.getFile().getName() + "> Results=" + getSearchResultCollectionFormattedSize(resCollection));
-					}
-				} else if (resultListener != null) {
-					resultListener.publish(regionResultCollection, false);
-					if (isDebugMode) {
-						LOG.info("UI >> Region results shown <" + phrase + "> Region=<" + region.getFile().getName() + "> Results=" + getSearchResultCollectionFormattedSize(regionResultCollection));
-					}
+				if (resultListener != null) {
+					resultListener.publish(resultCollection, progress.shouldAppend());
+				}
+				if (isDebugMode) {
+					LOG.info("UI >> Region results shown <" + phrase + "> Region=<" + region.getFile().getName()
+							+ "> Results=" + getSearchResultCollectionFormattedSize(resultCollection));
 				}
 			}
 		}, app::runInUIThread).join();

--- a/OsmAnd/src/net/osmand/plus/search/dialogs/QuickSearchDialogFragment.java
+++ b/OsmAnd/src/net/osmand/plus/search/dialogs/QuickSearchDialogFragment.java
@@ -40,7 +40,6 @@ import com.google.android.material.tabs.TabLayout;
 
 import net.osmand.Location;
 import net.osmand.PlatformUtil;
-import net.osmand.ResultMatcher;
 import net.osmand.binary.BinaryMapIndexReader;
 import net.osmand.data.*;
 import net.osmand.map.WorldRegion;
@@ -2459,77 +2458,81 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 
 	private void runCoreSearchInternal(String text, boolean showQuickResult, boolean searchMore,
 	                                   SearchResultListener resultListener, boolean preserveSelectedPoiTypeNames) {
-		searchUICore.search(text, showQuickResult, new ResultMatcher<SearchResult>() {
+		searchUICore.searchWithProgress(text, showQuickResult, new SearchProgressListener() {
 			@Override
-			public boolean publish(SearchResult object) {
-				if (object.objectType == SEARCH_STARTED) {
-					cancelPrev = false;
+			public void onSearchStarted(long requestId, SearchPhrase phrase) {
+				if (!searchUICore.isCurrentSearchRequest(requestId)) {
+					return;
 				}
-				if (paused || cancelPrev) {
-					return false;
-				}
-				switch (object.objectType) {
-					case SEARCH_STARTED:
-						if (resultListener != null) {
-							app.runInUIThread(() -> resultListener.searchStarted(object.requiredSearchPhrase));
+				cancelPrev = false;
+				if (!paused && resultListener != null) {
+					app.runInUIThread(() -> {
+						if (!paused && searchUICore.isCurrentSearchRequest(requestId)) {
+							resultListener.searchStarted(phrase);
 						}
-						break;
+					});
+				}
+			}
+
+			@Override
+			public void onProgress(SearchResultProgressSnapshot progress) {
+				if (paused || cancelPrev || !isCurrentProgressSnapshot(progress)) {
+					return;
+				}
+				switch (progress.getStage()) {
 					case SEARCH_FINISHED:
-						SearchResultCollection finalResults = getProgressResultCollection(object);
+						SearchResultCollection finalResults = getProgressResultCollection(progress);
+						SearchPhrase phrase = progress.getResultCollection().getPhrase();
 						app.runInUIThread(() -> {
-							if (paused || !isCurrentProgressSnapshot(object.progressSnapshot)) {
+							if (paused || !isCurrentProgressSnapshot(progress)) {
 								return;
 							}
 							if (finalResults != null) {
 								setResultCollection(finalResults);
 							}
 							searching = false;
-							if (resultListener == null || resultListener.searchFinished(object.requiredSearchPhrase)) {
+							if (resultListener == null || resultListener.searchFinished(phrase)) {
 								hideProgressBar();
-								SearchPhrase phrase = object.requiredSearchPhrase;
 								onSearchFinished(phrase);
 							}
 						});
 						break;
 					case FILTER_FINISHED:
-						SearchResultCollection filteredResults = getProgressResultCollection(object);
+						SearchResultCollection filteredResults = getProgressResultCollection(progress);
 						if (resultListener != null && filteredResults != null) {
 							app.runInUIThread(() -> {
-								if (isCurrentProgressSnapshot(object.progressSnapshot)) {
+								if (isCurrentProgressSnapshot(progress)) {
 									resultListener.publish(filteredResults, false);
 								}
 							});
 						}
 						break;
-					case SEARCH_API_FINISHED:
-						if (isCurrentProgressSnapshot(object.progressSnapshot)) {
-							showApiResults(object.progressSnapshot, resultListener);
-							switch (processTopIndexAfterLoad) {
-								case FILTER:
-									app.runInUIThread(() -> onFilterChipClick());
-									break;
-								case MAP:
-									app.runInUIThread(() -> onShowOnMapButtonClick());
-									break;
-							}
-							processTopIndexAfterLoad = ProcessTopIndex.NO;
+					case API_FINISHED:
+						showApiResults(progress, resultListener);
+						switch (processTopIndexAfterLoad) {
+							case FILTER:
+								app.runInUIThread(() -> onFilterChipClick());
+								break;
+							case MAP:
+								app.runInUIThread(() -> onShowOnMapButtonClick());
+								break;
 						}
+						processTopIndexAfterLoad = ProcessTopIndex.NO;
 						break;
-					case SEARCH_API_REGION_FINISHED:
-						if (isCurrentProgressSnapshot(object.progressSnapshot)) {
-							showRegionResults(object.progressSnapshot, resultListener);
-						}
-						break;
-					case PARTIAL_LOCATION:
-						showLocationToolbar();
+					case REGION_FINISHED:
+						showRegionResults(progress, resultListener);
 						break;
 					default:
 						break;
 				}
-
-				return true;
 			}
 
+			@Override
+			public void onPartialLocation(long requestId, SearchPhrase phrase) {
+				if (!paused && !cancelPrev && searchUICore.isCurrentSearchRequest(requestId)) {
+					showLocationToolbar();
+				}
+			}
 
 			@Override
 			public boolean isCancelled() {
@@ -2546,8 +2549,7 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 	}
 
 	@Nullable
-	private SearchResultCollection getProgressResultCollection(@NonNull SearchResult event) {
-		SearchResultProgressSnapshot progress = event.progressSnapshot;
+	private SearchResultCollection getProgressResultCollection(@NonNull SearchResultProgressSnapshot progress) {
 		return isCurrentProgressSnapshot(progress)
 				? SearchResultCollection.fromSnapshot(progress.getResultCollection())
 				: null;

--- a/OsmAnd/src/net/osmand/plus/search/dialogs/QuickSearchDialogFragment.java
+++ b/OsmAnd/src/net/osmand/plus/search/dialogs/QuickSearchDialogFragment.java
@@ -105,7 +105,6 @@ import net.osmand.util.RegionCodeUtils;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
 
 public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment implements OsmAndCompassListener,
 		OsmAndLocationListener, DownloadEvents, OnPreferenceChanged {
@@ -2467,7 +2466,7 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 				cancelPrev = false;
 				if (!paused && resultListener != null) {
 					app.runInUIThread(() -> {
-						if (!paused && searchUICore.isCurrentSearchRequest(requestId)) {
+						if (!paused && !cancelPrev && searchUICore.isCurrentSearchRequest(requestId)) {
 							resultListener.searchStarted(phrase);
 						}
 					});
@@ -2481,15 +2480,14 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 				}
 				switch (progress.getStage()) {
 					case SEARCH_FINISHED:
-						SearchResultCollection finalResults = getProgressResultCollection(progress);
-						SearchPhrase phrase = progress.getResultCollection().getPhrase();
 						app.runInUIThread(() -> {
-							if (paused || !isCurrentProgressSnapshot(progress)) {
+							if (paused || cancelPrev || !isCurrentProgressSnapshot(progress)) {
 								return;
 							}
-							if (finalResults != null) {
-								setResultCollection(finalResults);
-							}
+							SearchResultCollection finalResults = SearchResultCollection.fromSnapshot(
+									progress.getResultCollection());
+							SearchPhrase phrase = finalResults.getPhrase();
+							setResultCollection(finalResults);
 							searching = false;
 							if (resultListener == null || resultListener.searchFinished(phrase)) {
 								hideProgressBar();
@@ -2498,10 +2496,11 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 						});
 						break;
 					case FILTER_FINISHED:
-						SearchResultCollection filteredResults = getProgressResultCollection(progress);
-						if (resultListener != null && filteredResults != null) {
+						if (resultListener != null) {
 							app.runInUIThread(() -> {
-								if (isCurrentProgressSnapshot(progress)) {
+								if (!paused && !cancelPrev && isCurrentProgressSnapshot(progress)) {
+									SearchResultCollection filteredResults = SearchResultCollection.fromSnapshot(
+											progress.getResultCollection());
 									resultListener.publish(filteredResults, false);
 								}
 							});
@@ -2511,10 +2510,18 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 						showApiResults(progress, resultListener);
 						switch (processTopIndexAfterLoad) {
 							case FILTER:
-								app.runInUIThread(() -> onFilterChipClick());
+								app.runInUIThread(() -> {
+									if (!paused && !cancelPrev && isCurrentProgressSnapshot(progress)) {
+										onFilterChipClick();
+									}
+								});
 								break;
 							case MAP:
-								app.runInUIThread(() -> onShowOnMapButtonClick());
+								app.runInUIThread(() -> {
+									if (!paused && !cancelPrev && isCurrentProgressSnapshot(progress)) {
+										onShowOnMapButtonClick();
+									}
+								});
 								break;
 						}
 						processTopIndexAfterLoad = ProcessTopIndex.NO;
@@ -2529,9 +2536,7 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 
 			@Override
 			public void onPartialLocation(long requestId, SearchPhrase phrase) {
-				if (!paused && !cancelPrev && searchUICore.isCurrentSearchRequest(requestId)) {
-					showLocationToolbar();
-				}
+				showLocationToolbar(requestId);
 			}
 
 			@Override
@@ -2548,19 +2553,15 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 		}
 	}
 
-	@Nullable
-	private SearchResultCollection getProgressResultCollection(@NonNull SearchResultProgressSnapshot progress) {
-		return isCurrentProgressSnapshot(progress)
-				? SearchResultCollection.fromSnapshot(progress.getResultCollection())
-				: null;
-	}
-
 	private boolean isCurrentProgressSnapshot(@Nullable SearchResultProgressSnapshot progress) {
 		return progress != null && searchUICore.isCurrentSearchRequest(progress.getRequestId());
 	}
 
-	private void showLocationToolbar() {
+	private void showLocationToolbar(long requestId) {
 		app.runInUIThread(() -> {
+			if (paused || cancelPrev || !searchUICore.isCurrentSearchRequest(requestId)) {
+				return;
+			}
 			foundPartialLocation = true;
 			if (isAdded()) {
 				updateToolbarButton();
@@ -2570,11 +2571,12 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 
 	private void showApiResults(@NonNull SearchResultProgressSnapshot progress,
 	                            @Nullable SearchResultListener resultListener) {
-		SearchCoreAPI searchApi = progress.getSearchApi();
-		SearchResultCollection resultCollection = SearchResultCollection.fromSnapshot(progress.getResultCollection());
-		SearchPhrase phrase = resultCollection.getPhrase();
-		CompletableFuture.runAsync(() -> {
+		app.runInUIThread(() -> {
 			if (!paused && !cancelPrev && isCurrentProgressSnapshot(progress)) {
+				SearchCoreAPI searchApi = progress.getSearchApi();
+				SearchResultCollection resultCollection = SearchResultCollection.fromSnapshot(
+						progress.getResultCollection());
+				SearchPhrase phrase = resultCollection.getPhrase();
 				if (isDebugMode) {
 					LOG.info("UI >> Showing API results <" + phrase + "> API=<" + searchApi + "> Results="
 							+ getSearchResultCollectionFormattedSize(resultCollection));
@@ -2591,16 +2593,17 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 					app.showToastMessage(R.string.imprecise_coordinates);
 				}
 			}
-		}, app::runInUIThread).join();
+		});
 	}
 
 	private void showRegionResults(@NonNull SearchResultProgressSnapshot progress,
 	                               @Nullable SearchResultListener resultListener) {
-		BinaryMapIndexReader region = progress.getRegion();
-		SearchResultCollection resultCollection = SearchResultCollection.fromSnapshot(progress.getResultCollection());
-		SearchPhrase phrase = resultCollection.getPhrase();
-		CompletableFuture.runAsync(() -> {
+		app.runInUIThread(() -> {
 			if (!paused && !cancelPrev && isCurrentProgressSnapshot(progress)) {
+				BinaryMapIndexReader region = progress.getRegion();
+				SearchResultCollection resultCollection = SearchResultCollection.fromSnapshot(
+						progress.getResultCollection());
+				SearchPhrase phrase = resultCollection.getPhrase();
 				if (isDebugMode) {
 					LOG.info("UI >> Showing region results <" + phrase + "> Region=<" + region.getFile().getName()
 							+ "> Results=" + getSearchResultCollectionFormattedSize(resultCollection));
@@ -2613,7 +2616,7 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 							+ "> Results=" + getSearchResultCollectionFormattedSize(resultCollection));
 				}
 			}
-		}, app::runInUIThread).join();
+		});
 	}
 
 	private String getSearchResultCollectionFormattedSize(@Nullable SearchResultCollection resultCollection) {


### PR DESCRIPTION
## Summary

This PR refactors the search result data flow to establish clear ownership between `SearchUICore` and the Quick Search UI.

## Problem

Spatial search introduced incremental API and region updates. Search worker and UI code could operate on the same mutable `SearchResult` instances and collections concurrently. This could violate the comparator contract during sorting.

PR #25697 prevented the crash by blocking the search worker until UI processing finished, but it was a synchronization workaround rather than an ownership fix.

## Solution

- Make `SearchUICore` the owner of search result aggregation.
- Introduce immutable, request-scoped result collection snapshots.
- Add a typed `SearchProgressListener` for lifecycle and progress events.
- Stop exposing mutable worker-owned `SearchResult` instances to Quick Search.
- Recreate independent UI-owned result copies from snapshots.
- Preserve specialized result subtypes such as history results.
- Validate queued UI callbacks using their search request ID.
- Remove the blocking `CompletableFuture.join()` UI handoff.
- Preserve `PARTIAL_LOCATION` in final results while excluding it from intermediate API snapshots.

Legacy `ResultMatcher` consumers continue receiving the existing control events.

## Expected result

- Search worker and UI no longer share mutable search result collections.
- Incremental spatial search updates remain ordered.
- Stale results from cancelled searches or map pan/zoom requests are ignored.
- Sorting no longer depends on cross-thread synchronization.
- The search worker no longer waits for UI processing.

## Testing

- `OsmAnd-java:test`
- General search
- Spatial search
- Incremental region results
- Rapid query changes and cancellation
- Map pan/zoom during search
- Show on map
- Search more
- History results
- Partial-location results