### PR TITLE
Fix custom OBF filename collisions caused by version normalization

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/util/Algorithms.java
+++ b/OsmAnd-java/src/main/java/net/osmand/util/Algorithms.java
@@ -275,6 +275,21 @@ public class Algorithms {
 		return name;
 	}
 
+	/**
+	 * Removes a trailing {@code _<integer>} version segment immediately before a file extension or at the end of a name.
+	 */
+	public static String removeFileVersionSuffix(String fileName) {
+		int separatorIndex = fileName.lastIndexOf('_');
+		if (separatorIndex >= 0) {
+			int extensionIndex = fileName.indexOf('.', separatorIndex + 1);
+			int suffixEnd = extensionIndex >= 0 ? extensionIndex : fileName.length();
+			if (separatorIndex + 1 < suffixEnd && isInt(fileName.substring(separatorIndex + 1, suffixEnd))) {
+				return fileName.substring(0, separatorIndex) + fileName.substring(suffixEnd);
+			}
+		}
+		return fileName;
+	}
+
 	public static String getFileExtension(File f) {
 		return getFileNameExtension(f.getName());
 	}

--- a/OsmAnd/src/net/osmand/plus/download/DownloadActivityType.java
+++ b/OsmAnd/src/net/osmand/plus/download/DownloadActivityType.java
@@ -527,11 +527,7 @@ public class DownloadActivityType {
 					+ IndexConstants.STAR_MAP_INDEX_EXT;
 		} else if (fileName.endsWith(IndexConstants.BINARY_MAP_INDEX_EXT)
 				|| fileName.endsWith(IndexConstants.BINARY_MAP_INDEX_EXT_ZIP)) {
-			int l = fileName.lastIndexOf('_');
-			if (l == -1) {
-				l = fileName.length();
-			}
-			String baseNameWithoutVersion = fileName.substring(0, l);
+			String baseNameWithoutVersion = getBasenameWithoutVersion(fileName);
 			if (this == SRTM_COUNTRY_FILE) {
 				return baseNameWithoutVersion + SrtmDownloadItem.getExtension(item);
 			}
@@ -618,13 +614,14 @@ public class DownloadActivityType {
 			return fileName.substring(0, fileName.length() - WEATHER_MAP_INDEX_EXT.length())
 					.replace(FileNameTranslationHelper.WEATHER + "_", "");
 		}
-		int ls = fileName.lastIndexOf('_');
-		if (ls >= 0) {
-			return fileName.substring(0, ls);
-		} else if (fileName.indexOf('.') > 0) {
-			return fileName.substring(0, fileName.indexOf('.'));
-		}
-		return fileName;
+		return getBasenameWithoutVersion(fileName);
+	}
+
+	@NonNull
+	private static String getBasenameWithoutVersion(@NonNull String fileName) {
+		int extensionIndex = fileName.indexOf('.', fileName.lastIndexOf('_') + 1);
+		String basename = extensionIndex > 0 ? fileName.substring(0, extensionIndex) : fileName;
+		return Algorithms.removeFileVersionSuffix(basename);
 	}
 
 	public static boolean isVoiceTTS(@NonNull DownloadItem downloadItem) {

--- a/OsmAnd/src/net/osmand/plus/download/DownloadFileHelper.java
+++ b/OsmAnd/src/net/osmand/plus/download/DownloadFileHelper.java
@@ -318,7 +318,14 @@ public class DownloadFileHelper {
 						fs = de.fileToDownload;
 						first = false;
 					} else {
-						String name = Algorithms.removeFileVersionSuffix(entry.getName());
+						String name = entry.getName();
+						int separatorIndex = name.lastIndexOf('_');
+						if (separatorIndex > 0) {
+							int extensionIndex = name.indexOf('.', separatorIndex);
+							if (extensionIndex > 0) {
+								name = Algorithms.removeFileVersionSuffix(name);
+							}
+						}
 						fs = new File(de.fileToDownload.getParent(), name);
 					}
 				} else {

--- a/OsmAnd/src/net/osmand/plus/download/DownloadFileHelper.java
+++ b/OsmAnd/src/net/osmand/plus/download/DownloadFileHelper.java
@@ -318,16 +318,7 @@ public class DownloadFileHelper {
 						fs = de.fileToDownload;
 						first = false;
 					} else {
-						String name = entry.getName();
-						// small simplification
-						int ind = name.lastIndexOf('_');
-						if (ind > 0) {
-							// cut version
-							int i = name.indexOf('.', ind);
-							if (i > 0) {
-								name = name.substring(0, ind) + name.substring(i);
-							}
-						}
+						String name = Algorithms.removeFileVersionSuffix(entry.getName());
 						fs = new File(de.fileToDownload.getParent(), name);
 					}
 				} else {

--- a/OsmAnd/src/net/osmand/plus/download/DownloadResources.java
+++ b/OsmAnd/src/net/osmand/plus/download/DownloadResources.java
@@ -50,6 +50,7 @@ public class DownloadResources extends DownloadResourceGroup {
 	public boolean downloadFromInternetFailed;
 	public boolean mapVersionIsIncreased;
 	private List<IndexItem> rawResources;
+	private List<IndexItem> customResources = Collections.emptyList();
 	private Map<WorldRegion, List<IndexItem>> groupByRegion;
 	private OutdatedIndexesCollection outdatedItems = OutdatedIndexesCollection.emptyInstance();
 
@@ -181,6 +182,14 @@ public class DownloadResources extends DownloadResourceGroup {
 				outdatedItems = OutdatedIndexesCollector.collect(app, filtered, deprecatedItems);
 			}
 		}
+		updateCustomDownloadedFiles();
+	}
+
+	private void updateCustomDownloadedFiles() {
+		List<IndexItem> customItems = customResources;
+		for (IndexItem item : customItems) {
+			item.setDownloaded(item.getTargetFile(app).exists());
+		}
 	}
 
 	protected void updateOutdatedFiles() {
@@ -194,6 +203,7 @@ public class DownloadResources extends DownloadResourceGroup {
 
 	protected boolean prepareData(List<IndexItem> resources) {
 		this.rawResources = resources;
+		List<IndexItem> customResources = new ArrayList<>();
 
 		DownloadResourceGroup deprecatedMapsGroup = new DownloadResourceGroup(this, DownloadResourceGroupType.DELETED_MAPS);
 		addGroup(deprecatedMapsGroup);
@@ -324,7 +334,7 @@ public class DownloadResources extends DownloadResourceGroup {
 		if (!Algorithms.isEmpty(customRegions)) {
 			addGroup(extraMapsGroup);
 			for (WorldRegion region : customRegions) {
-				buildRegionsGroups(region, extraMapsGroup);
+				buildRegionsGroups(region, extraMapsGroup, customResources);
 			}
 		}
 
@@ -401,6 +411,7 @@ public class DownloadResources extends DownloadResourceGroup {
 		replaceIndividualSrtmWithGroups(region);
 		createMultipleDownloadItems(region);
 		trimEmptyGroups();
+		this.customResources = Collections.unmodifiableList(customResources);
 		updateLoadedFiles();
 		return true;
 	}
@@ -526,7 +537,8 @@ public class DownloadResources extends DownloadResourceGroup {
 		return collectedItems;
 	}
 
-	private void buildRegionsGroups(WorldRegion region, DownloadResourceGroup group) {
+	private void buildRegionsGroups(WorldRegion region, DownloadResourceGroup group,
+	                                List<IndexItem> customResources) {
 		LinkedList<WorldRegion> queue = new LinkedList<>();
 		LinkedList<DownloadResourceGroup> parent = new LinkedList<>();
 		queue.add(region);
@@ -539,10 +551,10 @@ public class DownloadResources extends DownloadResourceGroup {
 			mainGrp.region = reg;
 			parentGroup.addGroup(mainGrp);
 
-			if (reg instanceof CustomRegion) {
-				CustomRegion customRegion = (CustomRegion) reg;
+			if (reg instanceof CustomRegion customRegion) {
 				List<IndexItem> indexItems = customRegion.loadIndexItems();
 				if (!Algorithms.isEmpty(indexItems)) {
+					customResources.addAll(indexItems);
 					DownloadResourceGroup flatFiles = new DownloadResourceGroup(mainGrp, REGION_MAPS);
 					for (IndexItem ii : indexItems) {
 						flatFiles.addItem(ii);

--- a/OsmAnd/src/net/osmand/plus/importfiles/tasks/ObfImportTask.java
+++ b/OsmAnd/src/net/osmand/plus/importfiles/tasks/ObfImportTask.java
@@ -8,7 +8,6 @@ import androidx.fragment.app.FragmentActivity;
 import net.osmand.IProgress;
 import net.osmand.IndexConstants;
 import net.osmand.plus.R;
-import net.osmand.plus.download.DownloadActivityType;
 import net.osmand.plus.importfiles.ImportHelper;
 import net.osmand.util.Algorithms;
 
@@ -53,8 +52,8 @@ public class ObfImportTask extends BaseImportAsyncTask<Void, Void, String> {
 
 	@NonNull
 	private File getObfDestFile(@NonNull String name) {
-		if (endsWithVersionAndMapBinaryExt(name)) {
-			name = DownloadActivityType.NORMAL_FILE.getBasename(name, DownloadActivityType.NORMAL_FILE) + IndexConstants.BINARY_MAP_INDEX_EXT;
+		if (name.endsWith(IndexConstants.BINARY_MAP_INDEX_EXT)) {
+			name = Algorithms.removeFileVersionSuffix(name);
 		}
 		if (name.endsWith(IndexConstants.BINARY_ROAD_MAP_INDEX_EXT)) {
 			return app.getAppPath(IndexConstants.ROADS_INDEX_DIR + name);
@@ -66,17 +65,5 @@ public class ObfImportTask extends BaseImportAsyncTask<Void, Void, String> {
 			return app.getAppPath(IndexConstants.NAUTICAL_INDEX_DIR + name);
 		}
 		return app.getAppPath(name);
-	}
-
-	private boolean endsWithVersionAndMapBinaryExt(@NonNull String name) {
-		if (name.endsWith(IndexConstants.BINARY_MAP_INDEX_EXT)) {
-			int extIndex = name.indexOf(IndexConstants.BINARY_MAP_INDEX_EXT);
-			int underscoreIndex = name.lastIndexOf("_");
-			if (extIndex > underscoreIndex + 1) {
-				String versionPart = name.substring(underscoreIndex + 1, extIndex);
-				return Algorithms.isInt(versionPart);
-			}
-		}
-		return false;
 	}
 }

--- a/OsmAnd/test/java/net/osmand/plus/download/DownloadActivityTypeTest.java
+++ b/OsmAnd/test/java/net/osmand/plus/download/DownloadActivityTypeTest.java
@@ -1,0 +1,52 @@
+package net.osmand.plus.download;
+
+import static org.junit.Assert.assertEquals;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import net.osmand.util.Algorithms;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class DownloadActivityTypeTest {
+
+	@Test
+	public void removeFileVersionSuffixOnlyRemovesIntegerSuffix() {
+		assertEquals("Ukraine_europe.obf.zip", Algorithms.removeFileVersionSuffix("Ukraine_europe_2.obf.zip"));
+		assertEquals("custom_map_test.obf.zip",
+				Algorithms.removeFileVersionSuffix("custom_map_test.obf.zip"));
+		assertEquals("my.custom_map.obf.zip",
+				Algorithms.removeFileVersionSuffix("my.custom_map_2.obf.zip"));
+		assertEquals("custom_map_v2", Algorithms.removeFileVersionSuffix("custom_map_v2"));
+	}
+
+	@Test
+	public void getBasenameHandlesVersionAndSemanticSuffixes() {
+		assertEquals("waterway", getBasename("waterway.obf.zip"));
+		assertEquals("Ukraine_europe", getBasename("Ukraine_europe_2.obf.zip"));
+		assertEquals("Us_nfs_roads", getBasename("Us_nfs_roads.obf.zip"));
+		assertEquals("my.file", getBasename("my.file_2.obf.zip"));
+		assertEquals("my.file_test", getBasename("my.file_test.obf.zip"));
+		assertEquals("foo", getBasename("foo_2.wiki.obf.zip"));
+		assertEquals("my_map", getBasename("my_map_2"));
+		assertEquals("my_map_test", getBasename("my_map_test"));
+	}
+
+	@Test
+	public void getTargetFileNameUsesObfBasename() {
+		assertEquals("waterway.obf", getTargetFileName("waterway.obf.zip"));
+		assertEquals("my.custom_map.obf", getTargetFileName("my.custom_map_2.obf.zip"));
+		assertEquals("Us_nfs_roads.obf", getTargetFileName("Us_nfs_roads_1.obf.zip"));
+	}
+
+	private String getBasename(String fileName) {
+		return DownloadActivityType.NORMAL_FILE.getBasename(fileName, DownloadActivityType.NORMAL_FILE);
+	}
+
+	private String getTargetFileName(String fileName) {
+		return new IndexItem(fileName, null, 0, null, 0, 0,
+				DownloadActivityType.NORMAL_FILE, false, null).getTargetFileName();
+	}
+}


### PR DESCRIPTION
Additional context for review:

This PR contains two related Android fixes discovered while investigating the custom USFS map issue:

1. Filename normalization now removes only a trailing numeric `_<version>` suffix and preserves semantic suffixes such as `_roads`, `_trails`, `_test`, etc.
2. Custom download items now refresh their `downloaded` state from the canonical target file, fixing stale "Downloaded" status after a map is deleted.

Regression tests were added for filename normalization.

I also checked the corresponding iOS custom-download flow; this specific filename collision does not occur there.

Legacy files created by the old Android naming behavior (for example `Us_nfs.obf`) are intentionally not removed automatically, since such filenames may also represent legitimate custom maps. Cleanup/migration should be handled separately if needed.