### PR TITLE
Fix smart folder list filter counters

### DIFF
--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/SmartFolderHelper.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/SmartFolderHelper.kt
@@ -258,20 +258,25 @@ class SmartFolderHelper {
 	}
 
 	fun addTrackItemToSmartFolder(item: TrackItem) {
-		val newSet = allAvailableTrackItems
-		newSet.add(item)
-		allAvailableTrackItems = newSet
+		replaceAvailableTrackItems(listOf(item))
 		addTracksToSmartFolders(arrayListOf(item), smartFolderCollection)
 	}
 
 	fun addTrackItemsToSmartFolder(items: List<TrackItem>) {
+		replaceAvailableTrackItems(items)
 		if (smartFolderCollection.isEmpty()) {
 			return
 		}
-		val newSet = allAvailableTrackItems
-		newSet.addAll(items)
-		allAvailableTrackItems = newSet
 		addTracksToSmartFolders(items, smartFolderCollection)
+	}
+
+	private fun replaceAvailableTrackItems(items: List<TrackItem>) {
+		val newSet = HashSet(allAvailableTrackItems)
+		for (item in items) {
+			newSet.remove(item)
+			newSet.add(item)
+		}
+		allAvailableTrackItems = newSet
 	}
 
 	private fun addTracksToSmartFolders(items: List<TrackItem>, smartFolders: List<SmartFolder>) {

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/data/SmartFolder.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/data/SmartFolder.kt
@@ -56,18 +56,24 @@ class SmartFolder(@Serializable var folderName: String) : TracksGroup, Comparabl
 	}
 
 	/**
-	 * Ensures the track is present in the folder and forces a cache update.
+	 * Ensures the latest track instance is present in the folder and forces a cache update.
 	 * Since [TrackItem] is mutable, its properties (e.g., Activity) might have changed
 	 * even if it's already in the list, requiring a re-evaluation of organized groups.
 	 */
 	fun addTrackItem(trackItem: TrackItem, forceInvalidate: Boolean = false) {
-		var added = false
+		var changed = false
 		val currentItems = getTrackItems()
-		if (!currentItems.contains(trackItem)) {
+		val index = currentItems.indexOf(trackItem)
+		if (index == -1) {
 			trackItems = KCollectionUtils.addToList(currentItems, trackItem)
-			added = true
+			changed = true
+		} else if (currentItems[index] !== trackItem) {
+			val updatedItems = ArrayList(currentItems)
+			updatedItems[index] = trackItem
+			trackItems = updatedItems
+			changed = true
 		}
-		if (added || forceInvalidate) {
+		if (changed || forceInvalidate) {
 			invalidateCache()
 		}
 	}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/filters/ListTrackFilter.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/filters/ListTrackFilter.kt
@@ -2,8 +2,6 @@ package net.osmand.shared.gpx.filters
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
-import net.osmand.shared.data.StringIntPair
-import net.osmand.shared.gpx.GpxParameter
 import net.osmand.shared.gpx.TrackItem
 import net.osmand.shared.util.KAlgorithms
 import net.osmand.shared.util.SerialNames
@@ -34,17 +32,7 @@ open class ListTrackFilter : BaseTrackFilter {
 		}
 
 	fun updateFullCollection(items: List<TrackItem>?) {
-		if (KAlgorithms.isEmpty(items)) {
-			allItemsCollection = HashMap()
-		} else {
-			val newCollection = HashMap<String, Int>()
-			for (item in items!!) {
-				val folderName = item.dataItem?.getParameter(GpxParameter.FILE_DIR) ?: ""
-				val count = newCollection[folderName] ?: 0
-				newCollection[folderName] = count + 1
-			}
-			allItemsCollection = newCollection
-		}
+		allItemsCollection = createItemsCollection(items)
 	}
 
 	override fun isEnabled(): Boolean {
@@ -75,17 +63,35 @@ open class ListTrackFilter : BaseTrackFilter {
 			filterChangedListener?.onFilterChanged()
 		}
 
-	fun setFullItemsCollection(collection: List<StringIntPair>) {
-		val tmpAllItems = ArrayList<String>()
-		val tmpAllItemsCollection = HashMap<String, Int>()
-		for (pair in collection) {
-			if (pair.string != null && pair.integer != null) {
-				tmpAllItems.add(pair.string)
-				tmpAllItemsCollection[pair.string] = pair.integer
+	fun setFullItemsCollection(items: List<TrackItem>?) {
+		val collection = createItemsCollection(items)
+		for (selectedItem in selectedItems) {
+			if (!collection.containsKey(selectedItem)) {
+				collection[selectedItem] = 0
 			}
 		}
-		allItems = tmpAllItems
-		allItemsCollection = tmpAllItemsCollection
+		val sortedEntries = collection.entries.sortedWith { first, second ->
+			val comparison = if (collectionFilterParams.sortByName()) {
+				first.key.compareTo(second.key)
+			} else {
+				first.value.compareTo(second.value)
+			}
+			val directedComparison = if (collectionFilterParams.sortDescending()) -comparison else comparison
+			if (directedComparison != 0) directedComparison else first.key.compareTo(second.key)
+		}
+		allItems = ArrayList(sortedEntries.map { it.key })
+		allItemsCollection = collection
+	}
+
+	private fun createItemsCollection(items: List<TrackItem>?): HashMap<String, Int> {
+		val collection = HashMap<String, Int>()
+		for (item in items.orEmpty()) {
+			val value = getTrackPropertyValue(item)
+			if (value.isNotEmpty() || collectionFilterParams.includeEmptyValues()) {
+				collection[value] = (collection[value] ?: 0) + 1
+			}
+		}
+		return collection
 	}
 
 	fun setSelectedItems(selectedItems: List<String>) {

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/gpx/filters/ListTrackFilterTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/gpx/filters/ListTrackFilterTest.kt
@@ -1,0 +1,111 @@
+package net.osmand.shared.gpx.filters
+
+import net.osmand.shared.gpx.GpxDataItem
+import net.osmand.shared.gpx.GpxParameter
+import net.osmand.shared.gpx.GpxParameter.ACTIVITY_TYPE
+import net.osmand.shared.gpx.GpxParameter.COLOR
+import net.osmand.shared.gpx.GpxParameter.FILE_DIR
+import net.osmand.shared.gpx.GpxParameter.NEAREST_CITY_NAME
+import net.osmand.shared.gpx.TrackItem
+import net.osmand.shared.io.KFile
+import net.osmand.shared.util.KAlgorithms
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ListTrackFilterTest {
+
+	@Test
+	fun activityCollectionUsesTrackItemsAndSortsByCount() {
+		val filter = createListFilter(TrackFilterType.ACTIVITY)
+		val items = listOf(
+			createTrackItem("enduro-1", ACTIVITY_TYPE to "enduro_motorcycle"),
+			createTrackItem("enduro-2", ACTIVITY_TYPE to "enduro_motorcycle"),
+			createTrackItem("hiking", ACTIVITY_TYPE to "hiking"),
+			createTrackItem("unspecified")
+		)
+
+		filter.setFullItemsCollection(items)
+
+		assertEquals(listOf("enduro_motorcycle", "", "hiking"), filter.allItems)
+		assertEquals(2, filter.getTracksCountForItem("enduro_motorcycle"))
+		assertEquals(1, filter.getTracksCountForItem("hiking"))
+		assertEquals(1, filter.getTracksCountForItem(""))
+	}
+
+	@Test
+	fun colorCollectionUsesFilterValueConversion() {
+		val filter = createListFilter(TrackFilterType.COLOR)
+		val color = 0xffe044bb.toInt()
+		val colorName = KAlgorithms.colorToString(color)
+		val item = createTrackItem("colored", COLOR to color)
+
+		filter.setFullItemsCollection(listOf(item))
+		filter.setSelectedItems(listOf(colorName))
+
+		assertEquals(1, filter.getTracksCountForItem(colorName))
+		assertTrue(filter.isTrackAccepted(item))
+	}
+
+	@Test
+	fun cityCollectionExcludesUnspecifiedValues() {
+		val filter = createListFilter(TrackFilterType.CITY)
+		val items = listOf(
+			createTrackItem("unknown-city"),
+			createTrackItem("known-city", NEAREST_CITY_NAME to "Chania")
+		)
+
+		filter.setFullItemsCollection(items)
+
+		assertEquals(listOf("Chania"), filter.allItems)
+		assertFalse(filter.allItemsCollection.containsKey(""))
+	}
+
+	@Test
+	fun scopedUpdateKeepsVariantsAndSelectedItems() {
+		val filter = createListFilter(TrackFilterType.ACTIVITY)
+		val enduro = createTrackItem("enduro", ACTIVITY_TYPE to "enduro_motorcycle")
+		val hiking = createTrackItem("hiking", ACTIVITY_TYPE to "hiking")
+		filter.setFullItemsCollection(listOf(enduro, hiking))
+		filter.setSelectedItems(listOf("hiking"))
+
+		filter.updateFullCollection(listOf(enduro))
+
+		assertEquals(listOf("enduro_motorcycle", "hiking"), filter.allItems)
+		assertTrue(filter.isItemSelected("hiking"))
+		assertEquals(1, filter.getTracksCountForItem("enduro_motorcycle"))
+		assertEquals(0, filter.getTracksCountForItem("hiking"))
+	}
+
+	@Test
+	fun folderCollectionSortsByName() {
+		val filter = createListFilter(TrackFilterType.FOLDER)
+		val items = listOf(
+			createTrackItem("z-1", FILE_DIR to "Zulu"),
+			createTrackItem("z-2", FILE_DIR to "Zulu"),
+			createTrackItem("a", FILE_DIR to "Alpha")
+		)
+
+		filter.setFullItemsCollection(items)
+
+		assertEquals(listOf("Alpha", "Zulu"), filter.allItems)
+	}
+
+	private fun createListFilter(type: TrackFilterType): ListTrackFilter {
+		return TrackFiltersHelper.createFilter(type, null) as ListTrackFilter
+	}
+
+	private fun createTrackItem(
+		name: String,
+		vararg parameters: Pair<GpxParameter, Any?>
+	): TrackItem {
+		val file = KFile("/tracks/$name.gpx")
+		val dataItem = GpxDataItem.fromDatabase(file)
+		dataItem.setParameter(FILE_DIR, "")
+		for ((parameter, value) in parameters) {
+			assertTrue(dataItem.setParameter(parameter, value))
+		}
+		return TrackItem(file).apply { this.dataItem = dataItem }
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/myplaces/tracks/TracksSearchFilter.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/tracks/TracksSearchFilter.java
@@ -9,7 +9,6 @@ import net.osmand.CallbackWithObject;
 import net.osmand.PlatformUtil;
 import net.osmand.plus.OsmAndTaskManager;
 import net.osmand.plus.OsmandApplication;
-import net.osmand.shared.data.StringIntPair;
 import net.osmand.shared.gpx.TrackItem;
 import net.osmand.shared.gpx.data.TrackFolder;
 import net.osmand.shared.gpx.filters.BaseTrackFilter;
@@ -17,7 +16,6 @@ import net.osmand.shared.gpx.filters.DateTrackFilter;
 import net.osmand.shared.gpx.filters.FilterChangedListener;
 import net.osmand.shared.gpx.filters.ListTrackFilter;
 import net.osmand.shared.gpx.filters.RangeTrackFilter;
-import net.osmand.shared.gpx.filters.SingleFieldTrackFilterParams;
 import net.osmand.shared.gpx.filters.TextTrackFilter;
 import net.osmand.shared.gpx.filters.TrackFilterType;
 import net.osmand.shared.gpx.filters.TrackFiltersHelper;
@@ -76,6 +74,7 @@ public class TracksSearchFilter extends Filter implements FilterChangedListener 
 		app.getTaskManager().runInBackground(new OsmAndTaskManager.OsmAndTaskRunnable<Void, Void, Void>() {
 			@Override
 			protected Void doInBackground(Void... voids) {
+				List<TrackItem> trackItemsSnapshot = new ArrayList<>(trackItems);
 				DateTrackFilter dateFilter = (DateTrackFilter) getFilterByType(TrackFilterType.DATE_CREATION);
 				if (dateFilter != null) {
 					long minDate = app.getGpxDbHelper().getTracksMinCreateDate();
@@ -91,14 +90,7 @@ public class TracksSearchFilter extends Filter implements FilterChangedListener 
 						case SINGLE_FIELD_LIST -> {
 							ListTrackFilter filter = (ListTrackFilter) getFilterByType(trackFilterType);
 							if (filter != null) {
-								SingleFieldTrackFilterParams filterParams = (SingleFieldTrackFilterParams) trackFilterType.getAdditionalData();
-								List<StringIntPair> items = app.getGpxDbHelper().getStringIntItemsCollection(
-										trackFilterType.getProperty().getColumnName(),
-										filterParams.includeEmptyValues(),
-										filterParams.sortByName(),
-										filterParams.sortDescending()
-								);
-								filter.setFullItemsCollection(items);
+								filter.setFullItemsCollection(trackItemsSnapshot);
 								if (trackFilterType == TrackFilterType.FOLDER) {
 									if (currentFolder != null) {
 										filter.setFirstItem(currentFolder.getRelativePath());
@@ -178,19 +170,13 @@ public class TracksSearchFilter extends Filter implements FilterChangedListener 
 			results.values = res;
 			results.count = res.size();
 		}
-		ListTrackFilter folderFilter = (ListTrackFilter) getFilterByType(TrackFilterType.FOLDER);
-		if (folderFilter != null) {
-			if (Algorithms.isEmpty(filterSpecificSearchResults)) {
-				List<StringIntPair> items = app.getGpxDbHelper().getStringIntItemsCollection(
-						folderFilter.getTrackFilterType().getProperty().getColumnName(),
-						folderFilter.getCollectionFilterParams().includeEmptyValues(),
-						folderFilter.getCollectionFilterParams().sortByName(),
-						folderFilter.getCollectionFilterParams().sortDescending()
-				);
-				folderFilter.setFullItemsCollection(items);
-			} else {
-				List<TrackItem> ignoreFoldersItems = filterSpecificSearchResults.get(TrackFilterType.FOLDER);
-				folderFilter.updateFullCollection(ignoreFoldersItems);
+		for (BaseTrackFilter filter : currentFilters) {
+			if (filter instanceof ListTrackFilter listFilter) {
+				listFilter.setFullItemsCollection(trackItems);
+				if (filterCount > 0) {
+					List<TrackItem> filterItems = filterSpecificSearchResults.get(filter.getTrackFilterType());
+					listFilter.updateFullCollection(filterItems);
+				}
 			}
 		}
 		LOG.debug("found " + results.count + " tracks");
@@ -327,4 +313,3 @@ public class TracksSearchFilter extends Filter implements FilterChangedListener 
 		return new HashMap<>(filterSpecificSearchResults);
 	}
 }
-

--- a/OsmAnd/src/net/osmand/plus/myplaces/tracks/filters/FiltersAdapter.kt
+++ b/OsmAnd/src/net/osmand/plus/myplaces/tracks/filters/FiltersAdapter.kt
@@ -102,7 +102,7 @@ class FiltersAdapter(
 
 	fun onTracksFilteringComplete() {
 		for (i in 0 until items.size) {
-			if (items[i].trackFilterType.updateOnOtherFiltersChangeNeeded) {
+			if (items[i] is ListTrackFilter || items[i].trackFilterType.updateOnOtherFiltersChangeNeeded) {
 				notifyItemChanged(i)
 			}
 		}


### PR DESCRIPTION
Fixes #24890.

### Summary

Smart Folder counters for Activity, Color, Width, City, and Folder were initialized from raw `gpxTable` rows, while filtering results were calculated from loaded `TrackItem`s.

Duplicate or stale database rows could therefore make filter counters larger than the actual number of tracks.

### Changes

- Calculate list-filter values and counters from `TrackItem`s.
- Generalize counter aggregation to use each filter’s property and value conversion.
- Recalculate scoped counters for every list filter, not only Folder.
- Refresh all list-filter rows after filtering.
- Preserve available variants and selected values when scoped counts change.
- Add tests for activity, color, city, folder, unspecified values, ordering, and scoped updates.

### Scope

This PR does not change the GPX database schema or migrate duplicate rows. It makes the filter UI use the same source of truth as the displayed track results.