### PR TITLE
Show local solar eclipse times instead of worldwide ones (#25830)

### DIFF
--- a/OsmAnd-shared/src/commonMain/kotlin/io/github/cosinekitty/astronomy/astronomy.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/io/github/cosinekitty/astronomy/astronomy.kt
@@ -3202,6 +3202,32 @@ fun globalSolarEclipseWindow(event: GlobalSolarEclipseInfo): GlobalSolarEclipseW
 
 
 /**
+ * Local circumstances of an already known global solar eclipse.
+ *
+ * Unlike [searchLocalSolarEclipse], this function does not advance to another
+ * new moon: it reports how the eclipse identified by [event] appears to the
+ * observer, or `null` when the Moon's penumbra never reaches that location.
+ *
+ * Eclipses that happen entirely below the horizon are also reported, because the
+ * caller may want to present the contact times together with the Sun altitude
+ * carried by every [EclipseEvent].
+ */
+fun localSolarEclipseWindow(event: GlobalSolarEclipseInfo, observer: Observer): LocalSolarEclipseInfo? {
+    val shadow = try {
+        peakLocalMoonShadow(event.peak, observer)
+    } catch (e: InternalError) {
+        // The shadow axis never approaches the observer near the peak of this eclipse.
+        return null
+    }
+    if (shadow.r >= shadow.p) {
+        // The observer stays outside the penumbra: no eclipse at this location.
+        return null
+    }
+    return localEclipse(shadow, observer)
+}
+
+
+/**
  * Returns a representative point in the Moon's shadow at [time], or `null`
  * when the penumbra does not touch the Earth.
  */

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/SolarEclipseWindowTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/SolarEclipseWindowTest.kt
@@ -1,0 +1,99 @@
+package net.osmand.shared
+
+import io.github.cosinekitty.astronomy.GlobalSolarEclipseInfo
+import io.github.cosinekitty.astronomy.MINUTES_PER_DAY
+import io.github.cosinekitty.astronomy.Observer
+import io.github.cosinekitty.astronomy.Time
+import io.github.cosinekitty.astronomy.globalSolarEclipseWindow
+import io.github.cosinekitty.astronomy.localSolarEclipseWindow
+import io.github.cosinekitty.astronomy.searchGlobalSolarEclipse
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Covers the difference between the worldwide bounds of a solar eclipse and the
+ * circumstances seen by one observer, reported in issue 25830: the eclipse card
+ * used to present the worldwide times as the times for the map center.
+ *
+ * Reference values are the published circumstances of the total solar eclipse of
+ * 2026-08-12 and the local times quoted in that issue, all expressed in UT.
+ */
+class SolarEclipseWindowTest {
+
+    private val toleranceMinutes = 6.0
+
+    /** Soria, Spain - the observer location reported in the issue. */
+    private val soria = Observer(41.7636, -2.4650, 0.0)
+
+    /** Sydney, Australia - the same eclipse is not above the horizon anywhere near there. */
+    private val sydney = Observer(-33.8688, 151.2093, 0.0)
+
+    private fun eclipseOf20260812(): GlobalSolarEclipseInfo =
+        searchGlobalSolarEclipse(Time(2026, 8, 1, 0, 0, 0.0))
+
+    private fun assertTimeNear(expected: Time, actual: Time, message: String) {
+        val offsetMinutes = abs(actual.ut - expected.ut) * MINUTES_PER_DAY
+        assertTrue(offsetMinutes <= toleranceMinutes, "$message: off by $offsetMinutes minutes")
+    }
+
+    @Test
+    fun testWorldwideWindowCoversTheWholeEarth() {
+        val event = eclipseOf20260812()
+        val window = globalSolarEclipseWindow(event)
+
+        assertTimeNear(Time(2026, 8, 12, 15, 34, 0.0), window.start, "worldwide start")
+        assertTimeNear(Time(2026, 8, 12, 17, 46, 0.0), event.peak, "greatest eclipse")
+        assertTimeNear(Time(2026, 8, 12, 19, 57, 0.0), window.end, "worldwide end")
+    }
+
+    @Test
+    fun testLocalWindowUsesObserverContactTimes() {
+        val event = eclipseOf20260812()
+        val local = assertNotNull(localSolarEclipseWindow(event, soria), "eclipse visible from Soria")
+
+        assertTimeNear(Time(2026, 8, 12, 17, 34, 0.0), local.partialBegin.time, "local start")
+        assertTimeNear(Time(2026, 8, 12, 18, 29, 0.0), local.peak.time, "local maximum")
+        assertTimeNear(Time(2026, 8, 12, 19, 22, 0.0), local.partialEnd.time, "local end")
+    }
+
+    @Test
+    fun testLocalWindowDiffersFromWorldwideWindow() {
+        val event = eclipseOf20260812()
+        val window = globalSolarEclipseWindow(event)
+        val local = assertNotNull(localSolarEclipseWindow(event, soria), "eclipse visible from Soria")
+
+        // The observer enters the penumbra long after it first touches the Earth,
+        // and leaves it before the penumbra leaves the Earth.
+        assertTrue(
+            (local.partialBegin.time.ut - window.start.ut) * MINUTES_PER_DAY > 60.0,
+            "local start must be well after the worldwide start"
+        )
+        assertTrue(
+            (window.end.ut - local.partialEnd.time.ut) * MINUTES_PER_DAY > 15.0,
+            "local end must be before the worldwide end"
+        )
+        assertTrue(
+            local.partialBegin.time.ut < local.peak.time.ut &&
+                local.peak.time.ut < local.partialEnd.time.ut,
+            "local contact times must be ordered"
+        )
+    }
+
+    @Test
+    fun testLocalWindowReportsSunBelowHorizon() {
+        val event = eclipseOf20260812()
+        val local = assertNotNull(localSolarEclipseWindow(event, soria), "eclipse visible from Soria")
+
+        assertTrue(local.partialBegin.altitude > 0.0, "eclipse starts while the Sun is up")
+        assertTrue(local.partialEnd.altitude < 0.0, "the Sun sets before the eclipse ends")
+    }
+
+    @Test
+    fun testLocalWindowIsNullWhereTheEclipseNeverReaches() {
+        val event = eclipseOf20260812()
+        assertNull(localSolarEclipseWindow(event, sydney), "eclipse must not be visible from Sydney")
+    }
+}

--- a/OsmAnd/res/layout-land/solar_eclipse_timeline_card.xml
+++ b/OsmAnd/res/layout-land/solar_eclipse_timeline_card.xml
@@ -209,23 +209,23 @@
 
 				<LinearLayout
 					android:layout_width="match_parent"
-					android:layout_height="48dp"
+					android:layout_height="60dp"
 					android:baselineAligned="false"
 					android:orientation="horizontal">
 
 					<LinearLayout android:layout_width="0dp" android:layout_height="match_parent" android:layout_weight="1" android:gravity="start" android:orientation="vertical">
 						<TextView style="@style/TextAppearance.Material3.LabelSmall" android:layout_width="wrap_content" android:layout_height="16dp" android:text="@string/astro_eclipse_start" android:textColor="?attr/text_color_primary_v2" android:textSize="11sp" android:textStyle="bold" />
-						<TextView android:id="@+id/eclipse_start_time" style="@style/TextAppearance.Material3.LabelSmall" android:layout_width="wrap_content" android:layout_height="32dp" android:gravity="start|center_vertical" android:maxLines="2" android:textColor="?android:attr/textColorSecondary" android:textSize="10sp" />
+						<TextView android:id="@+id/eclipse_start_time" style="@style/TextAppearance.Material3.LabelSmall" android:layout_width="wrap_content" android:layout_height="44dp" android:gravity="start|top" android:maxLines="3" android:textColor="?android:attr/textColorSecondary" android:textSize="10sp" />
 					</LinearLayout>
 
 					<LinearLayout android:layout_width="0dp" android:layout_height="match_parent" android:layout_weight="1" android:gravity="center_horizontal" android:orientation="vertical">
 						<TextView style="@style/TextAppearance.Material3.LabelSmall" android:layout_width="wrap_content" android:layout_height="16dp" android:text="@string/astro_eclipse_maximum" android:textColor="@color/osmand_orange" android:textSize="11sp" android:textStyle="bold" />
-						<TextView android:id="@+id/eclipse_maximum_time" style="@style/TextAppearance.Material3.LabelSmall" android:layout_width="wrap_content" android:layout_height="32dp" android:gravity="center" android:maxLines="2" android:textColor="?android:attr/textColorSecondary" android:textSize="10sp" />
+						<TextView android:id="@+id/eclipse_maximum_time" style="@style/TextAppearance.Material3.LabelSmall" android:layout_width="wrap_content" android:layout_height="44dp" android:gravity="center_horizontal|top" android:maxLines="3" android:textColor="?android:attr/textColorSecondary" android:textSize="10sp" />
 					</LinearLayout>
 
 					<LinearLayout android:layout_width="0dp" android:layout_height="match_parent" android:layout_weight="1" android:gravity="end" android:orientation="vertical">
 						<TextView style="@style/TextAppearance.Material3.LabelSmall" android:layout_width="wrap_content" android:layout_height="16dp" android:text="@string/astro_eclipse_end" android:textColor="?attr/text_color_primary_v2" android:textSize="11sp" android:textStyle="bold" />
-						<TextView android:id="@+id/eclipse_end_time" style="@style/TextAppearance.Material3.LabelSmall" android:layout_width="wrap_content" android:layout_height="32dp" android:gravity="end|center_vertical" android:maxLines="2" android:textColor="?android:attr/textColorSecondary" android:textSize="10sp" />
+						<TextView android:id="@+id/eclipse_end_time" style="@style/TextAppearance.Material3.LabelSmall" android:layout_width="wrap_content" android:layout_height="44dp" android:gravity="end|top" android:maxLines="3" android:textColor="?android:attr/textColorSecondary" android:textSize="10sp" />
 					</LinearLayout>
 				</LinearLayout>
 			</LinearLayout>

--- a/OsmAnd/res/layout/solar_eclipse_timeline_card.xml
+++ b/OsmAnd/res/layout/solar_eclipse_timeline_card.xml
@@ -202,23 +202,23 @@
 
 			<LinearLayout
 				android:layout_width="match_parent"
-				android:layout_height="54dp"
+				android:layout_height="66dp"
 				android:baselineAligned="false"
 				android:orientation="horizontal">
 
 				<LinearLayout android:layout_width="0dp" android:layout_height="match_parent" android:layout_weight="1" android:gravity="start" android:orientation="vertical">
 					<TextView style="@style/TextAppearance.Material3.LabelMedium" android:layout_width="wrap_content" android:layout_height="18dp" android:text="@string/astro_eclipse_start" android:textColor="?attr/text_color_primary_v2" android:textSize="12sp" android:textStyle="bold" />
-					<TextView android:id="@+id/eclipse_start_time" style="@style/TextAppearance.Material3.LabelSmall" android:layout_width="wrap_content" android:layout_height="36dp" android:gravity="start|center_vertical" android:maxLines="2" android:textColor="?android:attr/textColorSecondary" android:textSize="11sp" />
+					<TextView android:id="@+id/eclipse_start_time" style="@style/TextAppearance.Material3.LabelSmall" android:layout_width="wrap_content" android:layout_height="48dp" android:gravity="start|top" android:maxLines="3" android:textColor="?android:attr/textColorSecondary" android:textSize="11sp" />
 				</LinearLayout>
 
 				<LinearLayout android:layout_width="0dp" android:layout_height="match_parent" android:layout_weight="1" android:gravity="center_horizontal" android:orientation="vertical">
 					<TextView style="@style/TextAppearance.Material3.LabelMedium" android:layout_width="wrap_content" android:layout_height="18dp" android:text="@string/astro_eclipse_maximum" android:textColor="@color/osmand_orange" android:textSize="12sp" android:textStyle="bold" />
-					<TextView android:id="@+id/eclipse_maximum_time" style="@style/TextAppearance.Material3.LabelSmall" android:layout_width="wrap_content" android:layout_height="36dp" android:gravity="center" android:maxLines="2" android:textColor="?android:attr/textColorSecondary" android:textSize="11sp" />
+					<TextView android:id="@+id/eclipse_maximum_time" style="@style/TextAppearance.Material3.LabelSmall" android:layout_width="wrap_content" android:layout_height="48dp" android:gravity="center_horizontal|top" android:maxLines="3" android:textColor="?android:attr/textColorSecondary" android:textSize="11sp" />
 				</LinearLayout>
 
 				<LinearLayout android:layout_width="0dp" android:layout_height="match_parent" android:layout_weight="1" android:gravity="end" android:orientation="vertical">
 					<TextView style="@style/TextAppearance.Material3.LabelMedium" android:layout_width="wrap_content" android:layout_height="18dp" android:text="@string/astro_eclipse_end" android:textColor="?attr/text_color_primary_v2" android:textSize="12sp" android:textStyle="bold" />
-					<TextView android:id="@+id/eclipse_end_time" style="@style/TextAppearance.Material3.LabelSmall" android:layout_width="wrap_content" android:layout_height="36dp" android:gravity="end|center_vertical" android:maxLines="2" android:textColor="?android:attr/textColorSecondary" android:textSize="11sp" />
+					<TextView android:id="@+id/eclipse_end_time" style="@style/TextAppearance.Material3.LabelSmall" android:layout_width="wrap_content" android:layout_height="48dp" android:gravity="end|top" android:maxLines="3" android:textColor="?android:attr/textColorSecondary" android:textSize="11sp" />
 				</LinearLayout>
 			</LinearLayout>
 

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -11,6 +11,7 @@
 	Strings for OsmAnd core
 	Thx - Hardy
 -->
+	<string name="astro_eclipse_column_below_horizon">Below horizon</string>
 	<string name="share_favorites_media_preparation_failed">Couldn\'t include attached media. Sharing points only.</string>
 	<plurals name="files_count">
 		<item quantity="one">%d file</item>

--- a/OsmAnd/src/net/osmand/plus/plugins/astronomy/StarMapFragment.kt
+++ b/OsmAnd/src/net/osmand/plus/plugins/astronomy/StarMapFragment.kt
@@ -24,7 +24,11 @@ import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.button.MaterialButton
+import io.github.cosinekitty.astronomy.EclipseEvent
 import io.github.cosinekitty.astronomy.EclipseKind
+import io.github.cosinekitty.astronomy.GlobalSolarEclipseInfo
+import io.github.cosinekitty.astronomy.GlobalSolarEclipseWindow
+import io.github.cosinekitty.astronomy.LocalSolarEclipseInfo
 import io.github.cosinekitty.astronomy.LunarEclipseMapFrame
 import io.github.cosinekitty.astronomy.LunarEclipsePhase
 import io.github.cosinekitty.astronomy.LunarEclipseState
@@ -182,6 +186,8 @@ class StarMapFragment : BaseFullScreenFragment(), IMapLocationListener, OsmAndLo
 	private var lastBoundEclipseEventKey: Double? = null
 	private var lastBoundEclipseSelectedTime = Double.NaN
 	private var lastBoundLocalEclipseState: SolarEclipseState? = null
+	private var lastBoundLocalEclipseWindow: LocalSolarEclipseInfo? = null
+	private var lastBoundEclipseColumnsLocal: Boolean? = null
 	private var lastBoundLocalLunarEclipseState: LunarEclipseState? = null
 	private var lastDisplayedEclipseLatitude = Double.NaN
 	private var lastDisplayedEclipseLongitude = Double.NaN
@@ -1623,10 +1629,15 @@ class StarMapFragment : BaseFullScreenFragment(), IMapLocationListener, OsmAndLo
 					else -> R.string.astro_partial_solar_eclipse
 				})
 				eclipseEventDate.text = formatEclipseDate(event.peak)
