### PR TITLE
Overestimated ETA for bunch of traffic light fix

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
@@ -320,14 +320,32 @@ public class RouteResultPreparation {
 	private static final double SLOW_DOWN_SPEED_THRESHOLD = 15;
 	// reference speed 30ms (108kmh) - 2ms (7kmh)
 	private static final double SLOW_DOWN_SPEED = 2;
-	
+
+	private static boolean segmentHasTag(RouteDataObject road, int segmentIndex, String tag) {
+		int[] segmentPointTypes = road.getPointTypes(segmentIndex);
+		if (segmentPointTypes != null) {
+			for (int type : segmentPointTypes) {
+				RouteTypeRule rule = road.region.quickGetEncodingRule(type);
+				if (rule != null && rule.getValue().equals(tag)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
 	public static void calculateTimeSpeed(RoutingContext ctx, List<RouteSegmentResult> result) {
+		ctx.currentCalculatedDistance = 0.0;
+		ctx.lastTrafficSignalDistance = -1;
+
 		for (int i = 0; i < result.size(); i++) {
 			RouteSegmentResult rr = result.get(i);
+			if (i > 0) {
+				ctx.currentCalculatedDistance += result.get(i-1).getDistance();
+			}
 			calculateTimeSpeed(ctx, rr);
 		}
 	}
-
 	public static void calculateTimeSpeed(RoutingContext ctx, RouteSegmentResult rr) {
 		// Naismith's/Scarf rules add additional travel time when moving uphill
 		boolean useNaismithRule = false;
@@ -372,6 +390,20 @@ public class RouteResultPreparation {
 			double obstacle = ctx.getRouter().defineObstacle(road, j, !plus);
 			if (obstacle < 0) {
 				obstacle = 0;
+			} else if (obstacle > 0) {
+				if (segmentHasTag(road, j,"traffic_signals")) {
+					// For groups with many traffic signals nearby take penalty only for first one. (After red signal next usually are green)
+					// XXXXX XXXXX   ->   Xxxxx Xxxxx
+					boolean isFirstStop = ctx.lastTrafficSignalDistance == -1;
+					double currentDistance = ctx.currentCalculatedDistance + distance;
+					double distanceFromPreviousStop = currentDistance - ctx.lastTrafficSignalDistance;
+					ctx.lastTrafficSignalDistance = currentDistance;
+					if (isFirstStop || distanceFromPreviousStop >= 100) {
+						obstacle = obstacle * 1.0;
+					} else {
+						obstacle = obstacle * 0.25;
+					}
+				}
 			}
 			distOnRoadToPass += d / speed + obstacle;  //this is time in seconds
 

--- a/OsmAnd-java/src/main/java/net/osmand/router/RoutingContext.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RoutingContext.java
@@ -85,6 +85,9 @@ public class RoutingContext {
 	public boolean leftSideNavigation;
 	public List<RouteSegmentResult> previouslyCalculatedRoute;
 	public PrecalculatedRouteDirection precalculatedRouteDirection;
+
+	public double currentCalculatedDistance;
+	public double lastTrafficSignalDistance;
 	
 	
 	// 2. Routing memory cache (big objects)


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd/issues/25390)
[related resources pr](https://github.com/osmandapp/OsmAnd-resources/pull/1485)

# Explanation of this bug

We have a route with a lot of traffic lights in one place:

<img width="400" alt="Screenshot 2026-08-25 at 04 47 53" src="https://github.com/user-attachments/assets/dbe7d69b-b02b-440c-80e8-1b1c1f8b6066" />

It looks other routers do not take a lot penalty for them. Speed diagram more correlating with route max speed limits.

<img width="400" alt="Screenshot 2026-08-25 at 04 13 43 copy" src="https://github.com/user-attachments/assets/2adb9996-a0d6-4ee8-bb8c-77a6964e3332" />

Our algorithm looks like way more detailed.

<img width="400"  alt="Screenshot 2026-08-28 at 11 51 03" src="https://github.com/user-attachments/assets/2a5ade9f-6376-4ebb-a6f9-baf1eed7209b" />

Also if we turn off penalty for traffic light, then our diagram will be more like another routers.

<img width="400"  alt="Screenshot 2026-08-28 at 12 13 17" src="https://github.com/user-attachments/assets/ec7b812f-7e96-4113-a832-fcab6e4de1ab" />

But i don't thing this is a proper way to fix.

[here is pr only with only routing. xml fix but I thin this is also not proper way to fix](url)

---

# Idea of this my fix

In logs i see the most slowing tags for this road. I will focus only on "traffic_signals":

```
20 sec   highway=traffic_signals
15 sec   crossing=traffic_signals
01 sec   highway=crossing
```

My guess, now our route gets penalty, like car stops on every traffic signal. Even if there are 5 signals on 50 meters. But I think, usually if we stop on one red signal, then several next signals are usually green. So in this fix I tried to simulate this. 

```
🔴🔴🔴🔴              🔴🔴🔴🔴             🔴🔴🔴🔴             🔴🔴🔴🔴
🔴🟢🟢🟢              🔴🟢🟢🟢             🔴🟢🟢🟢             🔴🟢🟢🟢
```

This is how it looks like in logs:
[skipped_traffic_signals_log.txt](https://github.com/user-attachments/files/31545429/skipped_traffic_signals_log.txt)

<details><summary>Spoiler</summary>
    <img width="674" height="998" alt="Screenshot 2026-08-28 at 12 28 30" src="https://github.com/user-attachments/assets/61834dda-fc63-45f1-93c2-a1b263d3523b" />
</details>

---

# Fix and tests

Full route
https://osmand.net/map/navigate/?start=52.423260,13.374245&end=52.533142,13.384974&profile=car#12/52.443842/13.353544

before:
<img width="200" alt="Screenshot 2026-08-28 at 11 55 13" src="https://github.com/user-attachments/assets/a1a3d610-f396-4d6c-992f-607b904c70a9" />    <img width="200"  alt="Screenshot 2026-08-28 at 11 55 36" src="https://github.com/user-attachments/assets/4b769767-90ac-4544-9c05-a558ce7e35c6" />

after: 
<img width="200" alt="Screenshot 2026-08-28 at 11 49 41" src="https://github.com/user-attachments/assets/9e3fc3d8-f72d-4d25-99f2-3f45bf5616af" /> <img width="200" alt="Screenshot 2026-08-28 at 11 50 06" src="https://github.com/user-attachments/assets/9bf24746-19ed-4fce-bf2d-089d9bdae436" />


---

Short route
https://osmand.net/map/navigate/?start=52.438720,13.386304&end=52.483090,13.386500&profile=car#14/52.4628/13.3666

before:
<img width="200"  alt="Screenshot 2026-08-28 at 11 54 26" src="https://github.com/user-attachments/assets/1c5f21a3-709d-4a3e-ab95-5fe4f6bfc3d9" />      <img width="200"  alt="Screenshot 2026-08-28 at 11 54 42" src="https://github.com/user-attachments/assets/78467d87-8b03-4db4-83af-f16590789b5d" />

after:
<img width="200"  alt="Screenshot 2026-08-28 at 11 50 42" src="https://github.com/user-attachments/assets/58baa9ff-c8d9-4c72-8902-7c85910259e5" />    <img width="200" alt="Screenshot 2026-08-28 at 11 51 03" src="https://github.com/user-attachments/assets/2106a66e-958c-41ad-8359-fedb0a48093c" />

