### PR TITLE
Show intermediate destinations in route details

### DIFF
--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/RouteDirectionsCard.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/RouteDirectionsCard.java
@@ -11,21 +11,26 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
-import net.osmand.shared.gpx.GpxFile;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.R;
 import net.osmand.plus.activities.MapActivity;
 import net.osmand.plus.helpers.AndroidUiHelper;
-import net.osmand.plus.routepreparationmenu.RouteDetailsFragment;
+import net.osmand.plus.helpers.TargetPoint;
+import net.osmand.plus.helpers.WaypointDialogHelper;
+import net.osmand.plus.routing.RouteCalculationResult;
+import net.osmand.plus.routing.RouteCalculationResult.IntermediatePointInfo;
 import net.osmand.plus.routing.RouteDirectionInfo;
 import net.osmand.plus.routing.RoutingHelper;
 import net.osmand.plus.settings.backend.ApplicationMode;
 import net.osmand.plus.utils.OsmAndFormatter;
 import net.osmand.plus.views.TurnPathHelper.RouteDrawable;
 import net.osmand.plus.views.mapwidgets.LanesDrawable;
+import net.osmand.shared.gpx.GpxFile;
 import net.osmand.util.Algorithms;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class RouteDirectionsCard extends MapBaseCard {
@@ -70,12 +75,53 @@ public class RouteDirectionsCard extends MapBaseCard {
 	}
 
 	private void createRouteDirections(LinearLayout cardsContainer) {
-		List<RouteDirectionInfo> routeDirections = routingHelper.getRouteDirections();
-		for (int i = 0; i < routeDirections.size(); i++) {
-			RouteDirectionInfo routeDirectionInfo = routeDirections.get(i);
-			View view = getRouteDirectionView(i, routeDirectionInfo, routeDirections);
+		RouteCalculationResult route = routingHelper.getRoute();
+		List<RouteDirectionInfo> routeDirections = new ArrayList<>(route.getRouteDirections(app));
+		List<IntermediatePointInfo> intermediatePointInfos = route.getIntermediatePointInfos();
+		List<TargetPoint> intermediatePoints = app.getTargetPointsHelper().getIntermediatePointsNavigation();
+		List<RouteDirectionItem> items = buildRouteDirectionItems(routeDirections,
+				intermediatePointInfos, intermediatePoints);
+		for (int i = 0; i < items.size(); i++) {
+			View view = getRouteDirectionView(items.get(i), i, items.size());
 			cardsContainer.addView(view);
 		}
+	}
+
+	@NonNull
+	static List<RouteDirectionItem> buildRouteDirectionItems(
+			@NonNull List<RouteDirectionInfo> routeDirections,
+			@NonNull List<IntermediatePointInfo> intermediatePointInfos,
+			@NonNull List<TargetPoint> intermediatePoints) {
+		List<RouteDirectionItem> items = new ArrayList<>();
+		int intermediateIndex = 0;
+		int cumulativeDistance = 0;
+		int cumulativeTime = 0;
+		for (int directionIndex = 0; directionIndex < routeDirections.size(); directionIndex++) {
+			RouteDirectionInfo direction = routeDirections.get(directionIndex);
+			while (intermediateIndex < intermediatePointInfos.size()
+					&& intermediatePointInfos.get(intermediateIndex).getRoutePointOffset() <= direction.routePointOffset) {
+				IntermediatePointInfo info = intermediatePointInfos.get(intermediateIndex);
+				TargetPoint point = intermediateIndex < intermediatePoints.size()
+						? intermediatePoints.get(intermediateIndex) : null;
+				items.add(RouteDirectionItem.intermediate(point, intermediateIndex, directionIndex,
+						info.getDistance(), info.getTime()));
+				intermediateIndex++;
+			}
+			boolean destination = directionIndex == routeDirections.size() - 1 && direction.distance == 0;
+			items.add(RouteDirectionItem.direction(direction, directionIndex,
+					cumulativeDistance, cumulativeTime, destination));
+			cumulativeDistance += direction.distance;
+			cumulativeTime += direction.getExpectedTime();
+		}
+		while (intermediateIndex < intermediatePointInfos.size()) {
+			IntermediatePointInfo info = intermediatePointInfos.get(intermediateIndex);
+			TargetPoint point = intermediateIndex < intermediatePoints.size()
+					? intermediatePoints.get(intermediateIndex) : null;
+			items.add(RouteDirectionItem.intermediate(point, intermediateIndex,
+					Math.max(0, routeDirections.size() - 1), info.getDistance(), info.getTime()));
+			intermediateIndex++;
+		}
+		return items;
 	}
 
 	private static String getTimeDescription(OsmandApplication app, RouteDirectionInfo model) {
@@ -83,7 +129,7 @@ public class RouteDirectionsCard extends MapBaseCard {
 		return Algorithms.formatDuration(timeInSeconds, app.accessibilityEnabled());
 	}
 
-	private View getRouteDirectionView(int directionInfoIndex, RouteDirectionInfo model, List<RouteDirectionInfo> directionsInfo) {
+	private View getRouteDirectionView(@NonNull RouteDirectionItem item, int itemIndex, int itemCount) {
 		MapActivity mapActivity = getMapActivity();
 		View row = themedInflater.inflate(R.layout.route_info_list_item, null);
 
@@ -94,41 +140,137 @@ public class RouteDirectionsCard extends MapBaseCard {
 		TextView cumulativeTimeLabel = row.findViewById(R.id.cumulative_time);
 		ImageView directionIcon = row.findViewById(R.id.direction);
 		ImageView lanesIcon = row.findViewById(R.id.lanes);
-		row.findViewById(R.id.divider).setVisibility(directionInfoIndex == directionsInfo.size() - 1 ? View.INVISIBLE : View.VISIBLE);
+		row.findViewById(R.id.divider).setVisibility(itemIndex == itemCount - 1 ? View.INVISIBLE : View.VISIBLE);
 
-		RouteDrawable drawable = new RouteDrawable(mapActivity, true);
-		drawable.setColorFilter(new PorterDuffColorFilter(getActiveColor(), PorterDuff.Mode.SRC_ATOP));
-		drawable.setRouteType(model.getTurnType());
-		directionIcon.setImageDrawable(drawable);
-
-		int[] lanes = model.getTurnType().getLanes();
-		if (lanes != null) {
-			LanesDrawable lanesDrawable = new LanesDrawable(mapActivity, 1);
-			lanesDrawable.lanes = lanes;
-			lanesDrawable.isTurnByTurn = true;
-			lanesDrawable.isNightMode = nightMode;
-			lanesDrawable.updateBounds();
-			lanesIcon.setImageDrawable(lanesDrawable);
-			lanesIcon.setVisibility(View.VISIBLE);
-		}
-
-		label.setText(model.getDescriptionRoutePart(app, true));
-		if (model.distance > 0) {
-			distanceLabel.setText(OsmAndFormatter.getFormattedDistance(model.distance, app));
-			timeLabel.setText(getTimeDescription(app, model));
-			row.setContentDescription(label.getText() + " " + timeLabel.getText());
-		} else {
-			if (Algorithms.isEmpty(model.getDescriptionRoutePart(app))) {
-				label.setText(mapActivity.getString((directionInfoIndex != directionsInfo.size() - 1) ? R.string.arrived_at_intermediate_point : R.string.arrived_at_destination));
+		if (item.isIntermediate()) {
+			directionIcon.setImageDrawable(app.getUIUtilities().getIcon(R.drawable.list_intermediate));
+			String pointType = mapActivity.getString(R.string.intermediate_point,
+					String.valueOf(item.getIntermediateIndex() + 1));
+			TargetPoint point = item.getTargetPoint();
+			if (point != null) {
+				String pointName = point.getRoutePointDescription(mapActivity, true);
+				label.setText(mapActivity.getString(R.string.ltr_or_rtl_combine_via_colon, pointType, pointName));
+			} else {
+				label.setText(pointType);
 			}
 			distanceLabel.setText("");
 			timeLabel.setText("");
-			row.setContentDescription("");
+		} else {
+			RouteDirectionInfo model = item.getDirection();
+			if (item.isDestination()) {
+				directionIcon.setImageDrawable(app.getUIUtilities().getIcon(R.drawable.list_destination));
+			} else {
+				RouteDrawable drawable = new RouteDrawable(mapActivity, true);
+				drawable.setColorFilter(new PorterDuffColorFilter(getActiveColor(), PorterDuff.Mode.SRC_ATOP));
+				drawable.setRouteType(model.getTurnType());
+				directionIcon.setImageDrawable(drawable);
+
+				int[] lanes = model.getTurnType().getLanes();
+				if (lanes != null) {
+					LanesDrawable lanesDrawable = new LanesDrawable(mapActivity, 1);
+					lanesDrawable.lanes = lanes;
+					lanesDrawable.isTurnByTurn = true;
+					lanesDrawable.isNightMode = nightMode;
+					lanesDrawable.updateBounds();
+					lanesIcon.setImageDrawable(lanesDrawable);
+					lanesIcon.setVisibility(View.VISIBLE);
+				}
+			}
+
+			label.setText(model.getDescriptionRoutePart(app, true));
+			if (model.distance > 0) {
+				distanceLabel.setText(OsmAndFormatter.getFormattedDistance(model.distance, app));
+				timeLabel.setText(getTimeDescription(app, model));
+			} else {
+				if (Algorithms.isEmpty(model.getDescriptionRoutePart(app))) {
+					label.setText(mapActivity.getString(R.string.arrived_at_destination));
+				}
+				distanceLabel.setText("");
+				timeLabel.setText("");
+			}
 		}
-		RouteDetailsFragment.CumulativeInfo cumulativeInfo = RouteDetailsFragment.getRouteDirectionCumulativeInfo(directionInfoIndex, directionsInfo);
-		cumulativeDistanceLabel.setText(OsmAndFormatter.getFormattedDistance(cumulativeInfo.distance, app));
-		cumulativeTimeLabel.setText(Algorithms.formatDuration(cumulativeInfo.time, app.accessibilityEnabled()));
-		row.setOnClickListener(v -> notifyButtonPressed(directionInfoIndex));
+		cumulativeDistanceLabel.setText(OsmAndFormatter.getFormattedDistance(item.getCumulativeDistance(), app));
+		cumulativeTimeLabel.setText(Algorithms.formatDuration(item.getCumulativeTime(), app.accessibilityEnabled()));
+		row.setContentDescription(label.getText() + " " + cumulativeTimeLabel.getText());
+		TargetPoint targetPoint = item.getTargetPoint();
+		if (targetPoint != null) {
+			row.setOnClickListener(v -> WaypointDialogHelper.showOnMap(app, mapActivity, targetPoint, false));
+		} else {
+			row.setOnClickListener(v -> notifyButtonPressed(item.getDirectionIndex()));
+		}
 		return row;
+	}
+
+	static class RouteDirectionItem {
+
+		@Nullable
+		private final RouteDirectionInfo direction;
+		@Nullable
+		private final TargetPoint targetPoint;
+		private final int intermediateIndex;
+		private final int directionIndex;
+		private final int cumulativeDistance;
+		private final int cumulativeTime;
+		private final boolean destination;
+
+		private RouteDirectionItem(@Nullable RouteDirectionInfo direction, @Nullable TargetPoint targetPoint,
+		                           int intermediateIndex, int directionIndex, int cumulativeDistance,
+		                           int cumulativeTime, boolean destination) {
+			this.direction = direction;
+			this.targetPoint = targetPoint;
+			this.intermediateIndex = intermediateIndex;
+			this.directionIndex = directionIndex;
+			this.cumulativeDistance = cumulativeDistance;
+			this.cumulativeTime = cumulativeTime;
+			this.destination = destination;
+		}
+
+		@NonNull
+		static RouteDirectionItem direction(@NonNull RouteDirectionInfo direction, int directionIndex,
+		                                    int cumulativeDistance, int cumulativeTime, boolean destination) {
+			return new RouteDirectionItem(direction, null, -1, directionIndex,
+					cumulativeDistance, cumulativeTime, destination);
+		}
+
+		@NonNull
+		static RouteDirectionItem intermediate(@Nullable TargetPoint targetPoint, int intermediateIndex,
+		                                       int directionIndex, int cumulativeDistance, int cumulativeTime) {
+			return new RouteDirectionItem(null, targetPoint, intermediateIndex, directionIndex,
+					cumulativeDistance, cumulativeTime, false);
+		}
+
+		boolean isIntermediate() {
+			return direction == null;
+		}
+
+		@NonNull
+		RouteDirectionInfo getDirection() {
+			return direction;
+		}
+
+		@Nullable
+		TargetPoint getTargetPoint() {
+			return targetPoint;
+		}
+
+		int getIntermediateIndex() {
+			return intermediateIndex;
+		}
+
+		int getDirectionIndex() {
+			return directionIndex;
+		}
+
+		int getCumulativeDistance() {
+			return cumulativeDistance;
+		}
+
+		int getCumulativeTime() {
+			return cumulativeTime;
+		}
+
+		boolean isDestination() {
+			return destination;
+		}
 	}
 }

--- a/OsmAnd/src/net/osmand/plus/routing/RouteCalculationResult.java
+++ b/OsmAnd/src/net/osmand/plus/routing/RouteCalculationResult.java
@@ -1445,6 +1445,46 @@ public class RouteCalculationResult {
 		return intermediatePoints.length - nextIntermediate;
 	}
 
+	@NonNull
+	public List<IntermediatePointInfo> getIntermediatePointInfos() {
+		List<IntermediatePointInfo> infos = new ArrayList<>();
+		for (int i = nextIntermediate; i < intermediatePoints.length; i++) {
+			int directionIndex = intermediatePoints[i];
+			if (directionIndex >= 0 && directionIndex < directions.size()) {
+				int routePointOffset = directions.get(directionIndex).routePointOffset;
+				int distance = getDistanceToPoint(routePointOffset);
+				int time = getLeftTimeToNextIntermediate(null, i - nextIntermediate);
+				infos.add(new IntermediatePointInfo(routePointOffset, distance, time));
+			}
+		}
+		return infos;
+	}
+
+	public static class IntermediatePointInfo {
+
+		private final int routePointOffset;
+		private final int distance;
+		private final int time;
+
+		public IntermediatePointInfo(int routePointOffset, int distance, int time) {
+			this.routePointOffset = routePointOffset;
+			this.distance = distance;
+			this.time = time;
+		}
+
+		public int getRoutePointOffset() {
+			return routePointOffset;
+		}
+
+		public int getDistance() {
+			return distance;
+		}
+
+		public int getTime() {
+			return time;
+		}
+	}
+
 	public int getLeftTime(Location fromLoc) {
 		int time = 0;
 		if (currentDirectionInfo < directions.size()) {

--- a/OsmAnd/test/java/net/osmand/plus/routepreparationmenu/cards/RouteDirectionsCardTest.java
+++ b/OsmAnd/test/java/net/osmand/plus/routepreparationmenu/cards/RouteDirectionsCardTest.java
@@ -1,0 +1,73 @@
+package net.osmand.plus.routepreparationmenu.cards;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import net.osmand.data.LatLon;
+import net.osmand.plus.helpers.TargetPoint;
+import net.osmand.plus.routepreparationmenu.cards.RouteDirectionsCard.RouteDirectionItem;
+import net.osmand.plus.routing.RouteCalculationResult.IntermediatePointInfo;
+import net.osmand.plus.routing.RouteDirectionInfo;
+import net.osmand.router.TurnType;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class RouteDirectionsCardTest {
+
+	@Test
+	public void insertsIntermediateDestinationsBeforeNextManeuver() {
+		List<RouteDirectionInfo> directions = Arrays.asList(
+				direction(0, 100),
+				direction(10, 100),
+				direction(20, 0));
+		List<IntermediatePointInfo> intermediateInfos = Arrays.asList(
+				new IntermediatePointInfo(5, 50, 5),
+				new IntermediatePointInfo(10, 100, 10));
+		TargetPoint first = new TargetPoint(new LatLon(1, 1), null, 0);
+		TargetPoint second = new TargetPoint(new LatLon(2, 2), null, 1);
+
+		List<RouteDirectionItem> items = RouteDirectionsCard.buildRouteDirectionItems(
+				directions, intermediateInfos, Arrays.asList(first, second));
+
+		assertEquals(5, items.size());
+		assertFalse(items.get(0).isIntermediate());
+		assertTrue(items.get(1).isIntermediate());
+		assertSame(first, items.get(1).getTargetPoint());
+		assertEquals(50, items.get(1).getCumulativeDistance());
+		assertEquals(5, items.get(1).getCumulativeTime());
+		assertEquals(1, items.get(1).getDirectionIndex());
+		assertTrue(items.get(2).isIntermediate());
+		assertSame(second, items.get(2).getTargetPoint());
+		assertEquals(100, items.get(2).getCumulativeDistance());
+		assertFalse(items.get(3).isIntermediate());
+		assertEquals(100, items.get(3).getCumulativeDistance());
+		assertTrue(items.get(4).isDestination());
+		assertEquals(200, items.get(4).getCumulativeDistance());
+	}
+
+	@Test
+	public void keepsRouteIntermediateWhenTargetMetadataIsUnavailable() {
+		List<RouteDirectionItem> items = RouteDirectionsCard.buildRouteDirectionItems(
+				Arrays.asList(direction(0, 100), direction(10, 0)),
+				Collections.singletonList(new IntermediatePointInfo(5, 50, 5)),
+				Collections.emptyList());
+
+		assertEquals(3, items.size());
+		assertTrue(items.get(1).isIntermediate());
+		assertNull(items.get(1).getTargetPoint());
+	}
+
+	private static RouteDirectionInfo direction(int routePointOffset, int distance) {
+		RouteDirectionInfo direction = new RouteDirectionInfo(10, TurnType.straight());
+		direction.routePointOffset = routePointOffset;
+		direction.distance = distance;
+		return direction;
+	}
+}


### PR DESCRIPTION
## Summary

- show every intermediate destination in Route Details at its position along the route
- use intermediate and final-destination markers with cumulative distance and time
- open the exact intermediate destination when its row is selected
- add focused coverage for ordering, cumulative values, and missing target metadata

Fixes #3793

## Root cause

Route calculation retained indexes for intermediate destinations, but Route Details rendered only the aggregated maneuver list. Intermediate identity and target metadata therefore never reached the list UI.

## Verification

- `JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk-17.jdk/Contents/Home ./gradlew assembleGplayFreeOpenglArm64Debug`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk-17.jdk/Contents/Home ./gradlew connectedGplayFreeOpenglArm64DebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=net.osmand.plus.routepreparationmenu.cards.RouteDirectionsCardTest`
  - 2 tests passed on a Pixel 9a AVD, Android 15 / API 35, arm64-v8a, 1080x2424 at 420 dpi
- manually reproduced the missing rows before the fix and verified the result with two intermediate destinations on the repository's offline test map
  - both intermediate rows appear in route order with cumulative distance/time and intermediate markers
  - the final destination uses the checkered marker
  - selecting an intermediate row opens the exact destination
  - no app runtime exceptions were found in logcat

## Human UI review

Human UI review was completed for the implementation committed as `c585a6c7e706a322e911108d1fbd5cc53d5a2461`. The committed code is unchanged from the reviewed working-tree result.

| Baseline: intermediate rows omitted | After: intermediate destination 1 |
| --- | --- |
| <img width="360" alt="Route Details before the fix, without intermediate destination rows" src="https://github.com/user-attachments/assets/c876cf89-0b42-479f-b52d-78840625871d" /> | <img width="360" alt="Route Details showing intermediate destination 1 with cumulative distance and time" src="https://github.com/user-attachments/assets/fb0b1984-7fc3-4437-909a-6467dc65d755" /> |

| After: intermediate destination 2 and final destination | Interaction: exact intermediate target |
| --- | --- |
| <img width="360" alt="Route Details showing intermediate destination 2 and the checkered final destination" src="https://github.com/user-attachments/assets/22975164-25db-4196-a076-8715fb1b312a" /> | <img width="360" alt="Map opened on the exact selected intermediate destination" src="https://github.com/user-attachments/assets/952567d9-6d2b-4c03-9ca0-6a1d7ed383de" /> |
