### PR TITLE
Re-enable separate map magnifier for Android Auto (#22693)

### DIFF
--- a/OsmAnd/src/net/osmand/core/android/MapRendererContext.java
+++ b/OsmAnd/src/net/osmand/core/android/MapRendererContext.java
@@ -192,8 +192,7 @@ public class MapRendererContext {
 	}
 
 	protected int getRasterTileSize() {
-		OsmandMap osmandMap = app.getOsmandMap();
-		float mapDensity = osmandMap != null ? osmandMap.getMapDensity() : app.getSettings().MAP_DENSITY.get();
+		float mapDensity = OsmandMap.getMapDensitySettings(app);
 		float mapDensityAligned = mapDensity > 2.0f ? 2.0f : Math.min(mapDensity, 1.0f);
 		return (int) (getReferenceTileSize() * mapDensityAligned);
 	}
@@ -246,7 +245,10 @@ public class MapRendererContext {
 			}
 		}
 		ResolvedMapStyle mapStyle = mapStyles.get(rendName);
-		float mapDensity = settings.MAP_DENSITY.get();
+		// must match getRasterTileSize(): the raster tile size and the style scale factor
+		// are two halves of the same magnifier, mixing the phone and the Android Auto values
+		// stretches the rendered tiles
+		float mapDensity = OsmandMap.getMapDensitySettings(app);
 		float textScale = settings.TEXT_SCALE.get();
 		QStringStringHash styleSettings = getMapStyleSettings();
 

--- a/OsmAnd/src/net/osmand/plus/auto/screens/MapMagnifierScreen.kt
+++ b/OsmAnd/src/net/osmand/plus/auto/screens/MapMagnifierScreen.kt
@@ -11,8 +11,9 @@ import androidx.car.app.model.Template
 import androidx.car.app.navigation.model.MapWithContentTemplate
 import androidx.lifecycle.LifecycleOwner
 import net.osmand.plus.R
-import net.osmand.plus.views.corenative.NativeCoreContext
 import java.util.Locale
