### PR TITLE
Show "By tapping" hint in Glide ratio to target widget settings

### DIFF
--- a/OsmAnd/res/layout/fragment_widget_settings_glide_target.xml
+++ b/OsmAnd/res/layout/fragment_widget_settings_glide_target.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="wrap_content"
+	android:orientation="vertical">
+
+	<net.osmand.plus.widgets.TextViewEx
+		style="@style/DescStyle"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:layout_marginHorizontal="@dimen/content_padding"
+		android:layout_marginVertical="@dimen/content_padding_small"
+		android:text="@string/switch_mode_by_tapping_on_widget"
+		android:textColor="?android:textColorSecondary" />
+
+</LinearLayout>

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/WidgetType.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/WidgetType.java
@@ -384,6 +384,8 @@ public enum WidgetType {
 			return new SensorWidgetSettingFragment();
 		} else if (this == GLIDE_AVERAGE) {
 			return new AverageGlideWidgetInfoFragment();
+		} else if (this == GLIDE_TARGET) {
+			return new GlideTargetWidgetInfoFragment();
 		} else if (this == DEV_ZOOM_LEVEL) {
 			return new ZoomLevelInfoFragment();
 		} else if (this == DEV_MEMORY) {

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/settings/GlideTargetWidgetInfoFragment.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/settings/GlideTargetWidgetInfoFragment.java
@@ -1,0 +1,22 @@
+package net.osmand.plus.views.mapwidgets.configure.settings;
+
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+
+import net.osmand.plus.R;
+import net.osmand.plus.views.mapwidgets.WidgetType;
+
+public class GlideTargetWidgetInfoFragment extends BaseSimpleWidgetInfoFragment {
+
+	@NonNull
+	@Override
+	public WidgetType getWidget() {
+		return WidgetType.GLIDE_TARGET;
+	}
+
+	@Override
+	protected void setupMainContent(@NonNull ViewGroup container) {
+		inflate(R.layout.fragment_widget_settings_glide_target, container);
+	}
+}


### PR DESCRIPTION
Follow-up to #25737, which was closed after the docs fix (osmandapp/web#1959 + `c4abb65ff`) while the app-side part was left open.

### Problem

The **Glide ratio to target** widget toggles between *Glide ratio to target* and *Target elevation* when tapped — `GlideTargetWidgetState.changeToNextState()` flips the `glide_widget_show_target_altitude` preference. But nothing in the app tells the user this: `WidgetType.getSettingsFragment()` had no branch for `GLIDE_TARGET`, so its context menu fell through to the generic `BaseSimpleWidgetInfoFragment` with no hint.

Sunrise/Sunset and Zoom level, which have the same kind of tap toggle, do show the note. The docs now state the shortcoming explicitly ("Switching option is not available in the widget's context menu") rather than the app fixing it.

### Change

- New `GlideTargetWidgetInfoFragment` extending `BaseSimpleWidgetInfoFragment`, inflating a one-row layout with the existing `switch_mode_by_tapping_on_widget` string.
- Wire `GLIDE_TARGET` to it in `WidgetType.getSettingsFragment()`.

No new strings, no behaviour change — only the missing hint. 40 lines across 3 files.

**Average glide ratio** is deliberately untouched: it has no `WidgetState` on Android, so there is no tap toggle to document. The *Average vertical speed* mode from the #25737 to-do list is still iOS-only and remains out of scope here.

### Testing

Not run through a full local build — the fresh worktree fails to link resources on unrelated generated POI icons (`mm_storage_tank`, `mx_special_star_stroked`), which are absent from the repo and come from `OsmAnd-resources`. Resource merging accepted the new layout. Please confirm on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)