### PR TITLE
Save the activity selected in the profile from Plan a route

### DIFF
--- a/OsmAnd/src/net/osmand/plus/measurementtool/SaveGpxRouteAsyncTask.java
+++ b/OsmAnd/src/net/osmand/plus/measurementtool/SaveGpxRouteAsyncTask.java
@@ -174,7 +174,7 @@ class SaveGpxRouteAsyncTask extends AsyncTask<Void, Void, Exception> {
         if (appMode == MeasurementEditingContext.DEFAULT_APP_MODE) {
             appMode = app.getSettings().getApplicationMode();
         }
-        String activityId = app.getSettings().CURRENT_TRACK_ROUTE_ACTIVITY.getProfileDefaultValue(appMode);
+        String activityId = app.getSettings().CURRENT_TRACK_ROUTE_ACTIVITY.getModeValue(appMode);
         if (syncWithEditedProfile) {
             metadata.setRouteActivity(helper.findRouteActivity(activityId));
         } else if (!Algorithms.isEmpty(activityId)) {


### PR DESCRIPTION
Fixes https://github.com/osmandapp/OsmAnd/issues/25756

`SaveGpxRouteAsyncTask` read `CURRENT_TRACK_ROUTE_ACTIVITY` with `getProfileDefaultValue()`, which ignores the stored value and falls back to the parent `ApplicationMode` default. A track planned with the Cycling profile was therefore always saved as *Road Cycling*, even when the profile's activity was set to *Gravel Biking*; a Motorcycle-based custom profile set to *Road Motorcycling* was saved as *Adventure Motorcycling*.

Read the stored value with `getModeValue()`, the same accessor `MonitoringSettingsFragment` uses to display the preference. Trip recording was never affected — `SavingTrackHelper` already reads it correctly.

### Testing

Checked on an API 35 emulator with a throwaway instrumentation test that was afterwards dropped as too trivial to keep: with the fix the saved activity matched the profile, and reverting the one-line change failed it with

```
expected:<gravel_biking> but was:<road_cycling>
expected:<road_motorcycling> but was:<adventure_motorcycling>
```

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Investigate whether the reported issues are regressions, reproduce them, prepare fixes on branches off 5.4, and consider automated tests where the problem is a regression.
2. Issues to look at: #25374, #25283, #25674, #25756, #25590.
3. Open pull requests against `r5.4` linking the issues.
4. Follow the repository AI-disclosure rules; drop the regression test and the visibility changes from this PR, the test is trivial.

Decided by the agent, not requested explicitly: which of the five issues to fix versus only triage, the branch names and commit wording, and the choice to verify the fix on an emulator before removing the test.
