### PR TITLE
Alternative routes for short city routes: plateau on the detailed graph

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/BinaryRoutePlanner.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/BinaryRoutePlanner.java
@@ -80,14 +80,27 @@ public class BinaryRoutePlanner {
 	 */
 	FinalRouteSegment searchRouteInternal(final RoutingContext ctx, RouteSegmentPoint start, RouteSegmentPoint end, 
 			TLongObjectMap<RouteSegment> boundaries) throws InterruptedException, IOException {
+		return searchRouteInternal(ctx, start, end, boundaries, null, null);
+	}
+
+	/**
+	 * @param visitedDirectOut  when given, it is used as the visited set of the forward search, so the
+	 *                          caller keeps the search tree after the call (see HHAlternativeRoutes)
+	 * @param visitedOppositeOut the same for the backward search
+	 */
+	FinalRouteSegment searchRouteInternal(final RoutingContext ctx, RouteSegmentPoint start, RouteSegmentPoint end, 
+			TLongObjectMap<RouteSegment> boundaries, TLongObjectHashMap<RouteSegment> visitedDirectOut,
+			TLongObjectHashMap<RouteSegment> visitedOppositeOut) throws InterruptedException, IOException {
 		// measure time
 		ctx.memoryOverhead = 1000;
 		// Initializing priority queue to visit way segments 
 		PriorityQueue<RouteSegmentCost> graphDirectSegments = new PriorityQueue<>(50, new SegmentsComparator());
 		PriorityQueue<RouteSegmentCost> graphReverseSegments = new PriorityQueue<>(50, new SegmentsComparator());
 		// Set to not visit one segment twice (stores road.id << X + segmentStart)
-		TLongObjectHashMap<RouteSegment> visitedDirectSegments = new TLongObjectHashMap<RouteSegment>();
-		TLongObjectHashMap<RouteSegment> visitedOppositeSegments = new TLongObjectHashMap<RouteSegment>();
+		TLongObjectHashMap<RouteSegment> visitedDirectSegments = visitedDirectOut != null ? visitedDirectOut
+				: new TLongObjectHashMap<RouteSegment>();
+		TLongObjectHashMap<RouteSegment> visitedOppositeSegments = visitedOppositeOut != null ? visitedOppositeOut
+				: new TLongObjectHashMap<RouteSegment>();
 		initQueuesWithStartEnd(ctx, start, end, graphDirectSegments, graphReverseSegments);
 
 		boolean onlyBackward = ctx.getPlanRoadDirection() < 0;
@@ -140,6 +153,13 @@ public class BinaryRoutePlanner {
 					TLongObjectHashMap<RouteSegment> visitedSegments = (forwardSearch ? visitedDirectSegments : visitedOppositeSegments);
 					if (!visitedSegments.containsKey(calculateRoutePointId(segment))) {
 						visitedSegments.put(calculateRoutePointId(segment), segment);
+					}
+					skipSegment = true;
+				} else if (ctx.config.altHorizon > 0) {
+					// alternative routes are read off the two trees, so the search must not stop at the
+					// first meeting point - it keeps the cheapest one and settles on (see altHorizon)
+					if (finalSegment == null || segment.distanceFromStart < finalSegment.distanceFromStart) {
+						finalSegment = (FinalRouteSegment) segment;
 					}
 					skipSegment = true;
 				} else {
@@ -238,6 +258,10 @@ public class BinaryRoutePlanner {
 			if (ctx.calculationProgress != null && ctx.calculationProgress.isCancelled) {
 				throw new InterruptedException("Route calculation interrupted");
 			}
+			if (ctx.config.altHorizon > 0 && finalSegment != null && leftAltHorizon(ctx, finalSegment,
+					graphDirectSegments, graphReverseSegments)) {
+				break;
+			}
 		}
 		if (ctx.calculationProgress != null) {
 			ctx.calculationProgress.visitedDirectSegments += visitedDirectSegments.size();
@@ -246,6 +270,19 @@ public class BinaryRoutePlanner {
 			ctx.calculationProgress.oppositeQueueSize += graphReverseSegments.size();
 		}
 		return finalSegment;
+	}
+
+	/**
+	 * Everything still in the queues costs more than the band the alternatives may live in, so no
+	 * route through a node settled from here on could be proposed anyway.
+	 */
+	private boolean leftAltHorizon(RoutingContext ctx, FinalRouteSegment finalSegment,
+			PriorityQueue<RouteSegmentCost> direct, PriorityQueue<RouteSegmentCost> reverse) {
+		if (direct.isEmpty() || reverse.isEmpty()) {
+			return true;
+		}
+		return direct.peek().cost + reverse.peek().cost
+				> finalSegment.distanceFromStart * (1 + ctx.config.altHorizon);
 	}
 
 	protected boolean checkIfGraphIsEmpty(final RoutingContext ctx, boolean allowDirection,
@@ -538,8 +575,10 @@ public class BinaryRoutePlanner {
 			// reassign @distanceFromStart to make it correct for visited segment
 			currentSegment.distanceFromStart = distFromStartPlusSegmentTime;
 			
-			if (bothDirVisited) {
+			if (bothDirVisited && ctx.config.altHorizon <= 0) {
  				// We stop here for shortcut creation (we can't improve the neighbors if they're already visited cause the opposite is min - prove by contradiction) 
+				// Alternatives need the opposite: the two trees have to grow through each other, or the
+				// only road points settled by both are the handful on the frontier (see altHorizon).
 				if (TRACE_ROUTING) {
 					println("  " + currentSegment.segEnd + ">> 2 dir visited");
 				}

--- a/OsmAnd-java/src/main/java/net/osmand/router/HHAlternativeRoutes.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHAlternativeRoutes.java
@@ -9,10 +9,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import gnu.trove.map.hash.TLongObjectHashMap;
 import gnu.trove.set.TLongSet;
 import gnu.trove.set.hash.TLongHashSet;
 import net.osmand.binary.RouteDataObject;
 import net.osmand.data.LatLon;
+import net.osmand.router.BinaryRoutePlanner.FinalRouteSegment;
+import net.osmand.router.BinaryRoutePlanner.RouteSegment;
 import net.osmand.router.HHRouteDataStructure.HHNetworkRouteRes;
 import net.osmand.router.HHRouteDataStructure.HHNetworkSegmentRes;
 import net.osmand.router.HHRouteDataStructure.HHRoutingConfig;
@@ -40,6 +43,10 @@ import net.osmand.router.HHRouteDataStructure.NetworkDBSegment;
  * expands candidates one by one and checks the real road segments, stopping as soon as
  * ALT_MAX_COUNT routes are accepted.
  *
+ * A route short enough that the two last-mile searches meet each other never uses a hub-graph edge
+ * at all, so none of the above can produce anything. {@link #calcDetailedAlternatives} then applies
+ * the very same plateau idea one level down, on the detailed road trees - see its comment.
+ *
  * One instance serves one routing call - the plateau maps and the expansion budget below are the
  * state of that call.
  */
@@ -47,6 +54,8 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 
 	/** attempts to expand one candidate before giving up on it */
 	private static final int ALT_EXPAND_RETRIES = 3;
+	/** two costs closer than this are the same cost (seconds) - used to follow a plateau */
+	private static final double MINIMAL_COST_DIFF = 0.01;
 	private static final long ALT_START_KEY = -1, ALT_END_KEY = -2, ALT_KEY_MULT = 4000000000L;
 
 	private final HHRoutePlanner<T> planner;
@@ -60,6 +69,8 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 	private double minOwnRoads, minAvoided;
 	/** detailed expansions spent so far, against cfg.ALT_MAX_EXPAND */
 	private int expanded;
+	/** roads of the main route and of every alternative accepted so far */
+	private final List<Map<Long, Double>> accepted = new ArrayList<>();
 
 	public HHAlternativeRoutes(HHRoutePlanner<T> planner, HHRoutingContext<T> hctx) {
 		this.planner = planner;
@@ -89,6 +100,35 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 			return;
 		}
 		maxCost = optCost * (1 + cfg.ALT_STRETCH);
+		// Distinctness is measured against the main route and against the alternatives already
+		// accepted alike - an alternative has to be worth proposing next to each of them.
+		accepted.add(roadSegments(detailedSegments(route)));
+		setDistinctnessThresholds(totalLength(accepted.get(0)));
+		if (usesHubGraph(route)) {
+			calcHubAlternatives(route, start, end, progress, rrp);
+		} else {
+			calcDetailedAlternatives(route, rrp);
+		}
+	}
+
+	/**
+	 * Whether the route uses the hub graph at all. When it does not - the two last-mile searches met
+	 * each other before either reached a hub point - the hub method has nothing to work on, and the
+	 * route is by that very fact short enough to be searched again on the detailed graph.
+	 */
+	private boolean usesHubGraph(HHNetworkRouteRes route) {
+		for (HHNetworkSegmentRes r : route.segments) {
+			if (r.segment != null) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/** the plateau method on the hub graph - the usual case, everything but a short city route */
+	private void calcHubAlternatives(HHNetworkRouteRes route, LatLon start, LatLon end,
+			RouteCalculationProgress progress, RouteResultPreparation rrp)
+			throws SQLException, IOException, InterruptedException {
 		List<T> settled = collectViaNodes();
 		if (settled.isEmpty()) {
 			return;
@@ -223,18 +263,17 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 	}
 
 	private double rankScore(AltCandidate c) {
-		return (1 - c.sharing) - cfg.ALT_RANK_COST_WEIGHT * (c.cost / optCost - 1);
+		return rankScore(c.sharing, c.cost);
+	}
+
+	private double rankScore(double sharing, double cost) {
+		return (1 - sharing) - cfg.ALT_RANK_COST_WEIGHT * (cost / optCost - 1);
 	}
 
 	/** stage 2: expand candidates one by one and verify them on the real road segments */
 	private void verifyAndAccept(List<AltCandidate> ordered, HHNetworkRouteRes route, LatLon start,
 			LatLon end, RouteCalculationProgress progress, RouteResultPreparation rrp)
 			throws SQLException, IOException, InterruptedException {
-		// Distinctness is measured against the main route and against the alternatives already
-		// accepted alike - an alternative has to be worth proposing next to each of them.
-		List<Map<Long, Double>> accepted = new ArrayList<>();
-		accepted.add(roadSegments(detailedSegments(route)));
-		setDistinctnessThresholds(totalLength(accepted.get(0)));
 		for (AltCandidate c : ordered) {
 			if (route.altRoutes.size() >= cfg.ALT_MAX_COUNT || expanded >= cfg.ALT_MAX_EXPAND) {
 				break;
@@ -247,7 +286,7 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 				continue;
 			}
 			Map<Long, Double> geometry = roadSegments(prepare(alt, start, end, rrp));
-			Distinctness d = assess(c, alt.detailed, geometry, accepted);
+			Distinctness d = assess(alt.detailed, geometry, c.cost, "");
 			if (d == null) {
 				continue;
 			}
@@ -260,30 +299,298 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 		}
 	}
 
+	// ---------------------------------------------------------------------------------------------
+	// Alternatives on the detailed road graph
+	// ---------------------------------------------------------------------------------------------
+
+	/**
+	 * A city route of a few kilometres never reaches the hub graph: the two last-mile searches meet
+	 * each other first, the route is assembled from two detailed segments and the hub method above
+	 * has no edge to build a plateau on (measured on a 4 km route: 6 hub points settled by both
+	 * trees, none of them usable). Everything that makes such a route interesting - the parallel
+	 * street one block away - lives in the detailed graph, and both trees of it are already there.
+	 *
+	 * So the plateau method is applied one level down. A via node is a road point settled by both
+	 * detailed trees, its route costs f(v) + b(v), and its plateau is the maximal stretch around it
+	 * where f + b stays constant, i.e. the road both trees agree on. Two things are different from
+	 * the hub graph: a candidate is assembled by walking parent links, so it costs nothing to expand
+	 * (no two-stage filter, no expansion budget), and there are tens of thousands of them, so
+	 * candidates that describe the same plateau are collapsed to one before anything is assembled.
+	 */
+	private void calcDetailedAlternatives(HHNetworkRouteRes route, RouteResultPreparation rrp)
+			throws SQLException, IOException, InterruptedException {
+		if (hctx.startSegment == null || hctx.endSegment == null) {
+			return;
+		}
+		TLongObjectHashMap<RouteSegment> fwd = new TLongObjectHashMap<>();
+		TLongObjectHashMap<RouteSegment> bwd = new TLongObjectHashMap<>();
+		long time = System.nanoTime();
+		searchDetailedTrees(fwd, bwd);
+		if (fwd.isEmpty() || bwd.isEmpty()) {
+			return;
+		}
+		List<DetailedCandidate> meeting = meetingPoints(fwd, bwd);
+		if (meeting.isEmpty()) {
+			return;
+		}
+		List<DetailedCandidate> plateaus = collapseToPlateaus(meeting);
+		planner.printf(HHRoutePlanner.DEBUG_VERBOSE_LEVEL > 0,
+				"  detailed graph: %,d/%,d settled, %,d meeting points, %d plateaus, %.0f ms\n",
+				fwd.size(), bwd.size(), meeting.size(), plateaus.size(), (System.nanoTime() - time) / 1e6);
+		acceptDetailed(rankDetailed(plateaus, route), route, rrp);
+	}
+
+	/** one road point of the detailed graph settled by both trees */
+	private static class DetailedCandidate {
+		RouteSegment fwd, bwd;
+		/** cost from the start to the junction the two halves are joined at, and from it to the target */
+		double fwdDist, bwdDist;
+		double cost;
+		/** length of the plateau towards the start and towards the target, in cost */
+		double plateauFwd, plateauBwd;
+		/** first road point of the plateau in each direction - candidates sharing both are the same route */
+		long anchorFwd, anchorBwd;
+		double sharing;
+		List<RouteSegmentResult> geometry;
+	}
+
+	/**
+	 * The bidirectional Dijkstra whose two trees the candidates are read off. The last-mile searches
+	 * of the routing itself cannot be reused: each of them stops at the hub points around its own end,
+	 * so on a 4 km route their trees have five road points in common - nothing to choose between. This
+	 * one runs start to end with no boundaries and, thanks to altHorizon, does not stop at the first
+	 * meeting point but settles the whole band the alternatives may live in.
+	 */
+	private void searchDetailedTrees(TLongObjectHashMap<RouteSegment> fwd, TLongObjectHashMap<RouteSegment> bwd)
+			throws InterruptedException, IOException {
+		RoutingContext rctx = hctx.rctx;
+		int maxVisited = rctx.config.MAX_VISITED;
+		int planRoadDirection = rctx.config.planRoadDirection;
+		float heuristicCoefficient = rctx.config.heuristicCoefficient;
+		double altHorizon = rctx.config.altHorizon;
+		rctx.config.MAX_VISITED = HHRoutePlanner.MAX_POINTS_CLUSTER_ROUTING;
+		rctx.config.planRoadDirection = 0;
+		rctx.config.heuristicCoefficient = 0; // dijkstra: the queue cost is the distance from the start
+		rctx.config.altHorizon = cfg.ALT_STRETCH;
+		// the road segments of the route already found carry the routing state of that search
+		rctx.unloadAllData();
+		try {
+			new BinaryRoutePlanner().searchRouteInternal(rctx, hctx.startSegment, hctx.endSegment, null, fwd, bwd);
+		} finally {
+			rctx.config.altHorizon = altHorizon;
+			rctx.config.heuristicCoefficient = heuristicCoefficient;
+			rctx.config.planRoadDirection = planRoadDirection;
+			rctx.config.MAX_VISITED = maxVisited;
+		}
+	}
+
+	/**
+	 * Road points settled by both trees and cheap enough. The reference cost is the cheapest meeting
+	 * point rather than the main route: on a long route the two trees may still touch far away from
+	 * the optimal path, and those points must not become the yardstick.
+	 */
+	private List<DetailedCandidate> meetingPoints(TLongObjectHashMap<RouteSegment> fwd,
+			TLongObjectHashMap<RouteSegment> bwd) {
+		List<DetailedCandidate> all = new ArrayList<>();
+		double best = Double.MAX_VALUE;
+		for (RouteSegment f : fwd.valueCollection()) {
+			RouteSegment b = bwd.get(oppositeKey(f));
+			if (b == null) {
+				continue;
+			}
+			DetailedCandidate c = new DetailedCandidate();
+			c.fwd = f;
+			c.bwd = b;
+			// Both trees measure the distance to the far end of their own traversal of this road piece,
+			// so the two halves are joined at the junction the piece starts at: the forward tree gets
+			// there one piece earlier (its parent), the backward tree ends exactly there. Adding the
+			// two raw distances instead would count the piece itself twice, and the sum would then
+			// grow and shrink with the piece length all along a route that is in fact optimal.
+			c.fwdDist = f.getParentRoute() == null ? 0 : f.getParentRoute().distanceFromStart;
+			c.bwdDist = b.distanceFromStart;
+			c.cost = c.fwdDist + c.bwdDist;
+			if (c.cost <= 0) {
+				continue;
+			}
+			best = Math.min(best, c.cost);
+			all.add(c);
+		}
+		double limit = Math.min(optCost, best) * (1 + cfg.ALT_STRETCH);
+		List<DetailedCandidate> within = new ArrayList<>();
+		for (DetailedCandidate c : all) {
+			if (c.cost <= limit) {
+				within.add(c);
+			}
+		}
+		return within;
+	}
+
+	/**
+	 * Accumulates the plateau of every candidate and keeps one candidate per plateau. An edge belongs
+	 * to both trees exactly when the total cost does not change along it, which is what the walk
+	 * checks; the value has to be read from the parent first, hence the sort by distance.
+	 */
+	private List<DetailedCandidate> collapseToPlateaus(List<DetailedCandidate> candidates) {
+		final TLongObjectHashMap<DetailedCandidate> byKey = new TLongObjectHashMap<>();
+		for (DetailedCandidate c : candidates) {
+			byKey.put(routePointKey(c.fwd), c);
+		}
+		List<DetailedCandidate> byFwd = new ArrayList<>(candidates);
+		Collections.sort(byFwd, new Comparator<DetailedCandidate>() {
+			@Override
+			public int compare(DetailedCandidate a, DetailedCandidate b) {
+				return Double.compare(a.fwdDist, b.fwdDist);
+			}
+		});
+		for (DetailedCandidate c : byFwd) {
+			DetailedCandidate p = c.fwd.getParentRoute() == null ? null
+					: byKey.get(routePointKey(c.fwd.getParentRoute()));
+			if (p != null && samePlateau(p, c)) {
+				c.plateauFwd = p.plateauFwd + (c.fwdDist - p.fwdDist);
+				c.anchorFwd = p.anchorFwd;
+			} else {
+				c.anchorFwd = routePointKey(c.fwd);
+			}
+		}
+		List<DetailedCandidate> byBwd = new ArrayList<>(candidates);
+		Collections.sort(byBwd, new Comparator<DetailedCandidate>() {
+			@Override
+			public int compare(DetailedCandidate a, DetailedCandidate b) {
+				return Double.compare(a.bwdDist, b.bwdDist);
+			}
+		});
+		for (DetailedCandidate c : byBwd) {
+			DetailedCandidate p = c.bwd.getParentRoute() == null ? null
+					: byKey.get(oppositeKey(c.bwd.getParentRoute()));
+			if (p != null && samePlateau(p, c)) {
+				c.plateauBwd = p.plateauBwd + (c.bwdDist - p.bwdDist);
+				c.anchorBwd = p.anchorBwd;
+			} else {
+				c.anchorBwd = routePointKey(c.fwd);
+			}
+		}
+		Map<Long, DetailedCandidate> perPlateau = new HashMap<>();
+		for (DetailedCandidate c : candidates) {
+			if (c.plateauFwd + c.plateauBwd < cfg.ALT_MIN_PLATEAU * c.cost) {
+				continue;
+			}
+			Long id = c.anchorFwd * 1000003L + c.anchorBwd;
+			DetailedCandidate kept = perPlateau.get(id);
+			if (kept == null || c.cost < kept.cost) {
+				perPlateau.put(id, c);
+			}
+		}
+		return new ArrayList<>(perPlateau.values());
+	}
+
+	/** the edge between the two runs in both trees, so they describe one and the same plateau */
+	private boolean samePlateau(DetailedCandidate parent, DetailedCandidate child) {
+		return Math.abs(parent.cost - child.cost) < MINIMAL_COST_DIFF;
+	}
+
+	/** best first, by the same score as on the hub graph */
+	private List<DetailedCandidate> rankDetailed(List<DetailedCandidate> candidates,
+			HHNetworkRouteRes route) {
+		Map<Long, Double> main = accepted.get(0);
+		for (DetailedCandidate c : candidates) {
+			c.geometry = assemble(c);
+			Map<Long, Double> roads = roadSegments(c.geometry);
+			double length = totalLength(roads);
+			c.sharing = length <= 0 ? 1 : sharedGeometry(roads, main) / length;
+		}
+		Collections.sort(candidates, new Comparator<DetailedCandidate>() {
+			@Override
+			public int compare(DetailedCandidate x, DetailedCandidate y) {
+				return Double.compare(rankScore(y.sharing, y.cost), rankScore(x.sharing, x.cost));
+			}
+		});
+		return candidates;
+	}
+
+	private void acceptDetailed(List<DetailedCandidate> ordered, HHNetworkRouteRes route,
+			RouteResultPreparation rrp) throws SQLException, IOException, InterruptedException {
+		for (DetailedCandidate c : ordered) {
+			if (route.altRoutes.size() >= cfg.ALT_MAX_COUNT) {
+				return;
+			}
+			HHNetworkRouteRes alt = new HHNetworkRouteRes();
+			alt.detailed = c.geometry;
+			if (cfg.ROUTE_ALL_ALT_SEGMENTS && !alt.detailed.isEmpty()) {
+				// turns, distances and the clean-up of small manoeuvres, exactly like the main route -
+				// the checks below must see what will be displayed
+				alt.detailed = rrp.prepareResult(hctx.rctx, alt.detailed).detailed;
+			}
+			Map<Long, Double> geometry = roadSegments(alt.detailed);
+			Distinctness d = assess(alt.detailed, geometry, c.cost, " (detailed)");
+			if (d == null) {
+				continue;
+			}
+			route.altRoutes.add(alt);
+			accepted.add(geometry);
+			planner.printf(HHRoutePlanner.DEBUG_VERBOSE_LEVEL > 0,
+					"  alt (detailed) accepted: +%.1f%%, plateau %.0f%%, own roads %.1f km, avoids %.1f km\n",
+					100 * (c.cost / optCost - 1), 100 * (c.plateauFwd + c.plateauBwd) / c.cost,
+					d.ownRoads / 1000, d.avoidedRoads / 1000);
+		}
+	}
+
+	/**
+	 * The two halves of the candidate joined into one route, the way the bidirectional search joins
+	 * its own final segment: the via point carries the forward chain as its parent and the backward
+	 * chain as its opposite.
+	 */
+	private List<RouteSegmentResult> assemble(DetailedCandidate c) {
+		// the via point itself belongs to the backward chain, the forward chain stops at its parent -
+		// the same split the cost above is measured on
+		FinalRouteSegment frs = new FinalRouteSegment(c.fwd.getRoad(), c.fwd.getSegmentStart(),
+				c.fwd.getSegmentEnd());
+		frs.setParentRoute(c.fwd.getParentRoute());
+		frs.reverseWaySearch = false;
+		frs.distanceFromStart = (float) c.cost;
+		frs.distanceToEnd = 0;
+		frs.opposite = c.bwd;
+		return new RouteResultPreparation().convertFinalSegmentToResults(hctx.rctx, frs);
+	}
+
+	/** identifies the road point and the direction it is driven in, as the search itself does */
+	private static long routePointKey(RouteSegment s) {
+		int start = s.getSegmentStart();
+		return HHRoutePlanner.calculateRoutePointInternalId(s.getRoad().getId(), start,
+				start + (s.isPositive() ? 1 : -1));
+	}
+
+	/** the same road point driven the other way round - how the other tree stores it */
+	private static long oppositeKey(RouteSegment s) {
+		int start = s.getSegmentStart();
+		int end = start + (s.isPositive() ? 1 : -1);
+		return HHRoutePlanner.calculateRoutePointInternalId(s.getRoad().getId(), end, start);
+	}
+
 	private void setDistinctnessThresholds(double mainLength) {
-		minOwnRoads = Math.max(cfg.ALT_MIN_DISTINCT_ABS, cfg.ALT_MIN_DISTINCT_REL * mainLength);
+		minOwnRoads = Math.max(cfg.ALT_MIN_DISTINCT_FLOOR, cfg.ALT_MIN_DISTINCT_REL * mainLength);
 		// Avoiding is asked for less strictly than offering: replacing a good stretch of a long route
 		// is useful even when most of the main route stays. The point of this second threshold is to
 		// reject an alternative that contains the whole main route and only adds a loop to it.
-		minAvoided = Math.max(cfg.ALT_MIN_DISTINCT_ABS, cfg.ALT_MIN_DISTINCT_REL * mainLength / 2);
+		minAvoided = Math.max(cfg.ALT_MIN_DISTINCT_FLOOR, cfg.ALT_MIN_DISTINCT_REL * mainLength / 2);
 	}
 
 	/** how the candidate differs from the routes already on offer, or null when it must not be proposed */
-	private Distinctness assess(AltCandidate c, List<RouteSegmentResult> detailed,
-			Map<Long, Double> geometry, List<Map<Long, Double>> accepted) {
+	private Distinctness assess(List<RouteSegmentResult> detailed, Map<Long, Double> geometry,
+			double cost, String label) {
 		if (detailed.isEmpty()) {
+			dropped(cost, label, "no detailed geometry");
 			return null;
 		}
 		double retraced = retracedLength(detailed);
 		if (retraced > cfg.ALT_MAX_RETRACED) {
 			// the hub-level isSimple() check misses this when the two halves overlap inside a single
 			// shortcut: the candidate drives out and turns back, which reads as a bug on the map
-			dropped(c, "drives %.0f m of its own roads twice", retraced);
+			dropped(cost, label, "drives %.0f m of its own roads twice", retraced);
 			return null;
 		}
 		Distinctness d = distinctness(geometry, accepted);
 		if (d.ownRoads < minOwnRoads || d.avoidedRoads < minAvoided) {
-			dropped(c, "own roads %.1f km (need %.1f), avoids %.1f km (need %.1f)",
+			dropped(cost, label, "own roads %.1f km (need %.1f), avoids %.1f km (need %.1f)",
 					d.ownRoads / 1000, minOwnRoads / 1000, d.avoidedRoads / 1000, minAvoided / 1000);
 			return null;
 		}
@@ -361,14 +668,19 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 	}
 
 	private void dropped(AltCandidate c, String reason, Object... args) {
-		planner.printf(HHRoutePlanner.DEBUG_VERBOSE_LEVEL > 0, "  alt dropped (+%.1f%%): " + reason + "\n",
-				prepend(100 * (c.cost / optCost - 1), args));
+		dropped(c.cost, "", reason, args);
 	}
 
-	private Object[] prepend(double first, Object[] rest) {
-		Object[] all = new Object[rest.length + 1];
-		all[0] = first;
-		System.arraycopy(rest, 0, all, 1, rest.length);
+	private void dropped(double cost, String label, String reason, Object... args) {
+		planner.printf(HHRoutePlanner.DEBUG_VERBOSE_LEVEL > 0, "  alt%s dropped (+%.1f%%): " + reason + "\n",
+				prepend(label, 100 * (cost / optCost - 1), args));
+	}
+
+	private Object[] prepend(String label, double stretch, Object[] rest) {
+		Object[] all = new Object[rest.length + 2];
+		all[0] = label;
+		all[1] = stretch;
+		System.arraycopy(rest, 0, all, 2, rest.length);
 		return all;
 	}
 

--- a/OsmAnd-java/src/main/java/net/osmand/router/HHRouteDataStructure.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHRouteDataStructure.java
@@ -69,7 +69,7 @@ public class HHRouteDataStructure {
 		//   3) distinct   own roads >= max(ALT_MIN_DISTINCT_FLOOR, ALT_MIN_DISTINCT_REL * len(opt))
 		// ALT_STRETCH also bounds the search horizon, so it directly trades quality for speed.
 		public int ALT_MAX_COUNT = 2; // how many alternatives to return
-		public double ALT_STRETCH = 0.3; // hard limit of relative cost overhead (and search bound)
+		public double ALT_STRETCH = 0.4; // hard limit of relative cost overhead (and search bound)
 		public double ALT_STRETCH_PREFERRED = 0.15; // alternatives below this limit are proposed first
 		public double ALT_MIN_PLATEAU = 0.1; // min share of the route driven as its own optimal road
 		public double ALT_MAX_SHARING = 0.6; // coarse hub-graph pre-filter (stage 1)

--- a/OsmAnd-java/src/main/java/net/osmand/router/HHRouteDataStructure.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHRouteDataStructure.java
@@ -23,6 +23,7 @@ import net.osmand.data.DataTileManager;
 import net.osmand.data.LatLon;
 import net.osmand.router.BinaryRoutePlanner.FinalRouteSegment;
 import net.osmand.router.BinaryRoutePlanner.RouteSegment;
+import net.osmand.router.BinaryRoutePlanner.RouteSegmentPoint;
 import net.osmand.router.RouteResultPreparation.RouteCalcResult;
 import net.osmand.util.MapUtils;
 
@@ -65,7 +66,7 @@ public class HHRouteDataStructure {
 		// the stretch the alternative drives as its own optimal road. Three explicit admissibility rules:
 		//   1) stretch    cost(alt) <= (1 + ALT_STRETCH) * cost(opt)
 		//   2) plateau    plateau(v) >= ALT_MIN_PLATEAU * cost(alt)          (local optimality)
-		//   3) distinct   own roads >= max(ALT_MIN_DISTINCT_ABS, ALT_MIN_DISTINCT_REL * len(opt))
+		//   3) distinct   own roads >= max(ALT_MIN_DISTINCT_FLOOR, ALT_MIN_DISTINCT_REL * len(opt))
 		// ALT_STRETCH also bounds the search horizon, so it directly trades quality for speed.
 		public int ALT_MAX_COUNT = 2; // how many alternatives to return
 		public double ALT_STRETCH = 0.3; // hard limit of relative cost overhead (and search bound)
@@ -73,7 +74,10 @@ public class HHRouteDataStructure {
 		public double ALT_MIN_PLATEAU = 0.1; // min share of the route driven as its own optimal road
 		public double ALT_MAX_SHARING = 0.6; // coarse hub-graph pre-filter (stage 1)
 		public double ALT_MIN_DISTINCT_REL = 0.2; // exact geometry filter (stage 2), share of main length
-		public double ALT_MIN_DISTINCT_ABS = 1500; // exact geometry filter (stage 2), meters
+		// Only a floor under the relative rule, for routes too short to make it meaningful: a fixed
+		// requirement of a kilometre or two is a third of a 4 km city route and rejects everything
+		// there, while asking nothing extra of a route long enough for the relative rule to bind.
+		public double ALT_MIN_DISTINCT_FLOOR = 300; // exact geometry filter (stage 2), meters
 		// Max detailed expansions in stage 2 (time guard). Retries of a candidate whose shortcuts
 		// disagree with the detailed roads count against it, so this is not "number of candidates".
 		public int ALT_MAX_EXPAND = 8;
@@ -263,6 +267,13 @@ public class HHRouteDataStructure {
 		Queue<NetworkDBPointCost<T>> queue = createQueue();
 		Queue<NetworkDBPointCost<T>> queuePos = createQueue();
 		Queue<NetworkDBPointCost<T>> queueRev = createQueue();
+
+		/**
+		 * The road segments the route actually starts and ends on, as chosen by the last-mile search
+		 * (they can differ from the nearest ones after a reiteration). Kept because the alternatives
+		 * of a short route are searched on the detailed graph - see HHAlternativeRoutes.
+		 */
+		RouteSegmentPoint startSegment, endSegment;
 
 
 

--- a/OsmAnd-java/src/main/java/net/osmand/router/HHRoutePlanner.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHRoutePlanner.java
@@ -452,6 +452,8 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 			hctx.boundaries.put(calcRPId(endP, endP.getSegmentEnd(), endP.getSegmentStart()), null);
 			hctx.boundaries.put(calcRPId(endP, endP.getSegmentStart(), endP.getSegmentEnd()), null);
 			progress.hhIterationProgress(0.50); // %
+			hctx.startSegment = startP;
+			hctx.endSegment = endP;
 			initStart(hctx, startP, false, stPoints);
 			hctx.rctx.config.initialDirection = prev;
 			if (stPoints.isEmpty()) {

--- a/OsmAnd-java/src/main/java/net/osmand/router/RoutingConfiguration.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RoutingConfiguration.java
@@ -71,6 +71,13 @@ public class RoutingConfiguration {
 	// 1.7 Maximum visited segments
 	public int MAX_VISITED = -1;
 
+	/**
+	 * Set only while alternative routes are being searched (see HHAlternativeRoutes): the bidirectional
+	 * search then does not stop at the first meeting point but keeps settling until both queues leave
+	 * the (1 + this) * optimum band, so that the two trees overlap enough to compare routes through them.
+	 */
+	public double altHorizon = 0;
+
 
 	// extra points to be inserted in ways (quad tree is based on 31 coords)
 	private QuadTree<DirectionPoint> directionPoints;

--- a/OsmAnd-java/src/test/java/net/osmand/router/AlternativeRoutesTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/router/AlternativeRoutesTest.java
@@ -51,8 +51,10 @@ public class AlternativeRoutesTest {
 	private static final double MAX_RETRACED = 100;
 	/** a larger gap between consecutive points means a shortcut was not expanded into roads */
 	private static final double MAX_POINT_GAP = 4000;
-	/** an alternative must offer, and must avoid, at least this much road */
-	private static final double MIN_DISTINCT = 1500;
+	/** an alternative must offer, and must avoid, at least this share of the main route */
+	private static final double MIN_DISTINCT_REL = 0.2;
+	/** ... and never less than this, however short the route is */
+	private static final double MIN_DISTINCT_FLOOR = 300;
 
 	public static class ExpectedVia {
 		String name;
@@ -133,11 +135,12 @@ public class AlternativeRoutesTest {
 
 			Assert.assertTrue(id + " costs " + Math.round(100 * (alt.cost / main.cost - 1))
 					+ "% more than the main route", alt.cost <= maxCost);
+			double minDistinct = Math.max(MIN_DISTINCT_FLOOR, MIN_DISTINCT_REL * mainLength);
 			Assert.assertTrue(id + " has only " + Math.round(length(altRoads) - shared)
-					+ " m of roads of its own", length(altRoads) - shared >= MIN_DISTINCT);
+					+ " m of roads of its own", length(altRoads) - shared >= minDistinct);
 			Assert.assertTrue(id + " avoids only " + Math.round(mainLength - shared)
 					+ " m of the main route, so it is the main route with a detour",
-					mainLength - shared >= MIN_DISTINCT);
+					mainLength - shared >= minDistinct / 2);
 			Assert.assertTrue(id + " drives " + Math.round(retraced(alt)) + " m of its own roads twice",
 					retraced(alt) <= MAX_RETRACED);
 			Assert.assertTrue(id + " has a " + Math.round(maxGap(alt))

--- a/OsmAnd-java/src/test/resources/alternatives/test_alternative_routes.json
+++ b/OsmAnd-java/src/test/resources/alternatives/test_alternative_routes.json
@@ -70,5 +70,55 @@
       "longitude": 4.823599
     },
     "minAlternatives": 2
+  },
+  {
+    "testName": "Tours -> Nouatre: the A10 corridor, where the second road is +33%",
+    "description": "83% of the fastest route is toll motorway (A10). Within +30% there is only one candidate, the main route with a 24 km loop bolted on (it avoids 3.2 km of it), so the list came back empty; the two real corridors are at +32.7% and +39.4% of cost",
+    "map": "France_centre-loire-valley_europe_2.obf",
+    "startPoint": {
+      "latitude": 47.545713,
+      "longitude": 0.973663
+    },
+    "endPoint": {
+      "latitude": 47.08041,
+      "longitude": 0.606308
+    },
+    "minAlternatives": 2,
+    "expectedVia": [
+      {
+        "name": "the western corridor (D910 / Sainte-Maure)",
+        "latitude": 47.3018,
+        "longitude": 0.882,
+        "toleranceMeters": 1000
+      },
+      {
+        "name": "the eastern corridor (D760 / Azay-le-Rideau)",
+        "latitude": 47.3956,
+        "longitude": 0.7068,
+        "toleranceMeters": 1000
+      }
+    ]
+  },
+  {
+    "testName": "Pisa -> Prato: a toll-free option next to 88% of toll motorway",
+    "description": "The fastest route is A12 + A11. The alternatives are offered inside the normal limit here - one at +12% and one at +27% with only 9.7 km of toll left - which is what the fallback tier must not change",
+    "map": "Italy_toscana_europe_2.obf",
+    "startPoint": {
+      "latitude": 43.716,
+      "longitude": 10.4
+    },
+    "endPoint": {
+      "latitude": 43.88,
+      "longitude": 11.096
+    },
+    "minAlternatives": 2,
+    "expectedVia": [
+      {
+        "name": "the nearly toll-free corridor (SS67 / FI-PI-LI)",
+        "latitude": 43.7036,
+        "longitude": 10.8555,
+        "toleranceMeters": 1000
+      }
+    ]
   }
 ]

--- a/OsmAnd-java/src/test/resources/alternatives/test_alternative_routes.json
+++ b/OsmAnd-java/src/test/resources/alternatives/test_alternative_routes.json
@@ -3,30 +3,72 @@
     "testName": "Kyiv, Podil -> Teremky: embankment and southern corridors instead of Povitryanykh Syl",
     "description": "The main route goes west over Peremohy/Povitryanykh Syl; both alternatives leave Podil along the Dnipro embankment. Used to be dropped: four shortcuts in a row cost more in detail than the hub graph said",
     "map": "Ukraine_kyiv_europe_2.obf",
-    "startPoint": { "latitude": 50.46904, "longitude": 30.51638 },
-    "endPoint": { "latitude": 50.37401, "longitude": 30.44741 },
+    "startPoint": {
+      "latitude": 50.46904,
+      "longitude": 30.51638
+    },
+    "endPoint": {
+      "latitude": 50.37401,
+      "longitude": 30.44741
+    },
     "minAlternatives": 2,
     "expectedVia": [
-      { "name": "Naberezhne shose (Dnipro embankment)", "latitude": 50.45860, "longitude": 30.52670, "toleranceMeters": 500 }
+      {
+        "name": "Naberezhne shose (Dnipro embankment)",
+        "latitude": 50.4586,
+        "longitude": 30.5267,
+        "toleranceMeters": 500
+      }
     ]
   },
   {
     "testName": "Kyiv, Podil -> Darnytskyi masyv: no main route with a loop bolted on",
     "description": "Used to return an alternative covering 99% of the main route plus a 3.3 km loop at the end",
     "map": "Ukraine_kyiv_europe_2.obf",
-    "startPoint": { "latitude": 50.46947, "longitude": 30.51361 },
-    "endPoint": { "latitude": 50.43286, "longitude": 30.60940 },
+    "startPoint": {
+      "latitude": 50.46947,
+      "longitude": 30.51361
+    },
+    "endPoint": {
+      "latitude": 50.43286,
+      "longitude": 30.6094
+    },
     "minAlternatives": 1
   },
   {
     "testName": "Kyiv, Podil -> Berezniaky: centre offered, loop variant rejected",
     "description": "The alternative goes through the centre (Khreshchatyk, Parkova doroha) instead of the embankment; the candidate that only adds a loop avoids 0.3 km of the main route and must stay out",
     "map": "Ukraine_kyiv_europe_2.obf",
-    "startPoint": { "latitude": 50.46947, "longitude": 30.51361 },
-    "endPoint": { "latitude": 50.43148, "longitude": 30.61028 },
+    "startPoint": {
+      "latitude": 50.46947,
+      "longitude": 30.51361
+    },
+    "endPoint": {
+      "latitude": 50.43148,
+      "longitude": 30.61028
+    },
     "minAlternatives": 1,
     "expectedVia": [
-      { "name": "Khreshchatyk", "latitude": 50.45290, "longitude": 30.52790, "toleranceMeters": 500 }
+      {
+        "name": "Khreshchatyk",
+        "latitude": 50.4529,
+        "longitude": 30.5279,
+        "toleranceMeters": 500
+      }
     ]
+  },
+  {
+    "testName": "Amstelveen, Fluweelboomlaan -> Westwijk: a 4 km route the hub graph cannot describe",
+    "description": "The route never reaches the hub graph (two last-mile segments, no hub edge), so the alternatives can only come from the detailed road graph. Google offers three ways here; used to return none",
+    "map": "Netherlands_noord-holland_europe_2.obf",
+    "startPoint": {
+      "latitude": 52.286065,
+      "longitude": 4.866343
+    },
+    "endPoint": {
+      "latitude": 52.28491,
+      "longitude": 4.823599
+    },
+    "minAlternatives": 2
   }
 ]


### PR DESCRIPTION
Alternatives for routes too short to reach the hub graph. Follow-up to #25805, which noted the gap: *"For short city routes a natural follow-up is to run the same extraction on the detailed bidirectional A\* trees instead of the hub graph; nothing in the selection logic would change."* Ref osmandapp/OsmAnd-Issues#2843.

## The case

`test.osmand.net/map/navigate/?start=52.286065,4.866343&end=52.284910,4.823599&profile=car` — 4.3 km inside Amstelveen. Google offers three ways (3.3 km / 8 min, 3.4 km / 8 min, 4.1 km / 10 min), we returned none.

Not a threshold problem. With debug on:

```
main route: hubEdges=0 lastMileSegs=2
settled=6 candidates=0 rejPlateau=6 rejSimple=0 rejShare=0
```

**The route has no hub-graph edge.** The two last-mile Dijkstras meet each other before either reaches a hub point, the route is assembled from two detailed segments, and the plateau method — which lives on hub-graph edges — has no material. The 6 hub points settled by both trees all fail `ALT_MIN_PLATEAU`. Relaxing the thresholds changes nothing, because there are no candidates to relax them for.

Same start, in the same code, same map:

| destination | route | hub edges | alternatives |
|---|---|---|---|
| Amstelveen (this case) | 4.3 km | **0** | 0 |
| Schiphol | 14.2 km | 1 | 2 |
| Amsterdam centre | 21.9 km | 5 | 2 |

## What it does

When `usesHubGraph(route)` is false, the plateau method runs one level down, on the detailed road graph. A via node is a road point settled by both trees, its route costs `f(v) + b(v)`, and its plateau is the maximal stretch around it where that sum stays constant — the road both trees agree on, exactly as on the hub graph.

Two things differ from the hub version. Expanding a candidate is a walk along parent links rather than a shortcut lookup, so it is free: no two-stage filter, no `ALT_MAX_EXPAND` budget, candidates that survive the plateau rule are assembled and checked on their real roads straight away. And there are tens of thousands of them, so candidates describing the same plateau are collapsed to one (by the pair of plateau anchors) before anything is assembled. Ranking, distinctness and the retraced check are the existing ones, unchanged.

Result on the route above: **2 alternatives at +5.7% and +11.1%**, 3.9 km and 1.8 km of their own roads. Shapes match what Google draws — the northern loop via Legmeerdijk/Sportlaan and the western one via Aalsmeerderweg.

| | time | distance | |
|---|---|---|---|
| main | 7:48 | 4337 m | |
| alt 1 | 8:32 | 4508 m | +5.7%, own roads 3.9 km, avoids 3.8 km |
| alt 2 | 8:54 | 4886 m | +11.1%, own roads 1.8 km, avoids 1.3 km |

## Three things that had to be right

**The last-mile trees cannot be reused.** They are already built and they are large (21266 and 6015 settled points here), which is why this looked free at first. But each stops at the hub points around its own end, so they overlap on **5 road points** — nothing to choose between. A dedicated bidirectional Dijkstra start → end, with no boundaries, is run instead.

**A plain bidirectional search prunes itself at the meeting.** `processRouteSegment` breaks on `bothDirVisited`, so the set settled by both trees is the frontier and nothing more: **14 points**. `RoutingConfiguration.altHorizon` — set only while alternatives are searched, `0` everywhere else — suppresses that break and keeps the search going until both queue tops sum above `(1 + ALT_STRETCH) * opt`. That gives **1265 meeting points, 6 plateaus**.

**The cost must be measured at the junction the two halves join at.** Both trees store the distance to the far end of their own traversal of a road piece, so the raw `f + b` counts that piece twice, and the sum then grows and shrinks with the piece length all along a route that is in fact optimal. The plateau — defined as the stretch where the sum is constant — is then never longer than one edge anywhere, including on the main route itself. Symptom: the largest plateau in the whole candidate set was 4% of cost against a 10% threshold, and not one candidate carried the main route's own plateau. Joining at the junction the piece *starts* at (`f(parent) + b`) fixes it; `assemble()` splits the two chains at the same point, so cost and geometry describe the same route.

## Cost

The extra search is bounded the same way the last mile already is (`MAX_POINTS_CLUSTER_ROUTING`) and only runs for routes that never reached the hub graph, i.e. the regime where HH itself is cheap:

```
without alternatives   ~200 ms
with 2 alternatives    ~345 ms   (alternative search 145-151 ms)
```

Routes that do use the hub graph take the existing path and are untouched — verified on the 14 km and 22 km routes above: same two alternatives, same distances, same timings.

## Threshold

`ALT_MIN_DISTINCT_ABS = 1500` → `ALT_MIN_DISTINCT_FLOOR = 300`. As a fixed requirement 1500 m was a third of a 4 km route, while binding nothing on the routes it was written for. Since the rule is `max(floor, ALT_MIN_DISTINCT_REL * len)`:

- own roads: identical above 7.5 km, where `0.2 * len` takes over;
- avoided roads: identical above 15 km, looser between 7.5 and 15 km (`0.1 * len` against the old flat 1500 m).

`AlternativeRoutesTest` asserted the same flat 1500 m independently of the config; it now mirrors the formula, otherwise its own sanity check would contradict the behaviour it tests.

## Tests

`OsmAnd-java`: 554 tests, all green. The route above is added to `test_alternative_routes.json` with `minAlternatives: 2`, and goes through the same `assertSaneAlternatives` as the rest — retraced ≤ 100 m, no unexpanded gaps, start and end match the main route.

End to end through `OsmAndServer` (`OBF_LOCATION=~/osmand/maps ./gradlew :OsmAndServer:bootRun`) and the web map (`yarn start:local-routing`): 41 features, `alternative` 1 and 2, 38 turn points. Turns ride along with their line, as fixed in the server PR.

## Notes for review

- Everything new in `BinaryRoutePlanner` is behind `ctx.config.altHorizon > 0`, which nothing but `HHAlternativeRoutes.searchDetailedTrees` ever sets, and which is restored in a `finally` together with `MAX_VISITED`, `planRoadDirection` and `heuristicCoefficient` — the same fields `initStart` already saves and restores around its own search.
- The gate is `usesHubGraph(route)`, not a distance: a route with no hub edge is by that very fact short enough to search again, whatever its length, and a route with hub edges never pays for this.
- `searchRouteInternal` gained an overload taking the two visited maps, so the caller keeps the trees. The old signature delegates to it with `null, null`.
- Candidate deduplication is by plateau anchors rather than by geometry: two candidates on one plateau describe one route, and finding that out by expanding both would defeat the point of the plateau.
- The hub-graph path is untouched apart from `assess()` and `dropped()` taking a cost instead of an `AltCandidate`, so both paths can share them.

---

## AI disclaimer

Written with Claude Code (Claude Opus 5), driven by @vshcherb. The requests it worked from, in order:

1. Why don't we build alternatives for this short route — `test.osmand.net/map/navigate/?start=52.286065,4.866343&end=52.284910,4.823599` — I want variety for traffic jams and such.
2. Let's remove the hard thresholds; Google finds three routes here (screenshot) and we found none.
3. Run a local prototype so I can test it in a browser.
4. Why an extra tool — here are the instructions (`bootRun` with `OBF_LOCATION`, `yarn start:local-routing`).
5. Create a PR and attach it to the issue.

All numbers above are measurements from those runs, not estimates. Request 3 was answered with a throwaway Leaflet page before request 4 pointed at the documented local setup; nothing from it is in this PR.
