### PR TITLE
HH alternative routes: plateau (via-node) method

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/HHAlternativeRoutes.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHAlternativeRoutes.java
@@ -18,36 +18,54 @@ import net.osmand.router.HHRouteDataStructure.HHNetworkSegmentRes;
 import net.osmand.router.HHRouteDataStructure.HHRoutingConfig;
 import net.osmand.router.HHRouteDataStructure.HHRoutingContext;
 import net.osmand.router.HHRouteDataStructure.NetworkDBPoint;
+import net.osmand.router.HHRouteDataStructure.NetworkDBPointRouteInfo;
 import net.osmand.router.HHRouteDataStructure.NetworkDBSegment;
 
-
-/* ======================= ALTERNATIVE ROUTES (plateau / via-node) =======================
- * Reuses the two shortest-path trees that the bidirectional HH search has already built,
- * so no extra Dijkstra run is needed - only the horizon of the main search is extended to
- * (1 + ALT_STRETCH) * opt (see runRoutingWithInitQueue).
+/**
+ * Alternative routes by the plateau (via-node) method.
+ *
+ * Reuses the two shortest-path trees that the bidirectional HH search has already built, so no
+ * extra Dijkstra run is needed - only the horizon of the main search is extended to
+ * (1 + ALT_STRETCH) * opt (see HHRoutePlanner.runRoutingWithInitQueue).
  *
  * A candidate is a "via node" v settled by both trees; its route is sp(s,v) + sp(v,t) and is
- * assembled by the existing createRouteSegmentFromFinalPoint(). The plateau of v is the maximal
- * chain of hub-graph edges around v belonging to BOTH trees - the stretch where the alternative
- * is simultaneously the best way to get there and the best way to go on, i.e. a road a driver
- * would actually name. A detour around one block has a zero plateau.
+ * assembled by the planner's createRouteSegmentFromFinalPoint(). The plateau of v is the maximal
+ * chain of hub-graph edges around v belonging to BOTH trees - the stretch where the alternative is
+ * simultaneously the best way to get there and the best way to go on, i.e. a road a driver would
+ * actually name. A detour around one block has a zero plateau.
  *
- * Selection runs in two stages because hub-graph edges are shortcuts several km long: two
- * different shortcuts may still cover the same streets, so hub-level sharing underestimates the
- * real overlap (measured: 20% by hubs vs 76% by geometry). Stage 1 filters cheaply on the hub
- * graph, stage 2 expands candidates one by one and checks the real road segments, stopping as
- * soon as ALT_MAX_COUNT routes are accepted.
+ * Selection runs in two stages because hub-graph edges are shortcuts several km long: two different
+ * shortcuts may still cover the same streets, so hub-level sharing underestimates the real overlap
+ * (measured: 20% by hubs vs 76% by geometry). Stage 1 filters cheaply on the hub graph, stage 2
+ * expands candidates one by one and checks the real road segments, stopping as soon as
+ * ALT_MAX_COUNT routes are accepted.
+ *
+ * One instance serves one routing call - the plateau maps and the expansion budget below are the
+ * state of that call.
  */
 public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 
-	private final HHRoutePlanner<T> planner;
-
-	public HHAlternativeRoutes(HHRoutePlanner<T> planner) {
-		this.planner = planner;
-	}
-
 	/** attempts to expand one candidate before giving up on it */
 	private static final int ALT_EXPAND_RETRIES = 3;
+	private static final long ALT_START_KEY = -1, ALT_END_KEY = -2, ALT_KEY_MULT = 4000000000L;
+
+	private final HHRoutePlanner<T> planner;
+	private final HHRoutingContext<T> hctx;
+	private final HHRoutingConfig cfg;
+
+	/** plateau length of a via node towards the start and towards the target */
+	private final Map<NetworkDBPoint, Double> plateauFwd = new HashMap<>(), plateauBwd = new HashMap<>();
+	private double optCost, maxCost;
+	/** how much own and avoided road an alternative must show, derived from the main route's length */
+	private double minOwnRoads, minAvoided;
+	/** detailed expansions spent so far, against cfg.ALT_MAX_EXPAND */
+	private int expanded;
+
+	public HHAlternativeRoutes(HHRoutePlanner<T> planner, HHRoutingContext<T> hctx) {
+		this.planner = planner;
+		this.hctx = hctx;
+		this.cfg = hctx.config;
+	}
 
 	private static class AltCandidate {
 		NetworkDBPoint via;
@@ -55,19 +73,36 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 		double plateau;
 		double sharing;
 		List<NetworkDBPoint> path;
-		TLongSet edges;
 	}
 
-	void calcAlternativeRoute(HHRoutingContext<T> hctx, HHNetworkRouteRes route,
-			LatLon start, LatLon end, RouteCalculationProgress progress, RouteResultPreparation rrp)
+	/** how much road an alternative offers that the routes it competes with do not, and vice versa */
+	private static class Distinctness {
+		double ownRoads;
+		double avoidedRoads;
+	}
+
+	void calcAlternativeRoute(HHNetworkRouteRes route, LatLon start, LatLon end,
+			RouteCalculationProgress progress, RouteResultPreparation rrp)
 			throws SQLException, IOException, InterruptedException {
-		HHRoutingConfig cfg = hctx.config;
-		double optCost = route.getHHRoutingTime();
+		optCost = route.getHHRoutingTime();
 		if (optCost <= 0 || cfg.ALT_MAX_COUNT <= 0) {
 			return;
 		}
-		double maxCost = optCost * (1 + cfg.ALT_STRETCH);
-		// ---- 1. via-node candidates: settled by both trees and within the stretch limit ----
+		maxCost = optCost * (1 + cfg.ALT_STRETCH);
+		List<T> settled = collectViaNodes();
+		if (settled.isEmpty()) {
+			return;
+		}
+		computePlateaus(settled);
+		List<AltCandidate> candidates = selectCandidates(settled, route);
+		if (candidates.isEmpty()) {
+			return;
+		}
+		verifyAndAccept(rank(candidates), route, start, end, progress, rrp);
+	}
+
+	/** via-node candidates: settled by both trees and within the stretch limit */
+	private List<T> collectViaNodes() {
 		List<T> settled = new ArrayList<>();
 		for (T p : hctx.queueAdded) {
 			if (p.rtPos != null && p.rtRev != null && p.rtPos.rtVisited && p.rtRev.rtVisited) {
@@ -77,110 +112,103 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 				}
 			}
 		}
