### PR TITLE
Revert "Fix occasional frozen pan gesture (#25736)" (#25814), keep null e1 guard

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/DoubleTapScaleDetector.java
+++ b/OsmAnd/src/net/osmand/plus/views/DoubleTapScaleDetector.java
@@ -64,20 +64,6 @@ public class DoubleTapScaleDetector {
 			mIsInZoomMode = false;
 			return false;
 		}
-		if (event.getAction() == MotionEvent.ACTION_CANCEL) {
-			// A cancelled gesture never delivers ACTION_UP. Without this reset the detector stays in
-			// zoom / double tap mode, and OsmandMapTileView keeps skipping the gesture detector and
-			// the map layers, so the whole next gesture is silently ignored.
-			boolean handled = mIsInZoomMode;
-			if (mIsInZoomMode) {
-				mIsInZoomMode = false;
-				listener.onZoomEnded(scale);
-			}
-			resetEvents();
-			mIsDoubleTapping = false;
-			mScrolling = false;
-			return handled;
-		}
 		if (event.getAction() == MotionEvent.ACTION_UP) {
 			boolean handled = false;
 			if (mIsInZoomMode) {

--- a/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
+++ b/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
@@ -1997,40 +1997,28 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 		return targetZoom;
 	}
 
-	/**
-	 * @return true if the map location under the given screen point was actually found. When it is
-	 * not found (renderer state is not ready yet, or the point does not hit the map surface) the
-	 * renderer leaves the location unchanged, so it stays equal to the current map target and must
-	 * not be used as a gesture anchor.
-	 */
-	private boolean findFirstTouchMapLocation(float touchPointX, float touchPointY) {
+	private void findFirstTouchMapLocation(float touchPointX, float touchPointY) {
 		MapRendererView mapRenderer = getMapRenderer();
 		if (mapRenderer != null) {
 			PointI touchPosition = new PointI((int) touchPointX, (int) touchPointY);
 			PointI touchLocation31 = mapRenderer.getTarget();
 			float height = mapRenderer.getHeightAndLocationFromElevatedPoint(touchPosition, touchLocation31);
-			boolean found = height > NativeUtilities.MIN_ALTITUDE_VALUE;
 			firstTouchLocationX = touchLocation31.getX();
 			firstTouchLocationY = touchLocation31.getY();
-			firstTouchLocationHeight = found ? height : 0.0f;
-			return found;
+			firstTouchLocationHeight = height > NativeUtilities.MIN_ALTITUDE_VALUE ? height : 0.0f;
 		}
-		return false;
 	}
 
-	private boolean findSecondTouchMapLocation(float touchPointX, float touchPointY) {
+	private void findSecondTouchMapLocation(float touchPointX, float touchPointY) {
 		MapRendererView mapRenderer = getMapRenderer();
 		if (mapRenderer != null) {
 			PointI touchPosition = new PointI((int) touchPointX, (int) touchPointY);
 			PointI touchLocation31 = mapRenderer.getTarget();
 			float height = mapRenderer.getHeightAndLocationFromElevatedPoint(touchPosition, touchLocation31);
-			boolean found = height > NativeUtilities.MIN_ALTITUDE_VALUE;
 			secondTouchLocationX = touchLocation31.getX();
 			secondTouchLocationY = touchLocation31.getY();
-			secondTouchLocationHeight = found ? height : 0.0f;
-			return found;
+			secondTouchLocationHeight = height > NativeUtilities.MIN_ALTITUDE_VALUE ? height : 0.0f;
 		}
-		return false;
 	}
 
 	public boolean onTouchEvent(MotionEvent event) {
@@ -2672,33 +2660,20 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 			if (multiTouchSupport == null || (!multiTouchSupport.isInTiltMode() && !multiTouchSupport.isInZoomAndRotationMode())) {
 				MeasurementToolLayer layer = getMeasurementToolLayer();
 				MapRendererView mapRenderer = getMapRenderer();
-				if (mapRenderer != null && e1 != null && (layer == null || !layer.isInMeasurementMode())) {
+				if (mapRenderer != null && (layer == null || !layer.isInMeasurementMode())) {
 					if (!targetChanged) {
+						targetChanged = true;
 						// Remember last target position before it is changed with map gesture
 						PointI targetPixelPosition = mapRenderer.getTargetScreenPosition();
-						if (!findFirstTouchMapLocation(e1.getX(), e1.getY())) {
-							// The touched map location can not be resolved, so it can not be used as
-							// a gesture anchor: setMapTarget() would keep failing for the whole gesture
-							// and the map would stay frozen until the finger is lifted. Drag the map
-							// the plain way instead, and retry anchoring on the next scroll event.
-							dragToAnimate(e2.getX() + distanceX, e2.getY() + distanceY, e2.getX(), e2.getY(), true);
-							return true;
-						}
-						targetChanged = true;
 						targetPixelX = targetPixelPosition.getX();
 						targetPixelY = targetPixelPosition.getY();
+						findFirstTouchMapLocation(e1.getX(), e1.getY());
 						rotate = MapUtils.unifyRotationTo360(-mapRenderer.getAzimuth());
 					}
 					scrollDistanceX = distanceX;
 					scrollDistanceY = distanceY;
 					PointI touchPoint = new PointI((int) (e2.getX() + scrollDistanceX), (int) (e2.getY() + scrollDistanceY));
-					if (!mapRenderer.setMapTarget(touchPoint, new PointI(firstTouchLocationX, firstTouchLocationY))
-							&& findFirstTouchMapLocation(touchPoint.getX(), touchPoint.getY())) {
-						// The anchor location can not be moved to the touch point anymore. Re-anchor to
-						// whatever is under the touch point now (this does not move the map by itself)
-						// so that the rest of the gesture keeps following the finger.
-						mapRenderer.setMapTarget(touchPoint, new PointI(firstTouchLocationX, firstTouchLocationY));
-					}
+					mapRenderer.setMapTarget(touchPoint, new PointI(firstTouchLocationX, firstTouchLocationY));
 					LatLon latLon = NativeUtilities.getLatLonFromElevatedPixel(mapRenderer, currentViewport, targetPixelX, targetPixelY);
 					currentViewport.setLatLonCenter(latLon.getLatitude(), latLon.getLongitude());
 					refreshMap();

--- a/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
+++ b/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
@@ -2660,7 +2660,7 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 			if (multiTouchSupport == null || (!multiTouchSupport.isInTiltMode() && !multiTouchSupport.isInZoomAndRotationMode())) {
 				MeasurementToolLayer layer = getMeasurementToolLayer();
 				MapRendererView mapRenderer = getMapRenderer();
-				if (mapRenderer != null && (layer == null || !layer.isInMeasurementMode())) {
+				if (mapRenderer != null && e1 != null && (layer == null || !layer.isInMeasurementMode())) {
 					if (!targetChanged) {
 						targetChanged = true;
 						// Remember last target position before it is changed with map gesture


### PR DESCRIPTION
Reverts #25814. Re: #25736 — @sonora confirmed the nightly still shows both the occasional hang after returning to position and the reliable refusal of the first pan after bringing the app back to the foreground.

## Why it could not have worked

The fallback that #25814 added is dead in exactly the situation it was written for. `dragToAnimate()` → `moveTo(fromX, fromY, toX, toY, …)` → `NativeUtilities.get31FromPixel()` → `MapRendererView.getLocationFromScreenPoint()` ends in:

```cpp
bool ok = updateInternalState(internalState, state, *getConfiguration(), RequiredToUnproject);
if (!ok) return false;
```

That is the same `updateInternalState()` failure that makes `getLocationFromElevatedPoint()` — and therefore the anchor in `findFirstTouchMapLocation()` — fail. And `moveTo()` has no `else`:

```java
if (from31 != null && to31 != null) { … }
```

So when the renderer cannot unproject a screen point, the anchored path and the fallback bail out together and the map stays frozen. The observed "no change" is what the patch predicts under its own hypothesis; it is not evidence for or against the diagnosis.

Reverting rather than leaving unproven code in master.

## Kept

One line: the null check on `e1` in `onScroll()`. `GestureDetector` may pass a null `e1` on recent Android versions and `e1.getX()` would throw. Unrelated to #25736.

## Next step for #25736

The post-foreground repro is 100% reproducible, which is worth more than the rare one. Four log lines in a nightly would locate where the gesture actually dies:

1. `OsmandMapTileView.onTouchEvent()` entry — action code. Does the touch reach the map view at all?
2. `MapTileViewOnGestureListener.onDown()` — does `GestureDetector` see the DOWN?
3. `onScroll()` entry — is it called, and what are `multiTouchSupport.isInTiltMode()` / `isInZoomAndRotationMode()` and `doubleTapScaleDetector.isInZoomMode()` / `isDoubleTapping()`?
4. Inside `onScroll()` — return values of the hit test and of `setMapTarget()`.

Those discriminate between the touch never arriving (a view/window problem, nothing to do with the renderer), a detector swallowing it, and the renderer refusing the move. Without that, any further fix is a guess.