+import kotlin.math.max
+import kotlin.math.min
 import kotlin.math.roundToInt
 
 class MapMagnifierScreen(
@@ -23,8 +24,8 @@ class MapMagnifierScreen(
 		lifecycle.addObserver(this)
 	}
 
-	private val magnifierValues = listOf(50, 75, 100, 125, 150, 200)
-	private var selectedIndex = 2
+	private var magnifierValues = DEFAULT_VALUES
+	private var selectedIndex = 0
 	private var initialAAMapDensity = 0f
 	private var isApplied = false
 
@@ -44,20 +45,38 @@ class MapMagnifierScreen(
 	override fun onFirstGetTemplate() {
 		super.onFirstGetTemplate()
 		val settings = app.settings
-		val mapDensity: Float = settings.MAP_DENSITY.get()
 		initialAAMapDensity = if (settings.AA_MAP_DENSITY.isSet) {
 			settings.AA_MAP_DENSITY.get()
 		} else {
 			0f
 		}
-		val selectedValue =
-			((if (isInitialValueSet()) initialAAMapDensity else mapDensity) * 100).roundToInt()
-		for (value in magnifierValues) {
-			if (selectedValue == value) {
-				selectedIndex = magnifierValues.indexOf(value)
-				break
-			}
+		// the value in use right now: the Android Auto one if it was ever changed here,
+		// the phone one otherwise
+		val currentValue =
+			((if (isInitialValueSet()) initialAAMapDensity else settings.MAP_DENSITY.get()) * 100)
+				.roundToInt()
+		magnifierValues = buildMagnifierValues(currentValue)
+		selectedIndex = max(0, magnifierValues.indexOf(currentValue))
+	}
+
+	/**
+	 * The phone offers values this screen does not (25 %, 400 % ...). Such a value has to stay
+	 * visible and selected, otherwise the head unit shows a selection the map does not use.
+	 * The list is kept within the host content limit around the selected item.
+	 */
+	private fun buildMagnifierValues(currentValue: Int): List<Int> {
+		val values = DEFAULT_VALUES.toMutableList()
+		if (!values.contains(currentValue)) {
+			values.add(currentValue)
+			values.sort()
 		}
+		val limit = if (contentLimit > 0) contentLimit else values.size
+		if (values.size <= limit) {
+			return values
+		}
+		var from = max(0, values.indexOf(currentValue) - limit / 2)
+		from = min(from, values.size - limit)
+		return values.subList(from, from + limit)
 	}
 
 	private fun isInitialValueSet(): Boolean {
@@ -77,8 +96,7 @@ class MapMagnifierScreen(
 		listBuilder.setOnSelectedListener { index ->
 			if (index >= 0 && index < magnifierValues.size) {
 				val value = magnifierValues[index].toFloat() / 100
-				val settings = app.settings
-				settings.AA_MAP_DENSITY.set(value)
+				app.settings.AA_MAP_DENSITY.set(value)
 				app.osmandMap.mapView.applyDisplayScaleSettings()
 				selectedIndex = index
 			}
@@ -111,5 +129,9 @@ class MapMagnifierScreen(
 			.setContentTemplate(listTemplate)
 			.setActionStrip(actionStrip)
 			.build()
+	}
+
+	companion object {
+		private val DEFAULT_VALUES = listOf(50, 75, 100, 125, 150, 200)
 	}
 }

--- a/OsmAnd/src/net/osmand/plus/auto/screens/SettingsScreen.java
+++ b/OsmAnd/src/net/osmand/plus/auto/screens/SettingsScreen.java
@@ -17,6 +17,8 @@ import net.osmand.plus.R;
 import net.osmand.plus.settings.backend.OsmandSettings;
 import net.osmand.plus.settings.enums.AndroidAutoMapMode;
 
+import java.util.Locale;
+
 /**
  * Settings screen demo.
  */
@@ -69,32 +71,24 @@ public final class SettingsScreen extends BaseAndroidAutoScreen {
 				.setOnClickListener(() -> getScreenManager().pushForResult(
 						new MapModeScreen(getCarContext()), result -> invalidate()));
 
-		ItemList.Builder configureMapModeBuilder = new ItemList.Builder();
-		configureMapModeBuilder.addItem(mapModeRowBuilder.build());
-
-		templateBuilder.addSectionedList(
-				SectionedItemList.create(
-						configureMapModeBuilder.build(),
-						getApp().getString(R.string.configure_map)));
-
 		CarIcon icon = new CarIcon.Builder(IconCompat.createWithResource(getApp(), R.drawable.ic_action_map_magnifier)).build();
 		Row.Builder magnifierRowBuilder = new Row.Builder()
 				.setTitle(getApp().getString(R.string.map_magnifier))
+				.addText(String.format(Locale.US, "%d %%",
+						Math.round(100 * getApp().getOsmandMap().getMapDensity())))
 				.setImage(icon)
 				.setBrowsable(true)
-				.setOnClickListener(() -> {
-					getScreenManager().push(new MapMagnifierScreen(getCarContext()));
-				});
+				.setOnClickListener(() -> getScreenManager().pushForResult(
+						new MapMagnifierScreen(getCarContext()), result -> invalidate()));
 
+		ItemList.Builder configureMapBuilder = new ItemList.Builder();
+		configureMapBuilder.addItem(mapModeRowBuilder.build());
+		configureMapBuilder.addItem(magnifierRowBuilder.build());
 
-		//todo revert when aa scale setting fixed
-//		ItemList.Builder configureMapSectionBuilder = new ItemList.Builder();
-//		configureMapSectionBuilder.addItem(magnifierRowBuilder.build());
-
-//		templateBuilder.addSectionedList(
-//				SectionedItemList.create(
-//						configureMapSectionBuilder.build(),
-//						getApp().getString(R.string.configure_map)));
+		templateBuilder.addSectionedList(
+				SectionedItemList.create(
+						configureMapBuilder.build(),
+						getApp().getString(R.string.configure_map)));
 
         /*
         ItemList.Builder sectionBBuilder = new ItemList.Builder();

--- a/OsmAnd/src/net/osmand/plus/configmap/ConfigureMapDialogs.java
+++ b/OsmAnd/src/net/osmand/plus/configmap/ConfigureMapDialogs.java
@@ -119,10 +119,11 @@ public class ConfigureMapDialogs {
 	                                       @NonNull OsmandPreference<Float> mapDensity,
 	                                       int value) {
 		mapDensity.set(value / 100.0f);
-		//todo revert when aa scale setting fixed
-//		if (!view.isCarView()) {
+		// while Android Auto owns the map view it renders with its own magnifier, the new phone
+		// value is applied by OsmandMapTileView.setView() once the map is given back to the phone
+		if (!view.isCarView()) {
 			view.applyDisplayScaleSettings();
-//		}
+		}
 	}
 
 	private record MapMagnifierValues(@NonNull TIntArrayList percentValues,

--- a/OsmAnd/src/net/osmand/plus/views/OsmandMap.java
+++ b/OsmAnd/src/net/osmand/plus/views/OsmandMap.java
@@ -151,20 +151,20 @@ public class OsmandMap {
 		return app.getSettings().TEXT_SCALE.get();
 	}
 
+	/**
+	 * Map magnifier of the surface the map is currently drawn on: Android Auto keeps its own value
+	 * once it was changed on the head unit, otherwise both displays follow the phone setting.
+	 * Every consumer of the magnifier must use this, so that the phone and the head unit values
+	 * never leak into each other.
+	 */
 	public static float getMapDensitySettings(@NonNull OsmandApplication app) {
 		OsmandSettings settings = app.getSettings();
-		float mapDensity = settings.MAP_DENSITY.get();
-		float aaMapDensity = settings.AA_MAP_DENSITY.get();
-		boolean aaMapDensitySet = settings.AA_MAP_DENSITY.isSet();
-		float densityToSet;
-		if (app.getOsmandMap() != null && app.getOsmandMap().mapView != null &&
-				app.getOsmandMap().mapView.isCarView() && aaMapDensitySet) {
-			densityToSet = aaMapDensity;
-		} else {
-			densityToSet = mapDensity;
+		// may be called while OsmandMap is still being constructed
+		OsmandMap osmandMap = app.getOsmandMap();
+		if (osmandMap != null && osmandMap.mapView != null && osmandMap.mapView.isCarView()
+				&& settings.AA_MAP_DENSITY.isSet()) {
+			return settings.AA_MAP_DENSITY.get();
 		}
-		//todo revert when aa scale setting fixed
-//		return densityToSet;
 		return settings.MAP_DENSITY.get();
 	}
 

--- a/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
+++ b/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
@@ -451,7 +451,6 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 				view.setDefaultFocusHighlightEnabled(false);
 			}
 			applyDisplayScaleSettings();
-			refreshMap(true);
 		}
 	}
 
@@ -739,11 +738,16 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 	}
 
 	public void applyDisplayScaleSettings() {
+		if (!hasMapRenderer()) {
+			// v1 rendering keeps rasterized tiles of the previous magnifier
+			app.getResourceManager().getRenderer().clearCache();
+		}
 		setComplexZoom(getZoom(), getSettingsMapDensity());
 		MapRendererContext mapContext = NativeCoreContext.getMapRendererContext();
 		if (mapContext != null) {
 			mapContext.updateMapSettings(true);
 		}
+		refreshMap(true);
 	}
 
 	public void setComplexZoom(int zoom, double mapDensity) {

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/widgets/RulerWidget.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/widgets/RulerWidget.java
@@ -16,7 +16,6 @@ import net.osmand.data.RotatedTileBox;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.R;
 import net.osmand.plus.helpers.AndroidUiHelper;
-import net.osmand.plus.settings.backend.OsmandSettings;
 import net.osmand.plus.utils.AndroidUtils;
 import net.osmand.plus.utils.OsmAndFormatter;
 import net.osmand.plus.views.OsmandMapTileView;
@@ -26,7 +25,6 @@ import net.osmand.plus.widgets.FrameLayoutEx;
 public class RulerWidget extends FrameLayoutEx implements ViewChangeProvider {
 
 	private final OsmandApplication app;
-	private final OsmandSettings settings;
 	private final OsmandMapTileView mapTileView;
 
 	private View layout;
@@ -56,9 +54,8 @@ public class RulerWidget extends FrameLayoutEx implements ViewChangeProvider {
 		super(context, attrs, defStyleAttr, defStyleRes);
 
 		this.app = AndroidUtils.getApp(context);
-		this.settings = app.getSettings();
 		this.mapTileView = app.getOsmandMap().getMapView();
-		this.cacheMapDensity = settings.MAP_DENSITY.get();
+		this.cacheMapDensity = app.getOsmandMap().getMapDensity();
 	}
 
 	@Override


### PR DESCRIPTION
Re-enables the separate map magnifier for Android Auto, hidden in 0425d6dc12 for 5.4.

Closes part of #22693.

## Why it did not work

Two reverts happened, for two different reasons.

**`c081809460` — Revert "Improve aa set scale" (#25291).** The reverted commit added
`updateCurrentViewportDensity()` to the viewport refresh path, moving the viewport density
to the car surface density while Android Auto renders. But every layer icon is scaled by

```java
getTextScale()           = TEXT_SCALE * getCarDensityScaleCoef();
getCarDensityScaleCoef() = mapView.getCarViewDensity() / mapView.getDensity();  // viewport density
```

Icons are rasterized from resources at the phone density and drawn pixel for pixel on the
head unit surface, which has fewer pixels per dp, so they are deliberately shrunk by
`carDensity / phoneDensity` (typically `1.325 / 2.625 ≈ 0.5`). Moving the viewport density
to the car density makes numerator and denominator equal, the coefficient collapses to 1 and
every icon — my location, POI, GPX markers, and every `AndroidUtils.dpToPxAuto()` dimension —
is drawn roughly twice as large. `getSettingsMapDensity()` also multiplies by the viewport
density, so the map scale jumped on connect. **This part is not restored here.**

**`0425d6dc12` — Revert scale setting for AA.** The actual defect behind the UI review
findings was never found: only half of the magnifier was made Android Auto aware.

| | value used |
|---|---|
| `MapRendererContext.getRasterTileSize()` | `OsmandMap.getMapDensity()` — Android Auto aware since 78e1c11d90 |
| `MapRendererContext.updateMapPresentationEnvironment()` | `settings.MAP_DENSITY` — always the phone |

Both are halves of the same magnifier: in the core, `displayDensityFactor * mapScaleFactor`
is the density the style is evaluated with (`MapPrimitiviser_P.cpp:642`,
`MapPresentationEnvironment_P.cpp:421`, `MapRasterizer_P.cpp:765` for `iconScale`), while the
raster tile size is the surface that result is drawn into. Mixing the two sources explains all
three review findings:

* **pixelised tiles at a large Android Auto value** — the tile grew, the style scale did not, so
  the tile is stretched;
* **"changing on phone after AA affects AA"** — a phone change moves `mapScaleFactor`, so
  `CachedMapPresentation.shouldRecreateMapPresentation()` fires and the environment is rebuilt
  under the head unit;
* **"scale not updated on AA"** — the reverse: an Android Auto change never moves
  `mapScaleFactor`, so the environment is never recreated and only the tile size changes.

## What this PR changes

* `MapRendererContext` reads the magnifier through `OsmandMap.getMapDensitySettings()` in both
  places, so the tile size and the style scale can never disagree.
* `OsmandMap.getMapDensitySettings()` restored (and simplified): Android Auto keeps its own value
  once it was changed on the head unit, both displays follow the phone value otherwise.
* `ConfigureMapDialogs` does not apply a phone magnifier change while Android Auto owns the map
  view; `OsmandMapTileView.setView()` applies it when the map is handed back to the phone.
* `applyDisplayScaleSettings()` drops the rasterized v1 tiles (the useful half of the reverted
  `d885cd5c1a`) and refreshes; the now duplicated `refreshMap(true)` in `setView()` is removed.
* `SettingsScreen` shows the magnifier row again — inside the **existing** Configure map section
  next to Map mode, not a second section with the same title (Map mode was added after the
  revert) — with the value currently in use as its subtitle.
* `MapMagnifierScreen` keeps a value the head unit list does not offer (25 %, 400 % …) visible
  and selected, instead of silently showing 100 %; the list stays within the host content limit.
* `RulerWidget` seeds its cache from the same source it later compares against.

## Testing

Compiles (`assembleNightlyFreeOpenglArm64Debug`). **Not yet verified on a head unit** — the
behaviour to check is the review list from #22693: phone and Android Auto values no longer leak
into each other, large Android Auto values are sharp, and the my location icon keeps its size on
the head unit.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Work out from the code why #22693 did not work, why it was reverted, and what to fix.
2. Note that the my location icon became huge in the car.
3. Build the PR; the user will review and test it afterwards.

Decided by the agent, not requested explicitly:
- Deliberately not restoring the viewport density change from `d885cd5c1a`, and restoring only
  its v1 cache clearing half.
- Putting the magnifier row into the existing Configure map section rather than adding a second
  section, and adding the current value as its subtitle.
- The out-of-list magnifier value handling in `MapMagnifierScreen` and the content limit window.
- The `RulerWidget` cache seed cleanup and dropping its then unused `settings` field.
- Simplifying `getMapDensitySettings()` while restoring it.