-		if (settled.isEmpty()) {
-			return;
-		}
-		// ---- 2. plateau length of every candidate ----
-		// plateauFwd(v) needs its parent computed first, so iterate in order of increasing distance
-		Map<NetworkDBPoint, Double> plateauFwd = new HashMap<>(), plateauBwd = new HashMap<>();
-		List<T> byDistFromStart = new ArrayList<>(settled);
-		byDistFromStart.sort(new Comparator<T>() {
+		return settled;
+	}
+
+	private void computePlateaus(List<T> settled) {
+		accumulatePlateau(settled, false, plateauFwd);
+		accumulatePlateau(settled, true, plateauBwd);
+	}
+
+	/**
+	 * Walks the chain of edges that both trees agree on and accumulates its length per node. A node
+	 * continues the chain of its parent when the opposite tree routes the parent back through it,
+	 * so the value has to be read from the parent first - hence the sort by distance.
+	 */
+	private void accumulatePlateau(List<T> settled, final boolean rev, Map<NetworkDBPoint, Double> plateau) {
+		List<T> byDist = new ArrayList<>(settled);
+		byDist.sort(new Comparator<T>() {
 			@Override
 			public int compare(T a, T b) {
-				return Double.compare(a.rtPos.rtDistanceFromStart, b.rtPos.rtDistanceFromStart);
+				return Double.compare(info(a, rev).rtDistanceFromStart, info(b, rev).rtDistanceFromStart);
 			}
 		});
-		for (T v : byDistFromStart) {
-			NetworkDBPoint prev = v.rtPos.rtRouteToPoint;
+		for (T v : byDist) {
+			NetworkDBPoint prev = info(v, rev).rtRouteToPoint;
 			double val = 0;
-			if (prev != null && prev.rtRev != null && prev.rtRev.rtRouteToPoint == v) {
-				Double acc = plateauFwd.get(prev);
-				val = (acc == null ? 0 : acc) + (v.rtPos.rtDistanceFromStart - prev.rtPos.rtDistanceFromStart);
+			if (prev != null && info(prev, !rev) != null && info(prev, !rev).rtRouteToPoint == v) {
+				Double acc = plateau.get(prev);
+				val = (acc == null ? 0 : acc)
+						+ (info(v, rev).rtDistanceFromStart - info(prev, rev).rtDistanceFromStart);
 			}
-			plateauFwd.put(v, val);
+			plateau.put(v, val);
 		}
-		List<T> byDistToEnd = new ArrayList<>(settled);
-		byDistToEnd.sort(new Comparator<T>() {
-			@Override
-			public int compare(T a, T b) {
-				return Double.compare(a.rtRev.rtDistanceFromStart, b.rtRev.rtDistanceFromStart);
-			}
-		});
-		for (T v : byDistToEnd) {
-			NetworkDBPoint next = v.rtRev.rtRouteToPoint;
-			double val = 0;
-			if (next != null && next.rtPos != null && next.rtPos.rtRouteToPoint == v) {
-				Double acc = plateauBwd.get(next);
-				val = (acc == null ? 0 : acc) + (v.rtRev.rtDistanceFromStart - next.rtRev.rtDistanceFromStart);
-			}
-			plateauBwd.put(v, val);
-		}
-		// ---- 3. stage 1: cheap admissibility on the hub graph ----
-		List<NetworkDBPoint> optNodes = new ArrayList<>();
-		for (HHNetworkSegmentRes r : route.segments) {
-			if (r.segment != null && r.segment.start != null && r.segment.end != null) {
-				if (optNodes.isEmpty()) {
-					optNodes.add(r.segment.start);
-				}
-				optNodes.add(r.segment.end);
-			}
-		}
-		TLongSet optEdges = pathEdges(optNodes);
+	}
+
+	/**
+	 * The point's search state in one direction, or null when that tree never reached it.
+	 * {@link NetworkDBPoint#rt} would allocate the missing one instead of saying so.
+	 */
+	private NetworkDBPointRouteInfo info(NetworkDBPoint p, boolean rev) {
+		return rev ? p.rtRev : p.rtPos;
+	}
+
+	/** stage 1: cheap admissibility on the hub graph */
+	private List<AltCandidate> selectCandidates(List<T> settled, HHNetworkRouteRes route) {
+		TLongSet optEdges = pathEdges(hubPath(route));
 		List<AltCandidate> candidates = new ArrayList<>();
 		TLongSet seenPaths = new TLongHashSet();
 		for (T v : settled) {
-			Double bwd = plateauBwd.get(v);
-			Double fwd = plateauFwd.get(v);
-			double cost = v.rtPos.rtDistanceFromStart + v.rtRev.rtDistanceFromStart;
-			double plateau = (fwd == null ? 0 : fwd) + (bwd == null ? 0 : bwd);
-			if (!isPlateauRepresentative(v, plateau, plateauFwd)) {
-				continue;
+			AltCandidate c = admissibleThrough(v, optEdges);
+			if (c != null && seenPaths.add(signature(c.path))) {
+				candidates.add(c);
 			}
-			if (plateau < cfg.ALT_MIN_PLATEAU * cost) {
-				continue;
-			}
-			List<NetworkDBPoint> path = pathThrough(v);
-			if (!isSimple(path)) {
-				// sp(s,v) and sp(v,t) are each optimal, but their concatenation is not necessarily a
-				// simple path: when both halves run over the same roads the candidate drives out and
-				// turns back. Cheap check first, the exact one is on the geometry in stage 2.
-				continue;
-			}
-			long signature = 0;
-			for (NetworkDBPoint n : path) {
-				signature = signature * 1000003L + n.index;
-			}
-			if (!seenPaths.add(signature)) {
-				continue;
-			}
-			double sharing = sharedCost(path, optEdges) / cost;
-			if (sharing > cfg.ALT_MAX_SHARING) {
-				continue;
-			}
-			AltCandidate c = new AltCandidate();
-			c.via = v;
-			c.cost = cost;
-			c.plateau = plateau;
-			c.path = path;
-			c.sharing = sharing;
-			c.edges = pathEdges(path);
-			candidates.add(c);
 		}
-		if (candidates.isEmpty()) {
-			return;
+		return candidates;
+	}
+
+	/** the candidate routed through this via node, or null when it fails one of the hub-graph rules */
+	private AltCandidate admissibleThrough(T via, TLongSet optEdges) {
+		Double fwd = plateauFwd.get(via);
+		Double bwd = plateauBwd.get(via);
+		double cost = via.rtPos.rtDistanceFromStart + via.rtRev.rtDistanceFromStart;
+		double plateau = (fwd == null ? 0 : fwd) + (bwd == null ? 0 : bwd);
+		if (!isPlateauRepresentative(via, plateau) || plateau < cfg.ALT_MIN_PLATEAU * cost) {
+			return null;
 		}
-		// rank by "as different as possible for as little extra time as possible"
-		final double finalOptCost = optCost;
-		final double costWeight = cfg.ALT_RANK_COST_WEIGHT;
+		List<NetworkDBPoint> path = pathThrough(via);
+		if (!isSimple(path)) {
+			// sp(s,v) and sp(v,t) are each optimal, but their concatenation is not necessarily a
+			// simple path: when both halves run over the same roads the candidate drives out and
+			// turns back. Cheap check first, the exact one is on the geometry in stage 2.
+			return null;
+		}
+		double sharing = sharedCost(path, optEdges) / cost;
+		if (sharing > cfg.ALT_MAX_SHARING) {
+			return null;
+		}
+		AltCandidate c = new AltCandidate();
+		c.via = via;
+		c.cost = cost;
+		c.plateau = plateau;
+		c.path = path;
+		c.sharing = sharing;
+		return c;
+	}
+
+	/**
+	 * Best first: as different as possible for as little extra time as possible, with everything
+	 * within ALT_STRETCH_PREFERRED proposed before the merely acceptable candidates.
+	 */
+	private List<AltCandidate> rank(List<AltCandidate> candidates) {
 		candidates.sort(new Comparator<AltCandidate>() {
 			@Override
 			public int compare(AltCandidate x, AltCandidate y) {
-				return Double.compare(rankScore(y, finalOptCost, costWeight), rankScore(x, finalOptCost, costWeight));
+				return Double.compare(rankScore(y), rankScore(x));
 			}
 		});
-		// alternatives within ALT_STRETCH_PREFERRED are proposed before the merely acceptable ones
-		List<AltCandidate> ordered = new ArrayList<>(candidates.size());
 		double preferredCost = optCost * (1 + cfg.ALT_STRETCH_PREFERRED);
+		List<AltCandidate> ordered = new ArrayList<>(candidates.size());
 		for (AltCandidate c : candidates) {
 			if (c.cost <= preferredCost) {
 				ordered.add(c);
@@ -191,107 +219,175 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 				ordered.add(c);
 			}
 		}
-		// ---- 4. stage 2: expand lazily and verify on the real road segments ----
-		List<Map<Long, Double>> acceptedGeometry = new ArrayList<>();
-		Map<Long, Double> mainGeometry = roadSegments(detailedSegments(route));
-		double mainLength = totalLength(mainGeometry);
-		double minOwnRoads = Math.max(cfg.ALT_MIN_DISTINCT_ABS, cfg.ALT_MIN_DISTINCT_REL * mainLength);
-		// Avoiding is asked for less strictly than offering: replacing a good stretch of a long route
-		// is useful even when most of the main route stays. The point of this second threshold is to
-		// reject an alternative that contains the whole main route and only adds a loop to it.
-		double minAvoided = Math.max(cfg.ALT_MIN_DISTINCT_ABS, cfg.ALT_MIN_DISTINCT_REL * mainLength / 2);
-		int expanded = 0;
+		return ordered;
+	}
+
+	private double rankScore(AltCandidate c) {
+		return (1 - c.sharing) - cfg.ALT_RANK_COST_WEIGHT * (c.cost / optCost - 1);
+	}
+
+	/** stage 2: expand candidates one by one and verify them on the real road segments */
+	private void verifyAndAccept(List<AltCandidate> ordered, HHNetworkRouteRes route, LatLon start,
+			LatLon end, RouteCalculationProgress progress, RouteResultPreparation rrp)
+			throws SQLException, IOException, InterruptedException {
+		// Distinctness is measured against the main route and against the alternatives already
+		// accepted alike - an alternative has to be worth proposing next to each of them.
+		List<Map<Long, Double>> accepted = new ArrayList<>();
+		accepted.add(roadSegments(detailedSegments(route)));
+		setDistinctnessThresholds(totalLength(accepted.get(0)));
 		for (AltCandidate c : ordered) {
 			if (route.altRoutes.size() >= cfg.ALT_MAX_COUNT || expanded >= cfg.ALT_MAX_EXPAND) {
 				break;
 			}
-			if (progress != null && progress.isCancelled) {
+			HHNetworkRouteRes alt = expand(c, progress, rrp);
+			if (isCancelled(progress)) {
 				return;
 			}
-			// retrieveSegmentsGeometry bails out half way when a shortcut cannot be expanded, or when
-			// its detailed cost turns out higher than the hub graph promised; it corrects the segment
-			// cost on the way out, so the next attempt usually succeeds. The main route recalculates
-			// in exactly the same situation - an alternative simply retries a few times.
-			HHNetworkRouteRes alt = null;
-			boolean needsRecalculation = true;
-			for (int attempt = 0; attempt < ALT_EXPAND_RETRIES && needsRecalculation
-					&& expanded < cfg.ALT_MAX_EXPAND; attempt++) {
-				alt = planner.createRouteSegmentFromFinalPoint(hctx, c.via);
-				if (alt.segments.isEmpty()) {
-					break;
-				}
-				needsRecalculation = planner.retrieveSegmentsGeometry(hctx, rrp, alt, true, progress, true);
-				expanded++;
-			}
-			if (progress != null && progress.isCancelled) {
-				return;
-			}
-			if (alt == null || alt.segments.isEmpty()) {
+			if (alt == null) {
 				continue;
 			}
-			if (needsRecalculation || !isFullyExpanded(alt)) {
-				// still incomplete: the rest of the segments have no geometry and would be drawn as
-				// straight lines between hub points, so the candidate is not usable
-				planner.printf(HHRoutePlanner.DEBUG_VERBOSE_LEVEL > 0, "  alt dropped: incomplete geometry (+%.1f%%)\n",
-						100 * (c.cost / optCost - 1));
-				continue;
-			}
-			// shortcut costs can be optimistic; now that the roads are known, check the real one
-			double realCost = alt.getHHRoutingDetailed();
-			if (realCost > maxCost) {
-				planner.printf(HHRoutePlanner.DEBUG_VERBOSE_LEVEL > 0, "  alt dropped: real cost +%.1f%% over the limit (hub graph said +%.1f%%)\n",
-						100 * (realCost / optCost - 1), 100 * (c.cost / optCost - 1));
-				continue;
-			}
-			c.cost = realCost;
-			// prepare the candidate exactly like the main route: turns, distances and the clean-up of
-			// small manoeuvres all happen here, and the checks below must see what will be displayed
-			planner.prepareRouteResults(hctx, alt, start, end, rrp);
-			if (cfg.ROUTE_ALL_ALT_SEGMENTS && !alt.detailed.isEmpty()) {
-				alt.detailed = rrp.prepareResult(hctx.rctx, alt.detailed).detailed;
-			}
-			List<RouteSegmentResult> detailed = alt.detailed;
-			if (detailed.isEmpty()) {
-				continue;
-			}
-			double retraced = retracedLength(detailed);
-			if (retraced > cfg.ALT_MAX_RETRACED) {
-				// sp(s,v) and sp(v,t) are each optimal, but their concatenation is not necessarily a
-				// simple path: when the two halves run over the same roads the candidate drives out
-				// and turns back, which reads as a bug on the map
-				planner.printf(HHRoutePlanner.DEBUG_VERBOSE_LEVEL > 0, "  alt dropped: drives %.0f m of its own roads twice (+%.1f%%)\n",
-						retraced, 100 * (c.cost / optCost - 1));
-				continue;
-			}
-			// Both directions matter. "Own roads" says the alternative offers something new; "roads
-			// avoided" says it actually replaces a part of the route it is an alternative to. Without
-			// the second one an alternative that contains the whole main route plus a loop passes.
-			Map<Long, Double> altGeometry = roadSegments(detailed);
-			double altLength = totalLength(altGeometry);
-			double ownRoads = altLength - sharedGeometry(altGeometry, mainGeometry);
-			double avoidedRoads = mainLength - sharedGeometry(mainGeometry, altGeometry);
-			for (Map<Long, Double> accepted : acceptedGeometry) {
-				ownRoads = Math.min(ownRoads, altLength - sharedGeometry(altGeometry, accepted));
-				avoidedRoads = Math.min(avoidedRoads,
-						totalLength(accepted) - sharedGeometry(accepted, altGeometry));
-			}
-			if (ownRoads < minOwnRoads || avoidedRoads < minAvoided) {
-				planner.printf(HHRoutePlanner.DEBUG_VERBOSE_LEVEL > 0,
-						"  alt rejected: +%.1f%%, own roads %.1f km (need %.1f), avoids %.1f km (need %.1f)\n",
-						100 * (c.cost / optCost - 1), ownRoads / 1000, minOwnRoads / 1000,
-						avoidedRoads / 1000, minAvoided / 1000);
+			Map<Long, Double> geometry = roadSegments(prepare(alt, start, end, rrp));
+			Distinctness d = assess(c, alt.detailed, geometry, accepted);
+			if (d == null) {
 				continue;
 			}
 			route.altRoutes.add(alt);
-			acceptedGeometry.add(roadSegments(detailed));
+			accepted.add(geometry);
 			planner.printf(HHRoutePlanner.DEBUG_VERBOSE_LEVEL > 0,
 					"  alt accepted: +%.1f%%, plateau %.0f%%, own roads %.1f km, avoids %.1f km\n",
-					100 * (c.cost / optCost - 1), 100 * c.plateau / c.cost, ownRoads / 1000, avoidedRoads / 1000);
+					100 * (c.cost / optCost - 1), 100 * c.plateau / c.cost,
+					d.ownRoads / 1000, d.avoidedRoads / 1000);
 		}
 	}
 
-	private static double rankScore(AltCandidate c, double optCost, double costWeight) {
-		return (1 - c.sharing) - costWeight * (c.cost / optCost - 1);
+	private void setDistinctnessThresholds(double mainLength) {
+		minOwnRoads = Math.max(cfg.ALT_MIN_DISTINCT_ABS, cfg.ALT_MIN_DISTINCT_REL * mainLength);
+		// Avoiding is asked for less strictly than offering: replacing a good stretch of a long route
+		// is useful even when most of the main route stays. The point of this second threshold is to
+		// reject an alternative that contains the whole main route and only adds a loop to it.
+		minAvoided = Math.max(cfg.ALT_MIN_DISTINCT_ABS, cfg.ALT_MIN_DISTINCT_REL * mainLength / 2);
+	}
+
+	/** how the candidate differs from the routes already on offer, or null when it must not be proposed */
+	private Distinctness assess(AltCandidate c, List<RouteSegmentResult> detailed,
+			Map<Long, Double> geometry, List<Map<Long, Double>> accepted) {
+		if (detailed.isEmpty()) {
+			return null;
+		}
+		double retraced = retracedLength(detailed);
+		if (retraced > cfg.ALT_MAX_RETRACED) {
+			// the hub-level isSimple() check misses this when the two halves overlap inside a single
+			// shortcut: the candidate drives out and turns back, which reads as a bug on the map
+			dropped(c, "drives %.0f m of its own roads twice", retraced);
+			return null;
+		}
+		Distinctness d = distinctness(geometry, accepted);
+		if (d.ownRoads < minOwnRoads || d.avoidedRoads < minAvoided) {
+			dropped(c, "own roads %.1f km (need %.1f), avoids %.1f km (need %.1f)",
+					d.ownRoads / 1000, minOwnRoads / 1000, d.avoidedRoads / 1000, minAvoided / 1000);
+			return null;
+		}
+		return d;
+	}
+
+	/** the candidate expanded into real roads, or null when it turned out to be unusable */
+	private HHNetworkRouteRes expand(AltCandidate c, RouteCalculationProgress progress,
+			RouteResultPreparation rrp) throws SQLException, IOException, InterruptedException {
+		// retrieveSegmentsGeometry bails out half way when a shortcut cannot be expanded, or when its
+		// detailed cost turns out higher than the hub graph promised; it corrects the segment cost on
+		// the way out, so the next attempt usually succeeds. The main route recalculates in exactly
+		// the same situation - an alternative simply retries a few times.
+		HHNetworkRouteRes alt = null;
+		boolean needsRecalculation = true;
+		for (int attempt = 0; attempt < ALT_EXPAND_RETRIES && needsRecalculation
+				&& expanded < cfg.ALT_MAX_EXPAND; attempt++) {
+			if (isCancelled(progress)) {
+				return null;
+			}
+			alt = planner.createRouteSegmentFromFinalPoint(hctx, c.via);
+			if (alt.segments.isEmpty()) {
+				return null;
+			}
+			needsRecalculation = planner.retrieveSegmentsGeometry(hctx, rrp, alt, true, progress, true);
+			expanded++;
+		}
+		if (alt == null || alt.segments.isEmpty()) {
+			return null;
+		}
+		if (needsRecalculation || !isFullyExpanded(alt)) {
+			// the rest of the segments have no geometry and would be drawn as straight lines between
+			// hub points, so the candidate is not usable
+			dropped(c, "incomplete geometry");
+			return null;
+		}
+		// shortcut costs can be optimistic; now that the roads are known, check the real one
+		double realCost = alt.getHHRoutingDetailed();
+		if (realCost > maxCost) {
+			dropped(c, "real cost +%.1f%% over the limit", 100 * (realCost / optCost - 1));
+			return null;
+		}
+		c.cost = realCost;
+		return alt;
+	}
+
+	/**
+	 * Prepares the candidate exactly like the main route: turns, distances and the clean-up of small
+	 * manoeuvres all happen here, and the checks that follow must see what will be displayed.
+	 */
+	private List<RouteSegmentResult> prepare(HHNetworkRouteRes alt, LatLon start, LatLon end,
+			RouteResultPreparation rrp) throws SQLException, IOException, InterruptedException {
+		planner.prepareRouteResults(hctx, alt, start, end, rrp);
+		if (cfg.ROUTE_ALL_ALT_SEGMENTS && !alt.detailed.isEmpty()) {
+			alt.detailed = rrp.prepareResult(hctx.rctx, alt.detailed).detailed;
+		}
+		return alt.detailed;
+	}
+
+	/**
+	 * Both directions matter. "Own roads" says the alternative offers something new; "roads avoided"
+	 * says it actually replaces a part of the route it is an alternative to. Without the second one
+	 * an alternative that contains a whole accepted route plus a loop passes.
+	 */
+	private Distinctness distinctness(Map<Long, Double> geometry, List<Map<Long, Double>> accepted) {
+		double length = totalLength(geometry);
+		Distinctness d = new Distinctness();
+		d.ownRoads = Double.MAX_VALUE;
+		d.avoidedRoads = Double.MAX_VALUE;
+		for (Map<Long, Double> other : accepted) {
+			d.ownRoads = Math.min(d.ownRoads, length - sharedGeometry(geometry, other));
+			d.avoidedRoads = Math.min(d.avoidedRoads, totalLength(other) - sharedGeometry(other, geometry));
+		}
+		return d;
+	}
+
+	private void dropped(AltCandidate c, String reason, Object... args) {
+		planner.printf(HHRoutePlanner.DEBUG_VERBOSE_LEVEL > 0, "  alt dropped (+%.1f%%): " + reason + "\n",
+				prepend(100 * (c.cost / optCost - 1), args));
+	}
+
+	private Object[] prepend(double first, Object[] rest) {
+		Object[] all = new Object[rest.length + 1];
+		all[0] = first;
+		System.arraycopy(rest, 0, all, 1, rest.length);
+		return all;
+	}
+
+	private boolean isCancelled(RouteCalculationProgress progress) {
+		return progress != null && progress.isCancelled;
+	}
+
+	/** the hub points of the optimal route, in order */
+	private List<NetworkDBPoint> hubPath(HHNetworkRouteRes route) {
+		List<NetworkDBPoint> nodes = new ArrayList<>();
+		for (HHNetworkSegmentRes r : route.segments) {
+			if (r.segment != null && r.segment.start != null && r.segment.end != null) {
+				if (nodes.isEmpty()) {
+					nodes.add(r.segment.start);
+				}
+				nodes.add(r.segment.end);
+			}
+		}
+		return nodes;
 	}
 
 	/** full s -> t sequence of hub points through the given via node, taken from both trees */
@@ -311,14 +407,20 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 		return path;
 	}
 
-	private static final long ALT_START_KEY = -1, ALT_END_KEY = -2, ALT_KEY_MULT = 4000000000L;
+	private long signature(List<NetworkDBPoint> path) {
+		long signature = 0;
+		for (NetworkDBPoint n : path) {
+			signature = signature * 1000003L + n.index;
+		}
+		return signature;
+	}
 
-	private static long edgeKey(long from, long to) {
+	private long edgeKey(long from, long to) {
 		return from * ALT_KEY_MULT + to;
 	}
 
 	/** edge keys of a full s -> t path including the first/last mile anchors */
-	private static TLongSet pathEdges(List<NetworkDBPoint> path) {
+	private TLongSet pathEdges(List<NetworkDBPoint> path) {
 		TLongSet edges = new TLongHashSet();
 		if (path.isEmpty()) {
 			return edges;
@@ -370,8 +472,7 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 	 * and on the edge going out, which is what makes the two halves of the candidate join smoothly
 	 * instead of turning back on themselves. At the end of a chain they need not agree.
 	 */
-	private static boolean isPlateauRepresentative(NetworkDBPoint v, double plateau,
-			Map<NetworkDBPoint, Double> plateauFwd) {
+	private boolean isPlateauRepresentative(NetworkDBPoint v, double plateau) {
 		if (plateau <= 0) {
 			return true; // no plateau at all, nothing to deduplicate
 		}
@@ -393,7 +494,7 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 	}
 
 	/** no hub point is visited twice, i.e. the two halves of the candidate do not overlap */
-	private static boolean isSimple(List<NetworkDBPoint> path) {
+	private boolean isSimple(List<NetworkDBPoint> path) {
 		TLongSet seen = new TLongHashSet();
 		for (NetworkDBPoint p : path) {
 			if (!seen.add(p.index)) {
@@ -404,7 +505,7 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 	}
 
 	/** length of the road pieces that `segments` drives more than once */
-	private static double retracedLength(List<RouteSegmentResult> segments) {
+	private double retracedLength(List<RouteSegmentResult> segments) {
 		TLongSet seen = new TLongHashSet();
 		double retraced = 0;
 		for (RouteSegmentResult r : segments) {
@@ -413,9 +514,8 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 			int step = i <= end ? 1 : -1;
 			while (i != end) {
 				int j = i + step;
-				if (!seen.add(o.getId() * 4096L + Math.min(i, j))) {
-					retraced += HHRoutePlanner.squareRootDist31(o.getPoint31XTile(i), o.getPoint31YTile(i),
-							o.getPoint31XTile(j), o.getPoint31YTile(j));
+				if (!seen.add(roadPieceKey(o, i, j))) {
+					retraced += pieceLength(o, i, j);
 				}
 				i = j;
 			}
@@ -424,7 +524,7 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 	}
 
 	/** every hub-graph segment was expanded into real roads, so nothing will be drawn as a straight line */
-	private static boolean isFullyExpanded(HHNetworkRouteRes route) {
+	private boolean isFullyExpanded(HHNetworkRouteRes route) {
 		for (HHNetworkSegmentRes s : route.segments) {
 			if (s.list == null || s.list.isEmpty()) {
 				return false;
@@ -433,7 +533,7 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 		return !route.segments.isEmpty();
 	}
 
-	private static List<RouteSegmentResult> detailedSegments(HHNetworkRouteRes route) {
+	private List<RouteSegmentResult> detailedSegments(HHNetworkRouteRes route) {
 		List<RouteSegmentResult> l = new ArrayList<>();
 		for (HHNetworkSegmentRes s : route.segments) {
 			if (s.list != null) {
@@ -444,10 +544,10 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 	}
 
 	/**
-	 * Road point pair -> covered length. RouteSegmentResult.getDistance() is only filled in
+	 * Road piece -> covered length. RouteSegmentResult.getDistance() is only filled in
 	 * prepareResult(), so the length is measured on the geometry here.
 	 */
-	private static Map<Long, Double> roadSegments(List<RouteSegmentResult> segments) {
+	private Map<Long, Double> roadSegments(List<RouteSegmentResult> segments) {
 		Map<Long, Double> m = new HashMap<>();
 		for (RouteSegmentResult r : segments) {
 			RouteDataObject o = r.getObject();
@@ -455,18 +555,26 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 			int step = i <= end ? 1 : -1;
 			while (i != end) {
 				int j = i + step;
-				long key = o.getId() * 4096L + Math.min(i, j);
-				double d = HHRoutePlanner.squareRootDist31(o.getPoint31XTile(i), o.getPoint31YTile(i),
-						o.getPoint31XTile(j), o.getPoint31YTile(j));
+				Long key = roadPieceKey(o, i, j);
 				Double prev = m.get(key);
-				m.put(key, (prev == null ? 0 : prev) + d);
+				m.put(key, (prev == null ? 0 : prev) + pieceLength(o, i, j));
 				i = j;
 			}
 		}
 		return m;
 	}
 
-	private static double totalLength(Map<Long, Double> segments) {
+	/** identifies one piece of road between two neighbouring points, whichever way it is driven */
+	private long roadPieceKey(RouteDataObject o, int i, int j) {
+		return o.getId() * 4096L + Math.min(i, j);
+	}
+
+	private double pieceLength(RouteDataObject o, int i, int j) {
+		return HHRoutePlanner.squareRootDist31(o.getPoint31XTile(i), o.getPoint31YTile(i),
+				o.getPoint31XTile(j), o.getPoint31YTile(j));
+	}
+
+	private double totalLength(Map<Long, Double> segments) {
 		double d = 0;
 		for (Double v : segments.values()) {
 			d += v;
@@ -475,7 +583,7 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 	}
 
 	/** length of the roads that the two routes have in common */
-	private static double sharedGeometry(Map<Long, Double> segments, Map<Long, Double> reference) {
+	private double sharedGeometry(Map<Long, Double> segments, Map<Long, Double> reference) {
 		double common = 0;
 		for (Map.Entry<Long, Double> e : segments.entrySet()) {
 			Double v = reference.get(e.getKey());
@@ -485,5 +593,4 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 		}
 		return common;
 	}
-
 }

--- a/OsmAnd-java/src/main/java/net/osmand/router/HHAlternativeRoutes.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHAlternativeRoutes.java
@@ -1,0 +1,489 @@
+package net.osmand.router;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import gnu.trove.set.TLongSet;
+import gnu.trove.set.hash.TLongHashSet;
+import net.osmand.binary.RouteDataObject;
+import net.osmand.data.LatLon;
+import net.osmand.router.HHRouteDataStructure.HHNetworkRouteRes;
+import net.osmand.router.HHRouteDataStructure.HHNetworkSegmentRes;
+import net.osmand.router.HHRouteDataStructure.HHRoutingConfig;
+import net.osmand.router.HHRouteDataStructure.HHRoutingContext;
+import net.osmand.router.HHRouteDataStructure.NetworkDBPoint;
+import net.osmand.router.HHRouteDataStructure.NetworkDBSegment;
+
+
+/* ======================= ALTERNATIVE ROUTES (plateau / via-node) =======================
+ * Reuses the two shortest-path trees that the bidirectional HH search has already built,
+ * so no extra Dijkstra run is needed - only the horizon of the main search is extended to
+ * (1 + ALT_STRETCH) * opt (see runRoutingWithInitQueue).
+ *
+ * A candidate is a "via node" v settled by both trees; its route is sp(s,v) + sp(v,t) and is
+ * assembled by the existing createRouteSegmentFromFinalPoint(). The plateau of v is the maximal
+ * chain of hub-graph edges around v belonging to BOTH trees - the stretch where the alternative
+ * is simultaneously the best way to get there and the best way to go on, i.e. a road a driver
+ * would actually name. A detour around one block has a zero plateau.
+ *
+ * Selection runs in two stages because hub-graph edges are shortcuts several km long: two
+ * different shortcuts may still cover the same streets, so hub-level sharing underestimates the
+ * real overlap (measured: 20% by hubs vs 76% by geometry). Stage 1 filters cheaply on the hub
+ * graph, stage 2 expands candidates one by one and checks the real road segments, stopping as
+ * soon as ALT_MAX_COUNT routes are accepted.
+ */
+public class HHAlternativeRoutes<T extends NetworkDBPoint> {
+
+	private final HHRoutePlanner<T> planner;
+
+	public HHAlternativeRoutes(HHRoutePlanner<T> planner) {
+		this.planner = planner;
+	}
+
+	/** attempts to expand one candidate before giving up on it */
+	private static final int ALT_EXPAND_RETRIES = 3;
+
+	private static class AltCandidate {
+		NetworkDBPoint via;
+		double cost;
+		double plateau;
+		double sharing;
+		List<NetworkDBPoint> path;
+		TLongSet edges;
+	}
+
+	void calcAlternativeRoute(HHRoutingContext<T> hctx, HHNetworkRouteRes route,
+			LatLon start, LatLon end, RouteCalculationProgress progress, RouteResultPreparation rrp)
+			throws SQLException, IOException, InterruptedException {
+		HHRoutingConfig cfg = hctx.config;
+		double optCost = route.getHHRoutingTime();
+		if (optCost <= 0 || cfg.ALT_MAX_COUNT <= 0) {
+			return;
+		}
+		double maxCost = optCost * (1 + cfg.ALT_STRETCH);
+		// ---- 1. via-node candidates: settled by both trees and within the stretch limit ----
+		List<T> settled = new ArrayList<>();
+		for (T p : hctx.queueAdded) {
+			if (p.rtPos != null && p.rtRev != null && p.rtPos.rtVisited && p.rtRev.rtVisited) {
+				double c = p.rtPos.rtDistanceFromStart + p.rtRev.rtDistanceFromStart;
+				if (c > 0 && c <= maxCost) {
+					settled.add(p);
+				}
+			}
+		}
+		if (settled.isEmpty()) {
+			return;
+		}
+		// ---- 2. plateau length of every candidate ----
+		// plateauFwd(v) needs its parent computed first, so iterate in order of increasing distance
+		Map<NetworkDBPoint, Double> plateauFwd = new HashMap<>(), plateauBwd = new HashMap<>();
+		List<T> byDistFromStart = new ArrayList<>(settled);
+		byDistFromStart.sort(new Comparator<T>() {
+			@Override
+			public int compare(T a, T b) {
+				return Double.compare(a.rtPos.rtDistanceFromStart, b.rtPos.rtDistanceFromStart);
+			}
+		});
+		for (T v : byDistFromStart) {
+			NetworkDBPoint prev = v.rtPos.rtRouteToPoint;
+			double val = 0;
+			if (prev != null && prev.rtRev != null && prev.rtRev.rtRouteToPoint == v) {
+				Double acc = plateauFwd.get(prev);
+				val = (acc == null ? 0 : acc) + (v.rtPos.rtDistanceFromStart - prev.rtPos.rtDistanceFromStart);
+			}
+			plateauFwd.put(v, val);
+		}
+		List<T> byDistToEnd = new ArrayList<>(settled);
+		byDistToEnd.sort(new Comparator<T>() {
+			@Override
+			public int compare(T a, T b) {
+				return Double.compare(a.rtRev.rtDistanceFromStart, b.rtRev.rtDistanceFromStart);
+			}
+		});
+		for (T v : byDistToEnd) {
+			NetworkDBPoint next = v.rtRev.rtRouteToPoint;
+			double val = 0;
+			if (next != null && next.rtPos != null && next.rtPos.rtRouteToPoint == v) {
+				Double acc = plateauBwd.get(next);
+				val = (acc == null ? 0 : acc) + (v.rtRev.rtDistanceFromStart - next.rtRev.rtDistanceFromStart);
+			}
+			plateauBwd.put(v, val);
+		}
+		// ---- 3. stage 1: cheap admissibility on the hub graph ----
+		List<NetworkDBPoint> optNodes = new ArrayList<>();
+		for (HHNetworkSegmentRes r : route.segments) {
+			if (r.segment != null && r.segment.start != null && r.segment.end != null) {
+				if (optNodes.isEmpty()) {
+					optNodes.add(r.segment.start);
+				}
+				optNodes.add(r.segment.end);
+			}
+		}
+		TLongSet optEdges = pathEdges(optNodes);
+		List<AltCandidate> candidates = new ArrayList<>();
+		TLongSet seenPaths = new TLongHashSet();
+		for (T v : settled) {
+			Double bwd = plateauBwd.get(v);
+			Double fwd = plateauFwd.get(v);
+			double cost = v.rtPos.rtDistanceFromStart + v.rtRev.rtDistanceFromStart;
+			double plateau = (fwd == null ? 0 : fwd) + (bwd == null ? 0 : bwd);
+			if (!isPlateauRepresentative(v, plateau, plateauFwd)) {
+				continue;
+			}
+			if (plateau < cfg.ALT_MIN_PLATEAU * cost) {
+				continue;
+			}
+			List<NetworkDBPoint> path = pathThrough(v);
+			if (!isSimple(path)) {
+				// sp(s,v) and sp(v,t) are each optimal, but their concatenation is not necessarily a
+				// simple path: when both halves run over the same roads the candidate drives out and
+				// turns back. Cheap check first, the exact one is on the geometry in stage 2.
+				continue;
+			}
+			long signature = 0;
+			for (NetworkDBPoint n : path) {
+				signature = signature * 1000003L + n.index;
+			}
+			if (!seenPaths.add(signature)) {
+				continue;
+			}
+			double sharing = sharedCost(path, optEdges) / cost;
+			if (sharing > cfg.ALT_MAX_SHARING) {
+				continue;
+			}
+			AltCandidate c = new AltCandidate();
+			c.via = v;
+			c.cost = cost;
+			c.plateau = plateau;
+			c.path = path;
+			c.sharing = sharing;
+			c.edges = pathEdges(path);
+			candidates.add(c);
+		}
+		if (candidates.isEmpty()) {
+			return;
+		}
+		// rank by "as different as possible for as little extra time as possible"
+		final double finalOptCost = optCost;
+		final double costWeight = cfg.ALT_RANK_COST_WEIGHT;
+		candidates.sort(new Comparator<AltCandidate>() {
+			@Override
+			public int compare(AltCandidate x, AltCandidate y) {
+				return Double.compare(rankScore(y, finalOptCost, costWeight), rankScore(x, finalOptCost, costWeight));
+			}
+		});
+		// alternatives within ALT_STRETCH_PREFERRED are proposed before the merely acceptable ones
+		List<AltCandidate> ordered = new ArrayList<>(candidates.size());
+		double preferredCost = optCost * (1 + cfg.ALT_STRETCH_PREFERRED);
+		for (AltCandidate c : candidates) {
+			if (c.cost <= preferredCost) {
+				ordered.add(c);
+			}
+		}
+		for (AltCandidate c : candidates) {
+			if (c.cost > preferredCost) {
+				ordered.add(c);
+			}
+		}
+		// ---- 4. stage 2: expand lazily and verify on the real road segments ----
+		List<Map<Long, Double>> acceptedGeometry = new ArrayList<>();
+		Map<Long, Double> mainGeometry = roadSegments(detailedSegments(route));
+		double mainLength = totalLength(mainGeometry);
+		double minOwnRoads = Math.max(cfg.ALT_MIN_DISTINCT_ABS, cfg.ALT_MIN_DISTINCT_REL * mainLength);
+		// Avoiding is asked for less strictly than offering: replacing a good stretch of a long route
+		// is useful even when most of the main route stays. The point of this second threshold is to
+		// reject an alternative that contains the whole main route and only adds a loop to it.
+		double minAvoided = Math.max(cfg.ALT_MIN_DISTINCT_ABS, cfg.ALT_MIN_DISTINCT_REL * mainLength / 2);
+		int expanded = 0;
+		for (AltCandidate c : ordered) {
+			if (route.altRoutes.size() >= cfg.ALT_MAX_COUNT || expanded >= cfg.ALT_MAX_EXPAND) {
+				break;
+			}
+			if (progress != null && progress.isCancelled) {
+				return;
+			}
+			// retrieveSegmentsGeometry bails out half way when a shortcut cannot be expanded, or when
+			// its detailed cost turns out higher than the hub graph promised; it corrects the segment
+			// cost on the way out, so the next attempt usually succeeds. The main route recalculates
+			// in exactly the same situation - an alternative simply retries a few times.
+			HHNetworkRouteRes alt = null;
+			boolean needsRecalculation = true;
+			for (int attempt = 0; attempt < ALT_EXPAND_RETRIES && needsRecalculation
+					&& expanded < cfg.ALT_MAX_EXPAND; attempt++) {
+				alt = planner.createRouteSegmentFromFinalPoint(hctx, c.via);
+				if (alt.segments.isEmpty()) {
+					break;
+				}
+				needsRecalculation = planner.retrieveSegmentsGeometry(hctx, rrp, alt, true, progress, true);
+				expanded++;
+			}
+			if (progress != null && progress.isCancelled) {
+				return;
+			}
+			if (alt == null || alt.segments.isEmpty()) {
+				continue;
+			}
+			if (needsRecalculation || !isFullyExpanded(alt)) {
+				// still incomplete: the rest of the segments have no geometry and would be drawn as
+				// straight lines between hub points, so the candidate is not usable
+				planner.printf(HHRoutePlanner.DEBUG_VERBOSE_LEVEL > 0, "  alt dropped: incomplete geometry (+%.1f%%)\n",
+						100 * (c.cost / optCost - 1));
+				continue;
+			}
+			// shortcut costs can be optimistic; now that the roads are known, check the real one
+			double realCost = alt.getHHRoutingDetailed();
+			if (realCost > maxCost) {
+				planner.printf(HHRoutePlanner.DEBUG_VERBOSE_LEVEL > 0, "  alt dropped: real cost +%.1f%% over the limit (hub graph said +%.1f%%)\n",
+						100 * (realCost / optCost - 1), 100 * (c.cost / optCost - 1));
+				continue;
+			}
+			c.cost = realCost;
+			// prepare the candidate exactly like the main route: turns, distances and the clean-up of
+			// small manoeuvres all happen here, and the checks below must see what will be displayed
+			planner.prepareRouteResults(hctx, alt, start, end, rrp);
+			if (cfg.ROUTE_ALL_ALT_SEGMENTS && !alt.detailed.isEmpty()) {
+				alt.detailed = rrp.prepareResult(hctx.rctx, alt.detailed).detailed;
+			}
+			List<RouteSegmentResult> detailed = alt.detailed;
+			if (detailed.isEmpty()) {
+				continue;
+			}
+			double retraced = retracedLength(detailed);
+			if (retraced > cfg.ALT_MAX_RETRACED) {
+				// sp(s,v) and sp(v,t) are each optimal, but their concatenation is not necessarily a
+				// simple path: when the two halves run over the same roads the candidate drives out
+				// and turns back, which reads as a bug on the map
+				planner.printf(HHRoutePlanner.DEBUG_VERBOSE_LEVEL > 0, "  alt dropped: drives %.0f m of its own roads twice (+%.1f%%)\n",
+						retraced, 100 * (c.cost / optCost - 1));
+				continue;
+			}
+			// Both directions matter. "Own roads" says the alternative offers something new; "roads
+			// avoided" says it actually replaces a part of the route it is an alternative to. Without
+			// the second one an alternative that contains the whole main route plus a loop passes.
+			Map<Long, Double> altGeometry = roadSegments(detailed);
+			double altLength = totalLength(altGeometry);
+			double ownRoads = altLength - sharedGeometry(altGeometry, mainGeometry);
+			double avoidedRoads = mainLength - sharedGeometry(mainGeometry, altGeometry);
+			for (Map<Long, Double> accepted : acceptedGeometry) {
+				ownRoads = Math.min(ownRoads, altLength - sharedGeometry(altGeometry, accepted));
+				avoidedRoads = Math.min(avoidedRoads,
+						totalLength(accepted) - sharedGeometry(accepted, altGeometry));
+			}
+			if (ownRoads < minOwnRoads || avoidedRoads < minAvoided) {
+				planner.printf(HHRoutePlanner.DEBUG_VERBOSE_LEVEL > 0,
+						"  alt rejected: +%.1f%%, own roads %.1f km (need %.1f), avoids %.1f km (need %.1f)\n",
+						100 * (c.cost / optCost - 1), ownRoads / 1000, minOwnRoads / 1000,
+						avoidedRoads / 1000, minAvoided / 1000);
+				continue;
+			}
+			route.altRoutes.add(alt);
+			acceptedGeometry.add(roadSegments(detailed));
+			planner.printf(HHRoutePlanner.DEBUG_VERBOSE_LEVEL > 0,
+					"  alt accepted: +%.1f%%, plateau %.0f%%, own roads %.1f km, avoids %.1f km\n",
+					100 * (c.cost / optCost - 1), 100 * c.plateau / c.cost, ownRoads / 1000, avoidedRoads / 1000);
+		}
+	}
+
+	private static double rankScore(AltCandidate c, double optCost, double costWeight) {
+		return (1 - c.sharing) - costWeight * (c.cost / optCost - 1);
+	}
+
+	/** full s -> t sequence of hub points through the given via node, taken from both trees */
+	private List<NetworkDBPoint> pathThrough(NetworkDBPoint via) {
+		List<NetworkDBPoint> path = new ArrayList<>();
+		NetworkDBPoint it = via;
+		while (it != null) {
+			path.add(it);
+			it = it.rt(false).rtRouteToPoint;
+		}
+		Collections.reverse(path);
+		it = via.rt(true).rtRouteToPoint;
+		while (it != null) {
+			path.add(it);
+			it = it.rt(true).rtRouteToPoint;
+		}
+		return path;
+	}
+
+	private static final long ALT_START_KEY = -1, ALT_END_KEY = -2, ALT_KEY_MULT = 4000000000L;
+
+	private static long edgeKey(long from, long to) {
+		return from * ALT_KEY_MULT + to;
+	}
+
+	/** edge keys of a full s -> t path including the first/last mile anchors */
+	private static TLongSet pathEdges(List<NetworkDBPoint> path) {
+		TLongSet edges = new TLongHashSet();
+		if (path.isEmpty()) {
+			return edges;
+		}
+		edges.add(edgeKey(ALT_START_KEY, path.get(0).index));
+		for (int i = 1; i < path.size(); i++) {
+			edges.add(edgeKey(path.get(i - 1).index, path.get(i).index));
+		}
+		edges.add(edgeKey(path.get(path.size() - 1).index, ALT_END_KEY));
+		return edges;
+	}
+
+	/** cost of the part of `path` that runs over the given edges (first/last mile included) */
+	private double sharedCost(List<NetworkDBPoint> path, TLongSet edges) {
+		if (path.isEmpty()) {
+			return 0;
+		}
+		double shared = 0;
+		NetworkDBPoint first = path.get(0), last = path.get(path.size() - 1);
+		if (edges.contains(edgeKey(ALT_START_KEY, first.index))) {
+			shared += first.rt(false).rtDistanceFromStart;
+		}
+		if (edges.contains(edgeKey(last.index, ALT_END_KEY))) {
+			shared += last.rt(true).rtDistanceFromStart;
+		}
+		for (int i = 1; i < path.size(); i++) {
+			NetworkDBPoint a = path.get(i - 1), b = path.get(i);
+			if (edges.contains(edgeKey(a.index, b.index))) {
+				shared += hubEdgeCost(a, b);
+			}
+		}
+		return shared;
+	}
+
+	private double hubEdgeCost(NetworkDBPoint a, NetworkDBPoint b) {
+		if (b.rt(false).rtRouteToPoint == a) {
+			return b.rt(false).rtDistanceFromStart - a.rt(false).rtDistanceFromStart;
+		}
+		if (a.rt(true).rtRouteToPoint == b) {
+			return a.rt(true).rtDistanceFromStart - b.rt(true).rtDistanceFromStart;
+		}
+		NetworkDBSegment segment = a.getSegment(b, true);
+		return segment == null ? 0 : segment.dist;
+	}
+
+	/**
+	 * All nodes of one plateau describe the same route, so only one of them is kept. The chosen one
+	 * is the node closest to the middle of the chain: there both trees agree on the edge coming in
+	 * and on the edge going out, which is what makes the two halves of the candidate join smoothly
+	 * instead of turning back on themselves. At the end of a chain they need not agree.
+	 */
+	private static boolean isPlateauRepresentative(NetworkDBPoint v, double plateau,
+			Map<NetworkDBPoint, Double> plateauFwd) {
+		if (plateau <= 0) {
+			return true; // no plateau at all, nothing to deduplicate
+		}
+		Double fwd = plateauFwd.get(v);
+		double own = Math.abs((fwd == null ? 0 : fwd) - plateau / 2);
+		// every node of the chain carries the same plateau length, so a neighbour that sits closer
+		// to the middle is the better representative
+		NetworkDBPoint prev = v.rt(false).rtRouteToPoint;
+		if (prev != null && plateauFwd.containsKey(prev) && prev.rt(true).rtRouteToPoint == v
+				&& Math.abs(plateauFwd.get(prev) - plateau / 2) < own) {
+			return false;
+		}
+		NetworkDBPoint next = v.rt(true).rtRouteToPoint;
+		if (next != null && plateauFwd.containsKey(next) && next.rt(false).rtRouteToPoint == v
+				&& Math.abs(plateauFwd.get(next) - plateau / 2) < own) {
+			return false;
+		}
+		return true;
+	}
+
+	/** no hub point is visited twice, i.e. the two halves of the candidate do not overlap */
+	private static boolean isSimple(List<NetworkDBPoint> path) {
+		TLongSet seen = new TLongHashSet();
+		for (NetworkDBPoint p : path) {
+			if (!seen.add(p.index)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/** length of the road pieces that `segments` drives more than once */
+	private static double retracedLength(List<RouteSegmentResult> segments) {
+		TLongSet seen = new TLongHashSet();
+		double retraced = 0;
+		for (RouteSegmentResult r : segments) {
+			RouteDataObject o = r.getObject();
+			int i = r.getStartPointIndex(), end = r.getEndPointIndex();
+			int step = i <= end ? 1 : -1;
+			while (i != end) {
+				int j = i + step;
+				if (!seen.add(o.getId() * 4096L + Math.min(i, j))) {
+					retraced += HHRoutePlanner.squareRootDist31(o.getPoint31XTile(i), o.getPoint31YTile(i),
+							o.getPoint31XTile(j), o.getPoint31YTile(j));
+				}
+				i = j;
+			}
+		}
+		return retraced;
+	}
+
+	/** every hub-graph segment was expanded into real roads, so nothing will be drawn as a straight line */
+	private static boolean isFullyExpanded(HHNetworkRouteRes route) {
+		for (HHNetworkSegmentRes s : route.segments) {
+			if (s.list == null || s.list.isEmpty()) {
+				return false;
+			}
+		}
+		return !route.segments.isEmpty();
+	}
+
+	private static List<RouteSegmentResult> detailedSegments(HHNetworkRouteRes route) {
+		List<RouteSegmentResult> l = new ArrayList<>();
+		for (HHNetworkSegmentRes s : route.segments) {
+			if (s.list != null) {
+				l.addAll(s.list);
+			}
+		}
+		return l;
+	}
+
+	/**
+	 * Road point pair -> covered length. RouteSegmentResult.getDistance() is only filled in
+	 * prepareResult(), so the length is measured on the geometry here.
+	 */
+	private static Map<Long, Double> roadSegments(List<RouteSegmentResult> segments) {
+		Map<Long, Double> m = new HashMap<>();
+		for (RouteSegmentResult r : segments) {
+			RouteDataObject o = r.getObject();
+			int i = r.getStartPointIndex(), end = r.getEndPointIndex();
+			int step = i <= end ? 1 : -1;
+			while (i != end) {
+				int j = i + step;
+				long key = o.getId() * 4096L + Math.min(i, j);
+				double d = HHRoutePlanner.squareRootDist31(o.getPoint31XTile(i), o.getPoint31YTile(i),
+						o.getPoint31XTile(j), o.getPoint31YTile(j));
+				Double prev = m.get(key);
+				m.put(key, (prev == null ? 0 : prev) + d);
+				i = j;
+			}
+		}
+		return m;
+	}
+
+	private static double totalLength(Map<Long, Double> segments) {
+		double d = 0;
+		for (Double v : segments.values()) {
+			d += v;
+		}
+		return d;
+	}
+
+	/** length of the roads that the two routes have in common */
+	private static double sharedGeometry(Map<Long, Double> segments, Map<Long, Double> reference) {
+		double common = 0;
+		for (Map.Entry<Long, Double> e : segments.entrySet()) {
+			Double v = reference.get(e.getKey());
+			if (v != null) {
+				common += Math.min(v, e.getValue());
+			}
+		}
+		return common;
+	}
+
+}

--- a/OsmAnd-java/src/main/java/net/osmand/router/HHRouteDataStructure.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHRouteDataStructure.java
@@ -76,6 +76,7 @@ public class HHRouteDataStructure {
 		public double ALT_MIN_DISTINCT_REL = 0.2; // exact geometry filter (stage 2), share of main length
 		public double ALT_MIN_DISTINCT_ABS = 1500; // exact geometry filter (stage 2), meters
 		public int ALT_MAX_EXPAND = 4; // max detailed expansions in stage 2 (time guard)
+		public double ALT_MAX_RETRACED = 100; // meters an alternative may drive twice (u-turn tolerance)
 		public double ALT_RANK_COST_WEIGHT = 3; // rank: (1 - shared) - weight * stretch
 
 		double MAX_COST;

--- a/OsmAnd-java/src/main/java/net/osmand/router/HHRouteDataStructure.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHRouteDataStructure.java
@@ -60,9 +60,23 @@ public class HHRouteDataStructure {
 		boolean CALC_ALTERNATIVES = false;
 		boolean USE_GC_MORE_OFTEN = false;
 		
-		double ALT_EXCLUDE_RAD_MULT = 0.3; // radius multiplier to exclude points
-		double ALT_EXCLUDE_RAD_MULT_IN = 3; // skip some points to speed up calculation
-		double ALT_NON_UNIQUENESS = 0.7; // 0.7 - 30% of points must be unique
+		// ---- alternative routes (plateau / via-node method), see HHRoutePlanner.calcAlternativeRoute ----
+		// A candidate route goes through a "via node" v settled by both search trees: sp(s,v) + sp(v,t).
+		// Its plateau is the maximal chain of hub-graph edges around v that belongs to BOTH trees, i.e.
+		// the stretch the alternative drives as its own optimal road. Three explicit admissibility rules:
+		//   1) stretch    cost(alt) <= (1 + ALT_STRETCH) * cost(opt)
+		//   2) plateau    plateau(v) >= ALT_MIN_PLATEAU * cost(alt)          (local optimality)
+		//   3) distinct   own roads >= max(ALT_MIN_DISTINCT_ABS, ALT_MIN_DISTINCT_REL * len(opt))
+		// ALT_STRETCH also bounds the search horizon, so it directly trades quality for speed.
+		public int ALT_MAX_COUNT = 2; // how many alternatives to return
+		public double ALT_STRETCH = 0.3; // hard limit of relative cost overhead (and search bound)
+		public double ALT_STRETCH_PREFERRED = 0.15; // alternatives below this limit are proposed first
+		public double ALT_MIN_PLATEAU = 0.1; // min share of the route driven as its own optimal road
+		public double ALT_MAX_SHARING = 0.6; // coarse hub-graph pre-filter (stage 1)
+		public double ALT_MIN_DISTINCT_REL = 0.2; // exact geometry filter (stage 2), share of main length
+		public double ALT_MIN_DISTINCT_ABS = 1500; // exact geometry filter (stage 2), meters
+		public int ALT_MAX_EXPAND = 4; // max detailed expansions in stage 2 (time guard)
+		public double ALT_RANK_COST_WEIGHT = 3; // rank: (1 - shared) - weight * stretch
 
 		double MAX_COST;
 		int MAX_DEPTH = -1; // max depth to go to
@@ -119,6 +133,12 @@ public class HHRouteDataStructure {
 		
 		public HHRoutingConfig calcAlternative() {
 			this.CALC_ALTERNATIVES = true;
+			return this;
+		}
+
+		public HHRoutingConfig calcAlternative(int maxCount) {
+			this.CALC_ALTERNATIVES = maxCount > 0;
+			this.ALT_MAX_COUNT = maxCount;
 			return this;
 		}
 		
@@ -498,6 +518,7 @@ public class HHRouteDataStructure {
 				detailed.addAll(res.detailed);
 				segments.addAll(res.segments);
 				altRoutes.clear();
+				alternatives.clear(); // not supported with intermediate points
 				uniquePoints.clear();
 			}
 		}

--- a/OsmAnd-java/src/main/java/net/osmand/router/HHRouteDataStructure.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHRouteDataStructure.java
@@ -16,7 +16,6 @@ import com.google.protobuf.CodedInputStream;
 import gnu.trove.iterator.TLongObjectIterator;
 import gnu.trove.map.hash.TIntObjectHashMap;
 import gnu.trove.map.hash.TLongObjectHashMap;
-import gnu.trove.set.hash.TLongHashSet;
 import net.osmand.binary.BinaryHHRouteReaderAdapter.HHRouteRegion;
 import net.osmand.binary.BinaryMapIndexReader;
 import net.osmand.binary.BinaryMapIndexReader.TagValuePair;
@@ -487,7 +486,6 @@ public class HHRouteDataStructure {
 		public RoutingStats stats;
 		public List<HHNetworkSegmentRes> segments = new ArrayList<>();
 		public List<HHNetworkRouteRes> altRoutes = new ArrayList<>();
-		public TLongHashSet uniquePoints = new TLongHashSet();
 		
 		public HHNetworkRouteRes() {
 			super(new ArrayList<RouteSegmentResult>());
@@ -506,6 +504,16 @@ public class HHRouteDataStructure {
 			return d;
 		}
 		
+		@Override
+		public List<List<RouteSegmentResult>> getAlternatives() {
+			// altRoutes is the storage - this is the same list seen through the generic result
+			List<List<RouteSegmentResult>> alts = new ArrayList<>(altRoutes.size());
+			for (HHNetworkRouteRes alt : altRoutes) {
+				alts.add(alt.detailed);
+			}
+			return alts;
+		}
+
 		public double getHHRoutingDetailed() {
 			double d = 0;
 			for (HHNetworkSegmentRes r : segments) {
@@ -520,9 +528,7 @@ public class HHRouteDataStructure {
 			} else {
 				detailed.addAll(res.detailed);
 				segments.addAll(res.segments);
-				altRoutes.clear();
-				alternatives.clear(); // not supported with intermediate points
-				uniquePoints.clear();
+				altRoutes.clear(); // not supported with intermediate points
 			}
 		}
 		

--- a/OsmAnd-java/src/main/java/net/osmand/router/HHRouteDataStructure.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHRouteDataStructure.java
@@ -57,7 +57,7 @@ public class HHRouteDataStructure {
 		boolean PRELOAD_SEGMENTS = false;
 		
 		boolean CACHE_CALCULATION_CONTEXT = false;
-		boolean CALC_ALTERNATIVES = false;
+		public boolean CALC_ALTERNATIVES = false;
 		boolean USE_GC_MORE_OFTEN = false;
 		
 		// ---- alternative routes (plateau / via-node method), see HHRoutePlanner.calcAlternativeRoute ----

--- a/OsmAnd-java/src/main/java/net/osmand/router/HHRouteDataStructure.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHRouteDataStructure.java
@@ -75,7 +75,9 @@ public class HHRouteDataStructure {
 		public double ALT_MAX_SHARING = 0.6; // coarse hub-graph pre-filter (stage 1)
 		public double ALT_MIN_DISTINCT_REL = 0.2; // exact geometry filter (stage 2), share of main length
 		public double ALT_MIN_DISTINCT_ABS = 1500; // exact geometry filter (stage 2), meters
-		public int ALT_MAX_EXPAND = 4; // max detailed expansions in stage 2 (time guard)
+		// Max detailed expansions in stage 2 (time guard). Retries of a candidate whose shortcuts
+		// disagree with the detailed roads count against it, so this is not "number of candidates".
+		public int ALT_MAX_EXPAND = 8;
 		public double ALT_MAX_RETRACED = 100; // meters an alternative may drive twice (u-turn tolerance)
 		public double ALT_RANK_COST_WEIGHT = 3; // rank: (1 - shared) - weight * stretch
 

--- a/OsmAnd-java/src/main/java/net/osmand/router/HHRoutePlanner.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHRoutePlanner.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -54,7 +55,6 @@ import net.osmand.util.MapUtils;
 
 public class HHRoutePlanner<T extends NetworkDBPoint> {
 	public static int DEBUG_VERBOSE_LEVEL = 0;
-	static int DEBUG_ALT_ROUTE_SELECTION = -1;
 	static final double MINIMAL_COST = 0.01;
 	private static final int PNT_SHORT_ROUTE_START_END = -1000;
 	public static final int MAX_POINTS_CLUSTER_ROUTING = 150000;
@@ -149,9 +149,6 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 //			c.calcAlternative();
 //			c.gc();
 			DEBUG_VERBOSE_LEVEL = 0;
-			DEBUG_ALT_ROUTE_SELECTION++;
-//			c.ALT_EXCLUDE_RAD_MULT_IN = 1;
-//			c.ALT_EXCLUDE_RAD_MULT = 0.05;
 //			c.INITIAL_DIRECTION = 30 / 180.0 * Math.PI;
 //			routingProfile = (routingProfile + 1) % networkDB.getRoutingProfiles().size();
 //			HHRoutingContext.USE_GLOBAL_QUEUE = true;
@@ -273,24 +270,15 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 			progress.hhIteration(HHIteration.ALTERNATIVES);
 			printf(SL > 0, " Alternative routes...");
 			long time = System.nanoTime();
-			calcAlternativeRoute(hctx, route, stPoints, endPoints, progress);
+			// detailed geometry of the alternatives is retrieved inside - it is needed to reject
+			// candidates that turn out to run on the very same roads as the main route
+			calcAlternativeRoute(hctx, route, progress, rrp);
 			if (progress.isCancelled) {
 				return cancelledStatus(hctx, stPoints, endPoints);
 			}
 			hctx.stats.altRoutingTime += (System.nanoTime() - time) / 1e6;
 			hctx.stats.routingTime += hctx.stats.altRoutingTime;
 			printf(SL > 0, "%d %.2f ms\n", route.altRoutes.size(), hctx.stats.altRoutingTime);
-
-			time = System.nanoTime();
-			for (HHNetworkRouteRes alt : route.altRoutes) {
-				retrieveSegmentsGeometry(hctx, rrp, alt, hctx.config.ROUTE_ALL_ALT_SEGMENTS, progress);
-				if (progress.isCancelled) {
-					return cancelledStatus(hctx, stPoints, endPoints);
-				}
-			}
-			altRoutes = (System.nanoTime() - time) / 1e6;
-			printf(SL > 0, "%.2f ms\n", altRoutes);
-			
 		}
 		long time = System.nanoTime();
 		printf(SL > 0, " Prepare results (turns, alt routes)...");
@@ -309,6 +297,21 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 		}
 		if (hctx.config.ROUTE_ALL_SEGMENTS && route.detailed != null) {
 			route.detailed = rrp.prepareResult(hctx.rctx, route.detailed).detailed;
+		}
+		if (!route.altRoutes.isEmpty()) {
+			// prepare the alternatives the same way as the main route, so that a caller can display
+			// them (and later let the user pick one) as regular routes
+			float mainRoutingTime = hctx.rctx.routingTime;
+			for (HHNetworkRouteRes alt : route.altRoutes) {
+				prepareRouteResults(hctx, alt, start, end, rrp);
+				if (hctx.config.ROUTE_ALL_ALT_SEGMENTS && !alt.detailed.isEmpty()) {
+					alt.detailed = rrp.prepareResult(hctx.rctx, alt.detailed).detailed;
+				}
+				if (!alt.detailed.isEmpty()) {
+					route.getAlternatives().add(alt.detailed);
+				}
+			}
+			hctx.rctx.routingTime = mainRoutingTime;
 		}
 		hctx.stats.prepTime += (System.nanoTime() - time) / 1e6;
 		printf(SL > 0, "%.2f ms\n", hctx.stats.prepTime);
@@ -513,155 +516,326 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 				stPoints.size(), endPoints.size(), hctx.stats.searchPointsTime);
 	}
 
-	private void calcAlternativeRoute(HHRoutingContext<T> hctx, HHNetworkRouteRes route, TLongObjectHashMap<T> stPoints,
-			TLongObjectHashMap<T> endPoints, RouteCalculationProgress progress) throws SQLException, IOException {
-		List<NetworkDBPoint>  exclude = new ArrayList<>();
-		try {
-			HHNetworkRouteRes rt = route;
-			// distances between all points and start/end
-			List<NetworkDBPoint> points = new ArrayList<>();
-			for (int i = 0; i < route.segments.size(); i++) {
-				NetworkDBSegment s = route.segments.get(i).segment;
-				if (s == null) {
-					continue;
-				}
-				if(points.size() == 0) {
-					points.add(s.start);
-				}
-				points.add(s.end);
-			}
-			double[] distances = new double[points.size()];
-			NetworkDBPoint prev = null;
-			for (int i = 0; i < distances.length; i++) {
-				NetworkDBPoint pnt = points.get(i);
-				if (i == 0) {
-					distances[i] = squareRootDist31(hctx.startX, hctx.startY, pnt.midX(), pnt.midY());
-				} else if (i == distances.length - 1) {
-					distances[i] = squareRootDist31(hctx.endX, hctx.endY, pnt.midX(), pnt.midY());
-				} else {
-					distances[i] = squareRootDist31(prev.midX(), prev.midY(), pnt.midX(), pnt.midY());
-				}
-				prev = pnt;
-			}
-			// calculate min(cumPos, cumNeg) distance
-			double[] cdistPos = new double[distances.length];
-			double[] cdistNeg = new double[distances.length];
-			for (int i = 0; i < distances.length; i++) {
-				if(i == 0) {
-					cdistPos[0] = distances[i];
-					cdistNeg[distances.length - 1] = distances[distances.length - 1];
-				} else {
-					cdistPos[i] = cdistPos[i - 1] + distances[i];
-					cdistNeg[distances.length - i - 1] = cdistNeg[distances.length - i] + distances[distances.length - i - 1];
-				}
-			}
-			double[] minDistance = new double[distances.length];
-			boolean[] useToSkip = new boolean[distances.length];
-			int altPoints = 0;
-			for (int i = 0; i < distances.length; i++) {
-				minDistance[i] = Math.min(cdistNeg[i], cdistPos[i]) * hctx.config.ALT_EXCLUDE_RAD_MULT;
-				boolean coveredByPrevious = false;
-				for (int j = 0; j < i; j++) {
-					if (useToSkip[j] && cdistPos[i] - cdistPos[j] < minDistance[j] * hctx.config.ALT_EXCLUDE_RAD_MULT_IN) {
-						coveredByPrevious = true;
-						break;
-					}
-				}
-				if(!coveredByPrevious) {
-					useToSkip[i] = true;
-					altPoints ++;
-				} else {
-					minDistance[i] = 0; // for printing purpose
-				}
-			}
-			if (DEBUG_VERBOSE_LEVEL >= 1) {
-				System.out.printf("Selected %d points for alternatives %s\n", altPoints, Arrays.toString(minDistance));
-			}
-			if (progress.isCancelled) {
-				return;
-			}
-			for (int i = 0; i < distances.length; i++) {
-				if (!useToSkip[i]) {
-					continue;
-				}
-				hctx.clearVisited(stPoints, endPoints);
-//				hctx.clearVisited();
-				for (NetworkDBPoint pnt : exclude) {
-					pnt.rtExclude = false;
-				}
-				exclude.clear();
-				
-				LatLon pnt = points.get(i).getPoint();
-				List<T> objs = hctx.pointsRect.getClosestObjects(pnt.getLatitude(), pnt.getLongitude(), minDistance[i]);
-				for (T p : objs) {
-					if (MapUtils.getDistance(p.getPoint(), pnt) <= minDistance[i]) {
-						exclude.add(p);
-						p.rtExclude = true;
-					}
-				}
-				
-				NetworkDBPoint finalPnt = runRoutingPointsToPoints(hctx, stPoints, endPoints);
-				if (progress.isCancelled) {
-					return;
-				}
-				if (finalPnt != null) {
-					double cost = (finalPnt.rt(false).rtDistanceFromStart + finalPnt.rt(true).rtDistanceFromStart);
-					if (DEBUG_VERBOSE_LEVEL == 1) {
-						System.out.println("Alternative route cost: " + cost);
-					}
-					rt = createRouteSegmentFromFinalPoint(hctx, finalPnt);
-					route.altRoutes.add(rt);
-				} else {
-					break;
-				}
-				
-			}
-			route.altRoutes.sort(new Comparator<HHNetworkRouteRes>() {
+	/* ======================= ALTERNATIVE ROUTES (plateau / via-node) =======================
+	 * Reuses the two shortest-path trees that the bidirectional HH search has already built,
+	 * so no extra Dijkstra run is needed - only the horizon of the main search is extended to
+	 * (1 + ALT_STRETCH) * opt (see runRoutingWithInitQueue).
+	 *
+	 * A candidate is a "via node" v settled by both trees; its route is sp(s,v) + sp(v,t) and is
+	 * assembled by the existing createRouteSegmentFromFinalPoint(). The plateau of v is the maximal
+	 * chain of hub-graph edges around v belonging to BOTH trees - the stretch where the alternative
+	 * is simultaneously the best way to get there and the best way to go on, i.e. a road a driver
+	 * would actually name. A detour around one block has a zero plateau.
+	 *
+	 * Selection runs in two stages because hub-graph edges are shortcuts several km long: two
+	 * different shortcuts may still cover the same streets, so hub-level sharing underestimates the
+	 * real overlap (measured: 20% by hubs vs 76% by geometry). Stage 1 filters cheaply on the hub
+	 * graph, stage 2 expands candidates one by one and checks the real road segments, stopping as
+	 * soon as ALT_MAX_COUNT routes are accepted.
+	 */
+	private static class AltCandidate {
+		NetworkDBPoint via;
+		double cost;
+		double plateau;
+		double sharing;
+		List<NetworkDBPoint> path;
+		TLongSet edges;
+	}
 
-				@Override
-				public int compare(HHNetworkRouteRes o1, HHNetworkRouteRes o2) {
-					return Double.compare(o1.getHHRoutingTime(), o2.getHHRoutingTime());
+	private void calcAlternativeRoute(HHRoutingContext<T> hctx, HHNetworkRouteRes route,
+			RouteCalculationProgress progress, RouteResultPreparation rrp)
+			throws SQLException, IOException, InterruptedException {
+		HHRoutingConfig cfg = hctx.config;
+		double optCost = route.getHHRoutingTime();
+		if (optCost <= 0 || cfg.ALT_MAX_COUNT <= 0) {
+			return;
+		}
+		double maxCost = optCost * (1 + cfg.ALT_STRETCH);
+		// ---- 1. via-node candidates: settled by both trees and within the stretch limit ----
+		List<T> settled = new ArrayList<>();
+		for (T p : hctx.queueAdded) {
+			if (p.rtPos != null && p.rtRev != null && p.rtPos.rtVisited && p.rtRev.rtVisited) {
+				double c = p.rtPos.rtDistanceFromStart + p.rtRev.rtDistanceFromStart;
+				if (c > 0 && c <= maxCost) {
+					settled.add(p);
 				}
-			});
-			int size = route.altRoutes.size();
-			if (size > 0) {
-				for(int k = 0; k < route.altRoutes.size(); ) {
-					HHNetworkRouteRes altR = route.altRoutes.get(k);
-					boolean unique = true;
-					for (int j = 0; j <= k; j++) {
-						HHNetworkRouteRes cmp = j == k ? route : route.altRoutes.get(j);
-						TLongHashSet cp = new TLongHashSet(altR.uniquePoints);
-						cp.retainAll(cmp.uniquePoints);
-						if (cp.size() >= hctx.config.ALT_NON_UNIQUENESS * altR.uniquePoints.size()) {
-							unique = false;
-							break;
-						}
-					}
-					if (unique) {
-						k++;
-					} else {
-						route.altRoutes.remove(k);
-					}
-				}
-				if (route.altRoutes.size() > 0) {
-					printf(HHRoutingConfig.STATS_VERBOSE_LEVEL > 0, "Cost %.2f - %.2f [%d unique / %d]...", route.altRoutes.get(0).getHHRoutingTime(),
-						route.altRoutes.get(route.altRoutes.size() - 1).getHHRoutingTime(), route.altRoutes.size(), size);
-				}
-				int ind = DEBUG_ALT_ROUTE_SELECTION % (route.altRoutes.size() + 1);
-				if (ind > 0) {
-					HHNetworkRouteRes rts = route.altRoutes.get(ind - 1);
-					printf(HHRoutingConfig.STATS_VERBOSE_LEVEL > 0, DEBUG_ALT_ROUTE_SELECTION + " select %.2f ", rts.getHHRoutingTime());
-					route.detailed = rts.detailed;
-					route.segments = rts.segments;
-					route.altRoutes = Collections.singletonList(rts);
-				}
-			}
-		} finally {
-			for (NetworkDBPoint pnt : exclude) {
-				pnt.rtExclude = false;
 			}
 		}
-				
+		if (settled.isEmpty()) {
+			return;
+		}
+		// ---- 2. plateau length of every candidate ----
+		// plateauFwd(v) needs its parent computed first, so iterate in order of increasing distance
+		Map<NetworkDBPoint, Double> plateauFwd = new HashMap<>(), plateauBwd = new HashMap<>();
+		List<T> byDistFromStart = new ArrayList<>(settled);
+		byDistFromStart.sort(new Comparator<T>() {
+			@Override
+			public int compare(T a, T b) {
+				return Double.compare(a.rtPos.rtDistanceFromStart, b.rtPos.rtDistanceFromStart);
+			}
+		});
+		for (T v : byDistFromStart) {
+			NetworkDBPoint prev = v.rtPos.rtRouteToPoint;
+			double val = 0;
+			if (prev != null && prev.rtRev != null && prev.rtRev.rtRouteToPoint == v) {
+				Double acc = plateauFwd.get(prev);
+				val = (acc == null ? 0 : acc) + (v.rtPos.rtDistanceFromStart - prev.rtPos.rtDistanceFromStart);
+			}
+			plateauFwd.put(v, val);
+		}
+		List<T> byDistToEnd = new ArrayList<>(settled);
+		byDistToEnd.sort(new Comparator<T>() {
+			@Override
+			public int compare(T a, T b) {
+				return Double.compare(a.rtRev.rtDistanceFromStart, b.rtRev.rtDistanceFromStart);
+			}
+		});
+		for (T v : byDistToEnd) {
+			NetworkDBPoint next = v.rtRev.rtRouteToPoint;
+			double val = 0;
+			if (next != null && next.rtPos != null && next.rtPos.rtRouteToPoint == v) {
+				Double acc = plateauBwd.get(next);
+				val = (acc == null ? 0 : acc) + (v.rtRev.rtDistanceFromStart - next.rtRev.rtDistanceFromStart);
+			}
+			plateauBwd.put(v, val);
+		}
+		// ---- 3. stage 1: cheap admissibility on the hub graph ----
+		List<NetworkDBPoint> optNodes = new ArrayList<>();
+		for (HHNetworkSegmentRes r : route.segments) {
+			if (r.segment != null && r.segment.start != null && r.segment.end != null) {
+				if (optNodes.isEmpty()) {
+					optNodes.add(r.segment.start);
+				}
+				optNodes.add(r.segment.end);
+			}
+		}
+		TLongSet optEdges = pathEdges(optNodes);
+		List<AltCandidate> candidates = new ArrayList<>();
+		TLongSet seenPaths = new TLongHashSet();
+		for (T v : settled) {
+			Double bwd = plateauBwd.get(v);
+			if (bwd != null && bwd > 0) {
+				continue; // keep one representative per plateau: the far end of the chain
+			}
+			Double fwd = plateauFwd.get(v);
+			double cost = v.rtPos.rtDistanceFromStart + v.rtRev.rtDistanceFromStart;
+			double plateau = (fwd == null ? 0 : fwd) + (bwd == null ? 0 : bwd);
+			if (plateau < cfg.ALT_MIN_PLATEAU * cost) {
+				continue;
+			}
+			List<NetworkDBPoint> path = pathThrough(v);
+			long signature = 0;
+			for (NetworkDBPoint n : path) {
+				signature = signature * 1000003L + n.index;
+			}
+			if (!seenPaths.add(signature)) {
+				continue;
+			}
+			double sharing = sharedCost(path, optEdges) / cost;
+			if (sharing > cfg.ALT_MAX_SHARING) {
+				continue;
+			}
+			AltCandidate c = new AltCandidate();
+			c.via = v;
+			c.cost = cost;
+			c.plateau = plateau;
+			c.path = path;
+			c.sharing = sharing;
+			c.edges = pathEdges(path);
+			candidates.add(c);
+		}
+		if (candidates.isEmpty()) {
+			return;
+		}
+		// rank by "as different as possible for as little extra time as possible"
+		final double finalOptCost = optCost;
+		final double costWeight = cfg.ALT_RANK_COST_WEIGHT;
+		candidates.sort(new Comparator<AltCandidate>() {
+			@Override
+			public int compare(AltCandidate x, AltCandidate y) {
+				return Double.compare(rankScore(y, finalOptCost, costWeight), rankScore(x, finalOptCost, costWeight));
+			}
+		});
+		// alternatives within ALT_STRETCH_PREFERRED are proposed before the merely acceptable ones
+		List<AltCandidate> ordered = new ArrayList<>(candidates.size());
+		double preferredCost = optCost * (1 + cfg.ALT_STRETCH_PREFERRED);
+		for (AltCandidate c : candidates) {
+			if (c.cost <= preferredCost) {
+				ordered.add(c);
+			}
+		}
+		for (AltCandidate c : candidates) {
+			if (c.cost > preferredCost) {
+				ordered.add(c);
+			}
+		}
+		// ---- 4. stage 2: expand lazily and verify on the real road segments ----
+		List<Map<Long, Double>> acceptedGeometry = new ArrayList<>();
+		Map<Long, Double> mainGeometry = roadSegments(detailedSegments(route));
+		double minDistinct = Math.max(cfg.ALT_MIN_DISTINCT_ABS,
+				cfg.ALT_MIN_DISTINCT_REL * geometryLength(detailedSegments(route)));
+		int expanded = 0;
+		for (AltCandidate c : ordered) {
+			if (route.altRoutes.size() >= cfg.ALT_MAX_COUNT || expanded >= cfg.ALT_MAX_EXPAND) {
+				break;
+			}
+			if (progress != null && progress.isCancelled) {
+				return;
+			}
+			HHNetworkRouteRes alt = createRouteSegmentFromFinalPoint(hctx, c.via);
+			if (alt.segments.isEmpty()) {
+				continue;
+			}
+			retrieveSegmentsGeometry(hctx, rrp, alt, true, progress);
+			if (progress != null && progress.isCancelled) {
+				return;
+			}
+			expanded++;
+			List<RouteSegmentResult> detailed = detailedSegments(alt);
+			double altLength = geometryLength(detailed);
+			double distinct = altLength * (1 - sharedGeometry(detailed, mainGeometry));
+			for (Map<Long, Double> accepted : acceptedGeometry) {
+				distinct = Math.min(distinct, altLength * (1 - sharedGeometry(detailed, accepted)));
+			}
+			if (distinct < minDistinct) {
+				printf(DEBUG_VERBOSE_LEVEL > 0, "  alt rejected: +%.1f%%, only %.1f km of own roads (need %.1f)\n",
+						100 * (c.cost / optCost - 1), distinct / 1000, minDistinct / 1000);
+				continue;
+			}
+			route.altRoutes.add(alt);
+			acceptedGeometry.add(roadSegments(detailed));
+			printf(DEBUG_VERBOSE_LEVEL > 0, "  alt accepted: +%.1f%%, plateau %.0f%%, own roads %.1f km\n",
+					100 * (c.cost / optCost - 1), 100 * c.plateau / c.cost, distinct / 1000);
+		}
+	}
+
+	private static double rankScore(AltCandidate c, double optCost, double costWeight) {
+		return (1 - c.sharing) - costWeight * (c.cost / optCost - 1);
+	}
+
+	/** full s -> t sequence of hub points through the given via node, taken from both trees */
+	private List<NetworkDBPoint> pathThrough(NetworkDBPoint via) {
+		List<NetworkDBPoint> path = new ArrayList<>();
+		NetworkDBPoint it = via;
+		while (it != null) {
+			path.add(it);
+			it = it.rt(false).rtRouteToPoint;
+		}
+		Collections.reverse(path);
+		it = via.rt(true).rtRouteToPoint;
+		while (it != null) {
+			path.add(it);
+			it = it.rt(true).rtRouteToPoint;
+		}
+		return path;
+	}
+
+	private static final long ALT_START_KEY = -1, ALT_END_KEY = -2, ALT_KEY_MULT = 4000000000L;
+
+	private static long edgeKey(long from, long to) {
+		return from * ALT_KEY_MULT + to;
+	}
+
+	/** edge keys of a full s -> t path including the first/last mile anchors */
+	private static TLongSet pathEdges(List<NetworkDBPoint> path) {
+		TLongSet edges = new TLongHashSet();
+		if (path.isEmpty()) {
+			return edges;
+		}
+		edges.add(edgeKey(ALT_START_KEY, path.get(0).index));
+		for (int i = 1; i < path.size(); i++) {
+			edges.add(edgeKey(path.get(i - 1).index, path.get(i).index));
+		}
+		edges.add(edgeKey(path.get(path.size() - 1).index, ALT_END_KEY));
+		return edges;
+	}
+
+	/** cost of the part of `path` that runs over the given edges (first/last mile included) */
+	private double sharedCost(List<NetworkDBPoint> path, TLongSet edges) {
+		if (path.isEmpty()) {
+			return 0;
+		}
+		double shared = 0;
+		NetworkDBPoint first = path.get(0), last = path.get(path.size() - 1);
+		if (edges.contains(edgeKey(ALT_START_KEY, first.index))) {
+			shared += first.rt(false).rtDistanceFromStart;
+		}
+		if (edges.contains(edgeKey(last.index, ALT_END_KEY))) {
+			shared += last.rt(true).rtDistanceFromStart;
+		}
+		for (int i = 1; i < path.size(); i++) {
+			NetworkDBPoint a = path.get(i - 1), b = path.get(i);
+			if (edges.contains(edgeKey(a.index, b.index))) {
+				shared += hubEdgeCost(a, b);
+			}
+		}
+		return shared;
+	}
+
+	private double hubEdgeCost(NetworkDBPoint a, NetworkDBPoint b) {
+		if (b.rt(false).rtRouteToPoint == a) {
+			return b.rt(false).rtDistanceFromStart - a.rt(false).rtDistanceFromStart;
+		}
+		if (a.rt(true).rtRouteToPoint == b) {
+			return a.rt(true).rtDistanceFromStart - b.rt(true).rtDistanceFromStart;
+		}
+		NetworkDBSegment segment = a.getSegment(b, true);
+		return segment == null ? 0 : segment.dist;
+	}
+
+	private static List<RouteSegmentResult> detailedSegments(HHNetworkRouteRes route) {
+		List<RouteSegmentResult> l = new ArrayList<>();
+		for (HHNetworkSegmentRes s : route.segments) {
+			if (s.list != null) {
+				l.addAll(s.list);
+			}
+		}
+		return l;
+	}
+
+	/**
+	 * Road point pair -> covered length. RouteSegmentResult.getDistance() is only filled in
+	 * prepareResult(), so the length is measured on the geometry here.
+	 */
+	private static Map<Long, Double> roadSegments(List<RouteSegmentResult> segments) {
+		Map<Long, Double> m = new HashMap<>();
+		for (RouteSegmentResult r : segments) {
+			RouteDataObject o = r.getObject();
+			int i = r.getStartPointIndex(), end = r.getEndPointIndex();
+			int step = i <= end ? 1 : -1;
+			while (i != end) {
+				int j = i + step;
+				long key = o.getId() * 4096L + Math.min(i, j);
+				double d = squareRootDist31(o.getPoint31XTile(i), o.getPoint31YTile(i),
+						o.getPoint31XTile(j), o.getPoint31YTile(j));
+				Double prev = m.get(key);
+				m.put(key, (prev == null ? 0 : prev) + d);
+				i = j;
+			}
+		}
+		return m;
+	}
+
+	private static double geometryLength(List<RouteSegmentResult> segments) {
+		double d = 0;
+		for (Double v : roadSegments(segments).values()) {
+			d += v;
+		}
+		return d;
+	}
+
+	/** share of `segments` length running on the very same roads as `reference` */
+	private static double sharedGeometry(List<RouteSegmentResult> segments, Map<Long, Double> reference) {
+		Map<Long, Double> own = roadSegments(segments);
+		double length = 0, common = 0;
+		for (Map.Entry<Long, Double> e : own.entrySet()) {
+			length += e.getValue();
+			Double v = reference.get(e.getKey());
+			if (v != null) {
+				common += Math.min(v, e.getValue());
+			}
+		}
+		return length <= 0 ? 1 : common / length;
 	}
 
 	protected HHRoutingContext<T> initHCtx(HHRoutingConfig c, LatLon start, LatLon end) throws SQLException, IOException {
@@ -1121,6 +1295,12 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 	
 	private T runRoutingWithInitQueue(HHRoutingContext<T> hctx) throws SQLException, IOException {
 		float DIR_CONFIG = hctx.config.DIJKSTRA_DIRECTION;
+		// Alternatives are extracted from the two search trees, so the search must not stop at the first
+		// meeting point: it keeps settling until the queue leaves the (1 + ALT_STRETCH) * opt horizon.
+		// The point returned is still the cheapest meeting point, i.e. the optimal route is unchanged.
+		boolean collectAlt = hctx.config.CALC_ALTERNATIVES;
+		T bestFinal = null;
+		double optCost = 0, altBound = Double.MAX_VALUE;
 		RouteCalculationProgress progress = hctx.rctx == null ? null : hctx.rctx.calculationProgress;
 		double straightStartEndCost = squareRootDist31(hctx.startX, hctx.startY, hctx.endX, hctx.endY) /
 				hctx.rctx.getRouter().getMaxSpeed();
@@ -1158,7 +1338,21 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 			boolean rev = pointCost.rev;
 			hctx.stats.pollQueueTime += (System.nanoTime() - tm) / 1e6;
 			hctx.stats.visitedVertices++;
-			if (point.rt(!rev).rtVisited) {
+			if (collectAlt && pointCost.cost > altBound) {
+				break;
+			}
+			if (collectAlt && point.rt(!rev).rtVisited) {
+				if (hctx.stats.firstRouteVisitedVertices == 0) {
+					hctx.stats.firstRouteVisitedVertices = hctx.stats.visitedVertices;
+				}
+				double rcost = point.rt(true).rtDistanceFromStart + point.rt(false).rtDistanceFromStart;
+				if (bestFinal == null || rcost < optCost) {
+					bestFinal = point;
+					optCost = rcost;
+					altBound = optCost * (1 + hctx.config.ALT_STRETCH);
+				}
+				// no early return: fall through to settle & expand, both trees must keep growing
+			} else if (point.rt(!rev).rtVisited) {
 				if (hctx.stats.firstRouteVisitedVertices == 0) {
 					hctx.stats.firstRouteVisitedVertices = hctx.stats.visitedVertices;
 					if (DIR_CONFIG == 0 && hctx.config.HEURISTIC_COEFFICIENT != 0) {
@@ -1210,7 +1404,7 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 				addConnectedToQueue(hctx, queue, point, rev);
 			}
 		}			
-		return null;
+		return collectAlt ? bestFinal : null;
 	}
 
 	private T scanFinalPoint(T finalPoint, List<T> lt) {

--- a/OsmAnd-java/src/main/java/net/osmand/router/HHRoutePlanner.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHRoutePlanner.java
@@ -666,8 +666,12 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 		// ---- 4. stage 2: expand lazily and verify on the real road segments ----
 		List<Map<Long, Double>> acceptedGeometry = new ArrayList<>();
 		Map<Long, Double> mainGeometry = roadSegments(detailedSegments(route));
-		double minDistinct = Math.max(cfg.ALT_MIN_DISTINCT_ABS,
-				cfg.ALT_MIN_DISTINCT_REL * geometryLength(detailedSegments(route)));
+		double mainLength = totalLength(mainGeometry);
+		double minOwnRoads = Math.max(cfg.ALT_MIN_DISTINCT_ABS, cfg.ALT_MIN_DISTINCT_REL * mainLength);
+		// Avoiding is asked for less strictly than offering: replacing a good stretch of a long route
+		// is useful even when most of the main route stays. The point of this second threshold is to
+		// reject an alternative that contains the whole main route and only adds a loop to it.
+		double minAvoided = Math.max(cfg.ALT_MIN_DISTINCT_ABS, cfg.ALT_MIN_DISTINCT_REL * mainLength / 2);
 		int expanded = 0;
 		for (AltCandidate c : ordered) {
 			if (route.altRoutes.size() >= cfg.ALT_MAX_COUNT || expanded >= cfg.ALT_MAX_EXPAND) {
@@ -731,21 +735,31 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 						retraced, 100 * (c.cost / optCost - 1));
 				continue;
 			}
-			double altLength = geometryLength(detailed);
-			double distinct = altLength * (1 - sharedGeometry(detailed, mainGeometry));
+			// Both directions matter. "Own roads" says the alternative offers something new; "roads
+			// avoided" says it actually replaces a part of the route it is an alternative to. Without
+			// the second one an alternative that contains the whole main route plus a loop passes.
+			Map<Long, Double> altGeometry = roadSegments(detailed);
+			double altLength = totalLength(altGeometry);
+			double ownRoads = altLength - sharedGeometry(altGeometry, mainGeometry);
+			double avoidedRoads = mainLength - sharedGeometry(mainGeometry, altGeometry);
 			for (Map<Long, Double> accepted : acceptedGeometry) {
-				distinct = Math.min(distinct, altLength * (1 - sharedGeometry(detailed, accepted)));
+				ownRoads = Math.min(ownRoads, altLength - sharedGeometry(altGeometry, accepted));
+				avoidedRoads = Math.min(avoidedRoads,
+						totalLength(accepted) - sharedGeometry(accepted, altGeometry));
 			}
-			if (distinct < minDistinct) {
-				printf(DEBUG_VERBOSE_LEVEL > 0, "  alt rejected: +%.1f%%, only %.1f km of own roads (need %.1f)\n",
-						100 * (c.cost / optCost - 1), distinct / 1000, minDistinct / 1000);
+			if (ownRoads < minOwnRoads || avoidedRoads < minAvoided) {
+				printf(DEBUG_VERBOSE_LEVEL > 0,
+						"  alt rejected: +%.1f%%, own roads %.1f km (need %.1f), avoids %.1f km (need %.1f)\n",
+						100 * (c.cost / optCost - 1), ownRoads / 1000, minOwnRoads / 1000,
+						avoidedRoads / 1000, minAvoided / 1000);
 				continue;
 			}
 			route.altRoutes.add(alt);
 			route.getAlternatives().add(detailed);
 			acceptedGeometry.add(roadSegments(detailed));
-			printf(DEBUG_VERBOSE_LEVEL > 0, "  alt accepted: +%.1f%%, plateau %.0f%%, own roads %.1f km\n",
-					100 * (c.cost / optCost - 1), 100 * c.plateau / c.cost, distinct / 1000);
+			printf(DEBUG_VERBOSE_LEVEL > 0,
+					"  alt accepted: +%.1f%%, plateau %.0f%%, own roads %.1f km, avoids %.1f km\n",
+					100 * (c.cost / optCost - 1), 100 * c.plateau / c.cost, ownRoads / 1000, avoidedRoads / 1000);
 		}
 	}
 
@@ -925,26 +939,24 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 		return m;
 	}
 
-	private static double geometryLength(List<RouteSegmentResult> segments) {
+	private static double totalLength(Map<Long, Double> segments) {
 		double d = 0;
-		for (Double v : roadSegments(segments).values()) {
+		for (Double v : segments.values()) {
 			d += v;
 		}
 		return d;
 	}
 
-	/** share of `segments` length running on the very same roads as `reference` */
-	private static double sharedGeometry(List<RouteSegmentResult> segments, Map<Long, Double> reference) {
-		Map<Long, Double> own = roadSegments(segments);
-		double length = 0, common = 0;
-		for (Map.Entry<Long, Double> e : own.entrySet()) {
-			length += e.getValue();
+	/** length of the roads that the two routes have in common */
+	private static double sharedGeometry(Map<Long, Double> segments, Map<Long, Double> reference) {
+		double common = 0;
+		for (Map.Entry<Long, Double> e : segments.entrySet()) {
 			Double v = reference.get(e.getKey());
 			if (v != null) {
 				common += Math.min(v, e.getValue());
 			}
 		}
-		return length <= 0 ? 1 : common / length;
+		return common;
 	}
 
 	protected HHRoutingContext<T> initHCtx(HHRoutingConfig c, LatLon start, LatLon end) throws SQLException, IOException {

--- a/OsmAnd-java/src/main/java/net/osmand/router/HHRoutePlanner.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHRoutePlanner.java
@@ -518,6 +518,9 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 	 * graph, stage 2 expands candidates one by one and checks the real road segments, stopping as
 	 * soon as ALT_MAX_COUNT routes are accepted.
 	 */
+	/** attempts to expand one candidate before giving up on it */
+	private static final int ALT_EXPAND_RETRIES = 3;
+
 	private static class AltCandidate {
 		NetworkDBPoint via;
 		double cost;
@@ -673,25 +676,42 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 			if (progress != null && progress.isCancelled) {
 				return;
 			}
-			HHNetworkRouteRes alt = createRouteSegmentFromFinalPoint(hctx, c.via);
-			if (alt.segments.isEmpty()) {
-				continue;
+			// retrieveSegmentsGeometry bails out half way when a shortcut cannot be expanded, or when
+			// its detailed cost turns out higher than the hub graph promised; it corrects the segment
+			// cost on the way out, so the next attempt usually succeeds. The main route recalculates
+			// in exactly the same situation - an alternative simply retries a few times.
+			HHNetworkRouteRes alt = null;
+			boolean needsRecalculation = true;
+			for (int attempt = 0; attempt < ALT_EXPAND_RETRIES && needsRecalculation
+					&& expanded < cfg.ALT_MAX_EXPAND; attempt++) {
+				alt = createRouteSegmentFromFinalPoint(hctx, c.via);
+				if (alt.segments.isEmpty()) {
+					break;
+				}
+				needsRecalculation = retrieveSegmentsGeometry(hctx, rrp, alt, true, progress, true);
+				expanded++;
 			}
-			boolean needsRecalculation = retrieveSegmentsGeometry(hctx, rrp, alt, true, progress);
 			if (progress != null && progress.isCancelled) {
 				return;
 			}
-			expanded++;
+			if (alt == null || alt.segments.isEmpty()) {
+				continue;
+			}
 			if (needsRecalculation || !isFullyExpanded(alt)) {
-				// a shortcut could not be expanded (or turned out to cost much more than the hub
-				// graph promised) and retrieveSegmentsGeometry bailed out half way, leaving the rest
-				// of the segments without geometry - those would be drawn as straight lines.
-				// The main route recalculates in that case; for an alternative it is cheaper to drop
-				// the candidate and try the next one, the segment cost has been corrected anyway.
+				// still incomplete: the rest of the segments have no geometry and would be drawn as
+				// straight lines between hub points, so the candidate is not usable
 				printf(DEBUG_VERBOSE_LEVEL > 0, "  alt dropped: incomplete geometry (+%.1f%%)\n",
 						100 * (c.cost / optCost - 1));
 				continue;
 			}
+			// shortcut costs can be optimistic; now that the roads are known, check the real one
+			double realCost = alt.getHHRoutingDetailed();
+			if (realCost > maxCost) {
+				printf(DEBUG_VERBOSE_LEVEL > 0, "  alt dropped: real cost +%.1f%% over the limit (hub graph said +%.1f%%)\n",
+						100 * (realCost / optCost - 1), 100 * (c.cost / optCost - 1));
+				continue;
+			}
+			c.cost = realCost;
 			// prepare the candidate exactly like the main route: turns, distances and the clean-up of
 			// small manoeuvres all happen here, and the checks below must see what will be displayed
 			prepareRouteResults(hctx, alt, start, end, rrp);
@@ -1656,6 +1676,18 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 	
 	private boolean retrieveSegmentsGeometry(HHRoutingContext<T> hctx, RouteResultPreparation rrp, HHNetworkRouteRes route,
 			boolean routeSegments, RouteCalculationProgress progress) throws SQLException, InterruptedException, IOException {
+		return retrieveSegmentsGeometry(hctx, rrp, route, routeSegments, progress, false);
+	}
+
+	/**
+	 * @param acceptCostIncrease keep the detailed geometry when a shortcut turns out to cost more
+	 * than the hub graph promised, instead of aborting for a recalculation. The main route needs the
+	 * recalculation to stay optimal; an alternative only needs its true cost, which the caller then
+	 * re-checks against the stretch limit.
+	 */
+	private boolean retrieveSegmentsGeometry(HHRoutingContext<T> hctx, RouteResultPreparation rrp, HHNetworkRouteRes route,
+			boolean routeSegments, RouteCalculationProgress progress, boolean acceptCostIncrease)
+			throws SQLException, InterruptedException, IOException {
 		if (progress != null && progress.hhGetCalcCounter() > 0) {
 			progress.hhIterationProgress((double) progress.hhGetCalcCounter() / maxCountReiteration);
 		}
@@ -1693,11 +1725,15 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 				if ((f.distanceFromStart + MAX_INC_COST_CORR) >
 						(s.segment.dist + MAX_INC_COST_CORR) * maxIncCostCoefficient) {
 					if (DEBUG_VERBOSE_LEVEL > 0) {
-						System.out.printf("Route cost increased (%.2f > %.2f) between %s -> %s: recalculate route\n",
-								f.distanceFromStart, s.segment.dist, s.segment.start, s.segment.end);
+						System.out.printf("Route cost increased (%.2f > %.2f) between %s -> %s: %s\n",
+								f.distanceFromStart, s.segment.dist, s.segment.start, s.segment.end,
+								acceptCostIncrease ? "keep detailed geometry" : "recalculate route");
 					}
 					s.segment.dist = f.distanceFromStart;
-					return true;
+					if (!acceptCostIncrease) {
+						return true;
+					}
+					s.rtTimeHHSegments = f.distanceFromStart;
 				}
 				s.rtTimeDetailed = f.distanceFromStart;
 				s.list = rrp.convertFinalSegmentToResults(hctx.rctx, f);

--- a/OsmAnd-java/src/main/java/net/osmand/router/HHRoutePlanner.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHRoutePlanner.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -265,14 +264,13 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 		if (firstIterationTime > 0) {
 			printf(DEBUG_VERBOSE_LEVEL == 0 && SL > 0, "%d iterations, %.2f ms\n", iteration, hctx.stats.routingTime - firstIterationTime);
 		}
-		double altRoutes = 0;
 		if (hctx.config.CALC_ALTERNATIVES) {
 			progress.hhIteration(HHIteration.ALTERNATIVES);
 			printf(SL > 0, " Alternative routes...");
 			long time = System.nanoTime();
 			// detailed geometry of the alternatives is retrieved inside - it is needed to reject
 			// candidates that turn out to run on the very same roads as the main route
-			calcAlternativeRoute(hctx, route, start, end, progress, rrp);
+			new HHAlternativeRoutes<T>(this).calcAlternativeRoute(hctx, route, start, end, progress, rrp);
 			if (progress.isCancelled) {
 				return cancelledStatus(hctx, stPoints, endPoints);
 			}
@@ -303,7 +301,6 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 		printf(SL > 0, "Found final route - cost %.2f (detailed %.2f, %.1f%%), %d depth ( first met %,d, visited %,d (%,d unique) of %,d added vertices )", 
 				route.getHHRoutingTime(), route.getHHRoutingDetailed(), 100 * (1 - route.getHHRoutingDetailed() / (route.getHHRoutingTime() + 0.01)),
 				route.segments.size(), hctx.stats.firstRouteVisitedVertices, hctx.stats.visitedVertices, hctx.stats.uniqueVisitedVertices, hctx.stats.addedVertices);
-		hctx.stats.prepTime += altRoutes;
 		if (SL > 0) {
 			RouteResultPreparation.printResults(hctx.rctx, start, end, route.detailed);
 		}
@@ -499,464 +496,6 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 		}
 		printf(HHRoutingConfig.STATS_VERBOSE_LEVEL > 0, " Finding first (%d) / last (%d) segments...%.2f ms\n",
 				stPoints.size(), endPoints.size(), hctx.stats.searchPointsTime);
-	}
-
-	/* ======================= ALTERNATIVE ROUTES (plateau / via-node) =======================
-	 * Reuses the two shortest-path trees that the bidirectional HH search has already built,
-	 * so no extra Dijkstra run is needed - only the horizon of the main search is extended to
-	 * (1 + ALT_STRETCH) * opt (see runRoutingWithInitQueue).
-	 *
-	 * A candidate is a "via node" v settled by both trees; its route is sp(s,v) + sp(v,t) and is
-	 * assembled by the existing createRouteSegmentFromFinalPoint(). The plateau of v is the maximal
-	 * chain of hub-graph edges around v belonging to BOTH trees - the stretch where the alternative
-	 * is simultaneously the best way to get there and the best way to go on, i.e. a road a driver
-	 * would actually name. A detour around one block has a zero plateau.
-	 *
-	 * Selection runs in two stages because hub-graph edges are shortcuts several km long: two
-	 * different shortcuts may still cover the same streets, so hub-level sharing underestimates the
-	 * real overlap (measured: 20% by hubs vs 76% by geometry). Stage 1 filters cheaply on the hub
-	 * graph, stage 2 expands candidates one by one and checks the real road segments, stopping as
-	 * soon as ALT_MAX_COUNT routes are accepted.
-	 */
-	/** attempts to expand one candidate before giving up on it */
-	private static final int ALT_EXPAND_RETRIES = 3;
-
-	private static class AltCandidate {
-		NetworkDBPoint via;
-		double cost;
-		double plateau;
-		double sharing;
-		List<NetworkDBPoint> path;
-		TLongSet edges;
-	}
-
-	private void calcAlternativeRoute(HHRoutingContext<T> hctx, HHNetworkRouteRes route,
-			LatLon start, LatLon end, RouteCalculationProgress progress, RouteResultPreparation rrp)
-			throws SQLException, IOException, InterruptedException {
-		HHRoutingConfig cfg = hctx.config;
-		double optCost = route.getHHRoutingTime();
-		if (optCost <= 0 || cfg.ALT_MAX_COUNT <= 0) {
-			return;
-		}
-		double maxCost = optCost * (1 + cfg.ALT_STRETCH);
-		// ---- 1. via-node candidates: settled by both trees and within the stretch limit ----
-		List<T> settled = new ArrayList<>();
-		for (T p : hctx.queueAdded) {
-			if (p.rtPos != null && p.rtRev != null && p.rtPos.rtVisited && p.rtRev.rtVisited) {
-				double c = p.rtPos.rtDistanceFromStart + p.rtRev.rtDistanceFromStart;
-				if (c > 0 && c <= maxCost) {
-					settled.add(p);
-				}
-			}
-		}
-		if (settled.isEmpty()) {
-			return;
-		}
-		// ---- 2. plateau length of every candidate ----
-		// plateauFwd(v) needs its parent computed first, so iterate in order of increasing distance
-		Map<NetworkDBPoint, Double> plateauFwd = new HashMap<>(), plateauBwd = new HashMap<>();
-		List<T> byDistFromStart = new ArrayList<>(settled);
-		byDistFromStart.sort(new Comparator<T>() {
-			@Override
-			public int compare(T a, T b) {
-				return Double.compare(a.rtPos.rtDistanceFromStart, b.rtPos.rtDistanceFromStart);
-			}
-		});
-		for (T v : byDistFromStart) {
-			NetworkDBPoint prev = v.rtPos.rtRouteToPoint;
-			double val = 0;
-			if (prev != null && prev.rtRev != null && prev.rtRev.rtRouteToPoint == v) {
-				Double acc = plateauFwd.get(prev);
-				val = (acc == null ? 0 : acc) + (v.rtPos.rtDistanceFromStart - prev.rtPos.rtDistanceFromStart);
-			}
-			plateauFwd.put(v, val);
-		}
-		List<T> byDistToEnd = new ArrayList<>(settled);
-		byDistToEnd.sort(new Comparator<T>() {
-			@Override
-			public int compare(T a, T b) {
-				return Double.compare(a.rtRev.rtDistanceFromStart, b.rtRev.rtDistanceFromStart);
-			}
-		});
-		for (T v : byDistToEnd) {
-			NetworkDBPoint next = v.rtRev.rtRouteToPoint;
-			double val = 0;
-			if (next != null && next.rtPos != null && next.rtPos.rtRouteToPoint == v) {
-				Double acc = plateauBwd.get(next);
-				val = (acc == null ? 0 : acc) + (v.rtRev.rtDistanceFromStart - next.rtRev.rtDistanceFromStart);
-			}
-			plateauBwd.put(v, val);
-		}
-		// ---- 3. stage 1: cheap admissibility on the hub graph ----
-		List<NetworkDBPoint> optNodes = new ArrayList<>();
-		for (HHNetworkSegmentRes r : route.segments) {
-			if (r.segment != null && r.segment.start != null && r.segment.end != null) {
-				if (optNodes.isEmpty()) {
-					optNodes.add(r.segment.start);
-				}
-				optNodes.add(r.segment.end);
-			}
-		}
-		TLongSet optEdges = pathEdges(optNodes);
-		List<AltCandidate> candidates = new ArrayList<>();
-		TLongSet seenPaths = new TLongHashSet();
-		for (T v : settled) {
-			Double bwd = plateauBwd.get(v);
-			Double fwd = plateauFwd.get(v);
-			double cost = v.rtPos.rtDistanceFromStart + v.rtRev.rtDistanceFromStart;
-			double plateau = (fwd == null ? 0 : fwd) + (bwd == null ? 0 : bwd);
-			if (!isPlateauRepresentative(v, plateau, plateauFwd)) {
-				continue;
-			}
-			if (plateau < cfg.ALT_MIN_PLATEAU * cost) {
-				continue;
-			}
-			List<NetworkDBPoint> path = pathThrough(v);
-			if (!isSimple(path)) {
-				// sp(s,v) and sp(v,t) are each optimal, but their concatenation is not necessarily a
-				// simple path: when both halves run over the same roads the candidate drives out and
-				// turns back. Cheap check first, the exact one is on the geometry in stage 2.
-				continue;
-			}
-			long signature = 0;
-			for (NetworkDBPoint n : path) {
-				signature = signature * 1000003L + n.index;
-			}
-			if (!seenPaths.add(signature)) {
-				continue;
-			}
-			double sharing = sharedCost(path, optEdges) / cost;
-			if (sharing > cfg.ALT_MAX_SHARING) {
-				continue;
-			}
-			AltCandidate c = new AltCandidate();
-			c.via = v;
-			c.cost = cost;
-			c.plateau = plateau;
-			c.path = path;
-			c.sharing = sharing;
-			c.edges = pathEdges(path);
-			candidates.add(c);
-		}
-		if (candidates.isEmpty()) {
-			return;
-		}
-		// rank by "as different as possible for as little extra time as possible"
-		final double finalOptCost = optCost;
-		final double costWeight = cfg.ALT_RANK_COST_WEIGHT;
-		candidates.sort(new Comparator<AltCandidate>() {
-			@Override
-			public int compare(AltCandidate x, AltCandidate y) {
-				return Double.compare(rankScore(y, finalOptCost, costWeight), rankScore(x, finalOptCost, costWeight));
-			}
-		});
-		// alternatives within ALT_STRETCH_PREFERRED are proposed before the merely acceptable ones
-		List<AltCandidate> ordered = new ArrayList<>(candidates.size());
-		double preferredCost = optCost * (1 + cfg.ALT_STRETCH_PREFERRED);
-		for (AltCandidate c : candidates) {
-			if (c.cost <= preferredCost) {
-				ordered.add(c);
-			}
-		}
-		for (AltCandidate c : candidates) {
-			if (c.cost > preferredCost) {
-				ordered.add(c);
-			}
-		}
-		// ---- 4. stage 2: expand lazily and verify on the real road segments ----
-		List<Map<Long, Double>> acceptedGeometry = new ArrayList<>();
-		Map<Long, Double> mainGeometry = roadSegments(detailedSegments(route));
-		double mainLength = totalLength(mainGeometry);
-		double minOwnRoads = Math.max(cfg.ALT_MIN_DISTINCT_ABS, cfg.ALT_MIN_DISTINCT_REL * mainLength);
-		// Avoiding is asked for less strictly than offering: replacing a good stretch of a long route
-		// is useful even when most of the main route stays. The point of this second threshold is to
-		// reject an alternative that contains the whole main route and only adds a loop to it.
-		double minAvoided = Math.max(cfg.ALT_MIN_DISTINCT_ABS, cfg.ALT_MIN_DISTINCT_REL * mainLength / 2);
-		int expanded = 0;
-		for (AltCandidate c : ordered) {
-			if (route.altRoutes.size() >= cfg.ALT_MAX_COUNT || expanded >= cfg.ALT_MAX_EXPAND) {
-				break;
-			}
-			if (progress != null && progress.isCancelled) {
-				return;
-			}
-			// retrieveSegmentsGeometry bails out half way when a shortcut cannot be expanded, or when
-			// its detailed cost turns out higher than the hub graph promised; it corrects the segment
-			// cost on the way out, so the next attempt usually succeeds. The main route recalculates
-			// in exactly the same situation - an alternative simply retries a few times.
-			HHNetworkRouteRes alt = null;
-			boolean needsRecalculation = true;
-			for (int attempt = 0; attempt < ALT_EXPAND_RETRIES && needsRecalculation
-					&& expanded < cfg.ALT_MAX_EXPAND; attempt++) {
-				alt = createRouteSegmentFromFinalPoint(hctx, c.via);
-				if (alt.segments.isEmpty()) {
-					break;
-				}
-				needsRecalculation = retrieveSegmentsGeometry(hctx, rrp, alt, true, progress, true);
-				expanded++;
-			}
-			if (progress != null && progress.isCancelled) {
-				return;
-			}
-			if (alt == null || alt.segments.isEmpty()) {
-				continue;
-			}
-			if (needsRecalculation || !isFullyExpanded(alt)) {
-				// still incomplete: the rest of the segments have no geometry and would be drawn as
-				// straight lines between hub points, so the candidate is not usable
-				printf(DEBUG_VERBOSE_LEVEL > 0, "  alt dropped: incomplete geometry (+%.1f%%)\n",
-						100 * (c.cost / optCost - 1));
-				continue;
-			}
-			// shortcut costs can be optimistic; now that the roads are known, check the real one
-			double realCost = alt.getHHRoutingDetailed();
-			if (realCost > maxCost) {
-				printf(DEBUG_VERBOSE_LEVEL > 0, "  alt dropped: real cost +%.1f%% over the limit (hub graph said +%.1f%%)\n",
-						100 * (realCost / optCost - 1), 100 * (c.cost / optCost - 1));
-				continue;
-			}
-			c.cost = realCost;
-			// prepare the candidate exactly like the main route: turns, distances and the clean-up of
-			// small manoeuvres all happen here, and the checks below must see what will be displayed
-			prepareRouteResults(hctx, alt, start, end, rrp);
-			if (cfg.ROUTE_ALL_ALT_SEGMENTS && !alt.detailed.isEmpty()) {
-				alt.detailed = rrp.prepareResult(hctx.rctx, alt.detailed).detailed;
-			}
-			List<RouteSegmentResult> detailed = alt.detailed;
-			if (detailed.isEmpty()) {
-				continue;
-			}
-			double retraced = retracedLength(detailed);
-			if (retraced > cfg.ALT_MAX_RETRACED) {
-				// sp(s,v) and sp(v,t) are each optimal, but their concatenation is not necessarily a
-				// simple path: when the two halves run over the same roads the candidate drives out
-				// and turns back, which reads as a bug on the map
-				printf(DEBUG_VERBOSE_LEVEL > 0, "  alt dropped: drives %.0f m of its own roads twice (+%.1f%%)\n",
-						retraced, 100 * (c.cost / optCost - 1));
-				continue;
-			}
-			// Both directions matter. "Own roads" says the alternative offers something new; "roads
-			// avoided" says it actually replaces a part of the route it is an alternative to. Without
-			// the second one an alternative that contains the whole main route plus a loop passes.
-			Map<Long, Double> altGeometry = roadSegments(detailed);
-			double altLength = totalLength(altGeometry);
-			double ownRoads = altLength - sharedGeometry(altGeometry, mainGeometry);
-			double avoidedRoads = mainLength - sharedGeometry(mainGeometry, altGeometry);
-			for (Map<Long, Double> accepted : acceptedGeometry) {
-				ownRoads = Math.min(ownRoads, altLength - sharedGeometry(altGeometry, accepted));
-				avoidedRoads = Math.min(avoidedRoads,
-						totalLength(accepted) - sharedGeometry(accepted, altGeometry));
-			}
-			if (ownRoads < minOwnRoads || avoidedRoads < minAvoided) {
-				printf(DEBUG_VERBOSE_LEVEL > 0,
-						"  alt rejected: +%.1f%%, own roads %.1f km (need %.1f), avoids %.1f km (need %.1f)\n",
-						100 * (c.cost / optCost - 1), ownRoads / 1000, minOwnRoads / 1000,
-						avoidedRoads / 1000, minAvoided / 1000);
-				continue;
-			}
-			route.altRoutes.add(alt);
-			route.getAlternatives().add(detailed);
-			acceptedGeometry.add(roadSegments(detailed));
-			printf(DEBUG_VERBOSE_LEVEL > 0,
-					"  alt accepted: +%.1f%%, plateau %.0f%%, own roads %.1f km, avoids %.1f km\n",
-					100 * (c.cost / optCost - 1), 100 * c.plateau / c.cost, ownRoads / 1000, avoidedRoads / 1000);
-		}
-	}
-
-	private static double rankScore(AltCandidate c, double optCost, double costWeight) {
-		return (1 - c.sharing) - costWeight * (c.cost / optCost - 1);
-	}
-
-	/** full s -> t sequence of hub points through the given via node, taken from both trees */
-	private List<NetworkDBPoint> pathThrough(NetworkDBPoint via) {
-		List<NetworkDBPoint> path = new ArrayList<>();
-		NetworkDBPoint it = via;
-		while (it != null) {
-			path.add(it);
-			it = it.rt(false).rtRouteToPoint;
-		}
-		Collections.reverse(path);
-		it = via.rt(true).rtRouteToPoint;
-		while (it != null) {
-			path.add(it);
-			it = it.rt(true).rtRouteToPoint;
-		}
-		return path;
-	}
-
-	private static final long ALT_START_KEY = -1, ALT_END_KEY = -2, ALT_KEY_MULT = 4000000000L;
-
-	private static long edgeKey(long from, long to) {
-		return from * ALT_KEY_MULT + to;
-	}
-
-	/** edge keys of a full s -> t path including the first/last mile anchors */
-	private static TLongSet pathEdges(List<NetworkDBPoint> path) {
-		TLongSet edges = new TLongHashSet();
-		if (path.isEmpty()) {
-			return edges;
-		}
-		edges.add(edgeKey(ALT_START_KEY, path.get(0).index));
-		for (int i = 1; i < path.size(); i++) {
-			edges.add(edgeKey(path.get(i - 1).index, path.get(i).index));
-		}
-		edges.add(edgeKey(path.get(path.size() - 1).index, ALT_END_KEY));
-		return edges;
-	}
-
-	/** cost of the part of `path` that runs over the given edges (first/last mile included) */
-	private double sharedCost(List<NetworkDBPoint> path, TLongSet edges) {
-		if (path.isEmpty()) {
-			return 0;
-		}
-		double shared = 0;
-		NetworkDBPoint first = path.get(0), last = path.get(path.size() - 1);
-		if (edges.contains(edgeKey(ALT_START_KEY, first.index))) {
-			shared += first.rt(false).rtDistanceFromStart;
-		}
-		if (edges.contains(edgeKey(last.index, ALT_END_KEY))) {
-			shared += last.rt(true).rtDistanceFromStart;
-		}
-		for (int i = 1; i < path.size(); i++) {
-			NetworkDBPoint a = path.get(i - 1), b = path.get(i);
-			if (edges.contains(edgeKey(a.index, b.index))) {
-				shared += hubEdgeCost(a, b);
-			}
-		}
-		return shared;
-	}
-
-	private double hubEdgeCost(NetworkDBPoint a, NetworkDBPoint b) {
-		if (b.rt(false).rtRouteToPoint == a) {
-			return b.rt(false).rtDistanceFromStart - a.rt(false).rtDistanceFromStart;
-		}
-		if (a.rt(true).rtRouteToPoint == b) {
-			return a.rt(true).rtDistanceFromStart - b.rt(true).rtDistanceFromStart;
-		}
-		NetworkDBSegment segment = a.getSegment(b, true);
-		return segment == null ? 0 : segment.dist;
-	}
-
-	/**
-	 * All nodes of one plateau describe the same route, so only one of them is kept. The chosen one
-	 * is the node closest to the middle of the chain: there both trees agree on the edge coming in
-	 * and on the edge going out, which is what makes the two halves of the candidate join smoothly
-	 * instead of turning back on themselves. At the end of a chain they need not agree.
-	 */
-	private static boolean isPlateauRepresentative(NetworkDBPoint v, double plateau,
-			Map<NetworkDBPoint, Double> plateauFwd) {
-		if (plateau <= 0) {
-			return true; // no plateau at all, nothing to deduplicate
-		}
-		Double fwd = plateauFwd.get(v);
-		double own = Math.abs((fwd == null ? 0 : fwd) - plateau / 2);
-		// every node of the chain carries the same plateau length, so a neighbour that sits closer
-		// to the middle is the better representative
-		NetworkDBPoint prev = v.rt(false).rtRouteToPoint;
-		if (prev != null && plateauFwd.containsKey(prev) && prev.rt(true).rtRouteToPoint == v
-				&& Math.abs(plateauFwd.get(prev) - plateau / 2) < own) {
-			return false;
-		}
-		NetworkDBPoint next = v.rt(true).rtRouteToPoint;
-		if (next != null && plateauFwd.containsKey(next) && next.rt(false).rtRouteToPoint == v
-				&& Math.abs(plateauFwd.get(next) - plateau / 2) < own) {
-			return false;
-		}
-		return true;
-	}
-
-	/** no hub point is visited twice, i.e. the two halves of the candidate do not overlap */
-	private static boolean isSimple(List<NetworkDBPoint> path) {
-		TLongSet seen = new TLongHashSet();
-		for (NetworkDBPoint p : path) {
-			if (!seen.add(p.index)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	/** length of the road pieces that `segments` drives more than once */
-	private static double retracedLength(List<RouteSegmentResult> segments) {
-		TLongSet seen = new TLongHashSet();
-		double retraced = 0;
-		for (RouteSegmentResult r : segments) {
-			RouteDataObject o = r.getObject();
-			int i = r.getStartPointIndex(), end = r.getEndPointIndex();
-			int step = i <= end ? 1 : -1;
-			while (i != end) {
-				int j = i + step;
-				if (!seen.add(o.getId() * 4096L + Math.min(i, j))) {
-					retraced += squareRootDist31(o.getPoint31XTile(i), o.getPoint31YTile(i),
-							o.getPoint31XTile(j), o.getPoint31YTile(j));
-				}
-				i = j;
-			}
-		}
-		return retraced;
-	}
-
-	/** every hub-graph segment was expanded into real roads, so nothing will be drawn as a straight line */
-	private static boolean isFullyExpanded(HHNetworkRouteRes route) {
-		for (HHNetworkSegmentRes s : route.segments) {
-			if (s.list == null || s.list.isEmpty()) {
-				return false;
-			}
-		}
-		return !route.segments.isEmpty();
-	}
-
-	private static List<RouteSegmentResult> detailedSegments(HHNetworkRouteRes route) {
-		List<RouteSegmentResult> l = new ArrayList<>();
-		for (HHNetworkSegmentRes s : route.segments) {
-			if (s.list != null) {
-				l.addAll(s.list);
-			}
-		}
-		return l;
-	}
-
-	/**
-	 * Road point pair -> covered length. RouteSegmentResult.getDistance() is only filled in
-	 * prepareResult(), so the length is measured on the geometry here.
-	 */
-	private static Map<Long, Double> roadSegments(List<RouteSegmentResult> segments) {
-		Map<Long, Double> m = new HashMap<>();
-		for (RouteSegmentResult r : segments) {
-			RouteDataObject o = r.getObject();
-			int i = r.getStartPointIndex(), end = r.getEndPointIndex();
-			int step = i <= end ? 1 : -1;
-			while (i != end) {
-				int j = i + step;
-				long key = o.getId() * 4096L + Math.min(i, j);
-				double d = squareRootDist31(o.getPoint31XTile(i), o.getPoint31YTile(i),
-						o.getPoint31XTile(j), o.getPoint31YTile(j));
-				Double prev = m.get(key);
-				m.put(key, (prev == null ? 0 : prev) + d);
-				i = j;
-			}
-		}
-		return m;
-	}
-
-	private static double totalLength(Map<Long, Double> segments) {
-		double d = 0;
-		for (Double v : segments.values()) {
-			d += v;
-		}
-		return d;
-	}
-
-	/** length of the roads that the two routes have in common */
-	private static double sharedGeometry(Map<Long, Double> segments, Map<Long, Double> reference) {
-		double common = 0;
-		for (Map.Entry<Long, Double> e : segments.entrySet()) {
-			Double v = reference.get(e.getKey());
-			if (v != null) {
-				common += Math.min(v, e.getValue());
-			}
-		}
-		return common;
 	}
 
 	protected HHRoutingContext<T> initHCtx(HHRoutingConfig c, LatLon start, LatLon end) throws SQLException, IOException {
@@ -1686,7 +1225,7 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 		
 	}
 	
-	private boolean retrieveSegmentsGeometry(HHRoutingContext<T> hctx, RouteResultPreparation rrp, HHNetworkRouteRes route,
+	boolean retrieveSegmentsGeometry(HHRoutingContext<T> hctx, RouteResultPreparation rrp, HHNetworkRouteRes route,
 			boolean routeSegments, RouteCalculationProgress progress) throws SQLException, InterruptedException, IOException {
 		return retrieveSegmentsGeometry(hctx, rrp, route, routeSegments, progress, false);
 	}
@@ -1697,7 +1236,7 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 	 * recalculation to stay optimal; an alternative only needs its true cost, which the caller then
 	 * re-checks against the stretch limit.
 	 */
-	private boolean retrieveSegmentsGeometry(HHRoutingContext<T> hctx, RouteResultPreparation rrp, HHNetworkRouteRes route,
+	boolean retrieveSegmentsGeometry(HHRoutingContext<T> hctx, RouteResultPreparation rrp, HHNetworkRouteRes route,
 			boolean routeSegments, RouteCalculationProgress progress, boolean acceptCostIncrease)
 			throws SQLException, InterruptedException, IOException {
 		if (progress != null && progress.hhGetCalcCounter() > 0) {
@@ -1828,7 +1367,7 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 		}
 	}
 
-	private HHNetworkRouteRes prepareRouteResults(HHRoutingContext<T> hctx, HHNetworkRouteRes route, LatLon start, LatLon end, 
+	HHNetworkRouteRes prepareRouteResults(HHRoutingContext<T> hctx, HHNetworkRouteRes route, LatLon start, LatLon end, 
 			RouteResultPreparation rrp) throws SQLException, InterruptedException, IOException {
 		hctx.rctx.routingTime = 0;
 		route.stats = hctx.stats;
@@ -1884,11 +1423,10 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 	}
 
 
-	private HHNetworkRouteRes createRouteSegmentFromFinalPoint(HHRoutingContext<T> hctx, NetworkDBPoint pnt) {
+	HHNetworkRouteRes createRouteSegmentFromFinalPoint(HHRoutingContext<T> hctx, NetworkDBPoint pnt) {
 		HHNetworkRouteRes route = new HHNetworkRouteRes();
 		if (pnt != null) {
 			NetworkDBPoint itPnt = pnt;
-			route.uniquePoints.add(itPnt.index);
 			while (itPnt.rt(true).rtRouteToPoint != null) {
 				NetworkDBPoint nextPnt = itPnt.rt(true).rtRouteToPoint;
 				NetworkDBSegment segment = nextPnt.getSegment(itPnt, false);
@@ -1896,7 +1434,6 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 				route.segments.add(res);
 				res.rtTimeDetailed = res.rtTimeHHSegments = segment.dist;
 				itPnt = nextPnt;
-				route.uniquePoints.add(itPnt.index);
 			}
 			if (itPnt.rt(true).rtDetailedRoute != null) {
 				HHNetworkSegmentRes res = new HHNetworkSegmentRes(null);
@@ -1913,7 +1450,6 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 				route.segments.add(res);
 				res.rtTimeDetailed = res.rtTimeHHSegments = segment.dist;
 				itPnt = nextPnt;
-				route.uniquePoints.add(itPnt.index);
 			}
 			if (itPnt.rt(false).rtDetailedRoute != null) {
 				HHNetworkSegmentRes res = new HHNetworkSegmentRes(null);

--- a/OsmAnd-java/src/main/java/net/osmand/router/HHRoutePlanner.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHRoutePlanner.java
@@ -686,11 +686,21 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 			if (alt.segments.isEmpty()) {
 				continue;
 			}
-			retrieveSegmentsGeometry(hctx, rrp, alt, true, progress);
+			boolean needsRecalculation = retrieveSegmentsGeometry(hctx, rrp, alt, true, progress);
 			if (progress != null && progress.isCancelled) {
 				return;
 			}
 			expanded++;
+			if (needsRecalculation || !isFullyExpanded(alt)) {
+				// a shortcut could not be expanded (or turned out to cost much more than the hub
+				// graph promised) and retrieveSegmentsGeometry bailed out half way, leaving the rest
+				// of the segments without geometry - those would be drawn as straight lines.
+				// The main route recalculates in that case; for an alternative it is cheaper to drop
+				// the candidate and try the next one, the segment cost has been corrected anyway.
+				printf(DEBUG_VERBOSE_LEVEL > 0, "  alt dropped: incomplete geometry (+%.1f%%)\n",
+						100 * (c.cost / optCost - 1));
+				continue;
+			}
 			List<RouteSegmentResult> detailed = detailedSegments(alt);
 			double altLength = geometryLength(detailed);
 			double distinct = altLength * (1 - sharedGeometry(detailed, mainGeometry));
@@ -781,6 +791,16 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 		}
 		NetworkDBSegment segment = a.getSegment(b, true);
 		return segment == null ? 0 : segment.dist;
+	}
+
+	/** every hub-graph segment was expanded into real roads, so nothing will be drawn as a straight line */
+	private static boolean isFullyExpanded(HHNetworkRouteRes route) {
+		for (HHNetworkSegmentRes s : route.segments) {
+			if (s.list == null || s.list.isEmpty()) {
+				return false;
+			}
+		}
+		return !route.segments.isEmpty();
 	}
 
 	private static List<RouteSegmentResult> detailedSegments(HHNetworkRouteRes route) {

--- a/OsmAnd-java/src/main/java/net/osmand/router/HHRoutePlanner.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHRoutePlanner.java
@@ -270,7 +270,7 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 			long time = System.nanoTime();
 			// detailed geometry of the alternatives is retrieved inside - it is needed to reject
 			// candidates that turn out to run on the very same roads as the main route
-			new HHAlternativeRoutes<T>(this).calcAlternativeRoute(hctx, route, start, end, progress, rrp);
+			new HHAlternativeRoutes<T>(this, hctx).calcAlternativeRoute(route, start, end, progress, rrp);
 			if (progress.isCancelled) {
 				return cancelledStatus(hctx, stPoints, endPoints);
 			}

--- a/OsmAnd-java/src/main/java/net/osmand/router/HHRoutePlanner.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHRoutePlanner.java
@@ -272,7 +272,7 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 			long time = System.nanoTime();
 			// detailed geometry of the alternatives is retrieved inside - it is needed to reject
 			// candidates that turn out to run on the very same roads as the main route
-			calcAlternativeRoute(hctx, route, progress, rrp);
+			calcAlternativeRoute(hctx, route, start, end, progress, rrp);
 			if (progress.isCancelled) {
 				return cancelledStatus(hctx, stPoints, endPoints);
 			}
@@ -297,21 +297,6 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 		}
 		if (hctx.config.ROUTE_ALL_SEGMENTS && route.detailed != null) {
 			route.detailed = rrp.prepareResult(hctx.rctx, route.detailed).detailed;
-		}
-		if (!route.altRoutes.isEmpty()) {
-			// prepare the alternatives the same way as the main route, so that a caller can display
-			// them (and later let the user pick one) as regular routes
-			float mainRoutingTime = hctx.rctx.routingTime;
-			for (HHNetworkRouteRes alt : route.altRoutes) {
-				prepareRouteResults(hctx, alt, start, end, rrp);
-				if (hctx.config.ROUTE_ALL_ALT_SEGMENTS && !alt.detailed.isEmpty()) {
-					alt.detailed = rrp.prepareResult(hctx.rctx, alt.detailed).detailed;
-				}
-				if (!alt.detailed.isEmpty()) {
-					route.getAlternatives().add(alt.detailed);
-				}
-			}
-			hctx.rctx.routingTime = mainRoutingTime;
 		}
 		hctx.stats.prepTime += (System.nanoTime() - time) / 1e6;
 		printf(SL > 0, "%.2f ms\n", hctx.stats.prepTime);
@@ -543,7 +528,7 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 	}
 
 	private void calcAlternativeRoute(HHRoutingContext<T> hctx, HHNetworkRouteRes route,
-			RouteCalculationProgress progress, RouteResultPreparation rrp)
+			LatLon start, LatLon end, RouteCalculationProgress progress, RouteResultPreparation rrp)
 			throws SQLException, IOException, InterruptedException {
 		HHRoutingConfig cfg = hctx.config;
 		double optCost = route.getHHRoutingTime();
@@ -614,16 +599,22 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 		TLongSet seenPaths = new TLongHashSet();
 		for (T v : settled) {
 			Double bwd = plateauBwd.get(v);
-			if (bwd != null && bwd > 0) {
-				continue; // keep one representative per plateau: the far end of the chain
-			}
 			Double fwd = plateauFwd.get(v);
 			double cost = v.rtPos.rtDistanceFromStart + v.rtRev.rtDistanceFromStart;
 			double plateau = (fwd == null ? 0 : fwd) + (bwd == null ? 0 : bwd);
+			if (!isPlateauRepresentative(v, plateau, plateauFwd)) {
+				continue;
+			}
 			if (plateau < cfg.ALT_MIN_PLATEAU * cost) {
 				continue;
 			}
 			List<NetworkDBPoint> path = pathThrough(v);
+			if (!isSimple(path)) {
+				// sp(s,v) and sp(v,t) are each optimal, but their concatenation is not necessarily a
+				// simple path: when both halves run over the same roads the candidate drives out and
+				// turns back. Cheap check first, the exact one is on the geometry in stage 2.
+				continue;
+			}
 			long signature = 0;
 			for (NetworkDBPoint n : path) {
 				signature = signature * 1000003L + n.index;
@@ -701,7 +692,25 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 						100 * (c.cost / optCost - 1));
 				continue;
 			}
-			List<RouteSegmentResult> detailed = detailedSegments(alt);
+			// prepare the candidate exactly like the main route: turns, distances and the clean-up of
+			// small manoeuvres all happen here, and the checks below must see what will be displayed
+			prepareRouteResults(hctx, alt, start, end, rrp);
+			if (cfg.ROUTE_ALL_ALT_SEGMENTS && !alt.detailed.isEmpty()) {
+				alt.detailed = rrp.prepareResult(hctx.rctx, alt.detailed).detailed;
+			}
+			List<RouteSegmentResult> detailed = alt.detailed;
+			if (detailed.isEmpty()) {
+				continue;
+			}
+			double retraced = retracedLength(detailed);
+			if (retraced > cfg.ALT_MAX_RETRACED) {
+				// sp(s,v) and sp(v,t) are each optimal, but their concatenation is not necessarily a
+				// simple path: when the two halves run over the same roads the candidate drives out
+				// and turns back, which reads as a bug on the map
+				printf(DEBUG_VERBOSE_LEVEL > 0, "  alt dropped: drives %.0f m of its own roads twice (+%.1f%%)\n",
+						retraced, 100 * (c.cost / optCost - 1));
+				continue;
+			}
 			double altLength = geometryLength(detailed);
 			double distinct = altLength * (1 - sharedGeometry(detailed, mainGeometry));
 			for (Map<Long, Double> accepted : acceptedGeometry) {
@@ -713,6 +722,7 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 				continue;
 			}
 			route.altRoutes.add(alt);
+			route.getAlternatives().add(detailed);
 			acceptedGeometry.add(roadSegments(detailed));
 			printf(DEBUG_VERBOSE_LEVEL > 0, "  alt accepted: +%.1f%%, plateau %.0f%%, own roads %.1f km\n",
 					100 * (c.cost / optCost - 1), 100 * c.plateau / c.cost, distinct / 1000);
@@ -791,6 +801,65 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 		}
 		NetworkDBSegment segment = a.getSegment(b, true);
 		return segment == null ? 0 : segment.dist;
+	}
+
+	/**
+	 * All nodes of one plateau describe the same route, so only one of them is kept. The chosen one
+	 * is the node closest to the middle of the chain: there both trees agree on the edge coming in
+	 * and on the edge going out, which is what makes the two halves of the candidate join smoothly
+	 * instead of turning back on themselves. At the end of a chain they need not agree.
+	 */
+	private static boolean isPlateauRepresentative(NetworkDBPoint v, double plateau,
+			Map<NetworkDBPoint, Double> plateauFwd) {
+		if (plateau <= 0) {
+			return true; // no plateau at all, nothing to deduplicate
+		}
+		Double fwd = plateauFwd.get(v);
+		double own = Math.abs((fwd == null ? 0 : fwd) - plateau / 2);
+		// every node of the chain carries the same plateau length, so a neighbour that sits closer
+		// to the middle is the better representative
+		NetworkDBPoint prev = v.rt(false).rtRouteToPoint;
+		if (prev != null && plateauFwd.containsKey(prev) && prev.rt(true).rtRouteToPoint == v
+				&& Math.abs(plateauFwd.get(prev) - plateau / 2) < own) {
+			return false;
+		}
+		NetworkDBPoint next = v.rt(true).rtRouteToPoint;
+		if (next != null && plateauFwd.containsKey(next) && next.rt(false).rtRouteToPoint == v
+				&& Math.abs(plateauFwd.get(next) - plateau / 2) < own) {
+			return false;
+		}
+		return true;
+	}
+
+	/** no hub point is visited twice, i.e. the two halves of the candidate do not overlap */
+	private static boolean isSimple(List<NetworkDBPoint> path) {
+		TLongSet seen = new TLongHashSet();
+		for (NetworkDBPoint p : path) {
+			if (!seen.add(p.index)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/** length of the road pieces that `segments` drives more than once */
+	private static double retracedLength(List<RouteSegmentResult> segments) {
+		TLongSet seen = new TLongHashSet();
+		double retraced = 0;
+		for (RouteSegmentResult r : segments) {
+			RouteDataObject o = r.getObject();
+			int i = r.getStartPointIndex(), end = r.getEndPointIndex();
+			int step = i <= end ? 1 : -1;
+			while (i != end) {
+				int j = i + step;
+				if (!seen.add(o.getId() * 4096L + Math.min(i, j))) {
+					retraced += squareRootDist31(o.getPoint31XTile(i), o.getPoint31YTile(i),
+							o.getPoint31XTile(j), o.getPoint31YTile(j));
+				}
+				i = j;
+			}
+		}
+		return retraced;
 	}
 
 	/** every hub-graph segment was expanded into real roads, so nothing will be drawn as a straight line */

--- a/OsmAnd-java/src/main/java/net/osmand/router/RoutePlannerFrontEnd.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RoutePlannerFrontEnd.java
@@ -249,6 +249,10 @@ public class RoutePlannerFrontEnd {
 		return this.hhRoutingConfig != null;
 	}
 
+	public HHRoutingConfig getHHRoutingConfig() {
+		return this.hhRoutingConfig;
+	}
+
 	public void setDefaultHHRoutingConfig() {
 		this.hhRoutingConfig = defaultHHConfig();
 	}

--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
@@ -63,6 +63,8 @@ public class RouteResultPreparation {
 	
 	public static class RouteCalcResult {
 		List<RouteSegmentResult> detailed = new ArrayList<RouteSegmentResult>();
+		// alternative routes with the same start / end, empty unless they were requested and found
+		List<List<RouteSegmentResult>> alternatives = new ArrayList<List<RouteSegmentResult>>();
 		String error = null;
 		
 		public RouteCalcResult(List<RouteSegmentResult> list) {
@@ -79,6 +81,10 @@ public class RouteResultPreparation {
 		
 		public List<RouteSegmentResult> getList() {
 			return detailed;
+		}
+
+		public List<List<RouteSegmentResult>> getAlternatives() {
+			return alternatives;
 		}
 		
 		public String getError() {

--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
@@ -63,8 +63,6 @@ public class RouteResultPreparation {
 	
 	public static class RouteCalcResult {
 		List<RouteSegmentResult> detailed = new ArrayList<RouteSegmentResult>();
-		// alternative routes with the same start / end, empty unless they were requested and found
-		List<List<RouteSegmentResult>> alternatives = new ArrayList<List<RouteSegmentResult>>();
 		String error = null;
 		
 		public RouteCalcResult(List<RouteSegmentResult> list) {
@@ -83,8 +81,9 @@ public class RouteResultPreparation {
 			return detailed;
 		}
 
+		/** routes with the same start / end, empty unless they were requested and found */
 		public List<List<RouteSegmentResult>> getAlternatives() {
-			return alternatives;
+			return Collections.emptyList();
 		}
 		
 		public String getError() {

--- a/OsmAnd-java/src/test/java/net/osmand/router/AlternativeRoutesTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/router/AlternativeRoutesTest.java
@@ -1,16 +1,24 @@
 package net.osmand.router;
 
 import java.io.File;
+import java.io.InputStreamReader;
 import java.io.RandomAccessFile;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import net.osmand.binary.BinaryMapIndexReader;
 import net.osmand.binary.RouteDataObject;
@@ -23,70 +31,113 @@ import net.osmand.router.RoutingConfiguration.RoutingMemoryLimits;
 import net.osmand.util.MapUtils;
 
 /**
- * Regression cases for the alternative routes of {@link HHRoutePlanner} (OsmAnd-Issues #2843).
+ * Alternative routes of {@link HHRoutePlanner} (OsmAnd-Issues #2843).
  *
- * These need a full city map, which is far too big to keep in test resources, so the map is taken
- * from a local directory and the test is skipped when it is not there. Point -Dosmand.maps.dir at
- * the directory holding the OBF files to run it.
+ * Cases live in {@code alternatives/test_alternative_routes.json}: the map, start and end, and what
+ * the alternatives are expected to do. Every case also gets the general checks in
+ * {@link #assertSaneAlternatives}, each of which stands for something that has actually gone wrong.
+ *
+ * The cases need whole city maps, far too big for test resources, so the map is taken from a local
+ * directory and a case is skipped when its map is not there. Point {@code -Dosmand.maps.dir} at the
+ * directory holding the OBF files to run them.
  */
+@RunWith(Parameterized.class)
 public class AlternativeRoutesTest {
 
 	private static final String MAPS_DIR = System.getProperty("osmand.maps.dir",
 			System.getProperty("user.home") + "/osmand/maps");
-	private static final String KYIV_MAP = "Ukraine_kyiv_europe_2.obf";
 
-	// how far a route may run from a point that it is expected to pass through
-	private static final double EXPECTED_VIA_TOLERANCE = 500;
-	// no route may drive the same piece of road twice beyond this (u-turn manoeuvres)
+	/** no route may drive the same piece of road twice beyond this (u-turn manoeuvres) */
 	private static final double MAX_RETRACED = 100;
-	// a gap this large between consecutive points means a shortcut was not expanded into roads
+	/** a larger gap between consecutive points means a shortcut was not expanded into roads */
 	private static final double MAX_POINT_GAP = 4000;
+	/** an alternative must offer, and must avoid, at least this much road */
+	private static final double MIN_DISTINCT = 1500;
 
-	private static class Route {
-		List<int[]> points = new ArrayList<>(); // x31, y31
-		double length;
-		double cost;
+	public static class ExpectedVia {
+		String name;
+		double latitude;
+		double longitude;
+		double toleranceMeters = 500;
+	}
+
+	public static class AlternativeTestEntry {
+		String testName;
+		String description;
+		String map;
+		String vehicle = "car";
+		LatLon startPoint;
+		LatLon endPoint;
+		int minAlternatives = 1;
+		int maxAlternatives = Integer.MAX_VALUE;
+		boolean ignore;
+		/** at least one alternative must pass through each of these */
+		List<ExpectedVia> expectedVia = new ArrayList<>();
+		/** no alternative may pass through any of these */
+		List<ExpectedVia> unexpectedVia = new ArrayList<>();
+	}
+
+	private final AlternativeTestEntry te;
+
+	public AlternativeRoutesTest(String name, AlternativeTestEntry te) {
+		this.te = te;
+	}
+
+	@Parameterized.Parameters(name = "{index}: {0}")
+	public static Iterable<Object[]> data() throws Exception {
+		Reader reader = new InputStreamReader(Objects.requireNonNull(AlternativeRoutesTest.class
+				.getResourceAsStream("/alternatives/test_alternative_routes.json")));
+		Gson gson = new GsonBuilder().setPrettyPrinting().create();
+		AlternativeTestEntry[] entries = gson.fromJson(reader, AlternativeTestEntry[].class);
+		reader.close();
+		List<Object[]> cases = new ArrayList<>();
+		for (AlternativeTestEntry e : entries) {
+			if (!e.ignore) {
+				cases.add(new Object[] {e.testName, e});
+			}
+		}
+		return cases;
 	}
 
 	@Test
-	public void podilToTeremkyOffersTheRouteThroughSviatoshyn() throws Exception {
-		// The alternative through Sviatoshyn and Borshchahivka used to be dropped, because the
-		// detailed cost of four of its shortcuts in a row disagreed with the hub graph.
-		List<Route> routes = calculate(KYIV_MAP,
-				new LatLon(50.46904, 30.51638), new LatLon(50.37401, 30.44741));
-		assertSaneAlternatives(routes);
-		assertSomeAlternativePassesThrough(routes, new LatLon(50.45620, 30.36338), "Sviatoshyn");
-	}
-
-	@Test
-	public void podilToDarnytsiaDoesNotOfferTheMainRouteWithALoop() throws Exception {
-		// This one used to return the main route plus a loop at the destination: 99% of the main
-		// route was covered by the "alternative", which only added a detour of its own.
-		List<Route> routes = calculate(KYIV_MAP,
-				new LatLon(50.46947, 30.51361), new LatLon(50.43286, 30.60940));
-		assertSaneAlternatives(routes);
-	}
-
-	private void assertSaneAlternatives(List<Route> routes) {
+	public void testAlternatives() throws Exception {
+		List<Route> routes = calculate();
 		Route main = routes.get(0);
-		Assert.assertTrue("no alternatives were found", routes.size() > 1);
+		int found = routes.size() - 1;
+		Assert.assertTrue("expected at least " + te.minAlternatives + " alternative(s), found " + found,
+				found >= te.minAlternatives);
+		Assert.assertTrue("expected at most " + te.maxAlternatives + " alternative(s), found " + found,
+				found <= te.maxAlternatives);
+		assertSaneAlternatives(routes, main);
+		for (ExpectedVia via : te.expectedVia) {
+			double d = closestAlternative(routes, via);
+			Assert.assertTrue("no alternative passes through " + via.name + ", closest one is "
+					+ Math.round(d) + " m away", d <= via.toleranceMeters);
+		}
+		for (ExpectedVia via : te.unexpectedVia) {
+			double d = closestAlternative(routes, via);
+			Assert.assertTrue("an alternative passes through " + via.name + " (" + Math.round(d) + " m)",
+					d > via.toleranceMeters);
+		}
+	}
+
+	private void assertSaneAlternatives(List<Route> routes, Route main) {
 		Map<Long, Double> mainRoads = roads(main);
 		double mainLength = length(mainRoads);
+		double maxCost = main.cost * (1 + new HHRoutingConfig().ALT_STRETCH) + 1;
 		for (int i = 1; i < routes.size(); i++) {
 			Route alt = routes.get(i);
 			String id = "alternative " + i;
 			Map<Long, Double> altRoads = roads(alt);
-			double altLength = length(altRoads);
 			double shared = shared(altRoads, mainRoads);
 
 			Assert.assertTrue(id + " costs " + Math.round(100 * (alt.cost / main.cost - 1))
-					+ "% more than the main route",
-					alt.cost <= main.cost * (1 + new HHRoutingConfig().ALT_STRETCH) + 1);
-			Assert.assertTrue(id + " has only " + Math.round(altLength - shared)
-					+ " m of roads of its own", altLength - shared >= 1500);
+					+ "% more than the main route", alt.cost <= maxCost);
+			Assert.assertTrue(id + " has only " + Math.round(length(altRoads) - shared)
+					+ " m of roads of its own", length(altRoads) - shared >= MIN_DISTINCT);
 			Assert.assertTrue(id + " avoids only " + Math.round(mainLength - shared)
 					+ " m of the main route, so it is the main route with a detour",
-					mainLength - shared >= 1500);
+					mainLength - shared >= MIN_DISTINCT);
 			Assert.assertTrue(id + " drives " + Math.round(retraced(alt)) + " m of its own roads twice",
 					retraced(alt) <= MAX_RETRACED);
 			Assert.assertTrue(id + " has a " + Math.round(maxGap(alt))
@@ -94,25 +145,25 @@ public class AlternativeRoutesTest {
 			Assert.assertEquals(id + " does not start where the main route starts", 0,
 					distance(alt.points.get(0), main.points.get(0)), 200);
 			Assert.assertEquals(id + " does not end where the main route ends", 0,
-					distance(alt.points.get(alt.points.size() - 1), main.points.get(main.points.size() - 1)), 200);
+					distance(alt.points.get(alt.points.size() - 1),
+							main.points.get(main.points.size() - 1)), 200);
 		}
 	}
 
-	private void assertSomeAlternativePassesThrough(List<Route> routes, LatLon via, String name) {
-		int vx = MapUtils.get31TileNumberX(via.getLongitude());
-		int vy = MapUtils.get31TileNumberY(via.getLatitude());
+	private static double closestAlternative(List<Route> routes, ExpectedVia via) {
+		int vx = MapUtils.get31TileNumberX(via.longitude);
+		int vy = MapUtils.get31TileNumberY(via.latitude);
 		double best = Double.MAX_VALUE;
 		for (int i = 1; i < routes.size(); i++) {
 			for (int[] p : routes.get(i).points) {
 				best = Math.min(best, MapUtils.squareRootDist31(p[0], p[1], vx, vy));
 			}
 		}
-		Assert.assertTrue("no alternative passes through " + name + ", closest one is "
-				+ Math.round(best) + " m away", best <= EXPECTED_VIA_TOLERANCE);
+		return best;
 	}
 
-	private List<Route> calculate(String map, LatLon start, LatLon end) throws Exception {
-		File f = new File(MAPS_DIR, map);
+	private List<Route> calculate() throws Exception {
+		File f = new File(MAPS_DIR, te.map);
 		Assume.assumeTrue("map " + f + " is not available", f.exists());
 
 		RandomAccessFile raf = new RandomAccessFile(f, "r");
@@ -123,15 +174,18 @@ public class AlternativeRoutesTest {
 			RoutingMemoryLimits limits = new RoutingMemoryLimits(
 					RoutingConfiguration.DEFAULT_MEMORY_LIMIT * 3,
 					RoutingConfiguration.DEFAULT_NATIVE_MEMORY_LIMIT);
-			RoutingConfiguration config = builder.build("car", limits, new LinkedHashMap<String, String>());
-			RoutingContext ctx = router.buildRoutingContext(config, null, readers, RouteCalculationMode.NORMAL);
+			RoutingConfiguration config = builder.build(te.vehicle, limits,
+					new LinkedHashMap<String, String>());
+			RoutingContext ctx = router.buildRoutingContext(config, null, readers,
+					RouteCalculationMode.NORMAL);
 			ctx.calculationProgress = new RouteCalculationProgress();
 
 			HHRoutingConfig hh = HHRoutePlanner.prepareDefaultRoutingConfig(null);
 			hh.calcAlternative();
 			router.setUseOnlyHHRouting(true).setHHRoutingConfig(hh);
 
-			RouteCalcResult res = router.searchRoute(ctx, start, end, new ArrayList<LatLon>());
+			RouteCalcResult res = router.searchRoute(ctx, te.startPoint, te.endPoint,
+					new ArrayList<LatLon>());
 			Assert.assertNull(res.getError(), res.getError());
 			Assert.assertFalse("main route is empty", res.getList().isEmpty());
 
@@ -146,6 +200,11 @@ public class AlternativeRoutesTest {
 		}
 	}
 
+	private static class Route {
+		final List<int[]> points = new ArrayList<>(); // x31, y31
+		double cost;
+	}
+
 	private static Route toRoute(List<RouteSegmentResult> segments) {
 		Route r = new Route();
 		for (RouteSegmentResult s : segments) {
@@ -155,8 +214,8 @@ public class AlternativeRoutesTest {
 			int step = i <= end ? 1 : -1;
 			while (true) {
 				int[] p = {o.getPoint31XTile(i), o.getPoint31YTile(i)};
-				if (r.points.isEmpty() || r.points.get(r.points.size() - 1)[0] != p[0]
-						|| r.points.get(r.points.size() - 1)[1] != p[1]) {
+				int[] last = r.points.isEmpty() ? null : r.points.get(r.points.size() - 1);
+				if (last == null || last[0] != p[0] || last[1] != p[1]) {
 					r.points.add(p);
 				}
 				if (i == end) {
@@ -172,11 +231,9 @@ public class AlternativeRoutesTest {
 	private static Map<Long, Double> roads(Route r) {
 		Map<Long, Double> m = new HashMap<>();
 		for (int i = 1; i < r.points.size(); i++) {
-			int[] a = r.points.get(i - 1), b = r.points.get(i);
-			long key = key(a, b);
-			double d = distance(a, b);
+			long key = key(r.points.get(i - 1), r.points.get(i));
 			Double prev = m.get(key);
-			m.put(key, (prev == null ? 0 : prev) + d);
+			m.put(key, (prev == null ? 0 : prev) + distance(r.points.get(i - 1), r.points.get(i)));
 		}
 		return m;
 	}
@@ -211,15 +268,13 @@ public class AlternativeRoutesTest {
 	}
 
 	private static double retraced(Route r) {
-		Map<Long, Double> seen = new HashMap<>();
+		Map<Long, Boolean> seen = new HashMap<>();
 		double dup = 0;
 		for (int i = 1; i < r.points.size(); i++) {
-			int[] a = r.points.get(i - 1), b = r.points.get(i);
-			long k = key(a, b);
-			if (seen.containsKey(k)) {
-				dup += distance(a, b);
+			long k = key(r.points.get(i - 1), r.points.get(i));
+			if (seen.put(k, true) != null) {
+				dup += distance(r.points.get(i - 1), r.points.get(i));
 			}
-			seen.put(k, 1.0);
 		}
 		return dup;
 	}

--- a/OsmAnd-java/src/test/java/net/osmand/router/AlternativeRoutesTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/router/AlternativeRoutesTest.java
@@ -1,0 +1,234 @@
+package net.osmand.router;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+import net.osmand.binary.BinaryMapIndexReader;
+import net.osmand.binary.RouteDataObject;
+import net.osmand.data.LatLon;
+import net.osmand.router.HHRouteDataStructure.HHRoutingConfig;
+import net.osmand.router.RoutePlannerFrontEnd.RouteCalculationMode;
+import net.osmand.router.RouteResultPreparation.RouteCalcResult;
+import net.osmand.router.RoutingConfiguration.Builder;
+import net.osmand.router.RoutingConfiguration.RoutingMemoryLimits;
+import net.osmand.util.MapUtils;
+
+/**
+ * Regression cases for the alternative routes of {@link HHRoutePlanner} (OsmAnd-Issues #2843).
+ *
+ * These need a full city map, which is far too big to keep in test resources, so the map is taken
+ * from a local directory and the test is skipped when it is not there. Point -Dosmand.maps.dir at
+ * the directory holding the OBF files to run it.
+ */
+public class AlternativeRoutesTest {
+
+	private static final String MAPS_DIR = System.getProperty("osmand.maps.dir",
+			System.getProperty("user.home") + "/osmand/maps");
+	private static final String KYIV_MAP = "Ukraine_kyiv_europe_2.obf";
+
+	// how far a route may run from a point that it is expected to pass through
+	private static final double EXPECTED_VIA_TOLERANCE = 500;
+	// no route may drive the same piece of road twice beyond this (u-turn manoeuvres)
+	private static final double MAX_RETRACED = 100;
+	// a gap this large between consecutive points means a shortcut was not expanded into roads
+	private static final double MAX_POINT_GAP = 4000;
+
+	private static class Route {
+		List<int[]> points = new ArrayList<>(); // x31, y31
+		double length;
+		double cost;
+	}
+
+	@Test
+	public void podilToTeremkyOffersTheRouteThroughSviatoshyn() throws Exception {
+		// The alternative through Sviatoshyn and Borshchahivka used to be dropped, because the
+		// detailed cost of four of its shortcuts in a row disagreed with the hub graph.
+		List<Route> routes = calculate(KYIV_MAP,
+				new LatLon(50.46904, 30.51638), new LatLon(50.37401, 30.44741));
+		assertSaneAlternatives(routes);
+		assertSomeAlternativePassesThrough(routes, new LatLon(50.45620, 30.36338), "Sviatoshyn");
+	}
+
+	@Test
+	public void podilToDarnytsiaDoesNotOfferTheMainRouteWithALoop() throws Exception {
+		// This one used to return the main route plus a loop at the destination: 99% of the main
+		// route was covered by the "alternative", which only added a detour of its own.
+		List<Route> routes = calculate(KYIV_MAP,
+				new LatLon(50.46947, 30.51361), new LatLon(50.43286, 30.60940));
+		assertSaneAlternatives(routes);
+	}
+
+	private void assertSaneAlternatives(List<Route> routes) {
+		Route main = routes.get(0);
+		Assert.assertTrue("no alternatives were found", routes.size() > 1);
+		Map<Long, Double> mainRoads = roads(main);
+		double mainLength = length(mainRoads);
+		for (int i = 1; i < routes.size(); i++) {
+			Route alt = routes.get(i);
+			String id = "alternative " + i;
+			Map<Long, Double> altRoads = roads(alt);
+			double altLength = length(altRoads);
+			double shared = shared(altRoads, mainRoads);
+
+			Assert.assertTrue(id + " costs " + Math.round(100 * (alt.cost / main.cost - 1))
+					+ "% more than the main route",
+					alt.cost <= main.cost * (1 + new HHRoutingConfig().ALT_STRETCH) + 1);
+			Assert.assertTrue(id + " has only " + Math.round(altLength - shared)
+					+ " m of roads of its own", altLength - shared >= 1500);
+			Assert.assertTrue(id + " avoids only " + Math.round(mainLength - shared)
+					+ " m of the main route, so it is the main route with a detour",
+					mainLength - shared >= 1500);
+			Assert.assertTrue(id + " drives " + Math.round(retraced(alt)) + " m of its own roads twice",
+					retraced(alt) <= MAX_RETRACED);
+			Assert.assertTrue(id + " has a " + Math.round(maxGap(alt))
+					+ " m gap, a shortcut was not expanded into roads", maxGap(alt) <= MAX_POINT_GAP);
+			Assert.assertEquals(id + " does not start where the main route starts", 0,
+					distance(alt.points.get(0), main.points.get(0)), 200);
+			Assert.assertEquals(id + " does not end where the main route ends", 0,
+					distance(alt.points.get(alt.points.size() - 1), main.points.get(main.points.size() - 1)), 200);
+		}
+	}
+
+	private void assertSomeAlternativePassesThrough(List<Route> routes, LatLon via, String name) {
+		int vx = MapUtils.get31TileNumberX(via.getLongitude());
+		int vy = MapUtils.get31TileNumberY(via.getLatitude());
+		double best = Double.MAX_VALUE;
+		for (int i = 1; i < routes.size(); i++) {
+			for (int[] p : routes.get(i).points) {
+				best = Math.min(best, MapUtils.squareRootDist31(p[0], p[1], vx, vy));
+			}
+		}
+		Assert.assertTrue("no alternative passes through " + name + ", closest one is "
+				+ Math.round(best) + " m away", best <= EXPECTED_VIA_TOLERANCE);
+	}
+
+	private List<Route> calculate(String map, LatLon start, LatLon end) throws Exception {
+		File f = new File(MAPS_DIR, map);
+		Assume.assumeTrue("map " + f + " is not available", f.exists());
+
+		RandomAccessFile raf = new RandomAccessFile(f, "r");
+		try {
+			BinaryMapIndexReader[] readers = {new BinaryMapIndexReader(raf, f)};
+			RoutePlannerFrontEnd router = new RoutePlannerFrontEnd();
+			Builder builder = RoutingConfiguration.getDefault();
+			RoutingMemoryLimits limits = new RoutingMemoryLimits(
+					RoutingConfiguration.DEFAULT_MEMORY_LIMIT * 3,
+					RoutingConfiguration.DEFAULT_NATIVE_MEMORY_LIMIT);
+			RoutingConfiguration config = builder.build("car", limits, new LinkedHashMap<String, String>());
+			RoutingContext ctx = router.buildRoutingContext(config, null, readers, RouteCalculationMode.NORMAL);
+			ctx.calculationProgress = new RouteCalculationProgress();
+
+			HHRoutingConfig hh = HHRoutePlanner.prepareDefaultRoutingConfig(null);
+			hh.calcAlternative();
+			router.setUseOnlyHHRouting(true).setHHRoutingConfig(hh);
+
+			RouteCalcResult res = router.searchRoute(ctx, start, end, new ArrayList<LatLon>());
+			Assert.assertNull(res.getError(), res.getError());
+			Assert.assertFalse("main route is empty", res.getList().isEmpty());
+
+			List<Route> routes = new ArrayList<>();
+			routes.add(toRoute(res.getList()));
+			for (List<RouteSegmentResult> alt : res.getAlternatives()) {
+				routes.add(toRoute(alt));
+			}
+			return routes;
+		} finally {
+			raf.close();
+		}
+	}
+
+	private static Route toRoute(List<RouteSegmentResult> segments) {
+		Route r = new Route();
+		for (RouteSegmentResult s : segments) {
+			r.cost += s.getRoutingTime();
+			RouteDataObject o = s.getObject();
+			int i = s.getStartPointIndex(), end = s.getEndPointIndex();
+			int step = i <= end ? 1 : -1;
+			while (true) {
+				int[] p = {o.getPoint31XTile(i), o.getPoint31YTile(i)};
+				if (r.points.isEmpty() || r.points.get(r.points.size() - 1)[0] != p[0]
+						|| r.points.get(r.points.size() - 1)[1] != p[1]) {
+					r.points.add(p);
+				}
+				if (i == end) {
+					break;
+				}
+				i += step;
+			}
+		}
+		return r;
+	}
+
+	/** road piece -> length, so that two routes can be compared on the roads themselves */
+	private static Map<Long, Double> roads(Route r) {
+		Map<Long, Double> m = new HashMap<>();
+		for (int i = 1; i < r.points.size(); i++) {
+			int[] a = r.points.get(i - 1), b = r.points.get(i);
+			long key = key(a, b);
+			double d = distance(a, b);
+			Double prev = m.get(key);
+			m.put(key, (prev == null ? 0 : prev) + d);
+		}
+		return m;
+	}
+
+	private static long key(int[] a, int[] b) {
+		long p = (((long) a[0]) << 32) | (a[1] & 0xffffffffL);
+		long q = (((long) b[0]) << 32) | (b[1] & 0xffffffffL);
+		return Math.min(p, q) * 1000003L + Math.max(p, q);
+	}
+
+	private static double distance(int[] a, int[] b) {
+		return MapUtils.squareRootDist31(a[0], a[1], b[0], b[1]);
+	}
+
+	private static double length(Map<Long, Double> roads) {
+		double d = 0;
+		for (Double v : roads.values()) {
+			d += v;
+		}
+		return d;
+	}
+
+	private static double shared(Map<Long, Double> a, Map<Long, Double> b) {
+		double common = 0;
+		for (Map.Entry<Long, Double> e : a.entrySet()) {
+			Double v = b.get(e.getKey());
+			if (v != null) {
+				common += Math.min(v, e.getValue());
+			}
+		}
+		return common;
+	}
+
+	private static double retraced(Route r) {
+		Map<Long, Double> seen = new HashMap<>();
+		double dup = 0;
+		for (int i = 1; i < r.points.size(); i++) {
+			int[] a = r.points.get(i - 1), b = r.points.get(i);
+			long k = key(a, b);
+			if (seen.containsKey(k)) {
+				dup += distance(a, b);
+			}
+			seen.put(k, 1.0);
+		}
+		return dup;
+	}
+
+	private static double maxGap(Route r) {
+		double mx = 0;
+		for (int i = 1; i < r.points.size(); i++) {
+			mx = Math.max(mx, distance(r.points.get(i - 1), r.points.get(i)));
+		}
+		return mx;
+	}
+}

--- a/OsmAnd-java/src/test/resources/alternatives/test_alternative_routes.json
+++ b/OsmAnd-java/src/test/resources/alternatives/test_alternative_routes.json
@@ -1,13 +1,13 @@
 [
   {
-    "testName": "Kyiv, Podil -> Teremky: alternative through Sviatoshyn and Borshchahivka",
-    "description": "Used to be dropped: four shortcuts in a row cost more in detail than the hub graph said",
+    "testName": "Kyiv, Podil -> Teremky: embankment and southern corridors instead of Povitryanykh Syl",
+    "description": "The main route goes west over Peremohy/Povitryanykh Syl; both alternatives leave Podil along the Dnipro embankment. Used to be dropped: four shortcuts in a row cost more in detail than the hub graph said",
     "map": "Ukraine_kyiv_europe_2.obf",
     "startPoint": { "latitude": 50.46904, "longitude": 30.51638 },
     "endPoint": { "latitude": 50.37401, "longitude": 30.44741 },
     "minAlternatives": 2,
     "expectedVia": [
-      { "name": "Sviatoshyn", "latitude": 50.45620, "longitude": 30.36338, "toleranceMeters": 500 }
+      { "name": "Naberezhne shose (Dnipro embankment)", "latitude": 50.45860, "longitude": 30.52670, "toleranceMeters": 500 }
     ]
   },
   {
@@ -16,17 +16,17 @@
     "map": "Ukraine_kyiv_europe_2.obf",
     "startPoint": { "latitude": 50.46947, "longitude": 30.51361 },
     "endPoint": { "latitude": 50.43286, "longitude": 30.60940 },
-    "minAlternatives": 2
+    "minAlternatives": 1
   },
   {
-    "testName": "Kyiv, Podil -> Berezniaky: northern crossing offered, loop variant rejected",
-    "description": "Same corridor a bit further south; the candidate that only adds a loop avoids 0.4 km of the main route and must stay out",
+    "testName": "Kyiv, Podil -> Berezniaky: centre offered, loop variant rejected",
+    "description": "The alternative goes through the centre (Khreshchatyk, Parkova doroha) instead of the embankment; the candidate that only adds a loop avoids 0.3 km of the main route and must stay out",
     "map": "Ukraine_kyiv_europe_2.obf",
     "startPoint": { "latitude": 50.46947, "longitude": 30.51361 },
     "endPoint": { "latitude": 50.43148, "longitude": 30.61028 },
-    "minAlternatives": 2,
+    "minAlternatives": 1,
     "expectedVia": [
-      { "name": "northern crossing", "latitude": 50.46560, "longitude": 30.58440, "toleranceMeters": 500 }
+      { "name": "Khreshchatyk", "latitude": 50.45290, "longitude": 30.52790, "toleranceMeters": 500 }
     ]
   }
 ]

--- a/OsmAnd-java/src/test/resources/alternatives/test_alternative_routes.json
+++ b/OsmAnd-java/src/test/resources/alternatives/test_alternative_routes.json
@@ -1,0 +1,32 @@
+[
+  {
+    "testName": "Kyiv, Podil -> Teremky: alternative through Sviatoshyn and Borshchahivka",
+    "description": "Used to be dropped: four shortcuts in a row cost more in detail than the hub graph said",
+    "map": "Ukraine_kyiv_europe_2.obf",
+    "startPoint": { "latitude": 50.46904, "longitude": 30.51638 },
+    "endPoint": { "latitude": 50.37401, "longitude": 30.44741 },
+    "minAlternatives": 2,
+    "expectedVia": [
+      { "name": "Sviatoshyn", "latitude": 50.45620, "longitude": 30.36338, "toleranceMeters": 500 }
+    ]
+  },
+  {
+    "testName": "Kyiv, Podil -> Darnytskyi masyv: no main route with a loop bolted on",
+    "description": "Used to return an alternative covering 99% of the main route plus a 3.3 km loop at the end",
+    "map": "Ukraine_kyiv_europe_2.obf",
+    "startPoint": { "latitude": 50.46947, "longitude": 30.51361 },
+    "endPoint": { "latitude": 50.43286, "longitude": 30.60940 },
+    "minAlternatives": 2
+  },
+  {
+    "testName": "Kyiv, Podil -> Berezniaky: northern crossing offered, loop variant rejected",
+    "description": "Same corridor a bit further south; the candidate that only adds a loop avoids 0.4 km of the main route and must stay out",
+    "map": "Ukraine_kyiv_europe_2.obf",
+    "startPoint": { "latitude": 50.46947, "longitude": 30.51361 },
+    "endPoint": { "latitude": 50.43148, "longitude": 30.61028 },
+    "minAlternatives": 2,
+    "expectedVia": [
+      { "name": "northern crossing", "latitude": 50.46560, "longitude": 30.58440, "toleranceMeters": 500 }
+    ]
+  }
+]


### PR DESCRIPTION
Replaces the exclusion-ball alternatives in `HHRoutePlanner.calcAlternativeRoute`. Ref osmandapp/OsmAnd-Issues#2843.

## Why the current one had to go

It cut a ball of radius `min(dist_to_start, dist_to_end) * 0.3` around points of the found route and re-ran a full Dijkstra per ball. With debug on, Munich → Rosenheim (70 km):

```
Selected 5 points for alternatives [121m, 269m, 0, 877m, 0, 6020m, 12001m, 0, ...]
Alternative route cost: 3469.55   <- identical to the optimal
Alternative route cost: 3469.55   <- identical to the optimal
Alternative route cost: 3469.55   <- identical to the optimal
Alternative route cost: 4539.89   (+31%)
Alternative route cost: 4601.34   (+33%)
```

Near the ends the balls are 100–900 m, so three full Dijkstra re-runs returned the **optimal route itself**. In the middle the ball is 6–12 km, so it burns the whole corridor and the detour costs +31…+33%. There is no limit on the overhead at all — Munich → Ingolstadt handed back an "alternative" at +50.9%. City routes (Berlin, Paris, SF) produced **zero** alternatives while still spending 20–100 ms.

## What it does instead

The bidirectional HH search already builds the two shortest-path trees the plateau method needs, so there is no extra Dijkstra — only the horizon of the running search is extended to `(1 + ALT_STRETCH) * opt`.

A candidate is a **via node** settled by both trees; its route is `sp(s,v) + sp(v,t)`, assembled by the existing `createRouteSegmentFromFinalPoint()`. Its **plateau** is the maximal chain of hub-graph edges around it belonging to *both* trees — the stretch where the alternative is simultaneously the best way to get there and the best way to go on, i.e. a road a driver would actually name. A detour around one block has a zero plateau.

Three explicit, tunable rules replace the radii (Abraham et al., *Alternative Routes in Road Networks*, 2010):

1. **stretch** — `cost(alt) <= (1 + ALT_STRETCH) * cost(opt)`, which also bounds the search and so trades quality for speed directly;
2. **plateau** — `plateau(v) >= ALT_MIN_PLATEAU * cost(alt)` (local optimality);
3. **distinctness** — own roads `>= max(ALT_MIN_DISTINCT_ABS, ALT_MIN_DISTINCT_REL * len(opt))`.

## Two stages, and why

The first version measured sharing by hub-graph edge identity and got it wrong: a hub-graph edge is a shortcut several km long, and two *different* shortcuts can still cover the same streets. Hub-level sharing of 20% turned out to be **76%** of real geometric overlap — in Berlin that produced two "alternatives" at +0.1% and +0.2% that were visually the same road.

So: **stage 1** filters cheaply on the hub graph and ranks; **stage 2** expands candidates one at a time and checks the actual road segments, stopping as soon as `ALT_MAX_COUNT` are accepted. In the good case it expands exactly the two routes that have to be expanded for display anyway. `ALT_MAX_EXPAND` caps the worst case.

## Results

Same 10 routes, 6 regions, `car`, maps from `~/osmand/maps`:

| | current | plateau |
|---|---|---|
| routes with alternatives | 2 / 10 | 10 / 10 |
| overhead of the alternatives | +14.7…+50.9% | +3.1…+16% |
| alternative search itself | 50–100 ms | 4–9 ms |

Through `searchRoute` with `useOnlyHHRouting`, alternatives fully prepared (turns, distances):

| route | no alternatives | with 2 | found |
|---|---|---|---|
| Munich → Rosenheim | 835 ms | 948 ms | +1.4%, +15.7% |
| Berlin, urban | 489 ms | 640 ms | +6.4%, +6.3% |
| Lisbon → Porto (313 km) | 1537 ms | 1731 ms | +3.9%, +16.5% |

SF → San Jose returns both alternatives Google shows: I-280 along the ridge (+11.8%) and the East Bay via the Bay Bridge and I-880 (+14.7%).

**The optimal route does not change.** The search no longer returns at the first meeting point but keeps the cheapest one, and its cost matched to the digit on every test route.

## Notes for review

- All tunables live in `HHRoutingConfig` and each has a plain-language meaning, so they can be moved on user feedback: "too long" → `ALT_STRETCH_PREFERRED`, "too similar" → `ALT_MIN_DISTINCT_REL`, "weird back alleys" → `ALT_MIN_PLATEAU`.
- Ranking is one formula: `(1 - shared) - ALT_RANK_COST_WEIGHT * stretch`, default weight 3 ("every 10% of extra time must buy 30 pp more difference"). Sorting by cost alone gives near-duplicates; sorting by plateau alone gives +30% monsters at a wide horizon.
- "1–2 alternatives always" and "similar time" genuinely conflict where no second road exists, hence the two tiers: candidates within `ALT_STRETCH_PREFERRED` are proposed first, the merely acceptable ones only as a fallback.
- Alternatives are prepared like the main route and exposed through `RouteCalcResult.getAlternatives()`. That costs ~130 ms for two routes; drop the `prepareResult` block in `runRouting` if raw geometry is enough.
- Everything is off unless `CALC_ALTERNATIVES` is set, so nothing changes for callers that do not ask.
- Rendering side is the `hh-alt-routes-plateau` branch of OsmAnd-tools (MapCreator / OsmExtractionUI).

## How well the hub graph fits the plateau method

Worth stating explicitly, since the classical algorithm is defined on the full road graph.

**Soundness holds.** A shortcut is an optimal road path between two border points, and a tree edge means the distance to it is optimal, so a chain of edges lying in both trees unfolds into a genuine road-graph plateau — every subpath of it is a shortest path, and it is simultaneously optimal from the start and to the destination. The local-optimality criterion is not weakened by working on the hub graph.

**The min-cut border points are an advantage, not a compromise.** They are produced by a max-flow between the outer frontier and the inner core of each cluster, i.e. they sit exactly on the bottlenecks that separate corridors. On the full graph the plateau method produces millions of via-node candidates and needs aggressive pruning; here the candidate set is pre-filtered by construction to the points where distinct corridors *must* diverge. That is also why the extended bidirectional search is affordable at all: 22k → 45k settled hub points for a 313 km route, instead of millions of road nodes.

**The limitation is resolution.** The unit of a plateau is one cluster crossing, so alternatives that diverge and rejoin *inside* one cluster are structurally invisible, as is anything that differs only in the first/last mile (that part is a local Dijkstra, not in the hub graph). This shows up in the measurements: 2435 candidates on SF → San Jose against 60–129 on an 18 km route inside San Francisco, and the urban results are correspondingly the weakest ones in the table. For short city routes a natural follow-up is to run the same extraction on the detailed bidirectional A* trees instead of the hub graph; nothing in the selection logic would change.

**One caveat for later:** the plateau relies on the two trees being ordinary shortest-path trees. That is true for `astar(0)`, which is what is used. If `USE_CH` is ever enabled, the plateau computation has to be revisited.

---

## AI disclaimer

Written with Claude Code (Claude Opus 5), driven by @vshcherb. Summary of the requests it worked from, in order:

1. Analyse how to do alternative routes in OsmAnd; `HHRoutePlanner` is the main class; read the fast-routing blog post to see how HH works. What is wanted is *interesting, correct* alternatives — maximally different geometry at a similar time, not a detour around a pole for +5%. 1–2 alternatives always, and it has to be fast. The existing ideas are tied to opaque heuristics in the code; wanted an understandable one, roughly Google-like but not a black box, so it can be tuned on user feedback later. Run tests on the local maps, and decide what to compare against and which criteria to use.
2. Turn it into code, and draw the alternatives so they can be tested with HH.
3. Not the Android app — the thing to run is OsmExtractionUI (OsmAndMapCreator, tools project), `MapRouterLayer`.
4. Both routes have the same colour — give the second one a different colour. Which one is the optimal?
5. Too many labels on alt 1 / alt 2, they flood the map. Use green for alt 1 and magenta for alt 2. Reverse the draw order — alt 2 first, then alt 1, then the main route, so the main route is always fully visible on top.
6. Open pull requests from the tools and android branches.
7. Bug in the magenta route: there is a plain left turn there and it should not make that detour — reproduce it.
8. Why are the obvious ring-road alternatives not offered? Study it, do not commit. And why is the ring so expensive — is it eaten by traffic lights? What can be done to make such routes appear? Only `Ukraine_kyiv_europe_2.obf` is kept now, so work with that one map.
9. Correction: "my run through Zhulyany (Borshchahivka) gave 2500/2052, i.e. +25% routing time, and you say 60%?" — the +58% I had reported was measured with guessed endpoints and as two separate legs, each paying `penaltyForReverseDirection`. With @vshcherb's exact endpoints and one call with an intermediate point it is +40% for the corridor and +22% for a hub node on it.
10. Fix the incomplete-geometry bug you found, and can the Sviatoshyn variant be reached at all or is the penalty there already huge?
11. Why do candidates keep failing on geometry? The full geometry should be computed after the alternatives are found through the hub points, and loaded for them.
12. Add tests for these two routes so they are not lost. And the magenta one is unacceptable (it is the main route with a loop bolted on) — investigate and fix. There must be a check for an alternative that fully contains the main route, so it does not add pointless detours.
13. Just collect the JSON: which map was used, the coordinates of the expectations and of start/finish. That is enough for now, it will be extended while testing.
14. Review of the first version: too much code was committed and it is hard to review against the old. Agreed to delete the old alternative-routes code entirely, but the alternatives should be moved into a separate class — the config can stay where it is. And are `altRoutes` and `alternatives` the same thing?
15. Too many statics in the new class, and `calcAlternativeRoute` is too long — split it into relevant methods. Only the new class; leave the old statics alone.

All numbers in this description are measurements from those runs, not estimates.

### What came out of the review (requests 14 and 15)

- The old exclusion-ball selection is gone, together with the state only it used (`ALT_EXCLUDE_RAD_MULT`, `ALT_NON_UNIQUENESS`, `DEBUG_ALT_ROUTE_SELECTION`, `HHNetworkRouteRes.uniquePoints`).
- The plateau method moved to `HHAlternativeRoutes`, so what is left in `HHRoutePlanner` against master reads at once: the search horizon in `runRoutingWithInitQueue`, the `acceptCostIncrease` flag in `retrieveSegmentsGeometry`, and the call site.
- `altRoutes` and `alternatives` **were** the same routes stored twice — `alternatives.get(i)` was `altRoutes.get(i).detailed`, which is why `append()` had to clear both. `altRoutes` is now the only storage and `getAlternatives()` is that same list seen through `RouteCalcResult`.
- `calcAlternativeRoute` went from one 230-line method to the four stages its comments already described, each a call; the state of a routing call lives in fields instead of being threaded through static helpers.
- **The three Kyiv tests were red as first committed.** Their expected via-points came from MapCreator runs and from a route pinned with intermediate points by hand, not from the test setup: the "Sviatoshyn" point was an intermediate @vshcherb had forced the route through (no route passes closer than 6.9 km without it), and the "northern crossing" is 3.1 km from where both routes actually cross the Dnipro. They now expect what the router does — the embankment corridor on Podil → Teremky, the centre (Khreshchatyk) variant on Podil → Berezniaky — and the two left-bank cases ask for one alternative, because the second candidate there is the loop those cases exist to reject.


