### PR TITLE
Fix favorites: import empty cloud favorite groups

### DIFF
--- a/OsmAnd/src/net/osmand/plus/settings/backend/backup/items/FavoritesSettingsItem.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/backup/items/FavoritesSettingsItem.java
@@ -182,6 +182,14 @@ public class FavoritesSettingsItem extends CollectionSettingsItem<FavoriteGroup>
 				}
 			}
 			for (FavoriteGroup group : appliedItems) {
+				// Empty groups have no points to trigger addFavourite(), but still need a local file.
+				FavoriteGroup localGroup = favoritesHelper.getGroup(group.getName());
+				if (localGroup == null) {
+					localGroup = favoritesHelper.addFavoriteGroup(group.getName(), group.getColor(),
+							group.getIconName(), group.getBackgroundType());
+				}
+				localGroup.copyAppearance(group);
+
 				PointsGroup pointsGroup = group.toPointsGroup(app);
 				for (FavouritePoint point : group.getPoints()) {
 					favoritesHelper.addFavourite(point, pointsGroup, new AddFavoriteOptions());


### PR DESCRIPTION
## Summary

Related to #24700.

Fixes the Android Cloud import path for empty Favorites groups.

- Creates the local Favorite group even when the downloaded GPX contains no points.
- Applies the group appearance and state: pinned, hidden, color, icon, and background.
- Prevents a successfully downloaded empty group from being detected as a local deletion on the next sync.

## Root cause

The Cloud reader recognized an empty Favorites group from its GPX metadata, but the import code only created local groups while adding their points.

For an empty group, no points were processed, so no local group file was created. The next sync then found the Cloud file without a local counterpart and marked it as deleted.