### PR TITLE
Fix removal criterion for the Compose semantics-handler workaround

### DIFF
--- a/OsmAnd/build-common.gradle
+++ b/OsmAnd/build-common.gradle
@@ -391,6 +391,8 @@ dependencies {
 	implementation 'androidx.preference:preference:1.1.0'
 	implementation 'androidx.lifecycle:lifecycle-process:2.6.0'
 	implementation "androidx.activity:activity:1.10.1"
+	// TODO(#25667): on BOM bump, if compose-ui >= 1.13.0 (b/486235925 fixed), delete
+	// OsmandApplication.applyComposeWorkarounds() and ComposeChipDetachFromWindowTest.
 	implementation platform('androidx.compose:compose-bom:2026.06.00')
 	implementation 'androidx.compose.ui:ui'
 	implementation 'androidx.compose.ui:ui-tooling-preview'

--- a/OsmAnd/src/net/osmand/plus/OsmandApplication.java
+++ b/OsmAnd/src/net/osmand/plus/OsmandApplication.java
@@ -322,7 +322,10 @@ public class OsmandApplication extends MultiDexApplication {
 	 * <p>
 	 * The flag only exists to support Compose on a non-main thread, which OsmAnd never does, so
 	 * falling back to the main looper handler is safe. To be removed once the upstream bug
-	 * (b/486998514) is fixed.
+	 * (b/486235925) is fixed.
+	 *
+	 * TODO(#25667): on BOM bump, if compose-ui >= 1.13.0 (b/486235925 fixed), delete this method
+	 * and ComposeChipDetachFromWindowTest.
 	 */
 	private void applyComposeWorkarounds() {
 		AndroidComposeUiFlags.isViewBasedSemanticsHandlerEnabled = false;

--- a/OsmAnd/test/java/net/osmand/test/ui/search/ComposeChipDetachFromWindowTest.kt
+++ b/OsmAnd/test/java/net/osmand/test/ui/search/ComposeChipDetachFromWindowTest.kt
@@ -53,6 +53,9 @@ class ComposeChipDetachFromWindowTest : AndroidTest() {
 	 * Guards the test above from silently becoming vacuous, and doubles as a reminder: as soon as
 	 * this one starts failing, the upstream bug is fixed and
 	 * `OsmandApplication.applyComposeWorkarounds()` can be dropped together with this test.
+	 *
+	 * TODO(#25667): on BOM bump, if compose-ui >= 1.13.0 (b/486235925 fixed), delete this test
+	 * and `OsmandApplication.applyComposeWorkarounds()`.
 	 */
 	@OptIn(ExperimentalComposeUiApi::class)
 	@Test
@@ -65,7 +68,7 @@ class ComposeChipDetachFromWindowTest : AndroidTest() {
 			AndroidComposeUiFlags.isViewBasedSemanticsHandlerEnabled = enabled
 		}
 		assertTrue(
-			"Expected the upstream Compose NPE, got $error. If Compose has fixed b/486998514, "
+			"Expected the upstream Compose NPE, got $error. If Compose has fixed b/486235925, "
 					+ "remove OsmandApplication.applyComposeWorkarounds() and this test.",
 			error is NullPointerException
 		)


### PR DESCRIPTION
## Summary
- The tripwire in `OsmandApplication.applyComposeWorkarounds()` and `ComposeChipDetachFromWindowTest` pointed at `b/486998514`, the flag-deletion tracker, instead of `b/486235925`, the tracker for the actual NPE fix (already shipped upstream, first in compose-ui 1.13.0-alpha01). Watching the wrong bug shows no progress even though the fix landed, and when `b/486998514` does close, the flag is deleted, turning the workaround into a compile error rather than a failing test.
- Corrects the bug ID in `OsmandApplication.java` and `ComposeChipDetachFromWindowTest.kt`.
- Adds a `TODO(#25667)` at the three sites named in #25806 (the compose-bom line, `applyComposeWorkarounds()`, and the canary test) so whoever next bumps the BOM is prompted to drop the workaround and its test once compose-ui reaches 1.13.0.

This is the "suggested minimum" from #25806; it does not add CI coverage for the canary test, which the issue notes is a heavier, separate ask.

## Test plan
- [x] `git diff` reviewed; changes are comment/string-literal only, no behavior change
- [ ] CI build (no test job currently runs `ComposeChipDetachFromWindowTest`, per #25806)

Fixes #25806

🤖 Generated with [Claude Code](https://claude.com/claude-code)