### PR TITLE
Fix occasional frozen pan gesture (#25736)

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/DoubleTapScaleDetector.java
+++ b/OsmAnd/src/net/osmand/plus/views/DoubleTapScaleDetector.java
@@ -64,6 +64,20 @@ public class DoubleTapScaleDetector {
 			mIsInZoomMode = false;
 			return false;
 		}
+		if (event.getAction() == MotionEvent.ACTION_CANCEL) {
+			// A cancelled gesture never delivers ACTION_UP. Without this reset the detector stays in
+			// zoom / double tap mode, and OsmandMapTileView keeps skipping the gesture detector and
+			// the map layers, so the whole next gesture is silently ignored.
+			boolean handled = mIsInZoomMode;
+			if (mIsInZoomMode) {
+				mIsInZoomMode = false;
+				listener.onZoomEnded(scale);
+			}
+			resetEvents();
+			mIsDoubleTapping = false;
+			mScrolling = false;
+			return handled;
+		}
 		if (event.getAction() == MotionEvent.ACTION_UP) {
 			boolean handled = false;
 			if (mIsInZoomMode) {

--- a/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
+++ b/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
@@ -1997,28 +1997,40 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 		return targetZoom;
 	}
 
-	private void findFirstTouchMapLocation(float touchPointX, float touchPointY) {
+	/**
+	 * @return true if the map location under the given screen point was actually found. When it is
+	 * not found (renderer state is not ready yet, or the point does not hit the map surface) the
+	 * renderer leaves the location unchanged, so it stays equal to the current map target and must
+	 * not be used as a gesture anchor.
+	 */
+	private boolean findFirstTouchMapLocation(float touchPointX, float touchPointY) {
 		MapRendererView mapRenderer = getMapRenderer();
 		if (mapRenderer != null) {
 			PointI touchPosition = new PointI((int) touchPointX, (int) touchPointY);
 			PointI touchLocation31 = mapRenderer.getTarget();
 			float height = mapRenderer.getHeightAndLocationFromElevatedPoint(touchPosition, touchLocation31);
+			boolean found = height > NativeUtilities.MIN_ALTITUDE_VALUE;
 			firstTouchLocationX = touchLocation31.getX();
 			firstTouchLocationY = touchLocation31.getY();
-			firstTouchLocationHeight = height > NativeUtilities.MIN_ALTITUDE_VALUE ? height : 0.0f;
+			firstTouchLocationHeight = found ? height : 0.0f;
+			return found;
 		}
+		return false;
 	}
 
-	private void findSecondTouchMapLocation(float touchPointX, float touchPointY) {
+	private boolean findSecondTouchMapLocation(float touchPointX, float touchPointY) {
 		MapRendererView mapRenderer = getMapRenderer();
 		if (mapRenderer != null) {
 			PointI touchPosition = new PointI((int) touchPointX, (int) touchPointY);
 			PointI touchLocation31 = mapRenderer.getTarget();
 			float height = mapRenderer.getHeightAndLocationFromElevatedPoint(touchPosition, touchLocation31);
+			boolean found = height > NativeUtilities.MIN_ALTITUDE_VALUE;
 			secondTouchLocationX = touchLocation31.getX();
 			secondTouchLocationY = touchLocation31.getY();
-			secondTouchLocationHeight = height > NativeUtilities.MIN_ALTITUDE_VALUE ? height : 0.0f;
+			secondTouchLocationHeight = found ? height : 0.0f;
+			return found;
 		}
+		return false;
 	}
 
 	public boolean onTouchEvent(MotionEvent event) {
@@ -2660,20 +2672,33 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 			if (multiTouchSupport == null || (!multiTouchSupport.isInTiltMode() && !multiTouchSupport.isInZoomAndRotationMode())) {
 				MeasurementToolLayer layer = getMeasurementToolLayer();
 				MapRendererView mapRenderer = getMapRenderer();
-				if (mapRenderer != null && (layer == null || !layer.isInMeasurementMode())) {
+				if (mapRenderer != null && e1 != null && (layer == null || !layer.isInMeasurementMode())) {
 					if (!targetChanged) {
-						targetChanged = true;
 						// Remember last target position before it is changed with map gesture
 						PointI targetPixelPosition = mapRenderer.getTargetScreenPosition();
+						if (!findFirstTouchMapLocation(e1.getX(), e1.getY())) {
+							// The touched map location can not be resolved, so it can not be used as
+							// a gesture anchor: setMapTarget() would keep failing for the whole gesture
+							// and the map would stay frozen until the finger is lifted. Drag the map
+							// the plain way instead, and retry anchoring on the next scroll event.
+							dragToAnimate(e2.getX() + distanceX, e2.getY() + distanceY, e2.getX(), e2.getY(), true);
+							return true;
+						}
+						targetChanged = true;
 						targetPixelX = targetPixelPosition.getX();
 						targetPixelY = targetPixelPosition.getY();
-						findFirstTouchMapLocation(e1.getX(), e1.getY());
 						rotate = MapUtils.unifyRotationTo360(-mapRenderer.getAzimuth());
 					}
 					scrollDistanceX = distanceX;
 					scrollDistanceY = distanceY;
 					PointI touchPoint = new PointI((int) (e2.getX() + scrollDistanceX), (int) (e2.getY() + scrollDistanceY));
-					mapRenderer.setMapTarget(touchPoint, new PointI(firstTouchLocationX, firstTouchLocationY));
+					if (!mapRenderer.setMapTarget(touchPoint, new PointI(firstTouchLocationX, firstTouchLocationY))
+							&& findFirstTouchMapLocation(touchPoint.getX(), touchPoint.getY())) {
+						// The anchor location can not be moved to the touch point anymore. Re-anchor to
+						// whatever is under the touch point now (this does not move the map by itself)
+						// so that the rest of the gesture keeps following the finger.
+						mapRenderer.setMapTarget(touchPoint, new PointI(firstTouchLocationX, firstTouchLocationY));
+					}
 					LatLon latLon = NativeUtilities.getLatLonFromElevatedPixel(mapRenderer, currentViewport, targetPixelX, targetPixelY);
 					currentViewport.setLatLonCenter(latLon.getLatitude(), latLon.getLongitude());
 					refreshMap();


### PR DESCRIPTION
Fixes #25736

## Symptom

Occasionally (~1 in 10–20 attempts) a pan gesture is completely ignored: the map stays absolutely stationary for as long as the finger is down, and the next gesture works again. Reported after tapping *My Position* and waiting 1–5 s, and reproducible right after bringing the app back to the foreground.

That shape — dead for a whole gesture, fine on the next one — points at state that is latched at `ACTION_DOWN` and only re-evaluated on the next one.

## Cause

`MapTileViewOnGestureListener.onScroll()` anchors the touched map location **once per gesture** (`if (!targetChanged)`) and then pins that anchor to the moving touch point via `mapRenderer.setMapTarget()`. Both steps could fail silently:

* `AtlasMapRenderer_OpenGL::getLocationFromElevatedPoint()` returns without touching `location31` when the hit test fails (`getRequiredInternalState()` cannot refresh — e.g. a not yet sized viewport — or the point misses the surface). It reports the failure only through the returned elevation (`_invalidElevationValue`, i.e. `NativeUtilities.MIN_ALTITUDE_VALUE`). `findFirstTouchMapLocation()` used that value only to reset the height and took the location as valid, so the anchor silently became the current map target.
* With such an anchor, `MapRenderer::setMapTarget()` gets `target31 == (-1, -1)` from `getNewTargetAndZoom()` and returns `false`. That return value was discarded.

Because the anchor is captured once and `targetChanged` is latched immediately, one failure froze the map for the entire gesture. Lifting the finger re-anchors, which is why the next attempt works.

This is consistent with all the conditions in the report: it needs location updates to be running (the renderer state is only mutated concurrently while a location animation is in flight), it appears a few seconds after re-centering (once the initial "back to my location" animation has ended and continuous per-fix animation has begun), it is racy and rare, and the same failure mode occurs through the zero-viewport path right after returning to the foreground.

## Changes

* `findFirstTouchMapLocation()` / `findSecondTouchMapLocation()` now return whether the hit test actually succeeded. Field assignment is unchanged, so multi-touch behaviour is untouched.
* `onScroll()` no longer latches an unresolved anchor — it falls back to plain `dragToAnimate()` for that event and retries anchoring on the next one — and it now checks the result of `setMapTarget()`, re-anchoring at `touchPoint` (a movement-neutral operation) so that a mid-gesture failure cannot freeze the rest of the drag.
* `onScroll()` guards against a null `e1`; `GestureDetector` may pass one on recent Android versions and `e1.getX()` would NPE.
* `DoubleTapScaleDetector` now resets on `ACTION_CANCEL`. It previously cleared `mIsInZoomMode` / `mIsDoubleTapping` only on `ACTION_UP`, so a cancelled gesture left them latched, and `OsmandMapTileView.onTouchEvent()` then skipped both the gesture detector and all layer touch handling for the whole next gesture — the same symptom, from an independent cause. This likely explains the "in rare cases it even takes 3 attempts" part of the report.

## Notes

* Since the issue is not reproducible on demand, this makes the failure recoverable rather than removing the underlying race. To confirm the diagnosis on a device, add `LOG.warn(...)` in the new fallback branch in `onScroll()` and check whether it fires exactly when the map freezes.
* Worth a separate look: `MapRenderer::getFreshState()` is a destructive read of `_requestedState.isChanged`, so `getRequiredInternalState()` can pair a cached internal state with a newer `MapRendererState`. Every UI-thread hit test is exposed to that mismatch while an animation is running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
