### PR TITLE
Add prototype sight line to Radius Ruler widget (#25801)

### DIFF
--- a/OsmAnd/res/layout/radius_ruler_widget_settings_fragment.xml
+++ b/OsmAnd/res/layout/radius_ruler_widget_settings_fragment.xml
@@ -88,4 +88,51 @@
 
 	</LinearLayout>
 
+	<View
+		android:id="@+id/sight_line_divider"
+		android:layout_width="match_parent"
+		android:layout_height="1dp"
+		android:layout_marginStart="@dimen/content_padding"
+		android:background="?divider_color_basic" />
+
+	<LinearLayout
+		android:id="@+id/sight_line_container"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:minHeight="@dimen/card_row_min_height"
+		android:orientation="horizontal"
+		android:gravity="center_vertical">
+
+		<androidx.appcompat.widget.AppCompatImageView
+			android:id="@+id/icon"
+			android:layout_width="@dimen/dialog_content_margin"
+			android:layout_height="@dimen/dialog_content_margin"
+			android:layout_marginStart="@dimen/content_padding"
+			app:srcCompat="@drawable/ic_action_direction_arrow" />
+
+		<net.osmand.plus.widgets.TextViewEx
+			android:id="@+id/text"
+			style="@style/TitleStyle"
+			android:layout_width="0dp"
+			android:layout_height="wrap_content"
+			android:layout_weight="1"
+			android:layout_marginStart="@dimen/dialog_button_height"
+			android:maxLines="1"
+			android:ellipsize="end"
+			android:text="@string/sight_line"
+			android:textColor="?android:textColorPrimary" />
+
+		<androidx.appcompat.widget.SwitchCompat
+			android:id="@+id/sight_line_switch"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginStart="@dimen/title_padding"
+			android:layout_marginEnd="@dimen/content_padding"
+			android:focusable="false"
+			android:focusableInTouchMode="false"
+			android:clickable="false"
+			android:saveEnabled="false" />
+
+	</LinearLayout>
+
 </LinearLayout>

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -2061,6 +2061,7 @@ You need to activate the sensor so OsmAnd can find it.</string>
     <string name="routing_attr_avoid_fords_name">Avoid fords</string>
     <string name="routing_attr_avoid_fords_description">Avoid fords</string>
     <string name="compass_on_circles">Compass on circles</string>
+    <string name="sight_line">Sight line</string>
     <string name="distance_circles">Distance-circles</string>
     <string name="routing_attr_avoid_4wd_only_name">Avoid 4WD roads</string>
     <string name="routing_attr_avoid_4wd_only_description">Avoid roads only suitable for 4WD vehicles</string>

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -959,6 +959,7 @@ public class OsmandSettings {
 
 	public final CommonPreference<RadiusRulerMode> RADIUS_RULER_MODE = new EnumStringPreference<>(this, "ruler_mode", RadiusRulerMode.FIRST, RadiusRulerMode.values()).makeProfile();
 	public final OsmandPreference<Boolean> SHOW_COMPASS_ON_RADIUS_RULER = new BooleanPreference(this, "show_compass_ruler", true).makeProfile();
+	public final OsmandPreference<Boolean> SHOW_SIGHT_LINE_ON_RADIUS_RULER = new BooleanPreference(this, "show_sight_line_ruler", false).makeProfile();
 
 	public final OsmandPreference<Boolean> SHOW_DISTANCE_RULER = new BooleanPreference(this, "show_distance_ruler", false).makeProfile();
 

--- a/OsmAnd/src/net/osmand/plus/views/layers/RadiusRulerControlLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/RadiusRulerControlLayer.java
@@ -26,6 +26,8 @@ import net.osmand.plus.R;
 import net.osmand.plus.activities.MapActivity;
 import net.osmand.plus.auto.NavigationSession;
 import net.osmand.plus.base.MapViewTrackingUtilities;
+import net.osmand.plus.plugins.PluginsHelper;
+import net.osmand.plus.plugins.development.OsmandDevelopmentPlugin;
 import net.osmand.plus.settings.backend.ApplicationMode;
 import net.osmand.plus.settings.backend.OsmandSettings;
 import net.osmand.plus.settings.enums.ScreenLayoutMode;
@@ -63,6 +65,8 @@ public class RadiusRulerControlLayer extends OsmandMapLayer implements OsmAndCom
 	private static final float MIN_PROJECTED_STEP_DP = 24;
 	private static final double MAX_GLOBE_MERCATOR_ANGLE = 2 * Math.PI - 1e-7;
 	private static final long POINT31_FULL_RANGE = 1L << 31;
+	private static final double SIGHT_LINE_DISTANCE_METERS = 500_000;
+	private static final int SIGHT_LINE_SEGMENTS = 50;
 
 	private OsmandApplication app;
 	private MapWidgetRegistry widgetRegistry;
@@ -94,6 +98,7 @@ public class RadiusRulerControlLayer extends OsmandMapLayer implements OsmAndCom
 	private Paint triangleNorthPaint;
 	private Paint redLinesPaint;
 	private Paint blueLinesPaint;
+	private Paint sightLinePaint;
 
 	private RenderingLineAttributes circleAttrs;
 	private RenderingLineAttributes circleAttrsAlt;
@@ -103,6 +108,7 @@ public class RadiusRulerControlLayer extends OsmandMapLayer implements OsmAndCom
 	private final Path arrowArc = new Path();
 	private final Path redCompassLines = new Path();
 	private final Path rulerCircle = new Path();
+	private final Path sightLinePath = new Path();
 
 	private final double[] degrees = new double[72];
 	public static final String[] CARDINAL_DIRECTIONS = {"N", "NE", "E", "SE", "S", "SW", "W", "NW"};
@@ -156,6 +162,11 @@ public class RadiusRulerControlLayer extends OsmandMapLayer implements OsmAndCom
 		triangleHeadingPaint = initPaintWithStyle(Style.FILL, colorHeadingArrow);
 		redLinesPaint = initPaintWithStyle(Style.STROKE, colorNorthArrow);
 		blueLinesPaint = initPaintWithStyle(Style.STROKE, colorHeadingArrow);
+
+		sightLinePaint = initPaintWithStyle(Style.STROKE, colorHeadingArrow);
+		sightLinePaint.setStrokeWidth(AndroidUtils.dpToPx(app, 2));
+		sightLinePaint.setPathEffect(new DashPathEffect(
+				new float[] {AndroidUtils.dpToPx(app, 10), AndroidUtils.dpToPx(app, 8)}, 0));
 
 		updatePaints();
 
@@ -300,13 +311,14 @@ public class RadiusRulerControlLayer extends OsmandMapLayer implements OsmAndCom
 			RadiusRulerMode radiusRulerMode = settings.RADIUS_RULER_MODE.get();
 			boolean showRadiusRuler = radiusRulerMode == RadiusRulerMode.FIRST || radiusRulerMode == RadiusRulerMode.SECOND;
 			boolean showCompass = settings.SHOW_COMPASS_ON_RADIUS_RULER.get() && tb.getZoom() >= SHOW_COMPASS_MIN_ZOOM;
+			boolean showSightLine = settings.SHOW_SIGHT_LINE_ON_RADIUS_RULER.get() && isSightLineAvailable();
 
 			boolean radiusRulerNightMode = radiusRulerMode == RadiusRulerMode.SECOND;
 			drawCenterIcon(canvas, tb, center, drawSettings.isNightMode(), radiusRulerNightMode);
 
 			if (showRadiusRuler) {
 				updateData(tb, center);
-				if (showCompass) {
+				if (showCompass || showSightLine) {
 					updateHeading();
 					resetDrawingPaths();
 				}
@@ -319,6 +331,10 @@ public class RadiusRulerControlLayer extends OsmandMapLayer implements OsmAndCom
 					} else {
 						drawRulerCircle(canvas, tb, circleIndex, center, attrs);
 					}
+				}
+
+				if (showSightLine) {
+					drawSightLine(canvas, tb, cachedHeading);
 				}
 			}
 			canvas.rotate(tb.getRotate(), center.x, center.y);
@@ -357,11 +373,16 @@ public class RadiusRulerControlLayer extends OsmandMapLayer implements OsmAndCom
 	}
 
 	private boolean isCompassRulerVisible() {
-		return view != null
-				&& app.getSettings().RADIUS_RULER_MODE.get() != RadiusRulerMode.EMPTY
-				&& app.getSettings().SHOW_COMPASS_ON_RADIUS_RULER.get()
-				&& view.getZoom() >= SHOW_COMPASS_MIN_ZOOM
-				&& isRulerWidgetOn();
+		if (view == null || app.getSettings().RADIUS_RULER_MODE.get() == RadiusRulerMode.EMPTY || !isRulerWidgetOn()) {
+			return false;
+		}
+		boolean compassVisible = app.getSettings().SHOW_COMPASS_ON_RADIUS_RULER.get() && view.getZoom() >= SHOW_COMPASS_MIN_ZOOM;
+		boolean sightLineVisible = app.getSettings().SHOW_SIGHT_LINE_ON_RADIUS_RULER.get() && isSightLineAvailable();
+		return compassVisible || sightLineVisible;
+	}
+
+	private boolean isSightLineAvailable() {
+		return PluginsHelper.isActive(OsmandDevelopmentPlugin.class);
 	}
 
 	private int getCompassCircleIndex(RotatedTileBox tb, QuadPoint center) {
@@ -782,6 +803,34 @@ public class RadiusRulerControlLayer extends OsmandMapLayer implements OsmAndCom
 	private void drawArrowArcPath(@NonNull Canvas canvas) {
 		if (!arrowArc.isEmpty()) {
 			canvas.drawPath(arrowArc, blueLinesPaint);
+		}
+	}
+
+	private void drawSightLine(Canvas canvas, RotatedTileBox tb, double heading) {
+		QuadPoint canvasOffset = getCachedAACanvasOffset();
+		double step = SIGHT_LINE_DISTANCE_METERS / SIGHT_LINE_SEGMENTS;
+
+		sightLinePath.reset();
+		for (int i = 0; i <= SIGHT_LINE_SEGMENTS; i++) {
+			double distance = step * i;
+			if (sphericalMap && !isVisibleGlobeDistance(distance)) {
+				break;
+			}
+			LatLon latLon = calculateDestinationPoint(currentCenterLatLon, distance, heading, sphericalMap);
+			PointF screenPoint = getRulerPixelFromLatLon(tb, latLon);
+			if (screenPoint == null) {
+				break;
+			}
+			float x = screenPoint.x + canvasOffset.x;
+			float y = screenPoint.y + canvasOffset.y;
+			if (sightLinePath.isEmpty()) {
+				sightLinePath.moveTo(x, y);
+			} else {
+				sightLinePath.lineTo(x, y);
+			}
+		}
+		if (!sightLinePath.isEmpty()) {
+			canvas.drawPath(sightLinePath, sightLinePaint);
 		}
 	}
 

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/settings/RadiusRulerWidgetInfoFragment.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/configure/settings/RadiusRulerWidgetInfoFragment.java
@@ -12,6 +12,8 @@ import androidx.annotation.NonNull;
 
 import net.osmand.plus.R;
 import net.osmand.plus.activities.MapActivity;
+import net.osmand.plus.plugins.PluginsHelper;
+import net.osmand.plus.plugins.development.OsmandDevelopmentPlugin;
 import net.osmand.plus.utils.ColorUtilities;
 import net.osmand.plus.utils.UiUtilities;
 import net.osmand.plus.utils.UiUtilities.CompoundButtonType;
@@ -25,9 +27,11 @@ public class RadiusRulerWidgetInfoFragment extends BaseSimpleWidgetInfoFragment 
 
 	private static final String KEY_RADIUS_RULER_MODE = "radius_ruler_mode";
 	private static final String KEY_SHOW_COMPASS = "show_compass";
+	private static final String KEY_SHOW_SIGHT_LINE = "show_sight_line";
 
 	private RadiusRulerMode radiusRulerMode;
 	private boolean showCompass;
+	private boolean showSightLine;
 
 	@NonNull
 	@Override
@@ -41,10 +45,12 @@ public class RadiusRulerWidgetInfoFragment extends BaseSimpleWidgetInfoFragment 
 
 		RadiusRulerMode defaultRadiusRulerMode = settings.RADIUS_RULER_MODE.getModeValue(appMode);
 		boolean defaultShowCompass = settings.SHOW_COMPASS_ON_RADIUS_RULER.getModeValue(appMode);
+		boolean defaultShowSightLine = settings.SHOW_SIGHT_LINE_ON_RADIUS_RULER.getModeValue(appMode);
 
 		String radiusRulerModeName = bundle.getString(KEY_RADIUS_RULER_MODE, defaultRadiusRulerMode.name());
 		radiusRulerMode = RadiusRulerMode.valueOf(radiusRulerModeName);
 		showCompass = bundle.getBoolean(KEY_SHOW_COMPASS, defaultShowCompass);
+		showSightLine = bundle.getBoolean(KEY_SHOW_SIGHT_LINE, defaultShowSightLine);
 	}
 
 	@Override
