### PR TITLE
Fix running tests on newer Android emulators

### DIFF
--- a/OsmAnd/build-common.gradle
+++ b/OsmAnd/build-common.gradle
@@ -445,12 +445,12 @@ dependencies {
 
 	//implementation "androidx.tracing:tracing:1.1.0"
 	//debugImplementation 'androidx.test:monitor:1.6.1'
-	androidTestImplementation "androidx.test:runner:1.5.2"
-	androidTestImplementation "androidx.test:rules:1.5.0"
-	androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+	androidTestImplementation "androidx.test:runner:1.7.0"
+	androidTestImplementation "androidx.test:rules:1.7.0"
+	androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 	//debugImplementation("androidx.test:core:1.5.0")
-	androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-	androidTestImplementation ('androidx.test.espresso:espresso-contrib:3.5.1') {
+	androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+	androidTestImplementation ('androidx.test.espresso:espresso-contrib:3.7.0') {
 		exclude module: "protobuf-lite"
 	}
 	implementation 'com.facebook.shimmer:shimmer:0.5.0@aar'


### PR DESCRIPTION
Previously it failed with `java.lang.NoSuchMethodException: android.hardware.input.InputManager.getInstance []`.

For me most tests still fail and I'm unsure which of these should not fail:

```
> Task :OsmAnd:connectedAndroidFullLegacyArm64DebugAndroidTest
Starting 11 tests on Medium_Phone(AVD) - 17

Medium_Phone(AVD) - 17 Tests 5/11 completed. (0 skipped) (0 failed)

> Task :OsmAnd:connectedAndroidFullLegacyArm64DebugAndroidTest

net.osmand.test.ui.map.CleanGpxLayerResourcesTest > test[Medium_Phone(AVD) - 17] [31mFAILED [0m
	java.lang.AssertionError: Cached segments didn't updated. Actual: -1032054530
	at org.junit.Assert.fail(Assert.java:89)

Medium_Phone(AVD) - 17 Tests 6/11 completed. (0 skipped) (1 failed)

> Task :OsmAnd:connectedAndroidFullLegacyArm64DebugAndroidTest

net.osmand.test.ui.map.POIClickTest > testClickOnMApPoint[Medium_Phone(AVD) - 17] [31mFAILED [0m
	java.lang.AssertionError: expected:<4> but was:<10>
	at org.junit.Assert.fail(Assert.java:89)

> Task :OsmAnd:connectedAndroidFullLegacyArm64DebugAndroidTest

net.osmand.test.ui.navigation.CrosswalkWarningTooEarlyTest > crosswalkWarningTooEarlyTest[Medium_Phone(AVD) - 17] [31mFAILED [0m
	java.lang.RuntimeException: java.io.FileNotFoundException: alarm_test.obf
	at net.osmand.test.ui.navigation.CrosswalkWarningTooEarlyTest.setup(CrosswalkWarningTooEarlyTest.java:60)

Medium_Phone(AVD) - 17 Tests 8/11 completed. (0 skipped) (3 failed)

> Task :OsmAnd:connectedAndroidFullLegacyArm64DebugAndroidTest

net.osmand.test.ui.navigation.GPXTrackAnalysisUpdatesTest > test[Medium_Phone(AVD) - 17] [31mFAILED [0m
	java.lang.RuntimeException: java.util.concurrent.ExecutionException: java.lang.AssertionError: Failed to get map renderer
	at androidx.test.espresso.Espresso.onIdle(Espresso.java:357)

Medium_Phone(AVD) - 17 Tests 9/11 completed. (0 skipped) (4 failed)

> Task :OsmAnd:connectedAndroidFullLegacyArm64DebugAndroidTest

net.osmand.test.ui.navigation.RouteRecalculationFromBeginningTest > test[Medium_Phone(AVD) - 17] [31mFAILED [0m
	androidx.test.espresso.AppNotIdleException: Looped for 4599 iterations over 60 SECONDS. The following Idle Conditions failed MAIN_LOOPER_HAS_IDLED(last message: { when=-11ms callback=net.osmand.plus.views.OsmandMapTileView$$ExternalSyntheticLambda4 target=android.os.Handler async=false heapIndex=-1 }).
	at androidx.test.espresso.IdlingPolicy.handleTimeout(IdlingPolicy.java:61)

Medium_Phone(AVD) - 17 Tests 10/11 completed. (0 skipped) (5 failed)

> Task :OsmAnd:connectedAndroidFullLegacyArm64DebugAndroidTest

net.osmand.test.ui.poi.EditPoiTypeSuggestionsTest > testPoiTypeSuggestions[Medium_Phone(AVD) - 17] [31mFAILED [0m
	androidx.test.espresso.PerformException: Error performing 'single click - At Coordinates: 581, 460 and precision: 16, 16' on view 'first matching item(view.getId() is <2131298305/net.osmand.plus:id/poiTypeEditText> and view has effective visibility <VISIBLE>)'.
	at androidx.test.espresso.PerformException$Builder.build(PerformException.java:86)
Tests on Medium_Phone(AVD) - 17 failed: There was 6 failure(s).

Finished 11 tests on Medium_Phone(AVD) - 17

> Task :OsmAnd:connectedAndroidFullLegacyArm64DebugAndroidTest FAILED
```