-				eclipseStartTime.text = formatEclipseColumn(window.start)
-				eclipseMaximumTime.text = formatEclipseColumn(event.peak)
-				eclipseEndTime.text = formatEclipseColumn(window.end)
 				lastBoundEclipseEventKey = event.peak.ut
+			}
+			val localWindow = state.localWindow
+			if (eventChanged || lastBoundLocalEclipseWindow !== localWindow ||
+				lastBoundEclipseColumnsLocal != (localWindow != null)
+			) {
+				bindEclipseColumns(localWindow, window, event)
+				lastBoundLocalEclipseWindow = localWindow
+				lastBoundEclipseColumnsLocal = localWindow != null
 			}
 			if (lastBoundEclipseSelectedTime != selectedTime.ut) {
 				val selectedMillis = selectedTime.toMillisecondsSince1970()
@@ -1652,8 +1663,12 @@ class StarMapFragment : BaseFullScreenFragment(), IMapLocationListener, OsmAndLo
 			eclipseTimeline.setRange(
 				startMillis,
 				endMillis,
-				event.peak.toMillisecondsSince1970(),
-				selectedTime.toMillisecondsSince1970()
+				(localWindow?.peak?.time ?: event.peak).toMillisecondsSince1970(),
+				selectedTime.toMillisecondsSince1970(),
+				partialContacts = listOfNotNull(localWindow?.partialBegin, localWindow?.partialEnd)
+					.map { it.time.toMillisecondsSince1970() },
+				totalContacts = listOfNotNull(localWindow?.totalBegin, localWindow?.totalEnd)
+					.map { it.time.toMillisecondsSince1970() }
 			)
 			val insideWindow = selectedTime.ut in window.start.ut..window.end.ut
 			eclipseFitPath.isEnabled = insideWindow && !state.mapLoading
@@ -1844,6 +1859,8 @@ class StarMapFragment : BaseFullScreenFragment(), IMapLocationListener, OsmAndLo
 		lastBoundEclipseEventKey = null
 		lastBoundEclipseSelectedTime = Double.NaN
 		lastBoundLocalEclipseState = null
+		lastBoundLocalEclipseWindow = null
+		lastBoundEclipseColumnsLocal = null
 		lastBoundLocalLunarEclipseState = null
 		lastDisplayedEclipseLatitude = Double.NaN
 		lastDisplayedEclipseLongitude = Double.NaN
@@ -2103,6 +2120,36 @@ class StarMapFragment : BaseFullScreenFragment(), IMapLocationListener, OsmAndLo
 		val millis = time.toMillisecondsSince1970()
 		val date = DateFormat.getDateInstance(DateFormat.SHORT, Locale.getDefault()).format(Date(millis))
 		return "$date\n${formatClockWithSeconds(millis)}"
+	}
+
+	private fun formatEclipseColumn(event: EclipseEvent): String {
+		val column = formatEclipseColumn(event.time)
+		return if (event.altitude <= 0.0) {
+			"$column\n${getString(R.string.astro_eclipse_column_below_horizon)}"
+		} else {
+			column
+		}
+	}
+
+	private fun bindEclipseColumns(
+		localWindow: LocalSolarEclipseInfo?,
+		window: GlobalSolarEclipseWindow,
+		event: GlobalSolarEclipseInfo
+	) {
+		if (localWindow != null) {
+			setTextIfChanged(eclipseStartTime, formatEclipseColumn(localWindow.partialBegin))
+			setTextIfChanged(eclipseMaximumTime, formatEclipseColumn(localWindow.peak))
+			setTextIfChanged(eclipseEndTime, formatEclipseColumn(localWindow.partialEnd))
+		} else {
+			// The eclipse never reaches the map center; the status line above says so.
+			setTextIfChanged(eclipseStartTime, formatEclipseColumn(window.start))
+			setTextIfChanged(eclipseMaximumTime, formatEclipseColumn(event.peak))
+			setTextIfChanged(eclipseEndTime, formatEclipseColumn(window.end))
+		}
+	}
+
+	private fun setTextIfChanged(view: TextView, text: String) {
+		if (view.text?.toString() != text) view.text = text
 	}
 
 	private fun formatClockWithSeconds(millis: Long): String {

--- a/OsmAnd/src/net/osmand/plus/plugins/astronomy/StarObjectsViewModel.kt
+++ b/OsmAnd/src/net/osmand/plus/plugins/astronomy/StarObjectsViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.viewModelScope
 import io.github.cosinekitty.astronomy.EclipseKind
 import io.github.cosinekitty.astronomy.GlobalSolarEclipseInfo
 import io.github.cosinekitty.astronomy.GlobalSolarEclipseWindow
+import io.github.cosinekitty.astronomy.LocalSolarEclipseInfo
 import io.github.cosinekitty.astronomy.LunarEclipseInfo
 import io.github.cosinekitty.astronomy.LunarEclipseMapFrame
 import io.github.cosinekitty.astronomy.LunarEclipseState
@@ -21,6 +22,7 @@ import io.github.cosinekitty.astronomy.SolarEclipseShadowPoint
 import io.github.cosinekitty.astronomy.SolarEclipseState
 import io.github.cosinekitty.astronomy.Time
 import io.github.cosinekitty.astronomy.globalSolarEclipseWindow
+import io.github.cosinekitty.astronomy.localSolarEclipseWindow
 import io.github.cosinekitty.astronomy.lunarEclipseMapFrame
 import io.github.cosinekitty.astronomy.lunarEclipseState
 import io.github.cosinekitty.astronomy.lunarEclipseWindow
@@ -57,6 +59,12 @@ data class SolarEclipseModeState(
 	val window: GlobalSolarEclipseWindow? = null,
 	val selectedTime: Time? = null,
 	val localState: SolarEclipseState? = null,
+	/**
+	 * Contact times at the map center, or null when the eclipse is not visible from there.
+	 * Keeps the previously calculated value while the map is being panned, so that the card
+	 * does not fall back to the worldwide times on every frame.
+	 */
+	val localWindow: LocalSolarEclipseInfo? = null,
 	val error: Boolean = false,
 	val navigationDirection: SolarEclipseNavigationDirection = SolarEclipseNavigationDirection.Initial,
 	val trackLoading: Boolean = false,
@@ -123,13 +131,16 @@ class StarObjectsViewModel(
 
 	private var eclipseSearchJob: Job? = null
 	private var eclipseLocalStateJob: Job? = null
+	private var eclipseLocalWindowJob: Job? = null
 	private var eclipseTrackJob: Job? = null
 	private var eclipseFrameJob: Job? = null
 	private var eclipseRequestId = 0L
 	private var eclipseMapRequestId = 0L
 	private var eclipseLocalRequestId = 0L
+	private var eclipseLocalWindowRequestId = 0L
 	private var eclipseFrameRequestId = 0L
 	private var pendingEclipseLocalRequest: LocalEclipseRequest? = null
+	private var pendingEclipseLocalWindowRequest: LocalWindowRequest? = null
 	private var pendingEclipseTrackRequest: TrackRequest? = null
 	private var pendingEclipseFrameTime: Time? = null
 	private val eclipseTrackCache = mutableMapOf<Double, SolarEclipseMapTrack>()
@@ -270,7 +281,7 @@ class StarObjectsViewModel(
 			} else {
 				event.peak
 			}
-			SearchResult(event, window, selectedTime)
+			SearchResult(event, window, selectedTime, localEclipseWindowOrNull(event, observer))
 		}
 	}
 
@@ -281,7 +292,12 @@ class StarObjectsViewModel(
 		val observer = state.observer ?: return
 		searchSolarEclipse(observer, SolarEclipseNavigationDirection.Previous) {
 			val event = previousGlobalSolarEclipse(current.peak)
-			SearchResult(event, globalSolarEclipseWindow(event), event.peak)
+			SearchResult(
+				event,
+				globalSolarEclipseWindow(event),
+				event.peak,
+				localEclipseWindowOrNull(event, observer)
+			)
 		}
 	}
 
@@ -292,7 +308,12 @@ class StarObjectsViewModel(
 		val observer = state.observer ?: return
 		searchSolarEclipse(observer, SolarEclipseNavigationDirection.Next) {
 			val event = nextGlobalSolarEclipse(current.peak)
-			SearchResult(event, globalSolarEclipseWindow(event), event.peak)
+			SearchResult(
+				event,
+				globalSolarEclipseWindow(event),
+				event.peak,
+				localEclipseWindowOrNull(event, observer)
+			)
 		}
 	}
 
@@ -327,6 +348,7 @@ class StarObjectsViewModel(
 		if (!state.active || sameObserver(state.observer, observer)) return
 		_solarEclipseModeState.value = state.copy(observer = observer)
 		calculateLocalEclipseState(observer, state.selectedTime)
+		calculateLocalEclipseWindow(state.event, observer)
 	}
 
 	fun requestSolarEclipseShadowPoint() {
@@ -370,12 +392,15 @@ class StarObjectsViewModel(
 		eclipseRequestId++
 		eclipseMapRequestId++
 		eclipseLocalRequestId++
+		eclipseLocalWindowRequestId++
 		eclipseFrameRequestId++
 		pendingEclipseLocalRequest = null
+		pendingEclipseLocalWindowRequest = null
 		pendingEclipseTrackRequest = null
 		pendingEclipseFrameTime = null
 		eclipseSearchJob?.cancel()
 		eclipseLocalStateJob?.cancel()
+		eclipseLocalWindowJob?.cancel()
 		eclipseTrackJob?.cancel()
 		eclipseFrameJob?.cancel()
 		_solarEclipseModeState.value = SolarEclipseModeState()
@@ -641,6 +666,8 @@ class StarObjectsViewModel(
 		eclipseSearchJob?.cancel()
 		eclipseLocalRequestId++
 		pendingEclipseLocalRequest = null
+		eclipseLocalWindowRequestId++
+		pendingEclipseLocalWindowRequest = null
 		eclipseFrameRequestId++
 		pendingEclipseFrameTime = null
 		pendingEclipseTrackRequest = null
@@ -677,10 +704,14 @@ class StarObjectsViewModel(
 					event = result.event,
 					window = result.window,
 					selectedTime = result.selectedTime,
+					localWindow = result.localWindow,
 					navigationDirection = direction,
 					trackLoading = true
 				)
 				calculateLocalEclipseState(currentObserver, result.selectedTime)
+				if (!sameObserver(observer, currentObserver)) {
+					calculateLocalEclipseWindow(result.event, currentObserver)
+				}
 				calculateSolarEclipseTrack(requestId, result.window)
 				calculateSolarEclipseMapFrame(result.selectedTime)
 			} catch (e: CancellationException) {
@@ -822,6 +853,41 @@ class StarObjectsViewModel(
 		}
 	}
 
+	private fun localEclipseWindowOrNull(
+		event: GlobalSolarEclipseInfo,
+		observer: Observer
+	): LocalSolarEclipseInfo? = try {
+		localSolarEclipseWindow(event, observer)
+	} catch (e: Exception) {
+		// Fall back to the worldwide times instead of leaving the card empty.
+		LOG.error("Unable to calculate local solar eclipse contact times", e)
+		null
+	}
+
+	private fun calculateLocalEclipseWindow(event: GlobalSolarEclipseInfo?, observer: Observer?) {
+		if (event == null || observer == null) return
+		pendingEclipseLocalWindowRequest = LocalWindowRequest(
+			requestId = ++eclipseLocalWindowRequestId,
+			event = event,
+			observer = observer
+		)
+		if (eclipseLocalWindowJob?.isActive == true) return
+		eclipseLocalWindowJob = viewModelScope.launch {
+			while (true) {
+				val request = pendingEclipseLocalWindowRequest ?: break
+				pendingEclipseLocalWindowRequest = null
+				val localWindow = withContext(Dispatchers.Default) {
+					localEclipseWindowOrNull(request.event, request.observer)
+				}
+				if (request.requestId != eclipseLocalWindowRequestId) continue
+				val latest = _solarEclipseModeState.value ?: continue
+				if (!latest.active || latest.event?.peak?.ut != request.event.peak.ut ||
+					!sameObserver(latest.observer, request.observer)) continue
+				_solarEclipseModeState.value = latest.copy(localWindow = localWindow)
+			}
+		}
+	}
+
 	fun refreshSkyObjects() {
 		_skyObjects.value = _skyObjects.value
 		_constellations.value = _constellations.value
@@ -836,7 +902,8 @@ class StarObjectsViewModel(
 	private data class SearchResult(
 		val event: GlobalSolarEclipseInfo,
 		val window: GlobalSolarEclipseWindow,
-		val selectedTime: Time
+		val selectedTime: Time,
+		val localWindow: LocalSolarEclipseInfo?
 	)
 
 	private data class LunarSearchResult(
@@ -849,6 +916,12 @@ class StarObjectsViewModel(
 		val requestId: Long,
 		val observer: Observer,
 		val time: Time
+	)
+
+	private data class LocalWindowRequest(
+		val requestId: Long,
+		val event: GlobalSolarEclipseInfo,
+		val observer: Observer
 	)
 
 	private data class TrackRequest(


### PR DESCRIPTION
Fixes #25830.

## Problem

The solar eclipse card showed the **worldwide** bounds of the eclipse under labels that everything around them reads as local. `Start` and `End` came from `globalSolarEclipseWindow()` — the first and last contact of the Moon's penumbra with the Earth *anywhere on the planet* — and `Maximum` came from the greatest eclipse, when the shadow axis passes closest to the Earth's centre. Those three instants are identical for every user on Earth.

For 2026-08-12 at Soria the card read 17:33:55 / 19:45:46 / 21:57:42 local time. Converted to UT (CEST = UT+2) those are 15:33:55 / 17:45:46 / 19:57:42, which match the published worldwide circumstances of that eclipse to within seconds. The observer's own times are 19:34 / 20:29 / 21:22 local.

As the reporter noticed, the sun/moon diagram was already right: it uses `solarEclipseState(time, observer)`, which is genuinely topocentric. Only the three headline numbers disagreed with it.

The lunar card is unaffected — a lunar eclipse's contact times really are the same instants for every observer.

## Change

**`localSolarEclipseWindow(event, observer)`** in `OsmAnd-shared`, next to `globalSolarEclipseWindow()`. It anchors on the peak of an already known global eclipse rather than calling the existing `searchLocalSolarEclipse()`, which advances to another new moon whenever the selected eclipse is invisible or entirely nocturnal at that location — that would desynchronise the card from the world shadow track. Returns `null` when the penumbra never reaches the observer.

The global search, previous/next navigation and the shadow-track map are untouched. `Start` / `Maximum` / `End` now come from `partialBegin` / `peak` / `partialEnd`, and a contact whose Sun altitude is not above the horizon is marked **Below horizon** — which is the reporter's second point, since the Sun sets at Soria before the eclipse ends.

The timeline gains the local contact markers that `EclipseTimelineView` already supported but the solar path never supplied, and its maximum tick follows the local peak. Its range deliberately stays the global window, so the shadow track remains scrubbable across the Earth.

When the eclipse does not reach the map centre at all there are no local times, and the columns keep showing the times of the event itself. The status line above them already reports that it is not visible from there.

### Stability while panning

`updateStarMap()` pushes a new observer on every frame of a map pan. The contact times are therefore calculated on the same background pass as the global window (so navigating between eclipses never shows the worldwide times first), the previously calculated value stays on screen until the new one is ready, and the columns are only rewritten when their text actually changes. The columns also reserve room for the third line, so the card keeps a stable height whether or not the note is shown — about 12dp taller than before, permanently.

## Validation

`OsmAnd-shared/src/commonTest/.../SolarEclipseWindowTest.kt` covers the worldwide bounds, the Soria contact times, the gap between the two, `partialEnd.altitude < 0`, and a `null` result for an observer the eclipse never reaches.

**Not yet run, and the change has not been built or exercised on an emulator.** `android/AGENTS.md` §9 forbids the agent from invoking Gradle; `AGENTS.override.md` prescribes a build plus emulator run for a UI change like this one. Whoever picks this up should run:

```
./gradlew :OsmAnd-shared:jvmTest --tests '*SolarEclipseWindowTest*'
./gradlew assembleGplayFreeOpenglArm64Debug
```

The worldwide expectations in the test are solid — they agree with both the published circumstances and the engine's own output quoted in the issue. The local expectations are the reporter's minute-rounded figures with a 6-minute tolerance and may need adjusting on the first real run.

Two things for UI review: the permanent ~12dp of extra card height, and that at large system font scales the third line can clip against the fixed height — the same tradeoff every other fixed-height row in this card already makes.

## Not included

The reporter's third point — the two rings around the Sun in the diagram. They are two stacked translucent circles at 1.7x and 1.3x the solar radius (`StarView.kt`), pure decoration with no physical meaning and hard edges that read as rings. Replacing them with a radial gradient is independent of this change and left for a separate PR.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Analyse issue #25830.
2. Implement the four steps proposed by that analysis: the shared-module local-circumstances function, wiring it into the view model without disturbing global navigation, driving the card columns from it with a horizon annotation, and feeding local contacts to the timeline.
3. Commit to a new branch without pushing.
4. Report that the below-horizon note and the scope wording flickered and made the card jump while panning the map.
5. Ask what "worldwide" meant in the proposed label.
6. Drop the scope caption strings entirely as unnecessary.
7. Commit, push and open this PR.

Decided by the agent, not requested explicitly:
- Anchoring on the global event instead of `searchLocalSolarEclipse()`, and returning `null` rather than throwing when the eclipse misses the observer.
- Keeping the timeline range global instead of clamping it to the local window, which step 4 of the approved plan had called for. Clamping would make the world shadow track unscrubbable; this was flagged at the time and the reviewer may still prefer clamping.
- Seeding the local window from the search pass, holding the previous value during panning, and the `setTextIfChanged` guard — all to satisfy the "no flicker" requirement from prompt 4.
- Reserving fixed height for the below-horizon line rather than letting the card resize.
- The regression test and its tolerances.
