### PR TITLE
Fix Address search back navigation returning to the previous city (#25748)

### DIFF
--- a/OsmAnd/src/net/osmand/plus/search/dialogs/QuickSearchDialogFragment.java
+++ b/OsmAnd/src/net/osmand/plus/search/dialogs/QuickSearchDialogFragment.java
@@ -235,7 +235,7 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 
 	private static boolean isDebugMode = SearchUICore.isDebugMode();
 	private ProcessTopIndex processTopIndexAfterLoad = ProcessTopIndex.NO;
-	private final Stack<SearchPhrase> addressSearchStack = new Stack<>();
+	private final Stack<String> addressSearchStack = new Stack<>();
 
 	private enum ProcessTopIndex {
 		FILTER,
@@ -727,7 +727,7 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 		if (tabBarHidden) {
 			resetSpatialSearchScope();
 			if (!addressSearchStack.isEmpty()) {
-				String newText = addressSearchStack.pop().getFullSearchPhrase();
+				String newText = addressSearchStack.pop();
 				searchEditText.setText(newText);
 				searchEditText.setSelection(newText.length());
 			} else {
@@ -3447,13 +3447,14 @@ public class QuickSearchDialogFragment extends BaseFullScreenDialogFragment impl
 				|| searchResult.objectType == GPX_TRACK) {
 			mainSearchFragment.showResult(searchResult);
 		} else {
+			saveAddressSearchState();
 			completeQueryWithObject(searchResult);
-			onSearchResultSelected();
 		}
 	}
 
-	public void onSearchResultSelected() {
-		SearchResultCollection searchResult = searchHelper.getCore().getCurrentSearchResult();
-		addressSearchStack.push(searchResult.getPhrase());
+	// Should be called before the selected result is applied to the search query,
+	// so that back navigation restores exactly the query which is displayed now.
+	public void saveAddressSearchState() {
+		addressSearchStack.push(searchEditText.getText().toString());
 	}
 }

--- a/OsmAnd/src/net/osmand/plus/search/dialogs/QuickSearchListFragment.java
+++ b/OsmAnd/src/net/osmand/plus/search/dialogs/QuickSearchListFragment.java
@@ -144,8 +144,8 @@ public abstract class QuickSearchListFragment extends BaseNestedListFragment {
 						if (sr.objectType == CITY || sr.objectType == VILLAGE || sr.objectType == STREET) {
 							showResult = true;
 						}
+						dialogFragment.saveAddressSearchState();
 						dialogFragment.completeQueryWithObject(sr);
-						dialogFragment.onSearchResultSelected();
 					}
 				}
 			}
@@ -153,8 +153,8 @@ public abstract class QuickSearchListFragment extends BaseNestedListFragment {
 	}
 
 	private void onSpatialCategorySearchResultClick(@NonNull SearchResult searchResult) {
+		dialogFragment.saveAddressSearchState();
 		dialogFragment.completeSpatialCategorySearchResult(searchResult);
-		dialogFragment.onSearchResultSelected();
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #25748

### Problem

In **Search → Address**, after opening a street in one city, going back to the **Nearest city** list and opening a street in a second city, two taps back led to the *first* city's street list instead of the Address tab.

### Cause

`QuickSearchDialogFragment.onSearchResultSelected()` pushed `searchUICore.getCurrentSearchResult().getPhrase()` onto the address back stack — the phrase of the last **finished** core search, not the query actually displayed.

Backing out to an empty query does not start a new core search (`reloadCities()` runs only once, guarded by `!isCitiesLoaded()`), so the core still held the previous city's phrase, and that stale phrase was pushed when the next city was selected.

Debug trace of the reported steps (Vaduz/Schaan on a Liechtenstein map):

```
push cur=''        live='Vaduz '                 <- tap Vaduz
push cur='Vaduz '  live='Vaduz Abtswingertweg '
pop='Vaduz '  /  pop=''                          <- two backs, stack empty, Address tab
push cur='Vaduz '  live='Schaan '                <- tap Schaan: stale 'Vaduz ' is pushed
push cur='Schaan '
pop='Schaan ' / pop='Vaduz '                     <- second back -> Vaduz instead of Address
```

Because it depends on whether the background search has finished, the bug shows up easily on large maps and almost never on small ones.

### Fix

Store the query text shown in the search field, captured **before** the selected result is applied to it (`completeQueryWithObject()` / `completeSpatialCategorySearchResult()` change the phrase synchronously via `selectSearchResult`).

### Testing

Emulator (Pixel 6A image, Liechtenstein map), steps from the issue: Vaduz → Abtswingertweg → back ×2 → Schaan → Bahnhofstrasse → back ×2. First back opens the city's street list, second back opens the **Address** tab with the Nearest cities list. Before the fix the second back opened the first city.

🤖 Generated with [Claude Code](https://claude.com/claude-code)