### PR TITLE
Restore custom GPX extension fields in point menus

### DIFF
--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxUtilities.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxUtilities.kt
@@ -61,8 +61,10 @@ object GpxUtilities {
 	const val PINNED_EXTENSION = "pinned"
 	const val POINT_TYPE_EXTENSION = "point_type"
 
-	const val GPXTPX_PREFIX = "gpxtpx:"
-	const val OSMAND_EXTENSIONS_PREFIX = "osmand:"
+	private const val GPXTPX_XML_PREFIX = "gpxtpx"
+	private const val OSMAND_XML_PREFIX = "osmand"
+	const val GPXTPX_PREFIX = "$GPXTPX_XML_PREFIX:"
+	const val OSMAND_EXTENSIONS_PREFIX = "$OSMAND_XML_PREFIX:"
 	const val OSM_PREFIX = "osm_tag_"
 	const val AMENITY_PREFIX = "amenity_"
 	const val ORIGIN_EXTENSION = "origin"
@@ -1688,6 +1690,16 @@ object GpxUtilities {
 		return supportedTag ?: tag.replace(XML_COLON, ":")
 	}
 
+	private fun getQualifiedExtensionTagName(parser: XmlPullParser): String? {
+		val name = parser.getName() ?: return null
+		val prefix = parser.getPrefix()
+		return if (prefix.isNullOrEmpty() || prefix == OSMAND_XML_PREFIX || prefix == GPXTPX_XML_PREFIX) {
+			name
+		} else {
+			"$prefix:$name"
+		}
+	}
+
 	@Throws(XmlParserException::class, IOException::class)
 	private fun readExtensionsText(parser: XmlPullParser, key: String, target: GpxExtensions) {
 		var tok: Int
@@ -1698,7 +1710,7 @@ object GpxUtilities {
 				if (tag != null && text != null) {
 					val value = text.toString()
 					if (!value.isBlank()) {
-						applyExtensionValue(target, tag, value)
+						applyExtensionValue(target, getQualifiedExtensionTagName(parser) ?: tag, value)
 					}
 				}
 				if (tag == key) {

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxUtilities.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxUtilities.kt
@@ -63,6 +63,7 @@ object GpxUtilities {
 
 	private const val GPXTPX_XML_PREFIX = "gpxtpx"
 	private const val OSMAND_XML_PREFIX = "osmand"
+	private const val GPXX_XML_PREFIX = "gpxx"
 	const val GPXTPX_PREFIX = "$GPXTPX_XML_PREFIX:"
 	const val OSMAND_EXTENSIONS_PREFIX = "$OSMAND_XML_PREFIX:"
 	const val OSM_PREFIX = "osm_tag_"
@@ -118,6 +119,13 @@ object GpxUtilities {
 			}
 		}
 	}
+
+	// Extensions from these namespaces keep their local tag names, so that a file binding the
+	// same namespace to another prefix (e.g. "ns3:hr" for TrackPointExtension) stays recognized.
+	private val KNOWN_EXTENSION_HOSTS = setOf("osmand.net", "garmin.com")
+
+	private val KNOWN_EXTENSION_PREFIXES =
+		setOf(OSMAND_XML_PREFIX, GPXTPX_XML_PREFIX, GPXX_XML_PREFIX)
 
 	private val SUPPORTED_EXTENSION_TAGS = mapOf(
 		"heartrate" to PointAttributes.SENSOR_TAG_HEART_RATE,
@@ -1693,11 +1701,14 @@ object GpxUtilities {
 	private fun getQualifiedExtensionTagName(parser: XmlPullParser): String? {
 		val name = parser.getName() ?: return null
 		val prefix = parser.getPrefix()
-		return if (prefix.isNullOrEmpty() || prefix == OSMAND_XML_PREFIX || prefix == GPXTPX_XML_PREFIX) {
-			name
-		} else {
-			"$prefix:$name"
+		if (prefix.isNullOrEmpty()) {
+			return name
 		}
+		val host = parser.getNamespace()?.lowercase()
+			?.substringAfter("://")?.substringBefore('/') ?: ""
+		val known = KNOWN_EXTENSION_HOSTS.any { host == it || host.endsWith(".$it") }
+				|| KNOWN_EXTENSION_PREFIXES.contains(prefix)
+		return if (known) name else "$prefix:$name"
 	}
 
 	@Throws(XmlParserException::class, IOException::class)

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/GpxUtilitiesLoadTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/GpxUtilitiesLoadTest.kt
@@ -66,6 +66,30 @@ class GpxUtilitiesLoadTest {
 	}
 
 	@Test
+	fun testLoadGpxFilePreservesCustomExtensionPrefix() {
+		val gpxFile = loadGpx(
+			"""
+			<gpx version="1.1" creator="test" xmlns:test="https://example.com/gpx/test">
+			  <wpt lat="10.0" lon="20.0">
+			    <extensions>
+			      <test:country>United States</test:country>
+			      <test:telephone>+1 804 828 0100</test:telephone>
+			    </extensions>
+			  </wpt>
+			</gpx>
+			""".trimIndent(),
+			addGeneralTrack = false
+		)
+
+		assertNull(gpxFile.error)
+		val extensions = gpxFile.getPointsList().single().getExtensionsToRead()
+		assertEquals("United States", extensions["test:country"])
+		assertEquals("+1 804 828 0100", extensions["test:telephone"])
+		assertNull(extensions["country"])
+		assertNull(extensions["telephone"])
+	}
+
+	@Test
 	fun testLoadGpxFilePreservesGeneralTrackBehaviorForMultipleSegments() {
 		val gpxFile = loadGpx(
 			"""

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/GpxUtilitiesLoadTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/GpxUtilitiesLoadTest.kt
@@ -73,7 +73,10 @@ class GpxUtilitiesLoadTest {
 			  <wpt lat="10.0" lon="20.0">
 			    <extensions>
 			      <test:country>United States</test:country>
+			      <test:state>Virginia</test:state>
 			      <test:telephone>+1 804 828 0100</test:telephone>
+			      <test:postcode>23284</test:postcode>
+			      <test:start_date>1838</test:start_date>
 			    </extensions>
 			  </wpt>
 			</gpx>
@@ -82,11 +85,62 @@ class GpxUtilitiesLoadTest {
 		)
 
 		assertNull(gpxFile.error)
+		val expected = mapOf(
+			"test:country" to "United States",
+			"test:state" to "Virginia",
+			"test:telephone" to "+1 804 828 0100",
+			"test:postcode" to "23284",
+			"test:start_date" to "1838"
+		)
 		val extensions = gpxFile.getPointsList().single().getExtensionsToRead()
-		assertEquals("United States", extensions["test:country"])
-		assertEquals("+1 804 828 0100", extensions["test:telephone"])
+		assertEquals(expected, extensions.filterKeys { it.startsWith("test:") })
 		assertNull(extensions["country"])
 		assertNull(extensions["telephone"])
+
+		val reloaded = loadGpx(writeGpxToString(gpxFile), addGeneralTrack = false)
+		assertNull(reloaded.error)
+		val reloadedExtensions = reloaded.getPointsList().single().getExtensionsToRead()
+		assertEquals(expected, reloadedExtensions.filterKeys { it.startsWith("test:") })
+	}
+
+	@Test
+	fun testLoadGpxFileResolvesKnownNamespacesBoundToAnotherPrefix() {
+		val gpxFile = loadGpx(
+			"""
+			<gpx version="1.1" creator="test"
+			     xmlns:ns1="https://osmand.net"
+			     xmlns:ns3="http://www.garmin.com/xmlschemas/TrackPointExtension/v1"
+			     xmlns:ns2="http://www.garmin.com/xmlschemas/GpxExtensions/v3"
+			     xmlns:test="https://example.com/gpx/test">
+			  <trk>
+			    <trkseg>
+			      <trkpt lat="10.0" lon="20.0">
+			        <extensions>
+			          <ns1:width>bold</ns1:width>
+			          <ns2:DisplayColor>Red</ns2:DisplayColor>
+			          <ns3:TrackPointExtension>
+			            <ns3:hr>145</ns3:hr>
+			            <ns3:cad>91</ns3:cad>
+			          </ns3:TrackPointExtension>
+			          <test:hr>1</test:hr>
+			        </extensions>
+			      </trkpt>
+			    </trkseg>
+			  </trk>
+			</gpx>
+			""".trimIndent(),
+			addGeneralTrack = false
+		)
+
+		assertNull(gpxFile.error)
+		val point = gpxFile.tracks[0].segments[0].points[0]
+		val extensions = point.getExtensionsToRead()
+		assertEquals("145", extensions[PointAttributes.SENSOR_TAG_HEART_RATE])
+		assertEquals("91", extensions[PointAttributes.SENSOR_TAG_CADENCE])
+		assertEquals("bold", extensions[GpxUtilities.LINE_WIDTH_EXTENSION])
+		assertEquals("Red", extensions["displaycolor"])
+		assertEquals(GpxUtilities.parseColor("Red", null), point.getColor(null as Int?))
+		assertEquals("1", extensions["test:hr"])
 	}
 
 	@Test

--- a/OsmAnd/build-common.gradle
+++ b/OsmAnd/build-common.gradle
@@ -445,12 +445,12 @@ dependencies {
 
 	//implementation "androidx.tracing:tracing:1.1.0"
 	//debugImplementation 'androidx.test:monitor:1.6.1'
-	androidTestImplementation "androidx.test:runner:1.5.2"
-	androidTestImplementation "androidx.test:rules:1.5.0"
-	androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+	androidTestImplementation "androidx.test:runner:1.7.0"
+	androidTestImplementation "androidx.test:rules:1.7.0"
+	androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 	//debugImplementation("androidx.test:core:1.5.0")
-	androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-	androidTestImplementation ('androidx.test.espresso:espresso-contrib:3.5.1') {
+	androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+	androidTestImplementation ('androidx.test.espresso:espresso-contrib:3.7.0') {
 		exclude module: "protobuf-lite"
 	}
 	implementation 'com.facebook.shimmer:shimmer:0.5.0@aar'

--- a/OsmAnd/src/net/osmand/plus/helpers/AmenityExtensionsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/AmenityExtensionsHelper.java
@@ -29,8 +29,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class AmenityExtensionsHelper {
 	public static final double MIN_UPHILL_DOWNHILL_FIXED_TO_SHOW = 10.0;
@@ -100,6 +102,18 @@ public class AmenityExtensionsHelper {
 			updatedExtensions.putAll(amenity.getAmenityExtensions(app.getPoiTypes(), false));
 		}
 		return updatedExtensions;
+	}
+
+	@NonNull
+	public static Set<String> getStoredExtensionFallbackKeys(@NonNull Map<String, String> storedExtensions) {
+		Set<String> fallbackKeys = new HashSet<>();
+		for (String key : storedExtensions.keySet()) {
+			// These prefixes already identify fields persisted from an Amenity by OsmAnd.
+			if (!key.startsWith(AMENITY_PREFIX) && !key.startsWith(OSM_PREFIX)) {
+				fallbackKeys.add(key);
+			}
+		}
+		return fallbackKeys;
 	}
 
 	@NonNull

--- a/OsmAnd/src/net/osmand/plus/helpers/AmenityExtensionsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/AmenityExtensionsHelper.java
@@ -6,6 +6,8 @@ import static net.osmand.data.Amenity.WIKIMEDIA_COMMONS;
 import static net.osmand.data.Amenity.WIKIPEDIA;
 import static net.osmand.gpx.GPXUtilities.OSM_PREFIX;
 import static net.osmand.shared.gpx.GpxUtilities.AMENITY_PREFIX;
+import static net.osmand.shared.gpx.GpxUtilities.GPXTPX_PREFIX;
+import static net.osmand.shared.gpx.GpxUtilities.OSMAND_EXTENSIONS_PREFIX;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -104,12 +106,19 @@ public class AmenityExtensionsHelper {
 		return updatedExtensions;
 	}
 
+	/**
+	 * Collects the keys stored on a point that came from an external GPX namespace, for example
+	 * "test:country". Only these may fall back to a generic row when OsmAnd's POI logic does not
+	 * recognize them; an unqualified key is an OsmAnd field ("hidden", "visited_date"), and the
+	 * OsmAnd, Garmin and Amenity namespaces are OsmAnd's own data.
+	 */
 	@NonNull
 	public static Set<String> getStoredExtensionFallbackKeys(@NonNull Map<String, String> storedExtensions) {
 		Set<String> fallbackKeys = new HashSet<>();
 		for (String key : storedExtensions.keySet()) {
-			// These prefixes already identify fields persisted from an Amenity by OsmAnd.
-			if (!key.startsWith(AMENITY_PREFIX) && !key.startsWith(OSM_PREFIX)) {
+			if (key.indexOf(':') > 0
+					&& !key.startsWith(AMENITY_PREFIX) && !key.startsWith(OSM_PREFIX)
+					&& !key.startsWith(OSMAND_EXTENSIONS_PREFIX) && !key.startsWith(GPXTPX_PREFIX)) {
 				fallbackKeys.add(key);
 			}
 		}

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/AmenityUIHelper.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/AmenityUIHelper.java
@@ -84,6 +84,7 @@ public class AmenityUIHelper extends MenuBuilder {
 	private Map<String, List<PoiType>> collectedPoiTypes = new HashMap<>();
 	private boolean osmEditingEnabled = PluginsHelper.isActive(OsmEditingPlugin.class);
 	private boolean lastBuiltRowIsDescription = false;
+	private Set<String> genericFallbackKeys = Collections.emptySet();
 
 	public AmenityUIHelper(@NonNull MapActivity mapActivity, String preferredLang,
 			@NonNull AdditionalInfoBundle infoBundle) {
@@ -342,6 +343,7 @@ public class AmenityUIHelper extends MenuBuilder {
 
 		AmenityInfoRow.Builder rowBuilder = new AmenityInfoRow.Builder(key);
 		rowBuilder.setCollapsableView(collapsableView);
+		boolean useGenericFallback = genericFallbackKeys.contains(key);
 
 		if (pType != null) {
 			PoiAdditionalUiRule poiAdditionalUiRule = PoiAdditionalUiRules.INSTANCE.findRule(key);
@@ -352,8 +354,9 @@ public class AmenityUIHelper extends MenuBuilder {
 				return null; // the "Others" value is already displayed as a title
 			}
 			collectedPoiTypes.computeIfAbsent(category, s -> new ArrayList<>()).add(poiType);
-		} else if (showDefaultTags) {
-			pType = new PoiType(poiTypes, poiCategory, null, key, poiCategory.getIconKeyName());
+		} else if (showDefaultTags || useGenericFallback) {
+			String displayKey = useGenericFallback ? getGenericFallbackDisplayKey(key) : key;
+			pType = new PoiType(poiTypes, poiCategory, null, displayKey, poiCategory.getIconKeyName());
 			pType.setText(true);
 			PoiAdditionalUiRule poiAdditionalUiRule = PoiAdditionalUiRules.INSTANCE.findRule(key);
 			poiAdditionalUiRule.fillRow(app, context, rowBuilder, this, pType, key, poiTypes.getPoiTranslation(vl), subtype);
@@ -776,5 +779,15 @@ public class AmenityUIHelper extends MenuBuilder {
 
 	public void setShowDefault(boolean showDefault) {
 		this.showDefaultTags = showDefault;
+	}
+
+	public void setGenericFallbackKeys(@NonNull Collection<String> genericFallbackKeys) {
+		this.genericFallbackKeys = new HashSet<>(genericFallbackKeys);
+	}
+
+	@NonNull
+	private String getGenericFallbackDisplayKey(@NonNull String key) {
+		int separatorIndex = key.indexOf(':');
+		return separatorIndex > 0 ? key.substring(separatorIndex + 1) : key;
 	}
 }

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/AmenityUIHelper.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/AmenityUIHelper.java
@@ -359,7 +359,9 @@ public class AmenityUIHelper extends MenuBuilder {
 			pType = new PoiType(poiTypes, poiCategory, null, displayKey, poiCategory.getIconKeyName());
 			pType.setText(true);
 			PoiAdditionalUiRule poiAdditionalUiRule = PoiAdditionalUiRules.INSTANCE.findRule(key);
-			poiAdditionalUiRule.fillRow(app, context, rowBuilder, this, pType, key, poiTypes.getPoiTranslation(vl), subtype);
+			// A custom GPX value is user data: show it as stored, do not translate it as a POI key.
+			String value = useGenericFallback ? vl : poiTypes.getPoiTranslation(vl);
+			poiAdditionalUiRule.fillRow(app, context, rowBuilder, this, pType, key, value, subtype);
 		} else {
 			return null; // skip non-translatable NON-poiType tags
 		}

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/FavouritePointMenuBuilder.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/FavouritePointMenuBuilder.java
@@ -45,6 +45,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class FavouritePointMenuBuilder extends MenuBuilder {
 
@@ -54,6 +55,7 @@ public class FavouritePointMenuBuilder extends MenuBuilder {
 	private AdditionalInfoBundle mergedAmenityInfoBundle;
 	private Map<String, String> mergedAmenityExtensions = new HashMap<>();
 	private Map<String, String> sourceAmenityExtensions = Collections.emptyMap();
+	private Set<String> genericFallbackKeys = Collections.emptySet();
 
 	public FavouritePointMenuBuilder(@NonNull MapActivity activity, @NonNull FavouritePoint point, @Nullable Amenity amenity) {
 		super(activity);
@@ -73,6 +75,7 @@ public class FavouritePointMenuBuilder extends MenuBuilder {
 		if (amenity == null) {
 			setAmenity(helper.findAmenityByIdentity(originName, lat, lon, storedExtensions));
 		}
+		genericFallbackKeys = AmenityExtensionsHelper.getStoredExtensionFallbackKeys(storedExtensions);
 		mergedAmenityExtensions = helper.getUpdatedAmenityExtensions(storedExtensions, amenity);
 		mergedAmenityInfoBundle = new AdditionalInfoBundle(app.getPoiTypes(), mergedAmenityExtensions);
 		if (amenity != null) {
@@ -109,6 +112,7 @@ public class FavouritePointMenuBuilder extends MenuBuilder {
 
 		if (!Algorithms.isEmpty(mergedAmenityExtensions)) {
 			AmenityUIHelper helper = new AmenityUIHelper(mapActivity, getPreferredMapAppLang(), mergedAmenityInfoBundle);
+			helper.setGenericFallbackKeys(genericFallbackKeys);
 			helper.setLight(isLightContent());
 			helper.setLatLon(getLatLon());
 			helper.setCollapseExpandListener(getCollapseExpandListener());

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/WptPtMenuBuilder.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/builders/WptPtMenuBuilder.java
@@ -35,14 +35,17 @@ import net.osmand.shared.gpx.primitives.WptPt;
 import net.osmand.util.Algorithms;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class WptPtMenuBuilder extends MenuBuilder {
 
 	private final WptPt wpt;
 	private Map<String, String> amenityExtensions = new HashMap<>();
+	private Set<String> genericFallbackKeys = Collections.emptySet();
 
 	public WptPtMenuBuilder(@NonNull MapActivity mapActivity, @NonNull WptPt wpt,
 			@Nullable PlaceDetailsObject detailsObject) {
@@ -63,6 +66,7 @@ public class WptPtMenuBuilder extends MenuBuilder {
 				setAmenity(helper.findAmenity(originName, wpt.getLatitude(), wpt.getLongitude()));
 			}
 		}
+		genericFallbackKeys = AmenityExtensionsHelper.getStoredExtensionFallbackKeys(wpt.getExtensionsToRead());
 		amenityExtensions = helper.getUpdatedAmenityExtensions(wpt.getExtensionsToRead(), amenity);
 	}
 
@@ -140,6 +144,7 @@ public class WptPtMenuBuilder extends MenuBuilder {
 			boolean light = isLightContent();
 			AdditionalInfoBundle bundle = new AdditionalInfoBundle(app.getPoiTypes(), amenityExtensions);
 			AmenityUIHelper helper = new AmenityUIHelper(mapActivity, getPreferredMapAppLang(), bundle);
+			helper.setGenericFallbackKeys(genericFallbackKeys);
 			helper.setLight(light);
 			helper.setLatLon(getLatLon());
 			helper.setCollapseExpandListener(getCollapseExpandListener());

--- a/OsmAnd/test/java/net/osmand/test/ui/poi/AmenityUIHelperStoredExtensionsTest.java
+++ b/OsmAnd/test/java/net/osmand/test/ui/poi/AmenityUIHelperStoredExtensionsTest.java
@@ -1,0 +1,138 @@
+package net.osmand.test.ui.poi;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.view.View;
+import android.widget.LinearLayout;
+
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.ActivityTestRule;
+
+import net.osmand.data.AdditionalInfoBundle;
+import net.osmand.data.Amenity;
+import net.osmand.plus.activities.MapActivity;
+import net.osmand.plus.helpers.AmenityExtensionsHelper;
+import net.osmand.plus.mapcontextmenu.builders.AmenityUIHelper;
+import net.osmand.plus.mapcontextmenu.builders.rows.AmenityInfoRow;
+import net.osmand.test.common.AndroidTest;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+@RunWith(AndroidJUnit4.class)
+public class AmenityUIHelperStoredExtensionsTest extends AndroidTest {
+
+	private static final String KNOWN_COLON_KEY = "authentication:phone_call:number";
+	private static final String CUSTOM_KEY = "test:country";
+	private static final String AMENITY_ONLY_KEY = "unknown:amenity:field";
+	private static final String STORED_AMENITY_KEY = "osm_tag_top_index_brand";
+	private static final String NORMALIZED_AMENITY_KEY = "top_index_brand";
+
+	@Rule
+	public ActivityTestRule<MapActivity> activityRule =
+			new ActivityTestRule<>(MapActivity.class, true, false);
+
+	private MapActivity mapActivity;
+
+	@Before
+	public void setUp() {
+		mapActivity = activityRule.launchActivity(null);
+	}
+
+	@Test
+	public void knownColonKeyUsesExistingPoiResolution() {
+		Map<String, String> extensions = Collections.singletonMap(KNOWN_COLON_KEY, "+380441234567");
+
+		Map<String, AmenityInfoRow> rows = buildRows(extensions, extensions.keySet());
+
+		AmenityInfoRow row = rows.get(KNOWN_COLON_KEY);
+		assertNotNull(row);
+		assertEquals("authentication_phone_call_number", row.name);
+		assertTrue(row.isText);
+	}
+
+	@Test
+	public void unknownStoredKeyUsesGenericFallback() {
+		Map<String, String> extensions = Collections.singletonMap(CUSTOM_KEY, "United States");
+
+		Map<String, AmenityInfoRow> rows = buildRows(extensions, extensions.keySet());
+
+		AmenityInfoRow row = rows.get(CUSTOM_KEY);
+		assertNotNull(row);
+		assertEquals("country", row.name);
+		assertEquals("United States", row.text);
+	}
+
+	@Test
+	public void unknownAmenityOnlyKeyIsNotShown() {
+		Map<String, String> extensions = Collections.singletonMap(AMENITY_ONLY_KEY, "internal value");
+
+		Map<String, AmenityInfoRow> rows = buildRows(extensions, Collections.emptySet());
+
+		assertFalse(rows.containsKey(AMENITY_ONLY_KEY));
+	}
+
+	@Test
+	public void mixedStoredAndAmenityExtensionsUseSourceAwareFallback() {
+		Map<String, String> storedExtensions = new HashMap<>();
+		storedExtensions.put(CUSTOM_KEY, "United States");
+		storedExtensions.put(KNOWN_COLON_KEY, "+380441234567");
+
+		Amenity amenity = new Amenity();
+		amenity.setAdditionalInfo(AMENITY_ONLY_KEY, "internal value");
+
+		AmenityExtensionsHelper extensionsHelper = new AmenityExtensionsHelper(app);
+		Map<String, String> mergedExtensions =
+				extensionsHelper.getUpdatedAmenityExtensions(storedExtensions, amenity);
+
+		Map<String, AmenityInfoRow> rows = buildRows(
+				mergedExtensions,
+				AmenityExtensionsHelper.getStoredExtensionFallbackKeys(storedExtensions));
+
+		assertTrue(rows.containsKey(CUSTOM_KEY));
+		assertEquals("authentication_phone_call_number", rows.get(KNOWN_COLON_KEY).name);
+		assertFalse(rows.containsKey(AMENITY_ONLY_KEY));
+	}
+
+	@Test
+	public void storedAmenityMetadataDoesNotUseGenericFallback() {
+		Map<String, String> storedExtensions =
+				Collections.singletonMap(STORED_AMENITY_KEY, "Internal brand index");
+		AmenityExtensionsHelper extensionsHelper = new AmenityExtensionsHelper(app);
+		Map<String, String> normalizedExtensions =
+				extensionsHelper.getUpdatedAmenityExtensions(storedExtensions, null);
+
+		Map<String, AmenityInfoRow> rows = buildRows(
+				normalizedExtensions,
+				AmenityExtensionsHelper.getStoredExtensionFallbackKeys(storedExtensions));
+
+		assertFalse(rows.containsKey(NORMALIZED_AMENITY_KEY));
+	}
+
+	@NonNull
+	private Map<String, AmenityInfoRow> buildRows(@NonNull Map<String, String> extensions,
+	                                              @NonNull Set<String> genericFallbackKeys) {
+		Map<String, AmenityInfoRow> rows = new HashMap<>();
+		AmenityUIHelper helper = new AmenityUIHelper(mapActivity, app.getLanguage(),
+				new AdditionalInfoBundle(app.getPoiTypes(), extensions)) {
+			@Override
+			public void buildAmenityRow(View view, AmenityInfoRow info) {
+				rows.put(info.key, info);
+			}
+		};
+		helper.setGenericFallbackKeys(genericFallbackKeys);
+		helper.buildInternal(new LinearLayout(mapActivity));
+		return rows;
+	}
+}

--- a/OsmAnd/test/java/net/osmand/test/ui/poi/AmenityUIHelperStoredExtensionsTest.java
+++ b/OsmAnd/test/java/net/osmand/test/ui/poi/AmenityUIHelperStoredExtensionsTest.java
@@ -17,12 +17,12 @@ import net.osmand.data.Amenity;
 import net.osmand.data.BackgroundType;
 import net.osmand.data.FavouritePoint;
 import net.osmand.data.SpecialPointType;
-import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.activities.MapActivity;
 import net.osmand.plus.helpers.AmenityExtensionsHelper;
 import net.osmand.plus.mapcontextmenu.builders.AmenityUIHelper;
 import net.osmand.plus.mapcontextmenu.builders.rows.AmenityInfoRow;
 import net.osmand.shared.gpx.primitives.WptPt;
+import net.osmand.test.common.AndroidTest;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -33,11 +33,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 @RunWith(AndroidJUnit4.class)
-public class AmenityUIHelperStoredExtensionsTest {
+public class AmenityUIHelperStoredExtensionsTest extends AndroidTest {
 
 	private static final String KNOWN_COLON_KEY = "authentication:phone_call:number";
 	private static final String CUSTOM_KEY = "test:country";
@@ -57,16 +55,11 @@ public class AmenityUIHelperStoredExtensionsTest {
 			new ActivityTestRule<>(MapActivity.class, true, false);
 
 	private MapActivity mapActivity;
-	private OsmandApplication app;
 
 	@Before
-	public void setUp() throws InterruptedException {
+	public void setup() {
+		super.setup();
 		mapActivity = activityRule.launchActivity(null);
-		app = (OsmandApplication) mapActivity.getApplication();
-		CountDownLatch appInitialized = new CountDownLatch(1);
-		app.getAppInitializer().addOnFinishListener(initializer -> appInitialized.countDown());
-		assertTrue("Application initialization timed out",
-				appInitialized.await(5, TimeUnit.MINUTES));
 	}
 
 	@Test

--- a/OsmAnd/test/java/net/osmand/test/ui/poi/AmenityUIHelperStoredExtensionsTest.java
+++ b/OsmAnd/test/java/net/osmand/test/ui/poi/AmenityUIHelperStoredExtensionsTest.java
@@ -14,11 +14,15 @@ import androidx.test.rule.ActivityTestRule;
 
 import net.osmand.data.AdditionalInfoBundle;
 import net.osmand.data.Amenity;
+import net.osmand.data.BackgroundType;
+import net.osmand.data.FavouritePoint;
+import net.osmand.data.SpecialPointType;
+import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.activities.MapActivity;
 import net.osmand.plus.helpers.AmenityExtensionsHelper;
 import net.osmand.plus.mapcontextmenu.builders.AmenityUIHelper;
 import net.osmand.plus.mapcontextmenu.builders.rows.AmenityInfoRow;
-import net.osmand.test.common.AndroidTest;
+import net.osmand.shared.gpx.primitives.WptPt;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -29,12 +33,21 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 @RunWith(AndroidJUnit4.class)
-public class AmenityUIHelperStoredExtensionsTest extends AndroidTest {
+public class AmenityUIHelperStoredExtensionsTest {
 
 	private static final String KNOWN_COLON_KEY = "authentication:phone_call:number";
 	private static final String CUSTOM_KEY = "test:country";
+	private static final String CUSTOM_REFERENCE_KEY = "test:reference";
+	private static final String CUSTOM_ROUTE_KEY = "test:route_id";
+	private static final String UNKNOWN_UNPREFIXED_KEY = "unknown_point_field";
+	private static final String HIDDEN_KEY = "hidden";
+	private static final String VISITED_DATE_KEY = "visited_date";
+	private static final String OFFSET_KEY = "offset";
+	private static final String FILTER_ONLY_KEY = "osmand_socket_type2";
 	private static final String AMENITY_ONLY_KEY = "unknown:amenity:field";
 	private static final String STORED_AMENITY_KEY = "osm_tag_top_index_brand";
 	private static final String NORMALIZED_AMENITY_KEY = "top_index_brand";
@@ -44,17 +57,24 @@ public class AmenityUIHelperStoredExtensionsTest extends AndroidTest {
 			new ActivityTestRule<>(MapActivity.class, true, false);
 
 	private MapActivity mapActivity;
+	private OsmandApplication app;
 
 	@Before
-	public void setUp() {
+	public void setUp() throws InterruptedException {
 		mapActivity = activityRule.launchActivity(null);
+		app = (OsmandApplication) mapActivity.getApplication();
+		CountDownLatch appInitialized = new CountDownLatch(1);
+		app.getAppInitializer().addOnFinishListener(initializer -> appInitialized.countDown());
+		assertTrue("Application initialization timed out",
+				appInitialized.await(5, TimeUnit.MINUTES));
 	}
 
 	@Test
 	public void knownColonKeyUsesExistingPoiResolution() {
 		Map<String, String> extensions = Collections.singletonMap(KNOWN_COLON_KEY, "+380441234567");
 
-		Map<String, AmenityInfoRow> rows = buildRows(extensions, extensions.keySet());
+		Map<String, AmenityInfoRow> rows = buildRows(extensions,
+				AmenityExtensionsHelper.getStoredExtensionFallbackKeys(extensions));
 
 		AmenityInfoRow row = rows.get(KNOWN_COLON_KEY);
 		assertNotNull(row);
@@ -64,23 +84,122 @@ public class AmenityUIHelperStoredExtensionsTest extends AndroidTest {
 
 	@Test
 	public void unknownStoredKeyUsesGenericFallback() {
-		Map<String, String> extensions = Collections.singletonMap(CUSTOM_KEY, "United States");
+		Map<String, String> extensions = new HashMap<>();
+		extensions.put(CUSTOM_KEY, "United States");
+		extensions.put("test:state", "Virginia");
+		extensions.put("test:telephone", "+1 804 828 0100");
+		extensions.put("test:postcode", "23284");
+		extensions.put("test:start_date", "1838");
 
-		Map<String, AmenityInfoRow> rows = buildRows(extensions, extensions.keySet());
+		Map<String, AmenityInfoRow> rows = buildRows(extensions,
+				AmenityExtensionsHelper.getStoredExtensionFallbackKeys(extensions));
 
-		AmenityInfoRow row = rows.get(CUSTOM_KEY);
-		assertNotNull(row);
-		assertEquals("country", row.name);
-		assertEquals("United States", row.text);
+		for (Map.Entry<String, String> entry : extensions.entrySet()) {
+			AmenityInfoRow row = rows.get(entry.getKey());
+			assertNotNull(entry.getKey(), row);
+			assertEquals(entry.getValue(), row.text);
+		}
+		assertEquals("country", rows.get(CUSTOM_KEY).name);
 	}
 
 	@Test
 	public void unknownAmenityOnlyKeyIsNotShown() {
 		Map<String, String> extensions = Collections.singletonMap(AMENITY_ONLY_KEY, "internal value");
 
-		Map<String, AmenityInfoRow> rows = buildRows(extensions, Collections.emptySet());
+		Map<String, AmenityInfoRow> rows = buildRows(extensions,
+				AmenityExtensionsHelper.getStoredExtensionFallbackKeys(Collections.emptyMap()));
 
 		assertFalse(rows.containsKey(AMENITY_ONLY_KEY));
+	}
+
+	@Test
+	public void internalPointFieldsAreNotShown() {
+		Map<String, String> storedExtensions = new HashMap<>();
+		storedExtensions.put(HIDDEN_KEY, "true");
+		storedExtensions.put(VISITED_DATE_KEY, "2024-01-01T00:00:00Z");
+		storedExtensions.put(OFFSET_KEY, "1");
+		storedExtensions.put(CUSTOM_KEY, "United States");
+
+		Map<String, AmenityInfoRow> rows = buildRows(storedExtensions,
+				AmenityExtensionsHelper.getStoredExtensionFallbackKeys(storedExtensions));
+
+		assertFalse(rows.containsKey(HIDDEN_KEY));
+		assertFalse(rows.containsKey(VISITED_DATE_KEY));
+		assertFalse(rows.containsKey(OFFSET_KEY));
+		assertTrue(rows.containsKey(CUSTOM_KEY));
+	}
+
+	/**
+	 * Canary: unqualified fields OsmAnd stores on a point must never enter the custom fallback.
+	 */
+	@Test
+	public void noInternalPointFieldIsTreatedAsCustom() {
+		FavouritePoint point = new FavouritePoint(50.45, 30.52, "name", "category", 100d, 1L);
+		point.setVisible(false);
+		point.setVisitedDate(1_704_067_200_000L);
+		point.setPickupDate(1_704_067_200_000L);
+		point.setCalendarEvent(true);
+		point.setAddress("address");
+		point.setColor(0xFFFF0000);
+		point.setIconIdFromName("special_star");
+		point.setBackgroundType(BackgroundType.CIRCLE);
+		point.setSpecialPointType(SpecialPointType.HOME);
+		point.setAmenityOriginName("origin");
+
+		WptPt wpt = point.toWpt(app);
+
+		Set<String> fallbackKeys =
+				AmenityExtensionsHelper.getStoredExtensionFallbackKeys(wpt.getExtensionsToRead());
+
+		assertEquals("internal point fields leaked into the custom fallback: " + fallbackKeys,
+				Collections.emptySet(), fallbackKeys);
+	}
+
+	@Test
+	public void unknownUnprefixedFieldDoesNotUseGenericFallback() {
+		Map<String, String> extensions = Collections.singletonMap(UNKNOWN_UNPREFIXED_KEY, "value");
+
+		Set<String> fallbackKeys = AmenityExtensionsHelper.getStoredExtensionFallbackKeys(extensions);
+		Map<String, AmenityInfoRow> rows = buildRows(extensions, fallbackKeys);
+
+		assertTrue(fallbackKeys.isEmpty());
+		assertFalse(rows.containsKey(UNKNOWN_UNPREFIXED_KEY));
+	}
+
+	@Test
+	public void genericFallbackShowsStoredValueAsIs() {
+		Map<String, String> extensions = Collections.singletonMap(CUSTOM_REFERENCE_KEY, "abc_def");
+
+		Map<String, AmenityInfoRow> rows = buildRows(extensions,
+				AmenityExtensionsHelper.getStoredExtensionFallbackKeys(extensions));
+
+		AmenityInfoRow row = rows.get(CUSTOM_REFERENCE_KEY);
+		assertNotNull(row);
+		assertEquals("abc_def", row.text);
+	}
+
+	/**
+	 * A custom field whose key contains "route", "content" or "wikipedia" is still dropped by the
+	 * amenity-only substring filters, which run before the fallback. Known gap of #25226.
+	 */
+	@Test
+	public void customFieldMatchingAmenityFilterIsStillNotShown() {
+		Map<String, String> extensions = Collections.singletonMap(CUSTOM_ROUTE_KEY, "1234");
+
+		Map<String, AmenityInfoRow> rows = buildRows(extensions,
+				AmenityExtensionsHelper.getStoredExtensionFallbackKeys(extensions));
+
+		assertFalse(rows.containsKey(CUSTOM_ROUTE_KEY));
+	}
+
+	@Test
+	public void knownFilterOnlyPoiFieldIsNotShown() {
+		Map<String, String> extensions = Collections.singletonMap(FILTER_ONLY_KEY, "yes");
+
+		Map<String, AmenityInfoRow> rows = buildRows(extensions,
+				AmenityExtensionsHelper.getStoredExtensionFallbackKeys(extensions));
+
+		assertFalse(rows.containsKey(FILTER_ONLY_KEY));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Fixes #25226.

Restores custom GPX extension fields in the Context Menu for Waypoints and Favorites.

The regression had two related causes:

1. External namespaced GPX extensions lost their XML prefix during parsing.

   For example:

   `<test:country>United States</test:country>`

   was read as `country`, which lost part of the field identity and could cause it to be incorrectly interpreted by the standard OsmAnd POI logic or filtered out.

2. Unknown extensions stored directly in a Waypoint/Favorite were filtered when building additional information for the Context Menu.

## Changes

- Preserve qualified keys for external prefixed GPX extensions:
  - `<test:country>` → `test:country`
- Keep existing `osmand` and `gpxtpx` extension handling backward-compatible.
- Do not classify custom GPX fields using `:`, because valid OSM keys such as `contact:phone` may also contain it.
- Keep the existing POI resolution as the first priority.
- If a field stored directly in a Waypoint/Favorite is not recognized by the standard POI logic, display it using a generic text row.
- Keep Amenity-derived metadata behavior unchanged.
- Exclude existing `osm_tag_` / `amenity_` persisted Amenity fields from the new generic fallback.

Conceptually:

- stored field + known POI type → existing specialized rendering
- stored field + unknown POI type → generic rendering
- Amenity-only field → existing behavior

No new persistent marker or provenance metadata is introduced.

## Verification

Tested with the GPX attached to #25226.

The following custom fields are displayed correctly again:

- Country
- Postcode
- Start date
- State
- Telephone

Verified:

- imported GPX Waypoint Context Menu;
- direct import as Favorite;
- reopening the Favorite after application restart;
- known OSM keys containing `:` still use the existing POI resolution;
- unknown Amenity-only fields are not exposed by the new fallback.

Regression tests were added for:

- preserving external GPX prefixes;
- existing POI resolution for known stored fields;
- generic fallback for unknown stored extensions;
- Amenity-only field filtering;
- mixed stored/Amenity data.

### POI regression check

Since `AmenityUIHelper` is shared with regular POI rendering, additional characterization checks were performed to make sure the new stored-extension fallback does not change existing Amenity output.

The comparison was performed in two stages:

1. A sample of 10,000 POIs was rendered before and after the change and the resulting rows were compared.
2. The same comparison was then run for all 138,016 POIs from the Kyiv map.

For the final implementation, the generated output was identical to the baseline:

- no existing rows were removed;
- no existing row values changed;
- no existing rows were reordered;
- no additional Amenity-only/internal fields appeared.

For the full Kyiv dataset, both baseline and updated snapshots contained 47,407,561 bytes and had the same SHA-256 hash.

These snapshot checks were used as development/characterization tests and are not included in the committed test suite.

## Known limitations / follow-ups

### Favorites imported by affected older versions

Some previously imported Favorites may already have lost the original namespace identity, for example:

`test:country` → `country`

Once the prefix has been discarded, the original namespace cannot be reliably reconstructed from the stored Favorite data.

If the field itself is still stored, the current fallback may still display it. If the original field data was already lost, re-importing the source GPX is required.

### GPX Waypoint → Add → Favorite

During manual testing, a separate existing data-loss flow was found:

`GPX Waypoint → Context Menu → Add → Save Favorite`

This path goes through `FavoritePointEditor.add(...)`, which creates a new `FavouritePoint` from basic point data and does not copy the source `WptPt` extensions.

Other GPX-to-Favorites flows that use `FavouritePoint.fromWpt(...)` do copy extensions.

This is a separate issue from #25226 and is intentionally not changed in this PR, since fixing it changes the semantics of the generic Add-to-Favorites flow for Waypoints in general, not only custom GPX extensions.