### PR TITLE
Fix false Global Settings changes from local preferences

### DIFF
--- a/OsmAnd/src/net/osmand/plus/AppVersionUpgradeOnInit.java
+++ b/OsmAnd/src/net/osmand/plus/AppVersionUpgradeOnInit.java
@@ -977,7 +977,7 @@ public class AppVersionUpgradeOnInit {
 	}
 
 	private void migrateLocalSorting(@NonNull OsmandSettings settings) {
-		CommonPreference<LocalSortMode> oldPref = settings.registerEnumStringPreference("local_maps_sort_mode", COUNTRY_NAME_ASCENDING, LocalSortMode.values(), LocalSortMode.class).makeGlobal();
+		CommonPreference<LocalSortMode> oldPref = settings.registerEnumStringPreference("local_maps_sort_mode", COUNTRY_NAME_ASCENDING, LocalSortMode.values(), LocalSortMode.class).makeGlobal().makeShared();
 		if (oldPref.isSet()) {
 			LocalSortMode sortMode = oldPref.get();
 			LocalItemUtils.getSortModePref(app, MAP_DATA).set(sortMode);

--- a/OsmAnd/src/net/osmand/plus/AppVersionUpgradeOnInit.java
+++ b/OsmAnd/src/net/osmand/plus/AppVersionUpgradeOnInit.java
@@ -977,7 +977,7 @@ public class AppVersionUpgradeOnInit {
 	}
 
 	private void migrateLocalSorting(@NonNull OsmandSettings settings) {
-		CommonPreference<LocalSortMode> oldPref = settings.registerEnumStringPreference("local_maps_sort_mode", COUNTRY_NAME_ASCENDING, LocalSortMode.values(), LocalSortMode.class).makeGlobal().makeShared();
+		CommonPreference<LocalSortMode> oldPref = settings.registerEnumStringPreference("local_maps_sort_mode", COUNTRY_NAME_ASCENDING, LocalSortMode.values(), LocalSortMode.class).makeGlobal();
 		if (oldPref.isSet()) {
 			LocalSortMode sortMode = oldPref.get();
 			LocalItemUtils.getSortModePref(app, MAP_DATA).set(sortMode);

--- a/OsmAnd/src/net/osmand/plus/download/local/LocalItemUtils.java
+++ b/OsmAnd/src/net/osmand/plus/download/local/LocalItemUtils.java
@@ -394,6 +394,6 @@ public class LocalItemUtils {
 		String prefId = "local_" + type.name().toLowerCase(Locale.US) + "_sort_mode";
 		LocalSortMode defMode = LocalSortMode.getDefaultSortMode(type);
 		LocalSortMode[] supportedModes = LocalSortMode.getSupportedModes(type);
-		return settings.registerEnumStringPreference(prefId, defMode, supportedModes, LocalSortMode.class).makeGlobal();
+		return settings.registerEnumStringPreference(prefId, defMode, supportedModes, LocalSortMode.class).makeGlobal().makeShared();
 	}
 }

--- a/OsmAnd/src/net/osmand/plus/download/local/LocalItemUtils.java
+++ b/OsmAnd/src/net/osmand/plus/download/local/LocalItemUtils.java
@@ -394,6 +394,6 @@ public class LocalItemUtils {
 		String prefId = "local_" + type.name().toLowerCase(Locale.US) + "_sort_mode";
 		LocalSortMode defMode = LocalSortMode.getDefaultSortMode(type);
 		LocalSortMode[] supportedModes = LocalSortMode.getSupportedModes(type);
-		return settings.registerEnumStringPreference(prefId, defMode, supportedModes, LocalSortMode.class).makeGlobal().makeShared();
+		return settings.registerEnumStringPreference(prefId, defMode, supportedModes, LocalSortMode.class).makeGlobal();
 	}
 }

--- a/OsmAnd/src/net/osmand/plus/plugins/mapillary/MapillaryPlugin.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/mapillary/MapillaryPlugin.java
@@ -103,7 +103,7 @@ public class MapillaryPlugin extends OsmandPlugin {
 		MAPILLARY_FILTER_FROM_DATE = registerLongPreference("mapillary_filter_from_date", 0).makeGlobal().makeShared();
 		MAPILLARY_FILTER_TO_DATE = registerLongPreference("mapillary_filter_to_date", 0).makeGlobal().makeShared();
 		MAPILLARY_FILTER_PANO = registerBooleanPreference("mapillary_filter_pano", false).makeGlobal().makeShared();
-		MAPILLARY_PHOTOS_ROW_COLLAPSED = registerBooleanPreference("mapillary_menu_collapsed", true).makeGlobal().makeShared();
+		MAPILLARY_PHOTOS_ROW_COLLAPSED = registerBooleanPreference("mapillary_menu_collapsed", true).makeGlobal();
 	}
 
 	@Override

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -1497,7 +1497,7 @@ public class OsmandSettings {
 	public final OsmandPreference<Boolean> SHOW_POI_LABEL = new BooleanPreference(this, "show_poi_label", false).makeProfile();
 
 	public final OsmandPreference<Boolean> ONLINE_PHOTOS_ROW_COLLAPSED = new BooleanPreference(this, "online_photos_menu_collapsed", true).makeGlobal();
-	public final OsmandPreference<Boolean> EXPLORE_NEARBY_ITEMS_ROW_COLLAPSED = new BooleanPreference(this, "online_photos_menu_collapsed", true).makeGlobal();
+	public final OsmandPreference<Boolean> EXPLORE_NEARBY_ITEMS_ROW_COLLAPSED = new BooleanPreference(this, "explore_nearby_items_menu_collapsed", true).makeGlobal();
 	public final OsmandPreference<Boolean> EXPLORE_HISTORY_ROW_COLLAPSED = new BooleanPreference(this, "explore_history_menu_collapsed", true).makeGlobal();
 	public final OsmandPreference<Boolean> ATTACHED_MEDIA_ROW_COLLAPSED = new BooleanPreference(this, "attached_media_menu_collapsed", true).makeGlobal();
 	public final OsmandPreference<Boolean> WEBGL_SUPPORTED = new BooleanPreference(this, "webgl_supported", true).makeGlobal();

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -1464,7 +1464,7 @@ public class OsmandSettings {
 	}
 
 	public final OsmandPreference<Boolean> DO_NOT_SHOW_STARTUP_MESSAGES = new BooleanPreference(this, "do_not_show_startup_messages", false).makeGlobal().makeShared().cache();
-	public final OsmandPreference<Boolean> SHOW_SUGGEST_MAP_DIALOG = new BooleanPreference(this, "show_download_map_dialog", true).makeGlobal().cache();
+	public final OsmandPreference<Boolean> SHOW_SUGGEST_MAP_DIALOG = new BooleanPreference(this, "show_download_map_dialog", true).makeGlobal().makeShared().cache();
 	public final OsmandPreference<Boolean> DO_NOT_USE_ANIMATIONS = new BooleanPreference(this, "do_not_use_animations", false).makeProfile().cache();
 
 	public final OsmandPreference<Boolean> SEND_ANONYMOUS_MAP_DOWNLOADS_DATA = new BooleanPreference(this, "send_anonymous_map_downloads_data", false).makeGlobal().makeShared().cache();
@@ -1654,7 +1654,7 @@ public class OsmandSettings {
 	public final CommonPreference<Boolean> SAVE_GLOBAL_TRACK_TO_GPX = new BooleanPreference(this, "save_global_track_to_gpx", false).makeGlobal().cache();
 	public final CommonPreference<Integer> SAVE_GLOBAL_TRACK_INTERVAL = new IntPreference(this, "save_global_track_interval", 5000).makeProfile().cache();
 	public final CommonPreference<Boolean> SAVE_GLOBAL_TRACK_REMEMBER = new BooleanPreference(this, "save_global_track_remember", false).makeProfile().cache();
-	public final CommonPreference<Boolean> SHOW_TRIP_REC_START_DIALOG = new BooleanPreference(this, "show_trip_recording_start_dialog", true).makeGlobal();
+	public final CommonPreference<Boolean> SHOW_TRIP_REC_START_DIALOG = new BooleanPreference(this, "show_trip_recording_start_dialog", true).makeGlobal().makeShared();
 	public final CommonPreference<Boolean> SHOW_BATTERY_OPTIMIZATION_DIALOG = new BooleanPreference(this, "show_battery_optimization_dialog", true).makeGlobal();
 	public final CommonPreference<Boolean> SAVE_TRACK_TO_GPX = new BooleanPreference(this, "save_track_to_gpx", false).makeProfile().cache();
 

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -953,7 +953,7 @@ public class OsmandSettings {
 	public final CommonPreference<Boolean> ENABLE_3D_MAPS = registerBooleanPreference("enable_3d_maps", true).makeProfile().makeShared().cache();
 	public final CommonPreference<Float> VERTICAL_EXAGGERATION_SCALE = registerFloatPreference("vertical_exaggeration_scale", 1f).makeProfile();
 
-	public final CommonPreference<Integer> SIMULATE_POSITION_SPEED = new IntPreference(this, "simulate_position_movement_speed", 1).makeGlobal().makeShared();
+	public final CommonPreference<Integer> SIMULATE_POSITION_SPEED = new IntPreference(this, "simulate_position_movement_speed", 1).makeGlobal();
 
 	public final CommonPreference<DistanceByTapTextSize> DISTANCE_BY_TAP_TEXT_SIZE = new EnumStringPreference<>(this, "distance_by_tap_text_size", DistanceByTapTextSize.NORMAL, DistanceByTapTextSize.values()).makeProfile();
 
@@ -989,7 +989,7 @@ public class OsmandSettings {
 
 	public final CommonPreference<Boolean> FORCE_PRIVATE_ACCESS_ROUTING_ASKED = new BooleanPreference(this, "force_private_access_routing", false).makeProfile().cache();
 
-	public final CommonPreference<Boolean> SHOW_CARD_TO_CHOOSE_DRAWER = new BooleanPreference(this, "show_card_to_choose_drawer", false).makeGlobal().makeShared();
+	public final CommonPreference<Boolean> SHOW_CARD_TO_CHOOSE_DRAWER = new BooleanPreference(this, "show_card_to_choose_drawer", false).makeGlobal();
 	public final CommonPreference<Boolean> SHOW_DASHBOARD_ON_START = new BooleanPreference(this, "should_show_dashboard_on_start", false).makeGlobal().makeShared();
 	public final CommonPreference<Boolean> SHOW_DASHBOARD_ON_MAP_SCREEN = new BooleanPreference(this, "show_dashboard_on_map_screen", false).makeGlobal().makeShared();
 	public final CommonPreference<Boolean> SHOW_OSMAND_WELCOME_SCREEN = new BooleanPreference(this, "show_osmand_welcome_screen", true).makeGlobal();
@@ -1024,7 +1024,7 @@ public class OsmandSettings {
 
 	public final OsmandPreference<Boolean> USE_LAST_APPLICATION_MODE_BY_DEFAULT = new BooleanPreference(this, "use_last_application_mode_by_default", false).makeGlobal().makeShared();
 
-	public final OsmandPreference<String> LAST_USED_APPLICATION_MODE = new StringPreference(this, "last_used_application_mode", ApplicationMode.DEFAULT.getStringKey()).makeGlobal().makeShared();
+	public final OsmandPreference<String> LAST_USED_APPLICATION_MODE = new StringPreference(this, "last_used_application_mode", ApplicationMode.DEFAULT.getStringKey()).makeGlobal();
 
 	public final OsmandPreference<ApplicationMode> DEFAULT_APPLICATION_MODE = new CommonPreference<ApplicationMode>(this, "default_application_mode_string", ApplicationMode.DEFAULT) {
 
@@ -1464,12 +1464,12 @@ public class OsmandSettings {
 	}
 
 	public final OsmandPreference<Boolean> DO_NOT_SHOW_STARTUP_MESSAGES = new BooleanPreference(this, "do_not_show_startup_messages", false).makeGlobal().makeShared().cache();
-	public final OsmandPreference<Boolean> SHOW_SUGGEST_MAP_DIALOG = new BooleanPreference(this, "show_download_map_dialog", true).makeGlobal().makeShared().cache();
+	public final OsmandPreference<Boolean> SHOW_SUGGEST_MAP_DIALOG = new BooleanPreference(this, "show_download_map_dialog", true).makeGlobal().cache();
 	public final OsmandPreference<Boolean> DO_NOT_USE_ANIMATIONS = new BooleanPreference(this, "do_not_use_animations", false).makeProfile().cache();
 
 	public final OsmandPreference<Boolean> SEND_ANONYMOUS_MAP_DOWNLOADS_DATA = new BooleanPreference(this, "send_anonymous_map_downloads_data", false).makeGlobal().makeShared().cache();
 	public final OsmandPreference<Boolean> SEND_ANONYMOUS_APP_USAGE_DATA = new BooleanPreference(this, "send_anonymous_app_usage_data", false).makeGlobal().makeShared().cache();
-	public final OsmandPreference<Boolean> SEND_ANONYMOUS_DATA_REQUEST_PROCESSED = new BooleanPreference(this, "send_anonymous_data_request_processed", false).makeGlobal().makeShared().cache();
+	public final OsmandPreference<Boolean> SEND_ANONYMOUS_DATA_REQUEST_PROCESSED = new BooleanPreference(this, "send_anonymous_data_request_processed", false).makeGlobal().cache();
 	public final OsmandPreference<Integer> SEND_ANONYMOUS_DATA_REQUESTS_COUNT = new IntPreference(this, "send_anonymous_data_requests_count", 0).makeGlobal().cache();
 	public final OsmandPreference<Integer> SEND_ANONYMOUS_DATA_LAST_REQUEST_NS = new IntPreference(this, "send_anonymous_data_last_request_ns", -1).makeGlobal().cache();
 
@@ -1496,10 +1496,10 @@ public class OsmandSettings {
 
 	public final OsmandPreference<Boolean> SHOW_POI_LABEL = new BooleanPreference(this, "show_poi_label", false).makeProfile();
 
-	public final OsmandPreference<Boolean> ONLINE_PHOTOS_ROW_COLLAPSED = new BooleanPreference(this, "online_photos_menu_collapsed", true).makeGlobal().makeShared();
-	public final OsmandPreference<Boolean> EXPLORE_NEARBY_ITEMS_ROW_COLLAPSED = new BooleanPreference(this, "online_photos_menu_collapsed", true).makeGlobal().makeShared();
-	public final OsmandPreference<Boolean> EXPLORE_HISTORY_ROW_COLLAPSED = new BooleanPreference(this, "explore_history_menu_collapsed", true).makeGlobal().makeShared();
-	public final OsmandPreference<Boolean> ATTACHED_MEDIA_ROW_COLLAPSED = new BooleanPreference(this, "attached_media_menu_collapsed", true).makeGlobal().makeShared();
+	public final OsmandPreference<Boolean> ONLINE_PHOTOS_ROW_COLLAPSED = new BooleanPreference(this, "online_photos_menu_collapsed", true).makeGlobal();
+	public final OsmandPreference<Boolean> EXPLORE_NEARBY_ITEMS_ROW_COLLAPSED = new BooleanPreference(this, "online_photos_menu_collapsed", true).makeGlobal();
+	public final OsmandPreference<Boolean> EXPLORE_HISTORY_ROW_COLLAPSED = new BooleanPreference(this, "explore_history_menu_collapsed", true).makeGlobal();
+	public final OsmandPreference<Boolean> ATTACHED_MEDIA_ROW_COLLAPSED = new BooleanPreference(this, "attached_media_menu_collapsed", true).makeGlobal();
 	public final OsmandPreference<Boolean> WEBGL_SUPPORTED = new BooleanPreference(this, "webgl_supported", true).makeGlobal();
 
 	public final OsmandPreference<String> PREFERRED_LOCALE = new StringPreference(this, "preferred_locale", "").makeGlobal().makeShared();
@@ -1654,8 +1654,8 @@ public class OsmandSettings {
 	public final CommonPreference<Boolean> SAVE_GLOBAL_TRACK_TO_GPX = new BooleanPreference(this, "save_global_track_to_gpx", false).makeGlobal().cache();
 	public final CommonPreference<Integer> SAVE_GLOBAL_TRACK_INTERVAL = new IntPreference(this, "save_global_track_interval", 5000).makeProfile().cache();
 	public final CommonPreference<Boolean> SAVE_GLOBAL_TRACK_REMEMBER = new BooleanPreference(this, "save_global_track_remember", false).makeProfile().cache();
-	public final CommonPreference<Boolean> SHOW_TRIP_REC_START_DIALOG = new BooleanPreference(this, "show_trip_recording_start_dialog", true).makeGlobal().makeShared();
-	public final CommonPreference<Boolean> SHOW_BATTERY_OPTIMIZATION_DIALOG = new BooleanPreference(this, "show_battery_optimization_dialog", true).makeGlobal().makeShared();
+	public final CommonPreference<Boolean> SHOW_TRIP_REC_START_DIALOG = new BooleanPreference(this, "show_trip_recording_start_dialog", true).makeGlobal();
+	public final CommonPreference<Boolean> SHOW_BATTERY_OPTIMIZATION_DIALOG = new BooleanPreference(this, "show_battery_optimization_dialog", true).makeGlobal();
 	public final CommonPreference<Boolean> SAVE_TRACK_TO_GPX = new BooleanPreference(this, "save_track_to_gpx", false).makeProfile().cache();
 
 	{
@@ -1750,7 +1750,7 @@ public class OsmandSettings {
 	public final OsmandPreference<Boolean> SPEAK_ROUTE_DEVIATION = new BooleanPreference(this, "speak_route_deviation", true).makeProfile().cache();
 
 	public final OsmandPreference<Boolean> SPEED_CAMERAS_UNINSTALLED = new BooleanPreference(this, "speed_cameras_uninstalled", false).makeGlobal().makeShared();
-	public final OsmandPreference<Boolean> SPEED_CAMERAS_ALERT_SHOWED = new BooleanPreference(this, "speed_cameras_alert_showed", false).makeGlobal().makeShared();
+	public final OsmandPreference<Boolean> SPEED_CAMERAS_ALERT_SHOWED = new BooleanPreference(this, "speed_cameras_alert_showed", false).makeGlobal();
 
 	public Set<String> getForbiddenTypes() {
 		Set<String> typeNames = new HashSet<>();
@@ -1769,8 +1769,8 @@ public class OsmandSettings {
 	public final OsmandPreference<Boolean> GPX_ROUTE_CALC_OSMAND_PARTS = new BooleanPreference(this, "gpx_routing_calculate_osmand_route", true).makeGlobal().makeShared().cache();
 	public final OsmandPreference<Boolean> GPX_CALCULATE_RTEPT = new BooleanPreference(this, "gpx_routing_calculate_rtept", true).makeGlobal().makeShared().cache();
 	public final OsmandPreference<Boolean> GPX_ROUTE_CALC = new BooleanPreference(this, "calc_gpx_route", false).makeGlobal().makeShared().cache();
-	public final OsmandPreference<Integer> GPX_SEGMENT_INDEX = new IntPreference(this, "gpx_route_segment", -1).makeGlobal().makeShared().cache();
-	public final OsmandPreference<Integer> GPX_ROUTE_INDEX = new IntPreference(this, "gpx_route_index", -1).makeGlobal().makeShared().cache();
+	public final OsmandPreference<Integer> GPX_SEGMENT_INDEX = new IntPreference(this, "gpx_route_segment", -1).makeGlobal().cache();
+	public final OsmandPreference<Integer> GPX_ROUTE_INDEX = new IntPreference(this, "gpx_route_index", -1).makeGlobal().cache();
 	public final OsmandPreference<Boolean> GPX_PASS_WHOLE_ROUTE = new BooleanPreference(this, "gpx_pass_whole_route", false).makeGlobal().makeShared().cache();
 	public final OsmandPreference<ReverseTrackStrategy> GPX_REVERSE_STRATEGY =
 			new EnumStringPreference<>(this, "gpx_reverse_strategy", ReverseTrackStrategy.RECALCULATE_ALL_ROUTE_POINTS, ReverseTrackStrategy.values()).makeGlobal().makeShared().cache();
@@ -1863,7 +1863,7 @@ public class OsmandSettings {
 	public final CommonPreference<String> LIVE_MONITORING_URL = new StringPreference(this, "live_monitoring_url",
 			"https://example.com?lat={0}&lon={1}&timestamp={2}&hdop={3}&altitude={4}&speed={5}").makeProfile();
 
-	public final CommonPreference<String> GPS_STATUS_APP = new StringPreference(this, "gps_status_app", "").makeGlobal().makeShared();
+	public final CommonPreference<String> GPS_STATUS_APP = new StringPreference(this, "gps_status_app", "").makeGlobal();
 
 	private final CommonPreference<String> MAP_INFO_CONTROLS = new StringPreference(this, "map_info_controls", "").makeProfile();
 
@@ -2314,7 +2314,7 @@ public class OsmandSettings {
 
 	public final CommonPreference<MediaStorageType> MEDIA_STORAGE_TYPE = new EnumStringPreference<>(this, "media_storage_type", MediaStorageType.MAIN_STORAGE, MediaStorageType.values()).makeGlobal().makeShared();
 
-	public final OsmandPreference<String> MEDIA_STORAGE_MANUAL_URI = new StringPreference(this, "media_storage_manual_uri", "").makeGlobal().makeShared();
+	public final OsmandPreference<String> MEDIA_STORAGE_MANUAL_URI = new StringPreference(this, "media_storage_manual_uri", "").makeGlobal();
 
 	public final OsmandPreference<Boolean> SHARED_STORAGE_MIGRATION_FINISHED = new BooleanPreference(this,
 			"shared_storage_migration_finished", false).makeGlobal();
@@ -2963,7 +2963,7 @@ public class OsmandSettings {
 		return impassableRoadsStorage.movePoint(latLonEx, latLonNew);
 	}
 
-	public final CommonPreference<Boolean> IS_QUICK_ACTION_TUTORIAL_SHOWN = new BooleanPreference(this, "quick_action_tutorial", false).makeGlobal().makeShared();
+	public final CommonPreference<Boolean> IS_QUICK_ACTION_TUTORIAL_SHOWN = new BooleanPreference(this, "quick_action_tutorial", false).makeGlobal();
 	public final ListStringPreference QUICK_ACTION_BUTTONS = (ListStringPreference) new ListStringPreference(this, "quick_action_buttons", DEFAULT_BUTTON_ID + ";", ";").makeGlobal();
 
 	public static boolean DEV_GRID_LAYOUT_SHOW_LOGS = false;
@@ -3358,7 +3358,7 @@ public class OsmandSettings {
 	// for background service
 	public boolean MAP_ACTIVITY_ENABLED = false;
 
-	public final OsmandPreference<Boolean> SAFE_MODE = new BooleanPreference(this, "safe_mode", false).makeGlobal().makeShared();
+	public final OsmandPreference<Boolean> SAFE_MODE = new BooleanPreference(this, "safe_mode", false).makeGlobal();
 	public final OsmandPreference<Boolean> PT_SAFE_MODE = new BooleanPreference(this, "pt_safe_mode", false).makeProfile();
 	public final OsmandPreference<Boolean> NATIVE_RENDERING_FAILED = new BooleanPreference(this, "native_rendering_failed_init", false).makeGlobal();
 
@@ -3373,7 +3373,7 @@ public class OsmandSettings {
 
 	public final OsmandPreference<Boolean> FOLLOW_THE_ROUTE = new BooleanPreference(this, "follow_to_route", false).makeGlobal();
 	public final OsmandPreference<String> FOLLOW_THE_GPX_ROUTE = new StringPreference(this, "follow_gpx", null).makeGlobal();
-	public final OsmandPreference<Boolean> SHOW_RESTART_NAVIGATION_DIALOG = new BooleanPreference(this, "show_restart_navigation_dialog", true).makeGlobal().makeShared();
+	public final OsmandPreference<Boolean> SHOW_RESTART_NAVIGATION_DIALOG = new BooleanPreference(this, "show_restart_navigation_dialog", true).makeGlobal();
 
 	public final OsmandPreference<String> SELECTED_TRAVEL_BOOK = new StringPreference(this, "selected_travel_book", "").makeGlobal().makeShared();
 
@@ -3548,9 +3548,9 @@ public class OsmandSettings {
 	public final OsmandPreference<Boolean> MAP_SCREEN_LAYOUT_CARD_DISMISSED =
 			new BooleanPreference(this, "map_screen_layout_card_dismissed", false).makeGlobal();
 
-	public final OsmandPreference<Boolean> TRIPLTEK_PROMO_SHOWED = new BooleanPreference(this, "tripltek_promo_showed", false).makeGlobal().makeShared();
-	public final OsmandPreference<Boolean> HUGEROCK_PROMO_SHOWED = new BooleanPreference(this, "hugerock_promo_showed", false).makeGlobal().makeShared();
-	public final OsmandPreference<Boolean> HMD_PROMO_SHOWED = new BooleanPreference(this, "hmd_promo_showed", false).makeGlobal().makeShared();
+	public final OsmandPreference<Boolean> TRIPLTEK_PROMO_SHOWED = new BooleanPreference(this, "tripltek_promo_showed", false).makeGlobal();
+	public final OsmandPreference<Boolean> HUGEROCK_PROMO_SHOWED = new BooleanPreference(this, "hugerock_promo_showed", false).makeGlobal();
+	public final OsmandPreference<Boolean> HMD_PROMO_SHOWED = new BooleanPreference(this, "hmd_promo_showed", false).makeGlobal();
 	public final CommonPreference<Integer> CONTEXT_GALLERY_SPAN_GRID_COUNT = new IntPreference(this, "context_gallery_span_grid_count", 3).makeProfile();
 	public final CommonPreference<Integer> CONTEXT_GALLERY_SPAN_GRID_COUNT_LANDSCAPE = new IntPreference(this, "context_gallery_span_grid_count_landscape", 7).makeProfile();
 

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -2312,7 +2312,7 @@ public class OsmandSettings {
 
 	public final OsmandPreference<Boolean> AUTO_COPY_MEDIA_TO_OSMAND_STORAGE = new BooleanPreference(this, "auto_copy_media_to_osmand_storage", false).makeGlobal().makeShared();
 
-	public final CommonPreference<MediaStorageType> MEDIA_STORAGE_TYPE = new EnumStringPreference<>(this, "media_storage_type", MediaStorageType.MAIN_STORAGE, MediaStorageType.values()).makeGlobal().makeShared();
+	public final CommonPreference<MediaStorageType> MEDIA_STORAGE_TYPE = new EnumStringPreference<>(this, "media_storage_type", MediaStorageType.MAIN_STORAGE, MediaStorageType.values()).makeGlobal();
 
 	public final OsmandPreference<String> MEDIA_STORAGE_MANUAL_URI = new StringPreference(this, "media_storage_manual_uri", "").makeGlobal();
 


### PR DESCRIPTION
## Summary

This change prevents local runtime, device-specific and ephemeral UI state from
creating false Global Settings Cloud changes.

A global preference remains `shared` only when it represents durable,
portable user state or intent that is meaningful to restore after reinstall or
on another device. Runtime, session, device-specific and ephemeral UI state
remains local.

The preferences below remain persisted on the device. This PR only removes
their inclusion in Global Settings backup and prevents their updates from
changing the Global Settings modification time. It does not change the general
Cloud Sync conflict algorithm.

<details>
<summary>Local preferences excluded from Cloud Sync</summary>

| Preference | Why it remains local |
|---|---|
| `SAFE_MODE` | Runtime recovery state that can be updated automatically during app startup. |
| `LAST_USED_APPLICATION_MODE` | Last active profile on the current device; updated during app startup and profile activation. |
| `SIMULATE_POSITION_SPEED` | Simulation session state; reset to the default value in route-less simulation. |
| `SHOW_CARD_TO_CHOOSE_DRAWER` | Onboarding marker for the Dashboard/Drawer choice card. |
| `SEND_ANONYMOUS_DATA_REQUEST_PROCESSED` | Records that the consent prompt was processed; the actual consent preferences remain independent. |
| `ONLINE_PHOTOS_ROW_COLLAPSED` | Collapsed state of an Online Photos context-menu row on the current device. |
| `EXPLORE_NEARBY_ITEMS_ROW_COLLAPSED` | Collapsed state of an Explore Nearby row on the current device. This PR also assigns it its own preference key instead of sharing the Online Photos key. |
| `EXPLORE_HISTORY_ROW_COLLAPSED` | Collapsed state of the Explore history row on the current device. |
| `ATTACHED_MEDIA_ROW_COLLAPSED` | Collapsed state of the attached-media row on the current device. |
| `MAPILLARY_PHOTOS_ROW_COLLAPSED` | Collapsed state of the Mapillary Photos row on the current device. |
| `SHOW_BATTERY_OPTIMIZATION_DIALOG` | Device-specific Android battery-optimization guidance. |
| `SPEED_CAMERAS_ALERT_SHOWED` | Marker that the speed-camera legal dialog was shown; it is not the user's legal choice itself. |
| `GPX_SEGMENT_INDEX` | Selected segment of the currently prepared GPX navigation session. |
| `GPX_ROUTE_INDEX` | Selected route of the currently prepared GPX navigation session. |
| `GPS_STATUS_APP` | Selected external GPS-status application; depends on packages installed on this device. |
| `MEDIA_STORAGE_MANUAL_URI` | Android SAF URI bound to the device, app installation and granted storage permission. |
| `IS_QUICK_ACTION_TUTORIAL_SHOWN` | Quick-action onboarding marker. |
| `SHOW_RESTART_NAVIGATION_DIALOG` | Restart-navigation dialog marker; safe to repeat after reinstall. |
| `TRIPLTEK_PROMO_SHOWED` | Build/device-specific promotional dialog marker. |
| `HUGEROCK_PROMO_SHOWED` | Build/device-specific promotional dialog marker. |
| `HMD_PROMO_SHOWED` | Build/device-specific promotional dialog marker. |

</details>

<details>
<summary>Preferences intentionally retained as shared</summary>

| Preference or group | Why it remains shared |
|---|---|
| `SHOW_SUGGEST_MAP_DIALOG` | Persistent user-controlled behavior for the Download map dialog, not a one-time marker. |
| `SHOW_TRIP_REC_START_DIALOG` | Persistent user-controlled behavior: whether trip recording starts immediately or asks for confirmation. |
| `local_<type>_sort_mode` and legacy `local_maps_sort_mode` | Per-category Local Maps sorting can be a durable user preference across devices and is retained in Cloud Sync. |
| `PREFERRED_LOCALE` | Explicit app-language or Android per-app-language choice that should be restored on another device. |
| `PLUGINS` | User-configured plugin setup can be meaningful to restore across devices. Automatic plugin activation is handled separately. |
| `SELECTED_GPX` | Restoring visible-track selection can avoid substantial manual work after reinstall or on another device. |
| `CURRENT_TRACK_*` | Current-track appearance is configured through user-facing controls, including Reset to default. |
| `SHOW_DASHBOARD_ON_START`, `SHOW_DASHBOARD_ON_MAP_SCREEN` | Persistent Dashboard behavior selected by the user. |
| Mapillary filters | User-configured Mapillary filtering criteria should remain portable across devices. |
| Per-type backup and version-history preferences | Existing user backup configuration remains shared unless a migration needs separate handling. |
| `SPEED_CAMERAS_UNINSTALLED` | Explicit, potentially legal-sensitive choice to remove speed-camera functionality. |

</details>

<details>
<summary>Deferred cases requiring separate technical or security work</summary>

| Preference or group | Why it is deferred | Possible direction |
|---|---|---|
| `USE_OPENGL_RENDER` | A shared user choice can currently be overwritten by automatic device-capability or crash fallback. | Split requested renderer from device-local effective fallback state. |
| `ENABLE_MSAA` | OpenGL quality/performance setting may depend on device capability and requires a separate writer/usage audit. | Keep shared only if it is exclusively an explicit user choice; otherwise separate requested and effective state. |
| `MEDIA_STORAGE_TYPE` | A restored `MANUALLY_SPECIFIED` type is not usable without a valid local SAF URI. | Define an explicit local fallback or pair the portable choice with device-local storage access. |
| OSM credentials and development URL | May contain sensitive authentication data and can also be changed by validation or authentication flows. | Perform a security review and keep credentials out of Cloud Sync if they are private access data. |
| External Sensors and OBD dynamic preferences | Values can be keyed by local hardware identifiers. | Keep device-specific state local; evaluate portable calibration separately. |
| `LAST_USED_FAV_ICONS`, `LAST_USED_PROFILE_ICONS` | Recent-selection history is useful but may change frequently and is not clearly durable cross-device intent. | Decide between local recency state and portable recent choices. |
| Map Sources | Repeated Local Changes appear to be based on SQLite and `.metainfo` modification times rather than the Global Settings preference timestamp. | Investigate in a separate follow-up. |

</details>

## Not included

- Temporary diagnostic logging is not part of this production change.
- This PR does not change the general Cloud Sync conflict algorithm.
- Follow-up work will focus on confirmed mixed cases where automatic runtime behavior can overwrite a shared user preference.