### PR TITLE
Fix GPX appearance reset during startup

### DIFF
--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxDataItem.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxDataItem.kt
@@ -14,6 +14,18 @@ class GpxDataItem private constructor(
 	private var analysis: GpxTrackAnalysis? = null
 
 	companion object {
+		private const val MIN_VERTICAL_EXAGGERATION = 1.0
+		private const val MAX_VERTICAL_EXAGGERATION = 3.0
+		private val ANALYSIS_METADATA_PARAMETERS = listOf(
+			GpxParameter.FILE_LAST_MODIFIED_TIME,
+			GpxParameter.FILE_CREATION_TIME,
+			GpxParameter.NEAREST_CITY_NAME,
+			GpxParameter.ACTIVITY_TYPE,
+			GpxParameter.DATA_VERSION
+		)
+		private val ANALYSIS_UPDATE_PARAMETERS =
+			(GpxParameter.entries.filter { it.analysisParameter } + ANALYSIS_METADATA_PARAMETERS).toSet()
+
 		fun isRegularTrack(file: KFile) = file.path().startsWith(PlatformUtil.getOsmAndContext().getGpxDir().path())
 
 		internal fun fromDatabase(file: KFile) = GpxDataItem(file, false)
@@ -43,6 +55,26 @@ class GpxDataItem private constructor(
 			}
 		}
 		setAnalysis(item.analysis)
+	}
+
+	internal fun copyAnalysisData(item: GpxDataItem) {
+		setAnalysis(item.analysis)
+		for (parameter in ANALYSIS_METADATA_PARAMETERS) {
+			setParameter(parameter, item.getParameter(parameter))
+		}
+	}
+
+	internal fun getAnalysisUpdateParameters(): Map<GpxParameter, Any?> =
+		getParameters().filterKeys { it in ANALYSIS_UPDATE_PARAMETERS }
+
+	internal fun normalizeAdditionalExaggeration(): Boolean {
+		val value: Double = requireParameter(GpxParameter.ADDITIONAL_EXAGGERATION)
+		return if (value < MIN_VERTICAL_EXAGGERATION || value > MAX_VERTICAL_EXAGGERATION) {
+			setParameter(GpxParameter.ADDITIONAL_EXAGGERATION, MIN_VERTICAL_EXAGGERATION)
+			true
+		} else {
+			false
+		}
 	}
 
 	private fun updateAnalysisParameters() {

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxDatabase.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxDatabase.kt
@@ -114,6 +114,44 @@ class GpxDatabase {
 		return updateGpxParameters(item, linkedMapOf(gpxParameter to value))
 	}
 
+	fun persistAnalyzedItem(item: GpxDataItem): GpxDataItem? {
+		var db: SQLiteConnection? = null
+		try {
+			db = openConnection(false) ?: return null
+			db.beginTransaction()
+			try {
+				// Re-read in the write transaction so analysis can only be merged into the
+				// latest user-controlled values.
+				val storedItem = getDataItem(item.file, db) as? GpxDataItem
+				val itemToPersist = storedItem?.apply { copyAnalysisData(item) } ?: item
+				val updateParameters = itemToPersist.getAnalysisUpdateParameters().toMutableMap()
+				if (itemToPersist.normalizeAdditionalExaggeration()) {
+					updateParameters[ADDITIONAL_EXAGGERATION] =
+						itemToPersist.getParameter(ADDITIONAL_EXAGGERATION)
+				}
+				if (storedItem != null) {
+					updateGpxParameters(
+						db,
+						GPX_TABLE_NAME,
+						updateParameters,
+						GpxDbUtils.getItemRowsToSearch(item.file)
+					)
+				} else {
+					insertItem(itemToPersist, db)
+				}
+				db.setTransactionSuccessful()
+				return itemToPersist
+			} finally {
+				db.endTransaction()
+			}
+		} catch (e: Exception) {
+			log.error("Failed to persist analyzed GPX item ${item.file.path()}", e)
+			return null
+		} finally {
+			db?.close()
+		}
+	}
+
 	private fun updateGpxParameters(item: DataItem, map: Map<GpxParameter, Any?>): Boolean {
 		val file = item.file
 		val tableName = GpxDbUtils.getTableName(file)

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxDbHelper.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxDbHelper.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import net.osmand.shared.api.SQLiteAPI.SQLiteConnection
 import net.osmand.shared.data.StringIntPair
 import net.osmand.shared.extensions.currentTimeMillis
 import net.osmand.shared.gpx.GpxReader.GpxReaderAdapter
@@ -28,14 +27,16 @@ object GpxDbHelper : GpxReaderAdapter {
 	private val dataItems = ConcurrentMutableMap<KFile, GpxDataItem>()
 	private var itemsVersion = AtomicInt(0)
 
-	private val readingItemsMap = mutableMapOf<KFile, GpxDataItem>()
+	// Queued reads must not retain metadata snapshots created before cache hydration.
+	private val readingFiles = mutableSetOf<KFile>()
+	private val resolvingFiles = mutableSetOf<KFile>()
 	private val readingItemsCallbacks = mutableMapOf<KFile, MutableList<GpxDataItemCallback>?>()
 
 	private const val READER_TASKS_LIMIT = 4
 	private var readers = mutableListOf<GpxReader>()
 	private var readerSync = Synchronizable()
 
-	private var initialized: Boolean = false
+	private val initialized = AtomicBoolean(false)
 	private var reconciliationRunning = AtomicBoolean(false)
 	private var reconciliationComplete = AtomicBoolean(false)
 	private var reconciliationAttempted = AtomicBoolean(false)
@@ -53,7 +54,7 @@ object GpxDbHelper : GpxReaderAdapter {
 	suspend fun loadItems() {
 		loadGpxItems()
 		loadGpxDirItems()
-		initialized = true
+		initialized.value = true
 	}
 
 	private suspend fun loadGpxItems() {
@@ -70,14 +71,14 @@ object GpxDbHelper : GpxReaderAdapter {
 		log.info("Hydrated GPX directory metadata in ${currentTimeMillis() - start} ms, items count ${dirItems.size}")
 	}
 
-	fun isInitialized() = initialized
+	fun isInitialized() = initialized.value
 
 	fun isFilesystemReconciliationRunning() = reconciliationRunning.value
 
 	fun isFilesystemReconciliationComplete() = reconciliationComplete.value
 
 	fun startFilesystemReconciliation() {
-		if (!initialized || reconciliationAttempted.value ||
+		if (!initialized.value || reconciliationAttempted.value ||
 				!reconciliationRunning.compareAndSet(expected = false, new = true)) {
 			return
 		}
@@ -149,7 +150,7 @@ object GpxDbHelper : GpxReaderAdapter {
 				val actualModifiedTime = file.lastModified()
 				if (item.getParameter<Long>(GpxParameter.FILE_LAST_MODIFIED_TIME) != actualModifiedTime
 						|| GpxDbUtils.isAnalyseNeeded(item, actualModifiedTime)) {
-					readGpxItem(file, item, null, false)
+					readGpxItem(file, null, false)
 					queuedModifiedItems++
 				}
 			}
@@ -245,9 +246,18 @@ object GpxDbHelper : GpxReaderAdapter {
 		return res
 	}
 
-	fun insertDataItem(item: DataItem, conn: SQLiteConnection) {
-		database.insertItem(item, conn)
-		putToCache(item)
+	fun persistAnalyzedItem(item: GpxDataItem): GpxDataItem {
+		val persistedItem = database.persistAnalyzedItem(item)
+		val cachedItem = dataItems[item.file]
+		val result = when {
+			persistedItem == null -> cachedItem ?: item
+			cachedItem != null -> cachedItem.apply { copyAnalysisData(persistedItem) }
+			else -> persistedItem
+		}
+		if (persistedItem != null) {
+			putToCache(result)
+		}
+		return result
 	}
 
 	fun updateDataItemParameter(
@@ -371,7 +381,7 @@ object GpxDbHelper : GpxReaderAdapter {
 			val shouldCheckAnalysis = callback != null || !isReading(file)
 			if (shouldCheckAnalysis && GpxDbUtils.isAnalyseNeeded(item)) {
 				val reconciliationFinished = reconciliationAttempted.value && !reconciliationRunning.value
-				readGpxItem(file, item, callback, reconciliationFinished)
+				readGpxItem(file, callback, reconciliationFinished)
 			}
 		}
 		return item
@@ -411,11 +421,12 @@ object GpxDbHelper : GpxReaderAdapter {
 	fun isReading(): Boolean = readerSync.synchronize { readers.isNotEmpty() }
 
 	fun isReading(file: KFile): Boolean =
-		readerSync.synchronize { readingItemsMap.contains(file) || readers.any { it.isReading(file) } }
+		readerSync.synchronize {
+			readingFiles.contains(file) || resolvingFiles.contains(file) || readers.any { it.isReading(file) }
+		}
 
 	private fun readGpxItem(
 		file: KFile,
-		item: GpxDataItem?,
 		callback: GpxDataItemCallback?,
 		startReader: Boolean = true
 	) {
@@ -423,8 +434,10 @@ object GpxDbHelper : GpxReaderAdapter {
 			if (callback != null) {
 				readingItemsCallbacks.getOrPut(file) { mutableListOf() }?.apply { add(callback) }
 			}
-			if (!isReading(file)) {
-				readingItemsMap[file] = item ?: GpxDataItem(file)
+			val alreadyReading = readingFiles.contains(file) || resolvingFiles.contains(file) ||
+					readers.any { it.isReading(file) }
+			if (!alreadyReading) {
+				readingFiles.add(file)
 				if (startReader && readers.size < READER_TASKS_LIMIT) {
 					startReading()
 				}
@@ -434,7 +447,7 @@ object GpxDbHelper : GpxReaderAdapter {
 
 	private fun startQueuedReaders() {
 		readerSync.synchronize {
-			while (readingItemsMap.isNotEmpty() && readers.size < READER_TASKS_LIMIT) {
+			while (readingFiles.isNotEmpty() && readers.size < READER_TASKS_LIMIT) {
 				startReading()
 			}
 		}
@@ -455,12 +468,39 @@ object GpxDbHelper : GpxReaderAdapter {
 
 	fun getGPXDatabase(): GpxDatabase = database
 
-	override fun pullNextFileItem(action: ((Pair<KFile, GpxDataItem>?) -> Unit)?): Pair<KFile, GpxDataItem>? =
-		readerSync.synchronize {
-			val result = readingItemsMap.entries.firstOrNull()?.toPair()?.apply { readingItemsMap.remove(first) }
-			action?.invoke(result)
-			result
+	override fun pullNextFileItem(
+		action: ((Pair<KFile, GpxDataItem?>?) -> Unit)?
+	): Pair<KFile, GpxDataItem?>? {
+		val file = readerSync.synchronize {
+			readingFiles.firstOrNull()?.also {
+				readingFiles.remove(it)
+				resolvingFiles.add(it)
+			}
 		}
+		var result: Pair<KFile, GpxDataItem?>? = null
+		try {
+			result = file?.let {
+				val item = dataItems[it] ?: try {
+					database.getGpxDataItem(it)
+				} catch (e: Exception) {
+					log.error("Failed to resolve queued GPX item ${it.path()}", e)
+					null
+				}
+				it to item
+			}
+			return result
+		} finally {
+			readerSync.synchronize {
+				try {
+					action?.invoke(result)
+				} finally {
+					if (file != null) {
+						resolvingFiles.remove(file)
+					}
+				}
+			}
+		}
+	}
 
 	override fun onGpxDataItemRead(item: GpxDataItem) {
 		putGpxDataItemToSmartFolder(item)
@@ -490,14 +530,15 @@ object GpxDbHelper : GpxReaderAdapter {
 
 	override fun onReadingCancelled() {
 		readerSync.synchronize {
-			readingItemsMap.clear()
+			readingFiles.clear()
+			resolvingFiles.clear()
 			readingItemsCallbacks.clear()
 		}
 	}
 
 	override fun onReadingFinished(reader: GpxReader, cancelled: Boolean) {
 		readerSync.synchronize {
-			if (readingItemsMap.isNotEmpty() && readers.size < READER_TASKS_LIMIT && !cancelled) {
+			if (readingFiles.isNotEmpty() && readers.size < READER_TASKS_LIMIT && !cancelled) {
 				startReading()
 			}
 			readers.remove(reader)

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxReader.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/gpx/GpxReader.kt
@@ -12,13 +12,8 @@ class GpxReader(private val adapter: GpxReaderAdapter)
 
 	companion object {
 		private val log = LoggerFactory.getLogger("GpxReader")
-
-		// TODO: Move to GpxAppearanceInfo.kt
-		const val MIN_VERTICAL_EXAGGERATION: Float = 1.0f
-		const val MAX_VERTICAL_EXAGGERATION: Float = 3.0f
 	}
 
-	private val database: GpxDatabase = GpxDbHelper.getGPXDatabase()
 	private var analyser = PlatformUtil.getTrackPointsAnalyser()
 	private var currentFile: KFile? = null
 	private var currentItem: GpxDataItem? = null
@@ -84,6 +79,9 @@ class GpxReader(private val adapter: GpxReaderAdapter)
 		val gpxFile = GpxUtilities.loadGpxFile(file, null, false)
 		val updatedItem = item ?: GpxDataItem(file)
 		if (gpxFile.error == null) {
+			if (item == null) {
+				updatedItem.readGpxParams(gpxFile)
+			}
 			updatedItem.setAnalysis(gpxFile.getAnalysis(file.lastModified(), null, null, analyser,
 				collectPointData = false))
 			if (!updatedItem.isRegularTrack()) {
@@ -101,33 +99,14 @@ class GpxReader(private val adapter: GpxReaderAdapter)
 			updatedItem.setParameter(GpxParameter.ACTIVITY_TYPE, routeActivityId)
 
 			setupNearestCityName(updatedItem)
+			updatedItem.normalizeAdditionalExaggeration()
 
-			val additionalExaggeration: Double =
-				updatedItem.requireParameter(GpxParameter.ADDITIONAL_EXAGGERATION)
-			if (additionalExaggeration < MIN_VERTICAL_EXAGGERATION ||
-				additionalExaggeration > MAX_VERTICAL_EXAGGERATION) {
-				updatedItem.setParameter(GpxParameter.ADDITIONAL_EXAGGERATION,
-					MIN_VERTICAL_EXAGGERATION.toDouble())
-			}
 			updatedItem.setParameter(
 				GpxParameter.DATA_VERSION,
 				GpxDbUtils.createDataVersion(ANALYSIS_VERSION)
 			)
 
-			val conn = database.openConnection(false)
-			if (conn != null) {
-				try {
-					if (database.isDataItemExists(file, conn)) {
-						GpxDbHelper.updateDataItem(updatedItem)
-					} else {
-						GpxDbHelper.insertDataItem(updatedItem, conn)
-					}
-				} catch (e: Exception) {
-					log.error(e.message)
-				} finally {
-					conn.close()
-				}
-			}
+			return GpxDbHelper.persistAnalyzedItem(updatedItem)
 		}
 		return updatedItem
 	}
@@ -149,7 +128,9 @@ class GpxReader(private val adapter: GpxReaderAdapter)
 	fun isReading(file: KFile): Boolean = currentFile == file
 
 	interface GpxReaderAdapter {
-		fun pullNextFileItem(action: ((Pair<KFile, GpxDataItem>?) -> Unit)? = null): Pair<KFile, GpxDataItem>?
+		fun pullNextFileItem(
+			action: ((Pair<KFile, GpxDataItem?>?) -> Unit)? = null
+		): Pair<KFile, GpxDataItem?>?
 
 		fun onGpxDataItemRead(item: GpxDataItem) {}
 		fun onProgressUpdate(vararg dataItems: GpxDataItem) {}

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/gpx/DataItemHydrationTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/gpx/DataItemHydrationTest.kt
@@ -4,6 +4,7 @@ import net.osmand.shared.io.KFile
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class DataItemHydrationTest {
 
@@ -57,6 +58,46 @@ class DataItemHydrationTest {
 			directory = true,
 			expected = "/storage/emulated/0/outside"
 		)
+	}
+
+	@Test
+	fun analysisMergePreservesAppearanceAndBackupTimestamp() {
+		val file = KFile("/gpx/customized.gpx")
+		val storedItem = GpxDataItem.fromDatabase(file).apply {
+			setParameter(GpxParameter.COLOR, 0xFF336699.toInt())
+			setParameter(GpxParameter.WIDTH, "bold")
+			setParameter(GpxParameter.SHOW_ARROWS, true)
+			setParameter(GpxParameter.JOIN_SEGMENTS, true)
+			setParameter(GpxParameter.ADDITIONAL_EXAGGERATION, 2.5)
+			setParameter(GpxParameter.APPEARANCE_LAST_MODIFIED_TIME, 1234L)
+		}
+		val analyzedItem = GpxDataItem.fromDatabase(file).apply {
+			setAnalysis(GpxTrackAnalysis())
+			setParameter(GpxParameter.COLOR, 0xFF000000.toInt())
+			setParameter(GpxParameter.FILE_LAST_MODIFIED_TIME, 5678L)
+			setParameter(GpxParameter.FILE_CREATION_TIME, 1000L)
+			setParameter(GpxParameter.NEAREST_CITY_NAME, "Amsterdam")
+			setParameter(GpxParameter.ACTIVITY_TYPE, "cycling")
+			setParameter(GpxParameter.DATA_VERSION, 42)
+		}
+
+		storedItem.copyAnalysisData(analyzedItem)
+
+		assertEquals(0xFF336699.toInt(), storedItem.getParameter(GpxParameter.COLOR))
+		assertEquals("bold", storedItem.getParameter(GpxParameter.WIDTH))
+		assertEquals(true, storedItem.getParameter(GpxParameter.SHOW_ARROWS))
+		assertEquals(true, storedItem.getParameter(GpxParameter.JOIN_SEGMENTS))
+		assertEquals(2.5, storedItem.getParameter(GpxParameter.ADDITIONAL_EXAGGERATION))
+		assertEquals(1234L, storedItem.getParameter(GpxParameter.APPEARANCE_LAST_MODIFIED_TIME))
+		assertEquals(5678L, storedItem.getParameter(GpxParameter.FILE_LAST_MODIFIED_TIME))
+		assertEquals("Amsterdam", storedItem.getParameter(GpxParameter.NEAREST_CITY_NAME))
+
+		val updatedParameters = storedItem.getAnalysisUpdateParameters().keys
+		assertTrue(updatedParameters.any { it.analysisParameter })
+		assertTrue(GpxParameter.getAppearanceParameters().none { it in updatedParameters })
+		assertFalse(GpxParameter.JOIN_SEGMENTS in updatedParameters)
+		assertFalse(GpxParameter.ADDITIONAL_EXAGGERATION in updatedParameters)
+		assertFalse(GpxParameter.APPEARANCE_LAST_MODIFIED_TIME in updatedParameters)
 	}
 
 	private fun assertResolvedPath(


### PR DESCRIPTION
## Summary

- queue GPX analysis work by file identity and resolve the authoritative hydrated database item before reading
- merge and persist only analysis-derived metadata in a single transaction, preserving track appearance and its backup modification timestamp
- initialize genuinely new database rows from GPX metadata and add regression coverage for user-controlled appearance fields

Fixes #24078