### PR TITLE
prevent invalid file names when saving routes

### DIFF
--- a/OsmAnd/src/net/osmand/plus/measurementtool/SaveAsNewTrackBottomSheetDialogFragment.java
+++ b/OsmAnd/src/net/osmand/plus/measurementtool/SaveAsNewTrackBottomSheetDialogFragment.java
@@ -3,6 +3,7 @@ package net.osmand.plus.measurementtool;
 import static net.osmand.IndexConstants.GPX_FILE_EXT;
 import static net.osmand.plus.measurementtool.adapter.FolderListAdapter.VIEW_TYPE_ADD;
 import static net.osmand.plus.measurementtool.adapter.FolderListAdapter.getFolders;
+import static net.osmand.plus.utils.FileUtils.ILLEGAL_FILE_NAME_CHARACTERS;
 
 import android.content.res.ColorStateList;
 import android.os.Bundle;
@@ -258,7 +259,9 @@ public class SaveAsNewTrackBottomSheetDialogFragment extends MenuBottomSheetDial
 		String text = name.trim();
 		if (text.isEmpty()) {
 			nameTextBox.setError(getString(R.string.empty_filename));
-		} else if (isFileExist(name)) {
+		} else if (ILLEGAL_FILE_NAME_CHARACTERS.matcher(text).find()) {
+			nameTextBox.setError(getString(R.string.file_name_containes_illegal_char));
+		} else if (isFileExist(text)) {
 			nameTextBox.setError(getString(R.string.file_with_name_already_exist));
 		} else {
 			nameTextBox.setError(null);


### PR DESCRIPTION
add `ILLEGAL_FILE_NAME_CHARACTERS` validation

_after changes_

<img width="668" height="313" alt="image" src="https://github.com/user-attachments/assets/c18c9986-82e6-492b-9f84-960dc1716c99" />

closes https://github.com/osmandapp/OsmAnd/issues/25795