@@ -52,6 +58,7 @@ public class RadiusRulerWidgetInfoFragment extends BaseSimpleWidgetInfoFragment 
 		inflate(R.layout.radius_ruler_widget_settings_fragment, container);
 		setupRadiusRulerModeSetting();
 		setupCompassSetting();
+		setupSightLineSetting();
 	}
 
 	private void setupRadiusRulerModeSetting() {
@@ -79,6 +86,7 @@ public class RadiusRulerWidgetInfoFragment extends BaseSimpleWidgetInfoFragment 
 
 			if (radiusRulerMode == RadiusRulerMode.EMPTY || previousMode == RadiusRulerMode.EMPTY) {
 				setupCompassSetting();
+				setupSightLineSetting();
 			}
 		};
 
@@ -141,6 +149,40 @@ public class RadiusRulerWidgetInfoFragment extends BaseSimpleWidgetInfoFragment 
 		updateIcon(icon, iconId, enabled);
 	}
 
+	private void setupSightLineSetting() {
+		View divider = view.findViewById(R.id.sight_line_divider);
+		View container = view.findViewById(R.id.sight_line_container);
+
+		if (!PluginsHelper.isActive(OsmandDevelopmentPlugin.class)) {
+			divider.setVisibility(View.GONE);
+			container.setVisibility(View.GONE);
+			return;
+		}
+		divider.setVisibility(View.VISIBLE);
+		container.setVisibility(View.VISIBLE);
+
+		ImageView icon = container.findViewById(R.id.icon);
+		TextView text = container.findViewById(R.id.text);
+		CompoundButton sightLineSwitch = container.findViewById(R.id.sight_line_switch);
+
+		boolean radiusRulerEnabled = radiusRulerMode != RadiusRulerMode.EMPTY;
+
+		updateIcon(icon, R.drawable.ic_action_direction_arrow, radiusRulerEnabled && showSightLine);
+		text.setText(R.string.sight_line);
+
+		UiUtilities.setupCompoundButton(sightLineSwitch, nightMode, CompoundButtonType.GLOBAL);
+		sightLineSwitch.setChecked(showSightLine);
+		sightLineSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
+			updateIcon(icon, R.drawable.ic_action_direction_arrow, isChecked && radiusRulerEnabled);
+			showSightLine = isChecked;
+		});
+		sightLineSwitch.setEnabled(radiusRulerEnabled);
+
+		container.setOnClickListener(v -> sightLineSwitch.setChecked(!sightLineSwitch.isChecked()));
+		container.setBackground(getPressedStateDrawable());
+		container.setEnabled(radiusRulerEnabled);
+	}
+
 	private void updateIcon(@NonNull ImageView icon, @DrawableRes int iconId, boolean enabled) {
 		int colorId = enabled
 				? ColorUtilities.getActiveIconColorId(nightMode)
@@ -154,6 +196,7 @@ public class RadiusRulerWidgetInfoFragment extends BaseSimpleWidgetInfoFragment 
 
 		settings.RADIUS_RULER_MODE.setModeValue(appMode, radiusRulerMode);
 		settings.SHOW_COMPASS_ON_RADIUS_RULER.setModeValue(appMode, showCompass);
+		settings.SHOW_SIGHT_LINE_ON_RADIUS_RULER.setModeValue(appMode, showSightLine);
 
 		MapActivity mapActivity = getMapActivity();
 		if (mapActivity != null) {
@@ -166,6 +209,7 @@ public class RadiusRulerWidgetInfoFragment extends BaseSimpleWidgetInfoFragment 
 		super.onSaveInstanceState(outState);
 		outState.putString(KEY_RADIUS_RULER_MODE, radiusRulerMode.name());
 		outState.putBoolean(KEY_SHOW_COMPASS, showCompass);
+		outState.putBoolean(KEY_SHOW_SIGHT_LINE, showSightLine);
 	}
 
 	private interface ModeSelectionCallback {


### PR DESCRIPTION
## Summary

Prototype implementation for #25801 - draws a real-time "sight line" on the map: a 500 km dashed line from the Radius Ruler widget's center, extending in the current device heading (compass) direction. This lets a user point their device at a distant landmark (e.g. a mountain peak) and see whether the line on the map intersects it, even after panning/zooming away from the current position. This addresses part 1 of the linked feature request; part 2 (distance/bearing line to screen center) is not covered here.

## How it works

A new "Sight line" toggle is added to the Radius Ruler widget's settings, next to the existing "Compass on circles" toggle.

When enabled, a blue dashed line is drawn from the widget's center out to 500 km in the direction of the current device heading, reusing the same distance/bearing projection logic as the existing distance circles (including the recently added spherical/globe map projection).

The toggle, and therefore the line, is only available when the OsmAnd Development plugin is active. This is intentional: the feature is a rough prototype meant to make the idea testable, not a finished UX, so it stays hidden from regular users until the issue is triaged and a proper UI design is agreed on.

## Status of this PR

This is a test/prototype implementation, meant to make the idea in #25801 tangible and testable rather than to be merged as-is. It intentionally does not cover:

- Product/UI design (icon, exact line style and length, settings placement, wording)
- - iOS parity
- - Part 2 of the issue (distance/bearing line to screen center)
Please do not merge this until the issue is accepted into the roadmap and has an agreed-upon UI design. Happy to iterate on or rework this PR based on that discussion.

## Testing

Tested manually on the Android emulator (Pixel 3a, API 33), debug build `nightlyFreeLegacyFatDebug`:

- Set a mock GPS location at Wawel Castle, Krakow, and a mock device heading of about 174 degrees (south) via the emulator's orientation sensor, pointing toward Rysy - the highest peak in Poland, about 98 km away.
- - Verified the dashed line renders from the widget center in the correct heading direction, matches the N/S/E/W labels on the Radius Ruler compass, and, zoomed out, visually lines up with the ridge leading to Rysy.
- - Verified the "Sight line" setting is hidden from the widget settings when the OsmAnd Development plugin is disabled, and reappears (keeping its previously saved value) once the plugin is enabled.
Screenshots: the sight line pointing south from Wawel Castle toward Rysy, and the Development-plugin visibility toggle (setting hidden vs. visible).

| Sight line at Wawel Castle | Sight line toward Rysy |
|---|---|
| <img width="500" alt="sight_line_1_wawel_closeup" src="https://github.com/user-attachments/assets/602f9c71-6649-4e01-9072-89f8cd1b404c" /> | <img width="500" alt="sight_line_3_rysy_target" src="https://github.com/user-attachments/assets/f0dd8a09-8420-41c3-8cf1-104798cc4181" /> |

| Development plugin off (setting hidden) | Development plugin on (setting visible) |
|---|---|
| <img width="500" alt="plugin_gate_off_hidden" src="https://github.com/user-attachments/assets/113d7fe1-05dc-4006-89c9-38810d84f14c" /> | <img width="500" alt="plugin_gate_on_visible" src="https://github.com/user-attachments/assets/8a66fca0-d440-424d-91c6-657df057e91b" /> |

---

*Idea and testing plan by @EugeneZmeuk. Code implementation and testing by Claude AI.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)