### PR TITLE
Keep the map scale text readable on tablets

### DIFF
--- a/OsmAnd/res/layout/map_ruler.xml
+++ b/OsmAnd/res/layout/map_ruler.xml
@@ -19,7 +19,7 @@
 			android:layout_gravity="bottom"
 			android:gravity="center_horizontal"
 			android:lineSpacingMultiplier="0.9"
-			android:textSize="@dimen/map_widget_text_size_small"
+			android:textSize="@dimen/map_ruler_text_size"
 			tools:text="100 m" />
 
 		<TextView
@@ -29,7 +29,7 @@
 			android:layout_gravity="bottom"
 			android:gravity="center_horizontal"
 			android:lineSpacingMultiplier="0.9"
-			android:textSize="@dimen/map_widget_text_size_small"
+			android:textSize="@dimen/map_ruler_text_size"
 			tools:text="100 m" />
 
 	</FrameLayout>

--- a/OsmAnd/res/values-large/sizes.xml
+++ b/OsmAnd/res/values-large/sizes.xml
@@ -11,6 +11,7 @@
 	<dimen name="map_address_height">60dp</dimen>
 	<dimen name="map_ruler_width">180dp</dimen>
 	<dimen name="map_ruler_bottom_margin">17dp</dimen>
+	<dimen name="map_ruler_text_size">23sp</dimen>
 	<dimen name="map_alarm_size">138dp</dimen>
 	<dimen name="map_alarm_bottom_text_margin">12dp</dimen>
 	<dimen name="map_alarm_text_size">35sp</dimen>

--- a/OsmAnd/res/values/sizes.xml
+++ b/OsmAnd/res/values/sizes.xml
@@ -134,6 +134,7 @@
 
 	<dimen name="map_ruler_width">120dp</dimen>
 	<dimen name="map_ruler_bottom_margin">9dp</dimen>
+	<dimen name="map_ruler_text_size">15sp</dimen>
 	<dimen name="map_alarm_size">92dp</dimen>
 	<dimen name="map_alarm_bottom_text_margin">8dp</dimen>
 


### PR DESCRIPTION
Part of https://github.com/osmandapp/OsmAnd/issues/25374

QA bisected the tablet scaling regression to nightly `#7851m` (ok) → `#7890m` (broken). The change in that window is `5ec248bc5d` "Removed tablet sizes for widget texts" (#25228, 5 June), which dropped `map_widget_text_size` / `map_widget_text_size_small` from `values-large`.

For left/right panel widgets that is intentional — their size is now user-controlled through the new widget appearance menu (#25018). But `map_ruler.xml` uses the same dimension and the map scale is **not** a panel widget, so there is no way to compensate: on a 10" tablet the ruler bar is still `180dp` wide (`values-large`) while its label dropped from `23sp` to `15sp`. That is the "1 km" label the reporter pointed at.

Give the ruler its own `map_ruler_text_size` dimension and restore the tablet value.

`item_elevation_stat_block.xml` reads the same dimension and is not a panel widget either — leaving it alone here, worth a separate look.

The remaining part of the issue (dmpr0's ToDo about width restrictions for the left/right panels depending on screen width) is a product decision and is not touched by this PR.

### Before / after

Tablet emulator, 2560 × 1600 (the reporter's Tab S5e resolution), same map position and zoom, same crop of the bottom-left corner.

| Before (`r5.4`) | After (this PR) |
| --- | --- |
| <img width="560" height="160" alt="map scale label at 15sp" src="https://github.com/user-attachments/assets/031572e7-d917-422e-b47d-e5e81807fe5f" /> | <img width="560" height="160" alt="map scale label at 23sp" src="https://github.com/user-attachments/assets/1f51d79d-d62c-48c5-bce3-610abc03918c" /> |

### Tests

Resource-only change, no automated coverage.

Related issues triaged in the same pass: #25756, #25590.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Investigate whether the reported issues are regressions, reproduce them, prepare fixes on branches off 5.4, and consider automated tests where the problem is a regression.
2. Issues to look at: #25374, #25283, #25674, #25756, #25590.
3. Open pull requests against `r5.4` linking the issues.
4. Add before/after screenshots of the fix to this PR, and follow the repository AI-disclosure rules.

Decided by the agent, not requested explicitly: narrowing the issue down to the map ruler instead of the panel widgets, introducing a separate `map_ruler_text_size` dimension rather than restoring the shared one, and the choice of device, map position and crop for the screenshots.
