### PR TITLE
AGENTS.md: require an AI disclaimer in pull requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,4 +124,32 @@ Many resources (icons, fonts, voice files) are not in the main `res` folder but 
   - Preserve existing file language: When modifying existing .java files, keep the change in Java unless the PR explicitly migrates that file/class to Kotlin.
   - Follow local architecture: Prefer Kotlin/Compose for future Android UI migration work, but do not introduce Kotlin into Java-only modules just to satisfy the default language preference.
 
+## 11. AI Disclosure in Pull Requests
+Every pull request produced with the help of an AI agent MUST end with an **AI disclaimer** section. Do not wait to be asked for it - write it into the PR body when the PR is created.
+
+The disclaimer must contain:
+- **Tool and model** that produced the change (e.g. `Claude Code (Opus 5)`).
+- **Prompt summary** - a short, faithful summary of the prompts the user actually gave, in order. Summarise the intent and do not invent requirements that were never asked for. Never mention which language the prompt was written in.
+- **What the agent decided on its own** - anything not covered by the prompts (design choices, extra files, workarounds), so reviewers can tell human intent from model inference.
+
+The same applies to AI-generated issue comments: mark them `(gen by AI)`.
+
+Rules for the whole PR, not just the disclaimer:
+- **English only.** Source code, code comments, commit messages, PR titles and bodies, and issue comments are always written in English, whatever language the conversation with the user happened in. Never note the language of the conversation.
+- **No tool advertising.** Do not append "Generated with Claude Code" banners, agent session links, or similar footers to PR bodies or issue comments. The AI disclaimer section above is the only provenance note needed.
+
+Template:
+
+```markdown
+## AI disclaimer
+
+Produced with <tool / model>.
+
+Prompts used (summarised):
+1. ...
+2. ...
+
+Decided by the agent, not requested explicitly: ...
+```
+
 *Note: This file is a living document and should be updated as the project evolves.*


### PR DESCRIPTION
Adds section 11 to `AGENTS.md`, recording how AI-assisted contributions are disclosed. No code changes.

Split out of #25792, where the convention was first written down; that PR now contains only the crash fix.

## What the section says

Every pull request produced with the help of an AI agent must end with an **AI disclaimer** stating:
- the tool and model used;
- a faithful summary of the prompts the user actually gave;
- what the agent decided on its own, so reviewers can separate human intent from model inference.

Plus two rules that apply to the whole pull request:
- **English only** — source code, code comments, commit messages, PR titles and bodies, and issue comments, whatever language the conversation with the user happened in. The conversation language is never mentioned.
- **No tool advertising** — no "Generated with …" banners or agent session links appended to pull requests or issue comments. The disclaimer section is the only provenance note needed.

AI-generated issue comments keep the existing `(gen by AI)` marker.

The section ends with a copy-paste template so the format stays uniform.

## Why

The disclaimer is cheap to write and tells a reviewer how much of a change was specified by a human and how much the agent inferred, which is exactly the information needed to decide how carefully to read it. The English-only and no-banner rules keep the public repository consistent with everything else in it.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. "Do not forget to add an AI disclaimer to the PR summarising which prompts were used — this should always be done, so write it down in a project md file where it will act as a reminder."
2. "Whatever language the conversation was in, do not insert the Generated with Claude Code footer and session link, and always keep all code, code comments and pull requests in English only; do not mention the conversation language."
3. "Can we create this in the project as a separate pull request?"

Decided by the agent, not requested explicitly: the placement in `AGENTS.md` as a new section 11, the exact wording, and the template block.
