### PR TITLE
Fix low-contrast button text on Test voice prompts screen

### DIFF
--- a/OsmAnd/src/net/osmand/plus/plugins/development/TestVoiceActivity.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/development/TestVoiceActivity.java
@@ -18,9 +18,11 @@ import androidx.appcompat.app.AlertDialog;
 
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.settings.backend.preferences.OsmandPreference;
+import net.osmand.plus.settings.enums.ThemeUsageContext;
 import net.osmand.plus.R;
 import net.osmand.plus.activities.OsmandActionBarActivity;
 import net.osmand.plus.routing.data.StreetName;
+import net.osmand.plus.utils.ColorUtilities;
 import net.osmand.plus.utils.InsetTarget;
 import net.osmand.plus.utils.InsetTargetsCollection;
 import net.osmand.plus.voice.CommandBuilder;
@@ -277,6 +279,9 @@ public class TestVoiceActivity extends OsmandActionBarActivity {
 		} else {
 			button.setPadding(40, 5, 10, 5);
 		}
+		boolean nightMode = app.getDaynightHelper().isNightMode(settings.APPLICATION_MODE.get(), ThemeUsageContext.APP);
+		int activeColor = ColorUtilities.getActiveColor(this, nightMode);
+		button.setTextColor(ColorUtilities.getContrastColor(this, activeColor, false));
 		if (description.startsWith("\u25BA (11.1)")) {
 			// Buttons with refreshable caption
 			buttonInfo = button;


### PR DESCRIPTION
## Summary
- The developer "Test voice prompts" screen (`TestVoiceActivity`) builds all of its buttons as plain `Button` widgets with no explicit color styling.
- In the light theme, `buttonStyle` is set to `Widget.AppCompat.Button.Colored`, which fills buttons with the accent color (`#237bff`), while the theme also forces primary text to near-black (`#1A1A1A`). Every button and section headline ends up rendering black text on a medium-blue background, which is low contrast (matches the screenshots in the issue).
- Fix: compute the resolved accent color for the current day/night theme and set each button's text color to a color that contrasts with it (`ColorUtilities.getContrastColor`), instead of relying on the ambient (and, for this style combination, broken) default text color.

Fixes #25634

## Test plan
- [x] `./gradlew :OsmAnd:compileAndroidFullLegacyArm64DebugJavaWithJavac` builds successfully
- [ ] Manually verify on-device: Settings → Configure profile → (enable Development plugin) → Test voice prompts, in both light and dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)