### PR TITLE
Fix crash in search results when a downloaded map item is removed

### DIFF
--- a/OsmAnd/src/net/osmand/plus/search/dialogs/QuickSearchListAdapter.java
+++ b/OsmAnd/src/net/osmand/plus/search/dialogs/QuickSearchListAdapter.java
@@ -80,6 +80,7 @@ public class QuickSearchListAdapter extends ArrayAdapter<QuickSearchListItem> {
 	private boolean selectAll;
 	private boolean exploreHistoryCard;
 	private final List<QuickSearchListItem> selectedItems = new ArrayList<>();
+	private final List<QuickSearchListItem> itemsToRemove = new ArrayList<>();
 	private final UpdateLocationViewCache updateLocationViewCache;
 	private final SearchTrackDataResolver trackDataResolver;
 
@@ -503,11 +504,10 @@ public class QuickSearchListAdapter extends ArrayAdapter<QuickSearchListItem> {
 		if (searchResult != null && searchResult.objectType == ObjectType.INDEX_ITEM) {
 			view = getConvertView(convertView, R.layout.search_download_map_list_item);
 			IndexItem indexItem = (IndexItem) searchResult.relatedObject;
+			bindIndexItem(view, indexItem, activity, nightMode);
 			if (indexItem.isDownloaded()) {
 				// remove item after downloading
-				remove(listItem);
-			} else {
-				bindIndexItem(view, indexItem, activity, nightMode);
+				removeItemDelayed(listItem);
 			}
 		} else if (searchResult != null && searchResult.objectType == ObjectType.GPX_TRACK) {
 			view = getConvertView(convertView, R.layout.search_list_item_full);
@@ -545,6 +545,30 @@ public class QuickSearchListAdapter extends ArrayAdapter<QuickSearchListItem> {
 			setupCheckBox(position, view, listItem);
 		}
 		return view;
+	}
+
+	/**
+	 * Schedules the item removal for the next UI message instead of removing it right away.
+	 * {@link #getView(int, View, ViewGroup)} is called from a layout pass, and modifying the
+	 * adapter content there leaves the list view with a stale item count for the rest of that
+	 * pass, which ends up in an {@link IndexOutOfBoundsException} on the following positions.
+	 */
+	private void removeItemDelayed(@NonNull QuickSearchListItem item) {
+		if (itemsToRemove.contains(item)) {
+			return;
+		}
+		itemsToRemove.add(item);
+		if (itemsToRemove.size() == 1) {
+			app.runInUIThread(() -> {
+				setNotifyOnChange(false);
+				for (QuickSearchListItem itemToRemove : itemsToRemove) {
+					remove(itemToRemove);
+				}
+				itemsToRemove.clear();
+				setNotifyOnChange(true);
+				notifyDataSetChanged();
+			});
+		}
 	}
 
 	private View bindSpatialCategorySearchResultItem(int position, @Nullable View convertView,
@@ -668,14 +692,13 @@ public class QuickSearchListAdapter extends ArrayAdapter<QuickSearchListItem> {
 	                          boolean useBigMargin) {
 		View divider = view.findViewById(R.id.divider);
 		if (divider != null) {
-			Object o = getItem(position);
-			if (position == getCount() - 1 || getItem(position + 1).getType() == HEADER
-					|| getItem(position + 1).getType() == BOTTOM_SHADOW || getItem(position + 1).getType() == CARD_DIVIDER) {
+			QuickSearchListItem nextItem = position >= 0 && position + 1 < getCount() ? getItem(position + 1) : null;
+			QuickSearchListItemType nextItemType = nextItem != null ? nextItem.getType() : null;
+			if (nextItemType == null || nextItemType == HEADER
+					|| nextItemType == BOTTOM_SHADOW || nextItemType == CARD_DIVIDER) {
 				divider.setVisibility(View.GONE);
 			} else {
 				divider.setVisibility(View.VISIBLE);
-				QuickSearchListItem nextItem = position < getCount() - 1 ? getItem(position + 1) : null;
-				QuickSearchListItemType nextItemType = nextItem != null ? nextItem.getType() : null;
 				if (nextItemType == SEARCH_MORE
 						|| nextItemType == SEARCH_ON_WEB
 						|| listItem.getType() == QuickSearchListItemType.SELECT_ALL) {


### PR DESCRIPTION
## Problem

Play Console crash `net.osmand.plus.search.dialogs.QuickSearchListAdapter.setupDivider` — `java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0` (5 events / 5 users in the last 28 days, versions 5.4.1 / 5.4.3 / 5.4.4).

```
at android.widget.ArrayAdapter.getItem (ArrayAdapter.java:394)
at net.osmand.plus.search.dialogs.QuickSearchListAdapter.setupDivider (QuickSearchListAdapter.java:671)
at net.osmand.plus.search.dialogs.QuickSearchListAdapter.getView (QuickSearchListAdapter.java:289)
at android.widget.AbsListView.obtainView (AbsListView.java:2707)
at android.widget.ListView.fillSpecific (ListView.java:1532)
at android.widget.ListView.layoutChildren (ListView.java:1928)
```

## Cause

`bindSearchResultItem()` removes a downloaded map row straight from `getView()`:

```java
if (indexItem.isDownloaded()) {
    // remove item after downloading
    remove(listItem);
}
```

`getView()` runs inside a `ListView` layout pass. `ArrayAdapter.remove()` shrinks the backing list right there, while the list view keeps the item count it captured at the start of the pass, so the rest of that pass reads past the end of the adapter. When the only row is the `INDEX_ITEM` (a downloadable map offered in the search results), the adapter becomes empty and `setupDivider()` — which calls `getItem(position)` for the same position `getView()` was called with — throws.

That happens after the user downloads a map from the search results: the item stays in the cached `SearchResultCollection`, so the next re-render of that collection (`updateListAdapter()` → `setListItems()` → `getListView().setSelection(0)` → `fillSpecific`, exactly the frames in the report) binds a row whose `isDownloaded()` has meanwhile flipped to `true`.

## Reproduction (emulator, 5.4.0 nightly, reproduced twice)

1. Have no local map for the searched region (map center far from it, so no other result matches).
2. Search `Andorra` — the result list is exactly `Andorra · 5.30 MB · Standard map` + `INCREASE SEARCH RADIUS`.
3. Tap the row, let the map download finish.
4. Clear the query and type `Andorra` again — the cached collection is re-rendered as a single row.

→ `IndexOutOfBoundsException: Index 0 out of bounds for length 0` at `QuickSearchListAdapter.java:671`, byte-for-byte the reported stack trace.

With this patch the same steps no longer crash and the downloaded row still disappears from the list.

## Fix

- `removeItemDelayed()` — the removal is posted to the UI handler and applied after the layout pass, batched under a single `notifyDataSetChanged()`.
- `bindIndexItem()` is now called in both branches, so the row is not left blank for the frame before it is removed.
- `setupDivider()` reads the *next* item through a bounds check instead of `getItem(position)` / `getItem(position + 1)`, so a mid-layout data change can no longer crash it. The dead `Object o = getItem(position);` line is gone. Behaviour is unchanged: no next item still means no divider.

Worth cherry-picking to `r5.4`.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Reproduce and fix the Play Console crash at `<link to the QuickSearchListAdapter.setupDivider issue>`.
2. Send the pull request once the fix is verified.

Decided by the agent, not requested explicitly:
- Root-cause analysis and the choice of fix (deferred removal via `app.runInUIThread()` rather than, say, filtering downloaded index items out when the rows are built).
- Keeping `bindIndexItem()` for the already-downloaded row so it is not blank for one frame.
- The extra bounds hardening in `setupDivider()` and the removal of the unused `Object o = getItem(position);` line.
- The reproduction scenario (Andorra map on an emulator with no local maps) and verification by building/installing the nightly debug flavour before and after the patch.
- Branch name, commit message and PR wording; targeting `master` and only suggesting the `r5.4` cherry-pick rather than opening a second PR.
