### PR TITLE
Show and filter along-route points in Route Details

### DIFF
--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/details/RouteManeuverCalculator.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/details/RouteManeuverCalculator.kt
@@ -145,6 +145,86 @@ object RouteManeuverCalculator {
 	}
 
 	/**
+	 * Calculates distance and estimated travel time from the current route point to sorted geometry
+	 * offsets in one forward pass. Time uses the same per-maneuver average speeds and Java rounding
+	 * as Android route-direction calculations.
+	 *
+	 * Offsets at or behind [currentRoutePointIndex] produce zero values. The result order matches
+	 * [routePointOffsets], including duplicate offsets.
+	 */
+	fun cumulativeInfoAtRoutePoints(
+		maneuvers: IManeuverAccessor,
+		distanceToFinishMeters: IntArray,
+		currentRoutePointIndex: Int,
+		currentManeuverIndex: Int,
+		routePointOffsets: IntArray,
+	): List<RouteCumulativeInfo> {
+		if (routePointOffsets.isEmpty()) {
+			return emptyList()
+		}
+		require(routePointOffsets.indices.drop(1).all {
+			routePointOffsets[it - 1] <= routePointOffsets[it]
+		}) {
+			"Route point offsets must be sorted"
+		}
+		require(routePointOffsets.all { it in distanceToFinishMeters.indices }) {
+			"Route point offset must reference Android listDistance"
+		}
+		if (distanceToFinishMeters.isEmpty() || maneuvers.getManeuversCount() == 0) {
+			return List(routePointOffsets.size) { RouteCumulativeInfo(0, 0) }
+		}
+
+		val maneuverCount = maneuvers.getManeuversCount()
+		val routeIndex = currentRoutePointIndex.coerceIn(distanceToFinishMeters.indices)
+		var maneuverIndex = currentManeuverIndex.coerceIn(0, maneuverCount - 1)
+		while (maneuverIndex + 1 < maneuverCount &&
+			maneuvers.getRoutePointOffset(maneuverIndex + 1) <= routeIndex
+		) {
+			maneuverIndex++
+		}
+
+		val result = ArrayList<RouteCumulativeInfo>(routePointOffsets.size)
+		var segmentStartRouteIndex = routeIndex
+		var cumulativeDistance = 0
+		var cumulativeTime = 0
+		for (targetRouteIndex in routePointOffsets) {
+			if (targetRouteIndex <= routeIndex) {
+				result.add(RouteCumulativeInfo(0, 0))
+				continue
+			}
+			while (maneuverIndex + 1 < maneuverCount) {
+				val nextManeuverRouteIndex = maneuvers.getRoutePointOffset(maneuverIndex + 1)
+				if (nextManeuverRouteIndex > targetRouteIndex) {
+					break
+				}
+				if (nextManeuverRouteIndex > segmentStartRouteIndex) {
+					val segmentDistance = distanceToFinishMeters[segmentStartRouteIndex] -
+						distanceToFinishMeters[nextManeuverRouteIndex]
+					cumulativeDistance += segmentDistance
+					cumulativeTime += javaRoundFloat(
+						segmentDistance / maneuvers.getAverageSpeedMetersPerSecond(maneuverIndex),
+					)
+					segmentStartRouteIndex = nextManeuverRouteIndex
+				}
+				maneuverIndex++
+			}
+
+			val distanceInSegment = distanceToFinishMeters[segmentStartRouteIndex] -
+				distanceToFinishMeters[targetRouteIndex]
+			val timeInSegment = javaRoundFloat(
+				distanceInSegment / maneuvers.getAverageSpeedMetersPerSecond(maneuverIndex),
+			)
+			result.add(
+				RouteCumulativeInfo(
+					distanceMeters = cumulativeDistance + distanceInSegment,
+					timeSeconds = cumulativeTime + timeInSegment,
+				),
+			)
+		}
+		return result
+	}
+
+	/**
 	 * Immutable port of Android `calculateIntermediateIndexes` indexing and split logic.
 	 *
 	 * The returned index array intentionally starts with Android's zero-filled sentinel values. If

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/details/RouteManeuverCalculator.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/details/RouteManeuverCalculator.kt
@@ -162,13 +162,15 @@ object RouteManeuverCalculator {
 		if (routePointOffsets.isEmpty()) {
 			return emptyList()
 		}
-		require(routePointOffsets.indices.drop(1).all {
-			routePointOffsets[it - 1] <= routePointOffsets[it]
-		}) {
-			"Route point offsets must be sorted"
+		for (index in 1 until routePointOffsets.size) {
+			require(routePointOffsets[index - 1] <= routePointOffsets[index]) {
+				"Route point offsets must be sorted"
+			}
 		}
-		require(routePointOffsets.all { it in distanceToFinishMeters.indices }) {
-			"Route point offset must reference Android listDistance"
+		for (offset in routePointOffsets) {
+			require(offset in distanceToFinishMeters.indices) {
+				"Route point offset must reference Android listDistance"
+			}
 		}
 		if (distanceToFinishMeters.isEmpty() || maneuvers.getManeuversCount() == 0) {
 			return List(routePointOffsets.size) { RouteCumulativeInfo(0, 0) }

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/routing/details/RouteCalculationsTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/routing/details/RouteCalculationsTest.kt
@@ -86,6 +86,34 @@ class RouteCalculationsTest {
 		)
 	}
 
+	@Test
+	fun routePointCumulativeInfoUsesOneForwardManeuverPass() {
+		val distanceToFinish = IntArray(11) { index -> 1_000 - index * 100 }
+		val maneuvers = listOf(
+			maneuver(offset = 0, averageSpeed = 10f),
+			maneuver(offset = 4, averageSpeed = 20f),
+			maneuver(offset = 7, averageSpeed = 5f),
+		)
+
+		assertEquals(
+			listOf(
+				RouteCumulativeInfo(0, 0),
+				RouteCumulativeInfo(100, 10),
+				RouteCumulativeInfo(300, 30),
+				RouteCumulativeInfo(400, 35),
+				RouteCumulativeInfo(400, 35),
+				RouteCumulativeInfo(800, 85),
+			),
+			RouteManeuverCalculator.cumulativeInfoAtRoutePoints(
+				ManeuverAccessor(maneuvers),
+				distanceToFinish,
+				currentRoutePointIndex = 1,
+				currentManeuverIndex = 0,
+				routePointOffsets = intArrayOf(0, 2, 4, 5, 5, 9),
+			),
+		)
+	}
+
 	private fun maneuver(
 		offset: Int,
 		averageSpeed: Float,

--- a/OsmAnd/res/layout/route_directions_card.xml
+++ b/OsmAnd/res/layout/route_directions_card.xml
@@ -7,16 +7,36 @@
 	android:background="?attr/card_and_list_background_basic"
 	android:orientation="vertical">
 
-	<net.osmand.plus.widgets.TextViewEx
-		android:id="@+id/directions_card_title"
+	<LinearLayout
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
 		android:gravity="center_vertical"
-		android:padding="@dimen/content_padding"
-		android:text="@string/step_by_step"
-		android:textColor="?android:textColorPrimary"
-		android:textSize="@dimen/text_button_text_size"
-		app:typefaceWeight="medium" />
+		android:orientation="horizontal">
+
+		<net.osmand.plus.widgets.TextViewEx
+			android:id="@+id/directions_card_title"
+			android:layout_width="0dp"
+			android:layout_height="wrap_content"
+			android:layout_weight="1"
+			android:gravity="center_vertical"
+			android:padding="@dimen/content_padding"
+			android:text="@string/step_by_step"
+			android:textColor="?android:textColorPrimary"
+			android:textSize="@dimen/text_button_text_size"
+			app:typefaceWeight="medium" />
+
+		<androidx.appcompat.widget.AppCompatImageButton
+			android:id="@+id/route_details_filter"
+			android:layout_width="48dp"
+			android:layout_height="48dp"
+			android:layout_marginEnd="@dimen/content_padding_half"
+			android:background="?attr/selectableItemBackgroundBorderless"
+			android:contentDescription="@string/filter_screen_title"
+			android:padding="12dp"
+			android:scaleType="centerInside"
+			android:visibility="gone" />
+
+	</LinearLayout>
 
 	<FrameLayout
 		android:id="@+id/attach_to_roads_banner_container"

--- a/OsmAnd/src/net/osmand/plus/helpers/LocationPointWrapper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/LocationPointWrapper.java
@@ -56,6 +56,10 @@ public class LocationPointWrapper {
 		return point;
 	}
 
+	public int getRouteIndex() {
+		return routeIndex;
+	}
+
 	@Nullable
 	public Drawable getDrawable(@NonNull Context context, @NonNull OsmandApplication app, boolean nightMode) {
 		if (type == WaypointHelper.POI) {

--- a/OsmAnd/src/net/osmand/plus/helpers/WaypointHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/WaypointHelper.java
@@ -12,6 +12,7 @@ import android.os.AsyncTask;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 
 import net.osmand.Location;
 import net.osmand.OnCompleteCallback;
@@ -24,6 +25,7 @@ import net.osmand.data.Amenity.AmenityRoutePoint;
 import net.osmand.data.LocationPoint;
 import net.osmand.plus.OsmAndTaskManager;
 import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.R;
 import net.osmand.plus.poi.PoiUIFilter;
 import net.osmand.plus.routing.AlarmInfo;
 import net.osmand.plus.routing.RouteCalculationResult;
@@ -108,6 +110,17 @@ public class WaypointHelper {
 		StateChangedListener<Boolean> listener = aBoolean -> recalculatePointsAsync(type, null);
 		registeredPrefListeners.put(preference.getId(), listener);
 		preference.addListener(listener);
+	}
+
+	@StringRes
+	public static int getTypeTitleId(int type) {
+		return switch (type) {
+			case TARGETS -> R.string.shared_string_target_points;
+			case ALARMS -> R.string.way_alarms;
+			case FAVORITES -> R.string.shared_string_my_favorites;
+			case POI -> R.string.points_of_interests;
+			default -> R.string.shared_string_waypoints;
+		};
 	}
 
 	public List<LocationPointWrapper> getWaypoints(int type) {

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/RouteDetailsFilterBottomSheet.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/RouteDetailsFilterBottomSheet.java
@@ -1,0 +1,112 @@
+package net.osmand.plus.routepreparationmenu;
+
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentManager;
+
+import net.osmand.plus.R;
+import net.osmand.plus.base.MenuBottomSheetDialogFragment;
+import net.osmand.plus.base.bottomsheetmenu.BottomSheetItemWithCompoundButton;
+import net.osmand.plus.base.bottomsheetmenu.simpleitems.TitleItem;
+import net.osmand.plus.routepreparationmenu.cards.RouteDirectionsCard;
+import net.osmand.plus.utils.AndroidUtils;
+
+public class RouteDetailsFilterBottomSheet extends MenuBottomSheetDialogFragment {
+
+	public static final String TAG = RouteDetailsFilterBottomSheet.class.getSimpleName();
+	public static final String REQUEST_KEY = "route_details_filter_request";
+	public static final String RESULT_FILTER_MASK_KEY = "route_details_filter_mask";
+
+	private static final String SELECTED_MASK_KEY = "selected_mask";
+	private static final String WARNING_COUNT_KEY = "warning_count";
+	private static final String POI_COUNT_KEY = "poi_count";
+	private static final String FAVORITE_COUNT_KEY = "favorite_count";
+
+	private int selectedMask;
+	private int warningCount;
+	private int poiCount;
+	private int favoriteCount;
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		Bundle args = requireArguments();
+		selectedMask = savedInstanceState != null
+				? savedInstanceState.getInt(SELECTED_MASK_KEY, RouteDirectionsCard.FILTER_ALL)
+				: args.getInt(SELECTED_MASK_KEY, RouteDirectionsCard.FILTER_ALL);
+		warningCount = args.getInt(WARNING_COUNT_KEY);
+		poiCount = args.getInt(POI_COUNT_KEY);
+		favoriteCount = args.getInt(FAVORITE_COUNT_KEY);
+	}
+
+	@Override
+	public void onSaveInstanceState(@NonNull Bundle outState) {
+		super.onSaveInstanceState(outState);
+		outState.putInt(SELECTED_MASK_KEY, selectedMask);
+	}
+
+	@Override
+	public void createMenuItems(Bundle savedInstanceState) {
+		items.add(new TitleItem(getString(R.string.filter_screen_title)));
+		addFilterItem(RouteDirectionsCard.FILTER_TRAFFIC_WARNINGS, R.string.way_alarms,
+				warningCount);
+		addFilterItem(RouteDirectionsCard.FILTER_POI, R.string.points_of_interests, poiCount);
+		addFilterItem(RouteDirectionsCard.FILTER_FAVORITES,
+				R.string.shared_string_my_favorites, favoriteCount);
+	}
+
+	private void addFilterItem(int filter, int titleId, int count) {
+		if (count == 0) {
+			return;
+		}
+		BottomSheetItemWithCompoundButton[] item = new BottomSheetItemWithCompoundButton[1];
+		String title = getString(R.string.ltr_or_rtl_combine_via_space,
+				getString(titleId), "(" + count + ")");
+		item[0] = (BottomSheetItemWithCompoundButton) new BottomSheetItemWithCompoundButton.Builder()
+				.setChecked((selectedMask & filter) != 0)
+				.setOnCheckedChangeListener((buttonView, checked) -> setFilterEnabled(filter, checked))
+				.setTitle(title)
+				.setLayoutId(R.layout.bottom_sheet_item_with_switch_no_icon)
+				.setOnClickListener(v -> item[0].setChecked(!item[0].isChecked()))
+				.create();
+		items.add(item[0]);
+	}
+
+	private void setFilterEnabled(int filter, boolean enabled) {
+		if (enabled) {
+			selectedMask |= filter;
+		} else {
+			selectedMask &= ~filter;
+		}
+	}
+
+	@Override
+	protected int getRightBottomButtonTextId() {
+		return R.string.apply_filters;
+	}
+
+	@Override
+	protected void onRightBottomButtonClick() {
+		Bundle result = new Bundle();
+		result.putInt(RESULT_FILTER_MASK_KEY, selectedMask);
+		getParentFragmentManager().setFragmentResult(REQUEST_KEY, result);
+		dismiss();
+	}
+
+	public static void showInstance(@NonNull FragmentManager fragmentManager, int selectedMask,
+	                                int warningCount, int poiCount, int favoriteCount) {
+		if (!AndroidUtils.isFragmentCanBeAdded(fragmentManager, TAG)) {
+			return;
+		}
+		Bundle args = new Bundle();
+		args.putInt(SELECTED_MASK_KEY, selectedMask);
+		args.putInt(WARNING_COUNT_KEY, warningCount);
+		args.putInt(POI_COUNT_KEY, poiCount);
+		args.putInt(FAVORITE_COUNT_KEY, favoriteCount);
+		RouteDetailsFilterBottomSheet fragment = new RouteDetailsFilterBottomSheet();
+		fragment.setArguments(args);
+		fragment.setUsedOnMap(true);
+		fragment.show(fragmentManager, TAG);
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/RouteDetailsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/RouteDetailsFragment.java
@@ -101,6 +101,7 @@ public class RouteDetailsFragment extends ContextMenuFragment
 		implements PublicTransportCardListener, CardListener {
 
 	public static final String ROUTE_ID_KEY = "route_id_key";
+	private static final String ROUTE_DETAILS_FILTER_MASK_KEY = "route_details_filter_mask";
 	private static final float PAGE_MARGIN = 5f;
 
 	private int routeId = -1;
@@ -115,6 +116,9 @@ public class RouteDetailsFragment extends ContextMenuFragment
 	private final List<BaseCard> menuCards = new ArrayList<>();
 	@Nullable
 	private PublicTransportCard transportCard;
+	@Nullable
+	private RouteDirectionsCard routeDirectionsCard;
+	private int routeDetailsFilterMask = RouteDirectionsCard.FILTER_ALL;
 	private RouteDetailsFragmentListener routeDetailsListener;
 	private final List<RouteInfoCard> routeInfoCards = new ArrayList<>();
 	private RouteDetailsMenu routeDetailsMenu;
@@ -164,6 +168,37 @@ public class RouteDetailsFragment extends ContextMenuFragment
 
 	public int getRouteId() {
 		return routeId;
+	}
+
+	@Override
+	public void onCreate(@Nullable Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		if (savedInstanceState != null) {
+			routeDetailsFilterMask = savedInstanceState.getInt(
+					ROUTE_DETAILS_FILTER_MASK_KEY, RouteDirectionsCard.FILTER_ALL);
+		}
+		getParentFragmentManager().setFragmentResultListener(
+				RouteDetailsFilterBottomSheet.REQUEST_KEY, this, (requestKey, result) -> {
+					routeDetailsFilterMask = result.getInt(
+							RouteDetailsFilterBottomSheet.RESULT_FILTER_MASK_KEY,
+							RouteDirectionsCard.FILTER_ALL) & RouteDirectionsCard.FILTER_ALL;
+					if (routeDirectionsCard != null) {
+						routeDirectionsCard.setFilterMask(routeDetailsFilterMask);
+						routeDirectionsCard.update();
+					}
+				});
+	}
+
+	@Override
+	public void onSaveInstanceState(@NonNull Bundle outState) {
+		super.onSaveInstanceState(outState);
+		outState.putInt(ROUTE_DETAILS_FILTER_MASK_KEY, routeDetailsFilterMask);
+	}
+
+	@Override
+	public void onDestroyView() {
+		routeDirectionsCard = null;
+		super.onDestroyView();
 	}
 
 	@Override
@@ -398,7 +433,11 @@ public class RouteDetailsFragment extends ContextMenuFragment
 		if (mapActivity == null) {
 			return;
 		}
-		RouteDirectionsCard directionsCard = new RouteDirectionsCard(mapActivity);
+		RouteDirectionsCard directionsCard = new RouteDirectionsCard(mapActivity,
+				routeDetailsFilterMask, (selectedMask, warningCount, poiCount, favoriteCount) ->
+				RouteDetailsFilterBottomSheet.showInstance(getParentFragmentManager(), selectedMask,
+						warningCount, poiCount, favoriteCount));
+		routeDirectionsCard = directionsCard;
 		directionsCard.setTransparentBackground(true);
 		directionsCard.setListener(this);
 		menuCards.add(directionsCard);

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/ShowAlongTheRouteBottomSheet.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/ShowAlongTheRouteBottomSheet.java
@@ -355,13 +355,7 @@ public class ShowAlongTheRouteBottomSheet extends MenuBottomSheetDialogFragment 
 
 		@NonNull
 		private String getHeader(int type) {
-			return switch (type) {
-				case WaypointHelper.TARGETS -> getString(R.string.shared_string_target_points);
-				case WaypointHelper.ALARMS -> getString(R.string.way_alarms);
-				case WaypointHelper.FAVORITES -> getString(R.string.shared_string_my_favorites);
-				case WaypointHelper.POI -> getString(R.string.points_of_interests);
-				default -> getString(R.string.shared_string_waypoints);
-			};
+			return getString(WaypointHelper.getTypeTitleId(type));
 		}
 
 		@NonNull

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/RouteDetailsItem.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/RouteDetailsItem.java
@@ -12,28 +12,44 @@ import net.osmand.shared.routing.details.RouteCumulativeInfo;
 /** Data-only model for one ordered row in the Route Details list. */
 class RouteDetailsItem {
 
-	enum Type {
-		INTERMEDIATE(false, 0),
-		TRAFFIC_WARNING(true, 1),
-		POI(true, 2),
-		FAVORITE(true, 3),
-		MANEUVER(false, 4),
-		DESTINATION(false, 5);
+	private static final int NOT_ALONG_ROUTE = -1;
 
-		private final boolean alongRoute;
+	enum Type {
+		INTERMEDIATE(NOT_ALONG_ROUTE, 0),
+		TRAFFIC_WARNING(WaypointHelper.ALARMS, 1),
+		POI(WaypointHelper.POI, 2),
+		FAVORITE(WaypointHelper.FAVORITES, 3),
+		MANEUVER(NOT_ALONG_ROUTE, 4),
+		DESTINATION(NOT_ALONG_ROUTE, 5);
+
+		private final int waypointType;
 		private final int orderAtSameRoutePoint;
 
-		Type(boolean alongRoute, int orderAtSameRoutePoint) {
-			this.alongRoute = alongRoute;
+		Type(int waypointType, int orderAtSameRoutePoint) {
+			this.waypointType = waypointType;
 			this.orderAtSameRoutePoint = orderAtSameRoutePoint;
 		}
 
 		boolean isAlongRoute() {
-			return alongRoute;
+			return waypointType != NOT_ALONG_ROUTE;
+		}
+
+		int getWaypointType() {
+			return waypointType;
 		}
 
 		int getOrderAtSameRoutePoint() {
 			return orderAtSameRoutePoint;
+		}
+
+		@NonNull
+		static Type ofWaypointType(int waypointType) {
+			for (Type type : values()) {
+				if (type.isAlongRoute() && type.waypointType == waypointType) {
+					return type;
+				}
+			}
+			throw new IllegalArgumentException("Unsupported along-route point type: " + waypointType);
 		}
 	}
 
@@ -85,26 +101,17 @@ class RouteDetailsItem {
 				cumulativeTime);
 	}
 
+	/**
+	 * @param routePointOffset geometry index the [cumulativeInfo] was calculated for, which is the
+	 * point's route index clamped to the current route; it must stay in sync with that calculation
+	 * because it is also the sort key of the row.
+	 */
 	@NonNull
 	static RouteDetailsItem alongRoute(@NonNull LocationPointWrapper locationPoint,
-	                                  @NonNull RouteCumulativeInfo cumulativeInfo) {
-		Type type;
-		switch (locationPoint.type) {
-			case WaypointHelper.ALARMS:
-				type = Type.TRAFFIC_WARNING;
-				break;
-			case WaypointHelper.POI:
-				type = Type.POI;
-				break;
-			case WaypointHelper.FAVORITES:
-				type = Type.FAVORITE;
-				break;
-			default:
-				throw new IllegalArgumentException("Unsupported along-route point type: "
-						+ locationPoint.type);
-		}
-		return new RouteDetailsItem(type, null, null, locationPoint, -1, -1,
-				locationPoint.getRouteIndex(), cumulativeInfo.getDistanceMeters(),
+	                                   int routePointOffset,
+	                                   @NonNull RouteCumulativeInfo cumulativeInfo) {
+		return new RouteDetailsItem(Type.ofWaypointType(locationPoint.type), null, null,
+				locationPoint, -1, -1, routePointOffset, cumulativeInfo.getDistanceMeters(),
 				cumulativeInfo.getTimeSeconds());
 	}
 

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/RouteDetailsItem.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/RouteDetailsItem.java
@@ -1,0 +1,162 @@
+package net.osmand.plus.routepreparationmenu.cards;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import net.osmand.plus.helpers.LocationPointWrapper;
+import net.osmand.plus.helpers.TargetPoint;
+import net.osmand.plus.helpers.WaypointHelper;
+import net.osmand.plus.routing.RouteDirectionInfo;
+import net.osmand.shared.routing.details.RouteCumulativeInfo;
+
+/** Data-only model for one ordered row in the Route Details list. */
+class RouteDetailsItem {
+
+	enum Type {
+		INTERMEDIATE(false, 0),
+		TRAFFIC_WARNING(true, 1),
+		POI(true, 2),
+		FAVORITE(true, 3),
+		MANEUVER(false, 4),
+		DESTINATION(false, 5);
+
+		private final boolean alongRoute;
+		private final int orderAtSameRoutePoint;
+
+		Type(boolean alongRoute, int orderAtSameRoutePoint) {
+			this.alongRoute = alongRoute;
+			this.orderAtSameRoutePoint = orderAtSameRoutePoint;
+		}
+
+		boolean isAlongRoute() {
+			return alongRoute;
+		}
+
+		int getOrderAtSameRoutePoint() {
+			return orderAtSameRoutePoint;
+		}
+	}
+
+	@NonNull
+	private final Type type;
+	@Nullable
+	private final RouteDirectionInfo direction;
+	@Nullable
+	private final TargetPoint targetPoint;
+	@Nullable
+	private final LocationPointWrapper locationPoint;
+	private final int intermediateIndex;
+	private final int directionIndex;
+	private final int routePointOffset;
+	private final int cumulativeDistance;
+	private final int cumulativeTime;
+
+	private RouteDetailsItem(@NonNull Type type, @Nullable RouteDirectionInfo direction,
+	                         @Nullable TargetPoint targetPoint,
+	                         @Nullable LocationPointWrapper locationPoint, int intermediateIndex,
+	                         int directionIndex, int routePointOffset, int cumulativeDistance,
+	                         int cumulativeTime) {
+		this.type = type;
+		this.direction = direction;
+		this.targetPoint = targetPoint;
+		this.locationPoint = locationPoint;
+		this.intermediateIndex = intermediateIndex;
+		this.directionIndex = directionIndex;
+		this.routePointOffset = routePointOffset;
+		this.cumulativeDistance = cumulativeDistance;
+		this.cumulativeTime = cumulativeTime;
+	}
+
+	@NonNull
+	static RouteDetailsItem direction(@NonNull RouteDirectionInfo direction, int directionIndex,
+	                                  @NonNull RouteCumulativeInfo cumulativeInfo,
+	                                  boolean destination) {
+		return new RouteDetailsItem(destination ? Type.DESTINATION : Type.MANEUVER, direction,
+				null, null, -1, directionIndex, direction.routePointOffset,
+				cumulativeInfo.getDistanceMeters(), cumulativeInfo.getTimeSeconds());
+	}
+
+	@NonNull
+	static RouteDetailsItem intermediate(@Nullable TargetPoint targetPoint, int intermediateIndex,
+	                                     int directionIndex, int routePointOffset,
+	                                     int cumulativeDistance, int cumulativeTime) {
+		return new RouteDetailsItem(Type.INTERMEDIATE, null, targetPoint, null,
+				intermediateIndex, directionIndex, routePointOffset, cumulativeDistance,
+				cumulativeTime);
+	}
+
+	@NonNull
+	static RouteDetailsItem alongRoute(@NonNull LocationPointWrapper locationPoint,
+	                                  @NonNull RouteCumulativeInfo cumulativeInfo) {
+		Type type;
+		switch (locationPoint.type) {
+			case WaypointHelper.ALARMS:
+				type = Type.TRAFFIC_WARNING;
+				break;
+			case WaypointHelper.POI:
+				type = Type.POI;
+				break;
+			case WaypointHelper.FAVORITES:
+				type = Type.FAVORITE;
+				break;
+			default:
+				throw new IllegalArgumentException("Unsupported along-route point type: "
+						+ locationPoint.type);
+		}
+		return new RouteDetailsItem(type, null, null, locationPoint, -1, -1,
+				locationPoint.getRouteIndex(), cumulativeInfo.getDistanceMeters(),
+				cumulativeInfo.getTimeSeconds());
+	}
+
+	@NonNull
+	Type getType() {
+		return type;
+	}
+
+	boolean isIntermediate() {
+		return type == Type.INTERMEDIATE;
+	}
+
+	boolean isDestination() {
+		return type == Type.DESTINATION;
+	}
+
+	boolean isAlongRoute() {
+		return type.isAlongRoute();
+	}
+
+	@Nullable
+	RouteDirectionInfo getDirection() {
+		return direction;
+	}
+
+	@Nullable
+	TargetPoint getTargetPoint() {
+		return targetPoint;
+	}
+
+	@Nullable
+	LocationPointWrapper getLocationPoint() {
+		return locationPoint;
+	}
+
+	int getIntermediateIndex() {
+		return intermediateIndex;
+	}
+
+	int getDirectionIndex() {
+		return directionIndex;
+	}
+
+	int getRoutePointOffset() {
+		return routePointOffset;
+	}
+
+	int getCumulativeDistance() {
+		return cumulativeDistance;
+	}
+
+	int getCumulativeTime() {
+		return cumulativeTime;
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/RouteDetailsListBuilder.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/RouteDetailsListBuilder.java
@@ -1,0 +1,91 @@
+package net.osmand.plus.routepreparationmenu.cards;
+
+import androidx.annotation.NonNull;
+
+import net.osmand.plus.helpers.TargetPoint;
+import net.osmand.plus.routing.RouteCalculationResult.IntermediatePointInfo;
+import net.osmand.plus.routing.RouteDirectionInfo;
+import net.osmand.plus.routing.SharedRouteDetailsProvider;
+import net.osmand.shared.routing.details.RouteCumulativeInfo;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+/** Builds the Route Details row sequence without any Android view dependencies. */
+class RouteDetailsListBuilder {
+
+	private static final Comparator<RouteDetailsItem> ROUTE_ORDER = (first, second) -> {
+		if (first.isDestination() != second.isDestination()) {
+			return first.isDestination() ? 1 : -1;
+		}
+		int routePointOrder = Integer.compare(first.getRoutePointOffset(), second.getRoutePointOffset());
+		if (routePointOrder != 0) {
+			return routePointOrder;
+		}
+		return Integer.compare(first.getType().getOrderAtSameRoutePoint(),
+				second.getType().getOrderAtSameRoutePoint());
+	};
+
+	private RouteDetailsListBuilder() {
+	}
+
+	@NonNull
+	static List<RouteDetailsItem> buildCoreItems(
+			@NonNull List<RouteDirectionInfo> routeDirections,
+			@NonNull List<IntermediatePointInfo> intermediatePointInfos,
+			@NonNull List<TargetPoint> intermediatePoints) {
+		List<RouteDetailsItem> items = new ArrayList<>(
+				routeDirections.size() + intermediatePointInfos.size());
+		List<RouteCumulativeInfo> cumulativeInfoByPosition =
+				SharedRouteDetailsProvider.getCumulativeInfoByPosition(routeDirections);
+		for (int directionIndex = 0; directionIndex < routeDirections.size(); directionIndex++) {
+			RouteDirectionInfo direction = routeDirections.get(directionIndex);
+			boolean destination = directionIndex == routeDirections.size() - 1
+					&& direction.distance == 0;
+			items.add(RouteDetailsItem.direction(direction, directionIndex,
+					cumulativeInfoByPosition.get(directionIndex), destination));
+		}
+
+		int nextDirectionIndex = 0;
+		for (int intermediateIndex = 0;
+		     intermediateIndex < intermediatePointInfos.size(); intermediateIndex++) {
+			IntermediatePointInfo info = intermediatePointInfos.get(intermediateIndex);
+			while (nextDirectionIndex < routeDirections.size()
+					&& routeDirections.get(nextDirectionIndex).routePointOffset
+					< info.getRoutePointOffset()) {
+				nextDirectionIndex++;
+			}
+			int directionIndex = Math.min(nextDirectionIndex,
+					Math.max(0, routeDirections.size() - 1));
+			TargetPoint targetPoint = intermediateIndex < intermediatePoints.size()
+					? intermediatePoints.get(intermediateIndex) : null;
+			items.add(RouteDetailsItem.intermediate(targetPoint, intermediateIndex,
+					directionIndex, info.getRoutePointOffset(), info.getDistance(), info.getTime()));
+		}
+		items.sort(ROUTE_ORDER);
+		return items;
+	}
+
+	@NonNull
+	static List<RouteDetailsItem> mergeAlongRouteItems(
+			@NonNull List<RouteDetailsItem> coreItems,
+			@NonNull List<RouteDetailsItem> alongRouteItems,
+			@NonNull Set<RouteDetailsItem.Type> visibleTypes,
+			int currentRoutePointIndex) {
+		List<RouteDetailsItem> result = new ArrayList<>(coreItems.size() + alongRouteItems.size());
+		result.addAll(coreItems);
+		for (RouteDetailsItem item : alongRouteItems) {
+			if (!item.isAlongRoute()) {
+				throw new IllegalArgumentException("Only along-route items can be merged");
+			}
+			if (item.getRoutePointOffset() > currentRoutePointIndex
+					&& visibleTypes.contains(item.getType())) {
+				result.add(item);
+			}
+		}
+		result.sort(ROUTE_ORDER);
+		return result;
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/RouteDetailsListBuilder.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/RouteDetailsListBuilder.java
@@ -68,20 +68,23 @@ class RouteDetailsListBuilder {
 		return items;
 	}
 
+	/**
+	 * Inserts the enabled along-route rows into the already ordered core rows. Callers pass only
+	 * points that are still ahead of the current route position; that filtering happens where the
+	 * route is available, so the counts backing the filter button match what is shown.
+	 */
 	@NonNull
 	static List<RouteDetailsItem> mergeAlongRouteItems(
 			@NonNull List<RouteDetailsItem> coreItems,
 			@NonNull List<RouteDetailsItem> alongRouteItems,
-			@NonNull Set<RouteDetailsItem.Type> visibleTypes,
-			int currentRoutePointIndex) {
+			@NonNull Set<RouteDetailsItem.Type> visibleTypes) {
 		List<RouteDetailsItem> result = new ArrayList<>(coreItems.size() + alongRouteItems.size());
 		result.addAll(coreItems);
 		for (RouteDetailsItem item : alongRouteItems) {
 			if (!item.isAlongRoute()) {
 				throw new IllegalArgumentException("Only along-route items can be merged");
 			}
-			if (item.getRoutePointOffset() > currentRoutePointIndex
-					&& visibleTypes.contains(item.getType())) {
+			if (visibleTypes.contains(item.getType())) {
 				result.add(item);
 			}
 		}

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/RouteDirectionsCard.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/RouteDirectionsCard.java
@@ -12,7 +12,6 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import net.osmand.data.PointDescription;
 import net.osmand.plus.OsmandApplication;
@@ -51,7 +50,7 @@ public class RouteDirectionsCard extends MapBaseCard {
 	public static final int FILTER_ALL = FILTER_TRAFFIC_WARNINGS | FILTER_POI | FILTER_FAVORITES;
 
 	private final RoutingHelper routingHelper;
-	@Nullable
+	@NonNull
 	private final FilterListener filterListener;
 	private int filterMask;
 
@@ -59,12 +58,8 @@ public class RouteDirectionsCard extends MapBaseCard {
 		void onFilterRequested(int selectedMask, int warningCount, int poiCount, int favoriteCount);
 	}
 
-	public RouteDirectionsCard(@NonNull MapActivity mapActivity) {
-		this(mapActivity, FILTER_ALL, null);
-	}
-
 	public RouteDirectionsCard(@NonNull MapActivity mapActivity, int filterMask,
-	                           @Nullable FilterListener filterListener) {
+	                           @NonNull FilterListener filterListener) {
 		super(mapActivity);
 		routingHelper = mapActivity.getRoutingHelper();
 		this.filterMask = filterMask & FILTER_ALL;
@@ -112,25 +107,16 @@ public class RouteDirectionsCard extends MapBaseCard {
 		List<RouteDirectionInfo> routeDirections = new ArrayList<>(route.getRouteDirections(app));
 		List<IntermediatePointInfo> intermediatePointInfos = route.getIntermediatePointInfos();
 		List<TargetPoint> intermediatePoints = app.getTargetPointsHelper().getIntermediatePointsNavigation();
-		List<RouteDetailsItem> coreItems = buildRouteDirectionItems(routeDirections,
+		List<RouteDetailsItem> coreItems = RouteDetailsListBuilder.buildCoreItems(routeDirections,
 				intermediatePointInfos, intermediatePoints);
 		List<RouteDetailsItem> alongRouteItems = buildAlongRouteItems(route);
 		setupFilterButton(alongRouteItems);
 		List<RouteDetailsItem> items = RouteDetailsListBuilder.mergeAlongRouteItems(coreItems,
-				alongRouteItems, getVisibleAlongRouteTypes(filterMask), route.getCurrentRoute());
+				alongRouteItems, getVisibleAlongRouteTypes(filterMask));
 		for (int i = 0; i < items.size(); i++) {
 			View view = getRouteDirectionView(items.get(i), i, items.size());
 			cardsContainer.addView(view);
 		}
-	}
-
-	@NonNull
-	static List<RouteDetailsItem> buildRouteDirectionItems(
-			@NonNull List<RouteDirectionInfo> routeDirections,
-			@NonNull List<IntermediatePointInfo> intermediatePointInfos,
-			@NonNull List<TargetPoint> intermediatePoints) {
-		return RouteDetailsListBuilder.buildCoreItems(routeDirections, intermediatePointInfos,
-				intermediatePoints);
 	}
 
 	@NonNull
@@ -162,7 +148,8 @@ public class RouteDirectionsCard extends MapBaseCard {
 				route.getCumulativeInfoAtRoutePoints(routePointOffsets);
 		List<RouteDetailsItem> items = new ArrayList<>(points.size());
 		for (int index = 0; index < points.size(); index++) {
-			items.add(RouteDetailsItem.alongRoute(points.get(index), cumulativeInfo.get(index)));
+			items.add(RouteDetailsItem.alongRoute(points.get(index), routePointOffsets[index],
+					cumulativeInfo.get(index)));
 		}
 		return items;
 	}
@@ -182,7 +169,7 @@ public class RouteDirectionsCard extends MapBaseCard {
 		if (favoriteCount > 0) {
 			availableMask |= FILTER_FAVORITES;
 		}
-		boolean visible = availableMask != 0 && filterListener != null;
+		boolean visible = availableMask != 0;
 		AndroidUiHelper.updateVisibility(filterButton, visible);
 		if (!visible) {
 			return;
@@ -194,7 +181,8 @@ public class RouteDirectionsCard extends MapBaseCard {
 				: getContentIcon(R.drawable.ic_action_filter_dark));
 		int visibleCount = Integer.bitCount(filterMask & availableMask);
 		int availableCount = Integer.bitCount(availableMask);
-		String filterState = visibleCount + "/" + availableCount;
+		String filterState = getString(R.string.ltr_or_rtl_combine_via_slash,
+				String.valueOf(visibleCount), String.valueOf(availableCount));
 		filterButton.setContentDescription(getString(R.string.ltr_or_rtl_combine_via_colon,
 				getString(R.string.filter_screen_title), filterState));
 		filterButton.setOnClickListener(v -> filterListener.onFilterRequested(filterMask,
@@ -353,16 +341,7 @@ public class RouteDirectionsCard extends MapBaseCard {
 
 	@NonNull
 	private String getAlongRouteTypeName(@NonNull RouteDetailsItem.Type type) {
-		switch (type) {
-			case TRAFFIC_WARNING:
-				return getString(R.string.way_alarms);
-			case POI:
-				return getString(R.string.points_of_interests);
-			case FAVORITE:
-				return getString(R.string.shared_string_my_favorites);
-			default:
-				throw new IllegalArgumentException("Unsupported along-route type: " + type);
-		}
+		return getString(WaypointHelper.getTypeTitleId(type.getWaypointType()));
 	}
 
 	@NonNull

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/RouteDirectionsCard.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/RouteDirectionsCard.java
@@ -12,6 +12,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import net.osmand.data.PointDescription;
 import net.osmand.plus.OsmandApplication;
@@ -44,17 +45,34 @@ import java.util.Set;
 
 public class RouteDirectionsCard extends MapBaseCard {
 
-	private static final Set<RouteDetailsItem.Type> ALL_ALONG_ROUTE_TYPES =
-			Collections.unmodifiableSet(EnumSet.of(
-					RouteDetailsItem.Type.TRAFFIC_WARNING,
-					RouteDetailsItem.Type.POI,
-					RouteDetailsItem.Type.FAVORITE));
+	public static final int FILTER_TRAFFIC_WARNINGS = 1;
+	public static final int FILTER_POI = 1 << 1;
+	public static final int FILTER_FAVORITES = 1 << 2;
+	public static final int FILTER_ALL = FILTER_TRAFFIC_WARNINGS | FILTER_POI | FILTER_FAVORITES;
 
 	private final RoutingHelper routingHelper;
+	@Nullable
+	private final FilterListener filterListener;
+	private int filterMask;
+
+	public interface FilterListener {
+		void onFilterRequested(int selectedMask, int warningCount, int poiCount, int favoriteCount);
+	}
 
 	public RouteDirectionsCard(@NonNull MapActivity mapActivity) {
+		this(mapActivity, FILTER_ALL, null);
+	}
+
+	public RouteDirectionsCard(@NonNull MapActivity mapActivity, int filterMask,
+	                           @Nullable FilterListener filterListener) {
 		super(mapActivity);
 		routingHelper = mapActivity.getRoutingHelper();
+		this.filterMask = filterMask & FILTER_ALL;
+		this.filterListener = filterListener;
+	}
+
+	public void setFilterMask(int filterMask) {
+		this.filterMask = filterMask & FILTER_ALL;
 	}
 
 	@Override
@@ -97,8 +115,9 @@ public class RouteDirectionsCard extends MapBaseCard {
 		List<RouteDetailsItem> coreItems = buildRouteDirectionItems(routeDirections,
 				intermediatePointInfos, intermediatePoints);
 		List<RouteDetailsItem> alongRouteItems = buildAlongRouteItems(route);
+		setupFilterButton(alongRouteItems);
 		List<RouteDetailsItem> items = RouteDetailsListBuilder.mergeAlongRouteItems(coreItems,
-				alongRouteItems, ALL_ALONG_ROUTE_TYPES, route.getCurrentRoute());
+				alongRouteItems, getVisibleAlongRouteTypes(filterMask), route.getCurrentRoute());
 		for (int i = 0; i < items.size(); i++) {
 			View view = getRouteDirectionView(items.get(i), i, items.size());
 			cardsContainer.addView(view);
@@ -146,6 +165,66 @@ public class RouteDirectionsCard extends MapBaseCard {
 			items.add(RouteDetailsItem.alongRoute(points.get(index), cumulativeInfo.get(index)));
 		}
 		return items;
+	}
+
+	private void setupFilterButton(@NonNull List<RouteDetailsItem> alongRouteItems) {
+		ImageView filterButton = view.findViewById(R.id.route_details_filter);
+		int warningCount = countItems(alongRouteItems, RouteDetailsItem.Type.TRAFFIC_WARNING);
+		int poiCount = countItems(alongRouteItems, RouteDetailsItem.Type.POI);
+		int favoriteCount = countItems(alongRouteItems, RouteDetailsItem.Type.FAVORITE);
+		int availableMask = 0;
+		if (warningCount > 0) {
+			availableMask |= FILTER_TRAFFIC_WARNINGS;
+		}
+		if (poiCount > 0) {
+			availableMask |= FILTER_POI;
+		}
+		if (favoriteCount > 0) {
+			availableMask |= FILTER_FAVORITES;
+		}
+		boolean visible = availableMask != 0 && filterListener != null;
+		AndroidUiHelper.updateVisibility(filterButton, visible);
+		if (!visible) {
+			return;
+		}
+
+		boolean filtered = (filterMask & availableMask) != availableMask;
+		filterButton.setImageDrawable(filtered
+				? getActiveIcon(R.drawable.ic_action_filter_dark)
+				: getContentIcon(R.drawable.ic_action_filter_dark));
+		int visibleCount = Integer.bitCount(filterMask & availableMask);
+		int availableCount = Integer.bitCount(availableMask);
+		String filterState = visibleCount + "/" + availableCount;
+		filterButton.setContentDescription(getString(R.string.ltr_or_rtl_combine_via_colon,
+				getString(R.string.filter_screen_title), filterState));
+		filterButton.setOnClickListener(v -> filterListener.onFilterRequested(filterMask,
+				warningCount, poiCount, favoriteCount));
+	}
+
+	private static int countItems(@NonNull List<RouteDetailsItem> items,
+	                              @NonNull RouteDetailsItem.Type type) {
+		int count = 0;
+		for (RouteDetailsItem item : items) {
+			if (item.getType() == type) {
+				count++;
+			}
+		}
+		return count;
+	}
+
+	@NonNull
+	static Set<RouteDetailsItem.Type> getVisibleAlongRouteTypes(int filterMask) {
+		Set<RouteDetailsItem.Type> types = EnumSet.noneOf(RouteDetailsItem.Type.class);
+		if ((filterMask & FILTER_TRAFFIC_WARNINGS) != 0) {
+			types.add(RouteDetailsItem.Type.TRAFFIC_WARNING);
+		}
+		if ((filterMask & FILTER_POI) != 0) {
+			types.add(RouteDetailsItem.Type.POI);
+		}
+		if ((filterMask & FILTER_FAVORITES) != 0) {
+			types.add(RouteDetailsItem.Type.FAVORITE);
+		}
+		return types;
 	}
 
 	private static String getTimeDescription(OsmandApplication app, RouteDirectionInfo model) {
@@ -239,7 +318,8 @@ public class RouteDirectionsCard extends MapBaseCard {
 		}
 		cumulativeDistanceLabel.setText(OsmAndFormatter.getFormattedDistance(item.getCumulativeDistance(), app));
 		cumulativeTimeLabel.setText(Algorithms.formatDuration(item.getCumulativeTime(), app.accessibilityEnabled()));
-		row.setContentDescription(label.getText() + " " + cumulativeTimeLabel.getText());
+		row.setContentDescription(getRowContentDescription(item, label, distanceLabel,
+				cumulativeDistanceLabel, cumulativeTimeLabel));
 		LocationPointWrapper locationPoint = item.getLocationPoint();
 		TargetPoint targetPoint = item.getTargetPoint();
 		if (locationPoint != null) {
@@ -251,6 +331,38 @@ public class RouteDirectionsCard extends MapBaseCard {
 			row.setOnClickListener(v -> notifyButtonPressed(item.getDirectionIndex()));
 		}
 		return row;
+	}
+
+	@NonNull
+	private String getRowContentDescription(@NonNull RouteDetailsItem item, @NonNull TextView label,
+	                                        @NonNull TextView distanceLabel,
+	                                        @NonNull TextView cumulativeDistanceLabel,
+	                                        @NonNull TextView cumulativeTimeLabel) {
+		StringBuilder description = new StringBuilder();
+		if (item.isAlongRoute()) {
+			description.append(getAlongRouteTypeName(item.getType())).append(' ');
+		}
+		description.append(label.getText()).append(' ')
+				.append(cumulativeDistanceLabel.getText()).append(' ')
+				.append(cumulativeTimeLabel.getText());
+		if (item.isAlongRoute() && !Algorithms.isEmpty(distanceLabel.getText())) {
+			description.append(' ').append(distanceLabel.getText());
+		}
+		return description.toString();
+	}
+
+	@NonNull
+	private String getAlongRouteTypeName(@NonNull RouteDetailsItem.Type type) {
+		switch (type) {
+			case TRAFFIC_WARNING:
+				return getString(R.string.way_alarms);
+			case POI:
+				return getString(R.string.points_of_interests);
+			case FAVORITE:
+				return getString(R.string.shared_string_my_favorites);
+			default:
+				throw new IllegalArgumentException("Unsupported along-route type: " + type);
+		}
 	}
 
 	@NonNull

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/RouteDirectionsCard.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/RouteDirectionsCard.java
@@ -4,6 +4,7 @@ import static net.osmand.plus.settings.enums.TrackApproximationType.MANUAL;
 
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
+import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
@@ -12,12 +13,15 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 
+import net.osmand.data.PointDescription;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.R;
 import net.osmand.plus.activities.MapActivity;
 import net.osmand.plus.helpers.AndroidUiHelper;
+import net.osmand.plus.helpers.LocationPointWrapper;
 import net.osmand.plus.helpers.TargetPoint;
 import net.osmand.plus.helpers.WaypointDialogHelper;
+import net.osmand.plus.helpers.WaypointHelper;
 import net.osmand.plus.routing.RouteCalculationResult;
 import net.osmand.plus.routing.RouteCalculationResult.IntermediatePointInfo;
 import net.osmand.plus.routing.RouteDirectionInfo;
@@ -27,12 +31,24 @@ import net.osmand.plus.utils.OsmAndFormatter;
 import net.osmand.plus.views.TurnPathHelper.RouteDrawable;
 import net.osmand.plus.views.mapwidgets.LanesDrawable;
 import net.osmand.shared.gpx.GpxFile;
+import net.osmand.shared.routing.details.RouteCumulativeInfo;
 import net.osmand.util.Algorithms;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 public class RouteDirectionsCard extends MapBaseCard {
+
+	private static final Set<RouteDetailsItem.Type> ALL_ALONG_ROUTE_TYPES =
+			Collections.unmodifiableSet(EnumSet.of(
+					RouteDetailsItem.Type.TRAFFIC_WARNING,
+					RouteDetailsItem.Type.POI,
+					RouteDetailsItem.Type.FAVORITE));
 
 	private final RoutingHelper routingHelper;
 
@@ -78,8 +94,11 @@ public class RouteDirectionsCard extends MapBaseCard {
 		List<RouteDirectionInfo> routeDirections = new ArrayList<>(route.getRouteDirections(app));
 		List<IntermediatePointInfo> intermediatePointInfos = route.getIntermediatePointInfos();
 		List<TargetPoint> intermediatePoints = app.getTargetPointsHelper().getIntermediatePointsNavigation();
-		List<RouteDetailsItem> items = buildRouteDirectionItems(routeDirections,
+		List<RouteDetailsItem> coreItems = buildRouteDirectionItems(routeDirections,
 				intermediatePointInfos, intermediatePoints);
+		List<RouteDetailsItem> alongRouteItems = buildAlongRouteItems(route);
+		List<RouteDetailsItem> items = RouteDetailsListBuilder.mergeAlongRouteItems(coreItems,
+				alongRouteItems, ALL_ALONG_ROUTE_TYPES, route.getCurrentRoute());
 		for (int i = 0; i < items.size(); i++) {
 			View view = getRouteDirectionView(items.get(i), i, items.size());
 			cardsContainer.addView(view);
@@ -93,6 +112,40 @@ public class RouteDirectionsCard extends MapBaseCard {
 			@NonNull List<TargetPoint> intermediatePoints) {
 		return RouteDetailsListBuilder.buildCoreItems(routeDirections, intermediatePointInfos,
 				intermediatePoints);
+	}
+
+	@NonNull
+	private List<RouteDetailsItem> buildAlongRouteItems(@NonNull RouteCalculationResult route) {
+		WaypointHelper waypointHelper = app.getWaypointHelper();
+		List<LocationPointWrapper> points = new ArrayList<>();
+		points.addAll(waypointHelper.getWaypoints(WaypointHelper.ALARMS));
+		points.addAll(waypointHelper.getWaypoints(WaypointHelper.POI));
+		points.addAll(waypointHelper.getWaypoints(WaypointHelper.FAVORITES));
+
+		int routePointCount = route.getImmutableAllLocations().size();
+		if (points.isEmpty() || routePointCount == 0) {
+			return Collections.emptyList();
+		}
+		int currentRoutePoint = route.getCurrentRoute();
+		int lastRoutePoint = routePointCount - 1;
+		points.removeIf(point -> point.getRouteIndex() < 0
+				|| Math.min(point.getRouteIndex(), lastRoutePoint) <= currentRoutePoint);
+		points.sort(Comparator.comparingInt(LocationPointWrapper::getRouteIndex));
+		if (points.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		int[] routePointOffsets = new int[points.size()];
+		for (int index = 0; index < points.size(); index++) {
+			routePointOffsets[index] = Math.min(points.get(index).getRouteIndex(), lastRoutePoint);
+		}
+		List<RouteCumulativeInfo> cumulativeInfo =
+				route.getCumulativeInfoAtRoutePoints(routePointOffsets);
+		List<RouteDetailsItem> items = new ArrayList<>(points.size());
+		for (int index = 0; index < points.size(); index++) {
+			items.add(RouteDetailsItem.alongRoute(points.get(index), cumulativeInfo.get(index)));
+		}
+		return items;
 	}
 
 	private static String getTimeDescription(OsmandApplication app, RouteDirectionInfo model) {
@@ -113,7 +166,31 @@ public class RouteDirectionsCard extends MapBaseCard {
 		ImageView lanesIcon = row.findViewById(R.id.lanes);
 		row.findViewById(R.id.divider).setVisibility(itemIndex == itemCount - 1 ? View.INVISIBLE : View.VISIBLE);
 
-		if (item.isIntermediate()) {
+		if (item.isAlongRoute()) {
+			LocationPointWrapper locationPoint = Objects.requireNonNull(item.getLocationPoint());
+			Drawable icon = locationPoint.getDrawable(mapActivity, app, nightMode);
+			if (icon == null) {
+				icon = getAlongRouteFallbackIcon(item.getType());
+			}
+			directionIcon.setImageDrawable(icon);
+
+			PointDescription pointDescription = locationPoint.getPoint().getPointDescription(app);
+			String description = Algorithms.isEmpty(pointDescription.getName())
+					? pointDescription.getTypeName() : pointDescription.getName();
+			label.setText(description);
+			timeLabel.setText("");
+			if (locationPoint.getDeviationDistance() > 0) {
+				distanceLabel.setText("+" + OsmAndFormatter.getFormattedDistance(
+						locationPoint.getDeviationDistance(), app));
+				int directionIconId = locationPoint.isDeviationDirectionRight()
+						? R.drawable.ic_small_turn_right : R.drawable.ic_small_turn_left;
+				distanceLabel.setCompoundDrawablesWithIntrinsicBounds(
+						app.getUIUtilities().getPaintedIcon(directionIconId, getActiveColor()),
+						null, null, null);
+			} else {
+				distanceLabel.setText("");
+			}
+		} else if (item.isIntermediate()) {
 			directionIcon.setImageDrawable(app.getUIUtilities().getIcon(R.drawable.list_intermediate));
 			String pointType = mapActivity.getString(R.string.intermediate_point,
 					String.valueOf(item.getIntermediateIndex() + 1));
@@ -163,13 +240,36 @@ public class RouteDirectionsCard extends MapBaseCard {
 		cumulativeDistanceLabel.setText(OsmAndFormatter.getFormattedDistance(item.getCumulativeDistance(), app));
 		cumulativeTimeLabel.setText(Algorithms.formatDuration(item.getCumulativeTime(), app.accessibilityEnabled()));
 		row.setContentDescription(label.getText() + " " + cumulativeTimeLabel.getText());
+		LocationPointWrapper locationPoint = item.getLocationPoint();
 		TargetPoint targetPoint = item.getTargetPoint();
-		if (targetPoint != null) {
+		if (locationPoint != null) {
+			row.setOnClickListener(v -> WaypointDialogHelper.showOnMap(app, mapActivity,
+					locationPoint.getPoint(), false));
+		} else if (targetPoint != null) {
 			row.setOnClickListener(v -> WaypointDialogHelper.showOnMap(app, mapActivity, targetPoint, false));
 		} else {
 			row.setOnClickListener(v -> notifyButtonPressed(item.getDirectionIndex()));
 		}
 		return row;
+	}
+
+	@NonNull
+	private Drawable getAlongRouteFallbackIcon(@NonNull RouteDetailsItem.Type type) {
+		int iconId;
+		switch (type) {
+			case TRAFFIC_WARNING:
+				iconId = R.drawable.ic_action_warning_colored;
+				break;
+			case POI:
+				iconId = R.drawable.ic_action_search_dark;
+				break;
+			case FAVORITE:
+				iconId = R.drawable.ic_action_favorite;
+				break;
+			default:
+				throw new IllegalArgumentException("Unsupported along-route type: " + type);
+		}
+		return app.getUIUtilities().getPaintedIcon(iconId, getActiveColor());
 	}
 
 }

--- a/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/RouteDirectionsCard.java
+++ b/OsmAnd/src/net/osmand/plus/routepreparationmenu/cards/RouteDirectionsCard.java
@@ -11,7 +11,6 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.R;
@@ -23,13 +22,11 @@ import net.osmand.plus.routing.RouteCalculationResult;
 import net.osmand.plus.routing.RouteCalculationResult.IntermediatePointInfo;
 import net.osmand.plus.routing.RouteDirectionInfo;
 import net.osmand.plus.routing.RoutingHelper;
-import net.osmand.plus.routing.SharedRouteDetailsProvider;
 import net.osmand.plus.settings.backend.ApplicationMode;
 import net.osmand.plus.utils.OsmAndFormatter;
 import net.osmand.plus.views.TurnPathHelper.RouteDrawable;
 import net.osmand.plus.views.mapwidgets.LanesDrawable;
 import net.osmand.shared.gpx.GpxFile;
-import net.osmand.shared.routing.details.RouteCumulativeInfo;
 import net.osmand.util.Algorithms;
 
 import java.util.ArrayList;
@@ -81,7 +78,7 @@ public class RouteDirectionsCard extends MapBaseCard {
 		List<RouteDirectionInfo> routeDirections = new ArrayList<>(route.getRouteDirections(app));
 		List<IntermediatePointInfo> intermediatePointInfos = route.getIntermediatePointInfos();
 		List<TargetPoint> intermediatePoints = app.getTargetPointsHelper().getIntermediatePointsNavigation();
-		List<RouteDirectionItem> items = buildRouteDirectionItems(routeDirections,
+		List<RouteDetailsItem> items = buildRouteDirectionItems(routeDirections,
 				intermediatePointInfos, intermediatePoints);
 		for (int i = 0; i < items.size(); i++) {
 			View view = getRouteDirectionView(items.get(i), i, items.size());
@@ -90,39 +87,12 @@ public class RouteDirectionsCard extends MapBaseCard {
 	}
 
 	@NonNull
-	static List<RouteDirectionItem> buildRouteDirectionItems(
+	static List<RouteDetailsItem> buildRouteDirectionItems(
 			@NonNull List<RouteDirectionInfo> routeDirections,
 			@NonNull List<IntermediatePointInfo> intermediatePointInfos,
 			@NonNull List<TargetPoint> intermediatePoints) {
-		List<RouteDirectionItem> items = new ArrayList<>();
-		List<RouteCumulativeInfo> cumulativeInfoByPosition =
-				SharedRouteDetailsProvider.getCumulativeInfoByPosition(routeDirections);
-		int intermediateIndex = 0;
-		for (int directionIndex = 0; directionIndex < routeDirections.size(); directionIndex++) {
-			RouteDirectionInfo direction = routeDirections.get(directionIndex);
-			while (intermediateIndex < intermediatePointInfos.size()
-					&& intermediatePointInfos.get(intermediateIndex).getRoutePointOffset() <= direction.routePointOffset) {
-				IntermediatePointInfo info = intermediatePointInfos.get(intermediateIndex);
-				TargetPoint point = intermediateIndex < intermediatePoints.size()
-						? intermediatePoints.get(intermediateIndex) : null;
-				items.add(RouteDirectionItem.intermediate(point, intermediateIndex, directionIndex,
-						info.getDistance(), info.getTime()));
-				intermediateIndex++;
-			}
-			boolean destination = directionIndex == routeDirections.size() - 1 && direction.distance == 0;
-			RouteCumulativeInfo cumulativeInfo = cumulativeInfoByPosition.get(directionIndex);
-			items.add(RouteDirectionItem.direction(direction, directionIndex,
-					cumulativeInfo.getDistanceMeters(), cumulativeInfo.getTimeSeconds(), destination));
-		}
-		while (intermediateIndex < intermediatePointInfos.size()) {
-			IntermediatePointInfo info = intermediatePointInfos.get(intermediateIndex);
-			TargetPoint point = intermediateIndex < intermediatePoints.size()
-					? intermediatePoints.get(intermediateIndex) : null;
-			items.add(RouteDirectionItem.intermediate(point, intermediateIndex,
-					Math.max(0, routeDirections.size() - 1), info.getDistance(), info.getTime()));
-			intermediateIndex++;
-		}
-		return items;
+		return RouteDetailsListBuilder.buildCoreItems(routeDirections, intermediatePointInfos,
+				intermediatePoints);
 	}
 
 	private static String getTimeDescription(OsmandApplication app, RouteDirectionInfo model) {
@@ -130,7 +100,7 @@ public class RouteDirectionsCard extends MapBaseCard {
 		return Algorithms.formatDuration(timeInSeconds, app.accessibilityEnabled());
 	}
 
-	private View getRouteDirectionView(@NonNull RouteDirectionItem item, int itemIndex, int itemCount) {
+	private View getRouteDirectionView(@NonNull RouteDetailsItem item, int itemIndex, int itemCount) {
 		MapActivity mapActivity = getMapActivity();
 		View row = themedInflater.inflate(R.layout.route_info_list_item, null);
 
@@ -202,76 +172,4 @@ public class RouteDirectionsCard extends MapBaseCard {
 		return row;
 	}
 
-	static class RouteDirectionItem {
-
-		@Nullable
-		private final RouteDirectionInfo direction;
-		@Nullable
-		private final TargetPoint targetPoint;
-		private final int intermediateIndex;
-		private final int directionIndex;
-		private final int cumulativeDistance;
-		private final int cumulativeTime;
-		private final boolean destination;
-
-		private RouteDirectionItem(@Nullable RouteDirectionInfo direction, @Nullable TargetPoint targetPoint,
-		                           int intermediateIndex, int directionIndex, int cumulativeDistance,
-		                           int cumulativeTime, boolean destination) {
-			this.direction = direction;
-			this.targetPoint = targetPoint;
-			this.intermediateIndex = intermediateIndex;
-			this.directionIndex = directionIndex;
-			this.cumulativeDistance = cumulativeDistance;
-			this.cumulativeTime = cumulativeTime;
-			this.destination = destination;
-		}
-
-		@NonNull
-		static RouteDirectionItem direction(@NonNull RouteDirectionInfo direction, int directionIndex,
-		                                    int cumulativeDistance, int cumulativeTime, boolean destination) {
-			return new RouteDirectionItem(direction, null, -1, directionIndex,
-					cumulativeDistance, cumulativeTime, destination);
-		}
-
-		@NonNull
-		static RouteDirectionItem intermediate(@Nullable TargetPoint targetPoint, int intermediateIndex,
-		                                       int directionIndex, int cumulativeDistance, int cumulativeTime) {
-			return new RouteDirectionItem(null, targetPoint, intermediateIndex, directionIndex,
-					cumulativeDistance, cumulativeTime, false);
-		}
-
-		boolean isIntermediate() {
-			return direction == null;
-		}
-
-		@NonNull
-		RouteDirectionInfo getDirection() {
-			return direction;
-		}
-
-		@Nullable
-		TargetPoint getTargetPoint() {
-			return targetPoint;
-		}
-
-		int getIntermediateIndex() {
-			return intermediateIndex;
-		}
-
-		int getDirectionIndex() {
-			return directionIndex;
-		}
-
-		int getCumulativeDistance() {
-			return cumulativeDistance;
-		}
-
-		int getCumulativeTime() {
-			return cumulativeTime;
-		}
-
-		boolean isDestination() {
-			return destination;
-		}
-	}
 }

--- a/OsmAnd/src/net/osmand/plus/routing/RouteCalculationResult.java
+++ b/OsmAnd/src/net/osmand/plus/routing/RouteCalculationResult.java
@@ -26,6 +26,7 @@ import net.osmand.router.TurnType;
 import net.osmand.shared.gpx.GpxFile;
 import net.osmand.shared.routing.details.RouteEventType;
 import net.osmand.shared.routing.details.RouteExitInfo;
+import net.osmand.shared.routing.details.RouteCumulativeInfo;
 import net.osmand.util.Algorithms;
 import net.osmand.util.MapUtils;
 
@@ -1290,6 +1291,12 @@ public class RouteCalculationResult {
 			return listDistance[currentRoute] - listDistance[locationIndex];
 		}
 		return 0;
+	}
+
+	@NonNull
+	public List<RouteCumulativeInfo> getCumulativeInfoAtRoutePoints(@NonNull int[] routePointOffsets) {
+		return SharedRouteDetailsProvider.getCumulativeInfoAtRoutePoints(directions, listDistance,
+				currentRoute, currentDirectionInfo, routePointOffsets);
 	}
 
 	public int getDistanceFromPoint(int locationIndex) {

--- a/OsmAnd/src/net/osmand/plus/routing/SharedRouteDetailsProvider.kt
+++ b/OsmAnd/src/net/osmand/plus/routing/SharedRouteDetailsProvider.kt
@@ -54,6 +54,21 @@ object SharedRouteDetailsProvider {
 	)
 
 	@JvmStatic
+	fun getCumulativeInfoAtRoutePoints(
+		directions: List<RouteDirectionInfo>,
+		distanceToFinishMeters: IntArray,
+		currentRoutePointIndex: Int,
+		currentDirectionIndex: Int,
+		routePointOffsets: IntArray,
+	): List<RouteCumulativeInfo> = RouteManeuverCalculator.cumulativeInfoAtRoutePoints(
+		ManeuverAccessor(directions),
+		distanceToFinishMeters,
+		currentRoutePointIndex,
+		currentDirectionIndex,
+		routePointOffsets,
+	)
+
+	@JvmStatic
 	fun calculateIntermediateIndexes(
 		context: Context?,
 		locations: List<Location>,

--- a/OsmAnd/test/java/net/osmand/plus/routepreparationmenu/cards/RouteDirectionsCardTest.java
+++ b/OsmAnd/test/java/net/osmand/plus/routepreparationmenu/cards/RouteDirectionsCardTest.java
@@ -17,6 +17,7 @@ import net.osmand.shared.routing.details.RouteCumulativeInfo;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -35,7 +36,7 @@ public class RouteDirectionsCardTest {
 		TargetPoint first = new TargetPoint(new LatLon(1, 1), null, 0);
 		TargetPoint second = new TargetPoint(new LatLon(2, 2), null, 1);
 
-		List<RouteDetailsItem> items = RouteDirectionsCard.buildRouteDirectionItems(
+		List<RouteDetailsItem> items = RouteDetailsListBuilder.buildCoreItems(
 				directions, intermediateInfos, Arrays.asList(first, second));
 
 		assertEquals(5, items.size());
@@ -56,7 +57,7 @@ public class RouteDirectionsCardTest {
 
 	@Test
 	public void keepsRouteIntermediateWhenTargetMetadataIsUnavailable() {
-		List<RouteDetailsItem> items = RouteDirectionsCard.buildRouteDirectionItems(
+		List<RouteDetailsItem> items = RouteDetailsListBuilder.buildCoreItems(
 				Arrays.asList(direction(0, 100), direction(10, 0)),
 				Collections.singletonList(new IntermediatePointInfo(5, 50, 5)),
 				Collections.emptyList());
@@ -72,13 +73,11 @@ public class RouteDirectionsCardTest {
 				Arrays.asList(direction(0, 100), direction(10, 100), direction(20, 0)),
 				Collections.singletonList(new IntermediatePointInfo(10, 100, 10)),
 				Collections.emptyList());
-		LocationPointWrapper passedWarning = point(WaypointHelper.ALARMS, 2);
 		LocationPointWrapper hiddenPoi = point(WaypointHelper.POI, 5);
 		LocationPointWrapper warning = point(WaypointHelper.ALARMS, 10);
 		LocationPointWrapper firstFavorite = point(WaypointHelper.FAVORITES, 10);
 		LocationPointWrapper secondFavorite = point(WaypointHelper.FAVORITES, 10);
 		List<RouteDetailsItem> alongRouteItems = Arrays.asList(
-				alongRoute(passedWarning),
 				alongRoute(hiddenPoi),
 				alongRoute(warning),
 				alongRoute(firstFavorite),
@@ -88,9 +87,9 @@ public class RouteDirectionsCardTest {
 				coreItems, alongRouteItems,
 				RouteDirectionsCard.getVisibleAlongRouteTypes(
 						RouteDirectionsCard.FILTER_TRAFFIC_WARNINGS
-								| RouteDirectionsCard.FILTER_FAVORITES), 2);
+								| RouteDirectionsCard.FILTER_FAVORITES));
 
-		List<RouteDetailsItem.Type> itemTypes = new java.util.ArrayList<>();
+		List<RouteDetailsItem.Type> itemTypes = new ArrayList<>();
 		for (RouteDetailsItem item : result) {
 			itemTypes.add(item.getType());
 		}
@@ -108,7 +107,7 @@ public class RouteDirectionsCardTest {
 	}
 
 	private static RouteDetailsItem alongRoute(LocationPointWrapper point) {
-		return RouteDetailsItem.alongRoute(point, new RouteCumulativeInfo(
+		return RouteDetailsItem.alongRoute(point, point.getRouteIndex(), new RouteCumulativeInfo(
 				point.getRouteIndex() * 10, point.getRouteIndex()));
 	}
 

--- a/OsmAnd/test/java/net/osmand/plus/routepreparationmenu/cards/RouteDirectionsCardTest.java
+++ b/OsmAnd/test/java/net/osmand/plus/routepreparationmenu/cards/RouteDirectionsCardTest.java
@@ -7,16 +7,19 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import net.osmand.data.LatLon;
+import net.osmand.plus.helpers.LocationPointWrapper;
 import net.osmand.plus.helpers.TargetPoint;
-import net.osmand.plus.routepreparationmenu.cards.RouteDirectionsCard.RouteDirectionItem;
+import net.osmand.plus.helpers.WaypointHelper;
 import net.osmand.plus.routing.RouteCalculationResult.IntermediatePointInfo;
 import net.osmand.plus.routing.RouteDirectionInfo;
 import net.osmand.router.TurnType;
+import net.osmand.shared.routing.details.RouteCumulativeInfo;
 
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 
 public class RouteDirectionsCardTest {
@@ -33,7 +36,7 @@ public class RouteDirectionsCardTest {
 		TargetPoint first = new TargetPoint(new LatLon(1, 1), null, 0);
 		TargetPoint second = new TargetPoint(new LatLon(2, 2), null, 1);
 
-		List<RouteDirectionItem> items = RouteDirectionsCard.buildRouteDirectionItems(
+		List<RouteDetailsItem> items = RouteDirectionsCard.buildRouteDirectionItems(
 				directions, intermediateInfos, Arrays.asList(first, second));
 
 		assertEquals(5, items.size());
@@ -54,7 +57,7 @@ public class RouteDirectionsCardTest {
 
 	@Test
 	public void keepsRouteIntermediateWhenTargetMetadataIsUnavailable() {
-		List<RouteDirectionItem> items = RouteDirectionsCard.buildRouteDirectionItems(
+		List<RouteDetailsItem> items = RouteDirectionsCard.buildRouteDirectionItems(
 				Arrays.asList(direction(0, 100), direction(10, 0)),
 				Collections.singletonList(new IntermediatePointInfo(5, 50, 5)),
 				Collections.emptyList());
@@ -62,6 +65,55 @@ public class RouteDirectionsCardTest {
 		assertEquals(3, items.size());
 		assertTrue(items.get(1).isIntermediate());
 		assertNull(items.get(1).getTargetPoint());
+	}
+
+	@Test
+	public void mergesEnabledFuturePointsByRouteIndexWithDeterministicTieOrder() {
+		List<RouteDetailsItem> coreItems = RouteDetailsListBuilder.buildCoreItems(
+				Arrays.asList(direction(0, 100), direction(10, 100), direction(20, 0)),
+				Collections.singletonList(new IntermediatePointInfo(10, 100, 10)),
+				Collections.emptyList());
+		LocationPointWrapper passedWarning = point(WaypointHelper.ALARMS, 2);
+		LocationPointWrapper hiddenPoi = point(WaypointHelper.POI, 5);
+		LocationPointWrapper warning = point(WaypointHelper.ALARMS, 10);
+		LocationPointWrapper firstFavorite = point(WaypointHelper.FAVORITES, 10);
+		LocationPointWrapper secondFavorite = point(WaypointHelper.FAVORITES, 10);
+		List<RouteDetailsItem> alongRouteItems = Arrays.asList(
+				alongRoute(passedWarning),
+				alongRoute(hiddenPoi),
+				alongRoute(warning),
+				alongRoute(firstFavorite),
+				alongRoute(secondFavorite));
+
+		List<RouteDetailsItem> result = RouteDetailsListBuilder.mergeAlongRouteItems(
+				coreItems, alongRouteItems,
+				EnumSet.of(RouteDetailsItem.Type.TRAFFIC_WARNING,
+						RouteDetailsItem.Type.FAVORITE), 2);
+
+		List<RouteDetailsItem.Type> itemTypes = new java.util.ArrayList<>();
+		for (RouteDetailsItem item : result) {
+			itemTypes.add(item.getType());
+		}
+		assertEquals(Arrays.asList(
+				RouteDetailsItem.Type.MANEUVER,
+				RouteDetailsItem.Type.INTERMEDIATE,
+				RouteDetailsItem.Type.TRAFFIC_WARNING,
+				RouteDetailsItem.Type.FAVORITE,
+				RouteDetailsItem.Type.FAVORITE,
+				RouteDetailsItem.Type.MANEUVER,
+				RouteDetailsItem.Type.DESTINATION), itemTypes);
+		assertSame(warning, result.get(2).getLocationPoint());
+		assertSame(firstFavorite, result.get(3).getLocationPoint());
+		assertSame(secondFavorite, result.get(4).getLocationPoint());
+	}
+
+	private static RouteDetailsItem alongRoute(LocationPointWrapper point) {
+		return RouteDetailsItem.alongRoute(point, new RouteCumulativeInfo(
+				point.getRouteIndex() * 10, point.getRouteIndex()));
+	}
+
+	private static LocationPointWrapper point(int type, int routeIndex) {
+		return new LocationPointWrapper(type, null, 0, routeIndex);
 	}
 
 	private static RouteDirectionInfo direction(int routePointOffset, int distance) {

--- a/OsmAnd/test/java/net/osmand/plus/routepreparationmenu/cards/RouteDirectionsCardTest.java
+++ b/OsmAnd/test/java/net/osmand/plus/routepreparationmenu/cards/RouteDirectionsCardTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 
 public class RouteDirectionsCardTest {
@@ -87,8 +86,9 @@ public class RouteDirectionsCardTest {
 
 		List<RouteDetailsItem> result = RouteDetailsListBuilder.mergeAlongRouteItems(
 				coreItems, alongRouteItems,
-				EnumSet.of(RouteDetailsItem.Type.TRAFFIC_WARNING,
-						RouteDetailsItem.Type.FAVORITE), 2);
+				RouteDirectionsCard.getVisibleAlongRouteTypes(
+						RouteDirectionsCard.FILTER_TRAFFIC_WARNINGS
+								| RouteDirectionsCard.FILTER_FAVORITES), 2);
 
 		List<RouteDetailsItem.Type> itemTypes = new java.util.ArrayList<>();
 		for (RouteDetailsItem item : result) {

--- a/OsmAnd/test/java/net/osmand/plus/routing/SharedRouteDetailsProviderCompatibilityTest.kt
+++ b/OsmAnd/test/java/net/osmand/plus/routing/SharedRouteDetailsProviderCompatibilityTest.kt
@@ -61,6 +61,21 @@ class SharedRouteDetailsProviderCompatibilityTest {
 				cumulativeInfoByPosition[position],
 			)
 		}
+		assertEquals(
+			listOf(
+				RouteCumulativeInfo(0, 0),
+				RouteCumulativeInfo(150, 13),
+				RouteCumulativeInfo(325, 27),
+				RouteCumulativeInfo(450, 45),
+			),
+			SharedRouteDetailsProvider.getCumulativeInfoAtRoutePoints(
+				directions,
+				distanceToFinish,
+				currentRoutePointIndex = 0,
+				currentDirectionIndex = 0,
+				routePointOffsets = intArrayOf(0, 1, 2, 3),
+			),
+		)
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- introduce a route-details list model that deterministically merges maneuvers, intermediate points, traffic warnings, POIs, and favorites
- display enabled Show along the route items inside the Turn-by-turn section
- add category filters with available-item counts, saved state, active-filter indication, and accessibility descriptions
- keep the UI backed by the shared route-details migration

## Validation

- compiled Gplay Free OpenGL ARM64 debug production and Android-test sources
- ran RouteDirectionsCardTest and SharedRouteDetailsProviderCompatibilityTest: 7 tests passed on a Pixel 9a emulator running API 35
- manually verified favorite insertion, filtering, active filter state, accessibility labels, and state restoration across rotation
- confirmed no current-package crash in logcat

Refs #3793