### PR TITLE
Quick action to show / hide individual tracks (#24990)

### DIFF
--- a/OsmAnd/res/layout/quick_action_show_hide_tracks.xml
+++ b/OsmAnd/res/layout/quick_action_show_hide_tracks.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:app="http://schemas.android.com/apk/res-auto"
+	xmlns:tools="http://schemas.android.com/tools"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:orientation="vertical">
+
+	<include layout="@layout/list_item_divider" />
+
+	<LinearLayout
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:background="?attr/list_background_color"
+		android:orientation="vertical"
+		android:paddingBottom="@dimen/content_padding_small">
+
+		<net.osmand.plus.widgets.TextViewEx
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_marginStart="@dimen/content_padding"
+			android:layout_marginTop="@dimen/content_padding_small"
+			android:layout_marginEnd="@dimen/content_padding"
+			android:letterSpacing="@dimen/text_button_letter_spacing"
+			android:text="@string/shared_string_tracks"
+			android:textColor="?android:textColorPrimary"
+			android:textSize="@dimen/default_list_text_size"
+			app:lineHeight="@dimen/default_title_line_height"
+			app:typefaceWeight="medium" />
+
+		<include
+			android:id="@+id/track_toggle"
+			layout="@layout/custom_radio_buttons"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_marginStart="@dimen/content_padding"
+			android:layout_marginTop="@dimen/content_padding_small"
+			android:layout_marginEnd="@dimen/content_padding" />
+
+		<net.osmand.plus.widgets.TextViewEx
+			android:id="@+id/always_ask_description"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_marginStart="@dimen/content_padding"
+			android:layout_marginTop="@dimen/content_padding_small"
+			android:layout_marginEnd="@dimen/content_padding"
+			android:letterSpacing="@dimen/description_letter_spacing"
+			android:text="@string/quick_action_tracks_always_ask_descr"
+			android:textColor="?android:textColorSecondary"
+			android:textSize="@dimen/default_list_text_size"
+			android:textStyle="normal"
+			app:lineHeight="@dimen/default_desc_line_height" />
+
+		<LinearLayout
+			android:id="@+id/selected_tracks_container"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:orientation="vertical">
+
+			<net.osmand.plus.widgets.TextViewEx
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_marginStart="@dimen/content_padding"
+				android:layout_marginTop="@dimen/content_padding_small"
+				android:layout_marginEnd="@dimen/content_padding"
+				android:letterSpacing="@dimen/description_letter_spacing"
+				android:text="@string/quick_action_tracks_select_descr"
+				android:textColor="?android:textColorSecondary"
+				android:textSize="@dimen/default_list_text_size"
+				android:textStyle="normal"
+				app:lineHeight="@dimen/default_desc_line_height" />
+
+			<androidx.recyclerview.widget.RecyclerView
+				android:id="@+id/list"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_marginTop="@dimen/content_padding_small"
+				android:nestedScrollingEnabled="false"
+				app:layoutManager="LinearLayoutManager" />
+
+			<FrameLayout
+				android:id="@+id/add_track_button_container"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:layout_marginStart="@dimen/content_padding"
+				android:layout_marginTop="@dimen/content_padding_small"
+				android:layout_marginEnd="@dimen/content_padding">
+
+				<net.osmand.plus.widgets.TextViewEx
+					android:id="@+id/add_track_button"
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:letterSpacing="@dimen/description_letter_spacing"
+					android:paddingStart="@dimen/content_padding"
+					android:paddingTop="@dimen/content_padding_half"
+					android:paddingEnd="@dimen/content_padding"
+					android:paddingBottom="@dimen/content_padding_half"
+					android:text="@string/quick_action_add_track"
+					android:textColor="?attr/colorPrimary"
+					android:textSize="@dimen/default_desc_text_size"
+					app:typefaceWeight="medium"
+					tools:background="@drawable/btn_solid_border_light" />
+
+			</FrameLayout>
+
+		</LinearLayout>
+
+	</LinearLayout>
+
+	<androidx.appcompat.widget.AppCompatImageView
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:layout_gravity="top"
+		android:scaleType="fitXY"
+		app:srcCompat="@drawable/bg_shadow_list_bottom" />
+
+</LinearLayout>

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -12,6 +12,10 @@
 	Thx - Hardy
 -->
 	<string name="astro_eclipse_column_below_horizon">Below horizon</string>
+	<string name="quick_action_add_track">Add track</string>
+	<string name="quick_action_tracks_select_descr">Add one or more tracks to show or hide them on the map with a single tap.</string>
+	<string name="quick_action_tracks_always_ask_descr">Tapping this action opens the list of tracks, where you can show or hide one or more of them.</string>
+	<string name="quick_action_all_tracks">All tracks</string>
 	<string name="share_favorites_media_preparation_failed">Couldn\'t include attached media. Sharing points only.</string>
 	<plurals name="files_count">
 		<item quantity="one">%d file</item>

--- a/OsmAnd/src/net/osmand/plus/quickaction/MapButtonsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/MapButtonsHelper.java
@@ -377,6 +377,7 @@ public class MapButtonsHelper {
 		// configure map
 		allTypes.add(ShowHideFavoritesAction.TYPE);
 		allTypes.add(ShowHideGpxTracksAction.TYPE);
+		allTypes.add(ShowHideTracksAction.TYPE);
 		allTypes.add(ShowHidePoiAction.TYPE);
 		allTypes.add(MapStyleAction.TYPE);
 		allTypes.add(DayNightModeAction.TYPE);

--- a/OsmAnd/src/net/osmand/plus/quickaction/QuickActionIds.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/QuickActionIds.java
@@ -79,4 +79,5 @@ public class QuickActionIds {
 	public static final int SHOW_HIDE_COORDINATE_GRID_ACTION_ID = 79;
 	public static final int SHOW_HIDE_WEATHER_LAYERS = 80;
 	public static final int SHOW_HIDE_WIND_ANIMATION_LAYER = 81;
+	public static final int SHOW_HIDE_TRACKS_ACTION_ID = 82;
 }

--- a/OsmAnd/src/net/osmand/plus/quickaction/actions/ShowHideGpxTracksAction.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/actions/ShowHideGpxTracksAction.java
@@ -23,7 +23,7 @@ public class ShowHideGpxTracksAction extends QuickAction {
 	public static final QuickActionType TYPE = new QuickActionType(SHOW_HIDE_GPX_TRACKS_ACTION_ID,
 			"gpx.showhide", ShowHideGpxTracksAction.class)
 			.nameActionRes(R.string.quick_action_verb_show_hide)
-			.nameRes(R.string.show_gpx).iconRes(R.drawable.ic_action_polygom_dark).nonEditable()
+			.nameRes(R.string.quick_action_all_tracks).iconRes(R.drawable.ic_action_polygom_dark).nonEditable()
 			.category(QuickActionType.CONFIGURE_MAP);
 
 	public ShowHideGpxTracksAction() {

--- a/OsmAnd/src/net/osmand/plus/quickaction/actions/ShowHideTracksAction.java
+++ b/OsmAnd/src/net/osmand/plus/quickaction/actions/ShowHideTracksAction.java
@@ -1,0 +1,376 @@
+package net.osmand.plus.quickaction.actions;
+
+import static net.osmand.plus.quickaction.CreateEditActionDialog.FileSelected;
+import static net.osmand.plus.quickaction.CreateEditActionDialog.TAG;
+import static net.osmand.plus.quickaction.QuickActionIds.SHOW_HIDE_TRACKS_ACTION_ID;
+import static net.osmand.plus.track.helpers.GpxSelectionHelper.CURRENT_TRACK;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.RecyclerView;
+
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.R;
+import net.osmand.plus.activities.MapActivity;
+import net.osmand.plus.configmap.tracks.TracksTabsFragment;
+import net.osmand.plus.helpers.AndroidUiHelper;
+import net.osmand.plus.quickaction.CreateEditActionDialog;
+import net.osmand.plus.quickaction.QuickAction;
+import net.osmand.plus.quickaction.QuickActionType;
+import net.osmand.plus.settings.enums.ThemeUsageContext;
+import net.osmand.plus.track.GpxSelectionParams;
+import net.osmand.plus.track.SelectTrackTabsFragment;
+import net.osmand.plus.track.helpers.GpxSelectionHelper;
+import net.osmand.plus.track.helpers.SelectedGpxFile;
+import net.osmand.plus.utils.AndroidUtils;
+import net.osmand.plus.utils.UiUtilities;
+import net.osmand.plus.widgets.multistatetoggle.TextToggleButton;
+import net.osmand.plus.widgets.multistatetoggle.TextToggleButton.TextRadioItem;
+import net.osmand.shared.gpx.GpxHelper;
+import net.osmand.shared.gpx.TrackItem;
+import net.osmand.shared.io.KFile;
+import net.osmand.util.Algorithms;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ShowHideTracksAction extends QuickAction implements FileSelected {
+
+	public static final QuickActionType TYPE = new QuickActionType(SHOW_HIDE_TRACKS_ACTION_ID,
+			"tracks.showhide", ShowHideTracksAction.class)
+			.nameActionRes(R.string.quick_action_verb_show_hide)
+			.nameRes(R.string.shared_string_tracks)
+			.iconRes(R.drawable.ic_action_polygom_dark)
+			.category(QuickActionType.CONFIGURE_MAP);
+
+	public static final String KEY_ALWAYS_ASK = "always_ask";
+	public static final String KEY_TRACKS = "tracks";
+
+	private transient EditText title;
+	private transient TextToggleButton trackToggleButton;
+	private transient TracksAdapter adapter;
+
+	public ShowHideTracksAction() {
+		super(TYPE);
+	}
+
+	public ShowHideTracksAction(QuickAction quickAction) {
+		super(quickAction);
+	}
+
+	@Override
+	public void execute(@NonNull MapActivity mapActivity, @Nullable Bundle params) {
+		OsmandApplication app = mapActivity.getApp();
+		List<String> paths = getExistingTracksPaths();
+
+		if (shouldAskEveryTime() || Algorithms.isEmpty(paths)) {
+			TracksTabsFragment.showInstance(mapActivity);
+		} else if (areTracksVisible(app, paths)) {
+			hideTracks(app, paths);
+		} else {
+			showTracks(app, paths);
+		}
+	}
+
+	private void showTracks(@NonNull OsmandApplication app, @NonNull List<String> paths) {
+		List<TrackItem> trackItems = new ArrayList<>();
+		for (String path : paths) {
+			if (CURRENT_TRACK.equals(path)) {
+				trackItems.add(new TrackItem(app.getSavingTrackHelper().getCurrentTrack().getGpxFile()));
+			} else {
+				trackItems.add(new TrackItem(new KFile(path)));
+			}
+		}
+		app.getSelectedGpxHelper().saveTracksVisibility(trackItems, false);
+	}
+
+	private void hideTracks(@NonNull OsmandApplication app, @NonNull List<String> paths) {
+		GpxSelectionHelper helper = app.getSelectedGpxHelper();
+		GpxSelectionParams params = GpxSelectionParams.newInstance()
+				.hideFromMap().syncGroup().saveSelection();
+		for (String path : paths) {
+			SelectedGpxFile selectedGpxFile = getSelectedGpxFile(app, path);
+			if (selectedGpxFile != null) {
+				helper.selectGpxFile(selectedGpxFile.getGpxFile(), params);
+			}
+		}
+		app.getOsmandMap().refreshMap();
+	}
+
+	private boolean areTracksVisible(@NonNull OsmandApplication app, @NonNull List<String> paths) {
+		for (String path : paths) {
+			if (getSelectedGpxFile(app, path) == null) {
+				return false;
+			}
+		}
+		return !Algorithms.isEmpty(paths);
+	}
+
+	@Nullable
+	private SelectedGpxFile getSelectedGpxFile(@NonNull OsmandApplication app, @NonNull String path) {
+		GpxSelectionHelper helper = app.getSelectedGpxHelper();
+		return CURRENT_TRACK.equals(path)
+				? helper.getSelectedCurrentRecordingTrack()
+				: helper.getSelectedFileByPath(path);
+	}
+
+	@Override
+	public String getActionText(@NonNull OsmandApplication app) {
+		String actionName;
+		if (shouldAskEveryTime()) {
+			actionName = app.getString(getActionNameRes());
+		} else {
+			actionName = isActionWithSlash(app)
+					? app.getString(R.string.shared_string_hide)
+					: app.getString(R.string.shared_string_show);
+		}
+		return app.getString(R.string.ltr_or_rtl_combine_via_dash, actionName, getName(app));
+	}
+
+	@Override
+	public boolean isActionWithSlash(@NonNull OsmandApplication app) {
+		return !shouldAskEveryTime() && areTracksVisible(app, getExistingTracksPaths());
+	}
+
+	@Override
+	public void setAutoGeneratedTitle(EditText title) {
+		this.title = title;
+	}
+
+	@Override
+	public void drawUI(@NonNull ViewGroup parent, @NonNull MapActivity mapActivity, boolean nightMode) {
+		View view = UiUtilities.inflate(parent.getContext(), nightMode, R.layout.quick_action_show_hide_tracks, parent, false);
+		parent.addView(view);
+
+		setupTracksList(view, mapActivity);
+		setupAddTrackButton(view, mapActivity, nightMode);
+		setupTrackToggleButton(view, mapActivity);
+	}
+
+	private void setupTracksList(@NonNull View container, @NonNull MapActivity mapActivity) {
+		adapter = new TracksAdapter(mapActivity, getTracksPaths());
+
+		RecyclerView recyclerView = container.findViewById(R.id.list);
+		recyclerView.setAdapter(adapter);
+	}
+
+	private void setupAddTrackButton(@NonNull View container, @NonNull MapActivity mapActivity, boolean nightMode) {
+		View buttonContainer = container.findViewById(R.id.add_track_button_container);
+		View button = container.findViewById(R.id.add_track_button);
+
+		AndroidUtils.setBackground(container.getContext(), buttonContainer, nightMode,
+				R.drawable.ripple_light, R.drawable.ripple_dark);
+		AndroidUtils.setBackground(container.getContext(), button, nightMode,
+				R.drawable.btn_solid_border_light, R.drawable.btn_solid_border_dark);
+
+		buttonContainer.setOnClickListener(v -> showSelectTrackDialog(mapActivity));
+	}
+
+	private void setupTrackToggleButton(@NonNull View container, @NonNull MapActivity mapActivity) {
+		OsmandApplication app = mapActivity.getApp();
+		boolean nightMode = app.getDaynightHelper().isNightMode(ThemeUsageContext.OVER_MAP);
+
+		LinearLayout toggleContainer = container.findViewById(R.id.track_toggle);
+		trackToggleButton = new TextToggleButton(app, toggleContainer, nightMode);
+
+		TextRadioItem alwaysAskButton = new TextRadioItem(app.getString(R.string.confirm_every_run));
+		TextRadioItem selectTracksButton = new TextRadioItem(app.getString(R.string.shared_string_select));
+
+		alwaysAskButton.setOnClickListener((radioItem, view) -> {
+			updateTracksVisibility(container, true);
+			return true;
+		});
+		selectTracksButton.setOnClickListener((radioItem, view) -> {
+			updateTracksVisibility(container, false);
+			return true;
+		});
+
+		trackToggleButton.setItems(alwaysAskButton, selectTracksButton);
+		trackToggleButton.setSelectedItem(shouldAskEveryTime() ? alwaysAskButton : selectTracksButton);
+		updateTracksVisibility(container, shouldAskEveryTime());
+	}
+
+	private void updateTracksVisibility(@NonNull View container, boolean alwaysAsk) {
+		AndroidUiHelper.updateVisibility(container.findViewById(R.id.always_ask_description), alwaysAsk);
+		AndroidUiHelper.updateVisibility(container.findViewById(R.id.selected_tracks_container), !alwaysAsk);
+	}
+
+	private void showSelectTrackDialog(@NonNull MapActivity mapActivity) {
+		Fragment fragment = mapActivity.getFragmentsHelper().getFragment(TAG);
+		CreateEditActionDialog dialog = fragment instanceof CreateEditActionDialog
+				? ((CreateEditActionDialog) fragment) : null;
+		if (dialog != null) {
+			SelectTrackTabsFragment.showInstance(mapActivity.getSupportFragmentManager(), dialog);
+		}
+	}
+
+	@Override
+	public void onGpxFileSelected(@NonNull View container, @NonNull MapActivity mapActivity, @NonNull String gpxFilePath) {
+		if (adapter != null) {
+			adapter.addTrack(Algorithms.isEmpty(gpxFilePath) ? CURRENT_TRACK : gpxFilePath);
+		}
+	}
+
+	@Override
+	public boolean fillParams(@NonNull View root, @NonNull MapActivity mapActivity) {
+		boolean alwaysAsk = trackToggleButton == null || trackToggleButton.getSelectedItemIndex() == 0;
+		getParams().put(KEY_ALWAYS_ASK, String.valueOf(alwaysAsk));
+
+		return alwaysAsk || !Algorithms.isEmpty(getTracksPaths());
+	}
+
+	private boolean shouldAskEveryTime() {
+		String alwaysAsk = getParams().get(KEY_ALWAYS_ASK);
+		return alwaysAsk == null || Boolean.parseBoolean(alwaysAsk);
+	}
+
+	@NonNull
+	private List<String> getExistingTracksPaths() {
+		List<String> paths = new ArrayList<>();
+		for (String path : getTracksPaths()) {
+			if (CURRENT_TRACK.equals(path) || new File(path).exists()) {
+				paths.add(path);
+			}
+		}
+		return paths;
+	}
+
+	@NonNull
+	private List<String> getTracksPaths() {
+		String tracks = getParams().get(KEY_TRACKS);
+		if (Algorithms.isBlank(tracks)) {
+			return new ArrayList<>();
+		}
+		try {
+			List<String> paths = new ArrayList<>();
+			JSONArray jsonArray = new JSONArray(tracks);
+			for (int i = 0; i < jsonArray.length(); i++) {
+				String path = jsonArray.getString(i);
+				if (!Algorithms.isBlank(path)) {
+					paths.add(path);
+				}
+			}
+			return paths;
+		} catch (JSONException e) {
+			return Collections.emptyList();
+		}
+	}
+
+	private void saveTracksPaths(@NonNull List<String> paths) {
+		getParams().put(KEY_TRACKS, new JSONArray(paths).toString());
+	}
+
+	@NonNull
+	private String getTrackName(@NonNull OsmandApplication app, @NonNull String path) {
+		return CURRENT_TRACK.equals(path)
+				? app.getString(R.string.shared_string_currently_recording_track)
+				: GpxHelper.INSTANCE.getGpxTitle(new File(path).getName());
+	}
+
+	@NonNull
+	private String getGeneratedTitle(@NonNull OsmandApplication app, @NonNull List<String> paths) {
+		if (Algorithms.isEmpty(paths)) {
+			return "";
+		}
+		String name = getTrackName(app, paths.get(0));
+		return paths.size() > 1 ? name + " +" + (paths.size() - 1) : name;
+	}
+
+	private void updateAutoGeneratedTitle(@NonNull OsmandApplication app, @NonNull String previousTitle,
+			@NonNull List<String> paths) {
+		if (title == null) {
+			return;
+		}
+		String currentTitle = title.getText().toString();
+		if (currentTitle.equals(previousTitle) || currentTitle.equals(app.getString(getNameRes()))) {
+			title.setText(getGeneratedTitle(app, paths));
+		}
+	}
+
+	private class TracksAdapter extends RecyclerView.Adapter<TracksAdapter.TrackViewHolder> {
+
+		private final MapActivity mapActivity;
+		private final List<String> paths;
+
+		public TracksAdapter(@NonNull MapActivity mapActivity, @NonNull List<String> paths) {
+			this.mapActivity = mapActivity;
+			this.paths = paths;
+		}
+
+		public void addTrack(@NonNull String path) {
+			if (!paths.contains(path)) {
+				OsmandApplication app = mapActivity.getApp();
+				String previousTitle = getGeneratedTitle(app, paths);
+
+				paths.add(path);
+				saveTracksPaths(paths);
+				notifyDataSetChanged();
+
+				updateAutoGeneratedTitle(app, previousTitle, paths);
+			}
+		}
+
+		@NonNull
+		@Override
+		public TrackViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+			LayoutInflater inflater = LayoutInflater.from(parent.getContext());
+			return new TrackViewHolder(inflater.inflate(R.layout.quick_action_deletable_list_item, parent, false));
+		}
+
+		@Override
+		public void onBindViewHolder(@NonNull TrackViewHolder holder, int position) {
+			OsmandApplication app = mapActivity.getApp();
+			String path = paths.get(position);
+
+			holder.icon.setImageDrawable(app.getUIUtilities().getThemedIcon(R.drawable.ic_action_polygom_dark));
+			holder.title.setText(getTrackName(app, path));
+			holder.delete.setOnClickListener(view -> {
+				int index = holder.getBindingAdapterPosition();
+				if (index != RecyclerView.NO_POSITION) {
+					String previousTitle = getGeneratedTitle(app, paths);
+
+					paths.remove(index);
+					saveTracksPaths(paths);
+					notifyDataSetChanged();
+
+					updateAutoGeneratedTitle(app, previousTitle, paths);
+				}
+			});
+		}
+
+		@Override
+		public int getItemCount() {
+			return paths.size();
+		}
+
+		class TrackViewHolder extends RecyclerView.ViewHolder {
+
+			private final TextView title;
+			private final ImageView icon;
+			private final ImageView delete;
+
+			public TrackViewHolder(@NonNull View itemView) {
+				super(itemView);
+
+				title = itemView.findViewById(R.id.title);
+				icon = itemView.findViewById(R.id.icon);
+				delete = itemView.findViewById(R.id.delete);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #24990.

### Problem

The only track-related quick action, `Show / Hide - Tracks`, toggles **all** tracks at once (hide everything / restore the previous selection). There is no way to switch a single track, or a small set of tracks, on and off from the map.

### Solution

A new editable quick action in the **Configure map** category with two modes, following the pattern of `Simulate - Location by GPX`:

* **Always ask** (default) - tapping the action opens the tracks dialog, where one or more tracks can be toggled and applied.
* **Select** - one or more tracks are picked when the action is created; a single tap then shows them all, and the next tap hides them again. The button label and icon switch between `Show - <track>` and `Hide - <track>`, and the action name is auto-generated from the chosen tracks (`Kyiv_Loop +1`).

Tracks whose files no longer exist are ignored, and the currently recording track is supported as well.

The existing action that toggles everything is renamed from `Tracks` to `All tracks`, so the two entries can be told apart in the action list.

| Action list | Always ask | Select |
|---|---|---|
| <img src="https://github.com/user-attachments/assets/5e7eb01e-793c-43a6-949b-a882b41292cc" width="260"> | <img src="https://github.com/user-attachments/assets/3e84252c-0302-4f20-ba71-f9d5568529b3" width="260"> | <img src="https://github.com/user-attachments/assets/40fe5569-f039-4d23-adeb-81b02ae6735f" width="260"> |

### Changes

* `ShowHideTracksAction` - new quick action (id 82, `tracks.showhide`).
* `quick_action_show_hide_tracks.xml` - editing UI.
* `MapButtonsHelper`, `QuickActionIds` - registration.
* `ShowHideGpxTracksAction` - name changed to `All tracks`.
* 4 new strings.

### Testing

Manually on an Android 15 emulator (Pixel Tablet + phone, `androidFull-legacy-arm64` debug build) with three test GPX files:

* the action appears in `Add action -> Configure map` next to `All tracks`;
* **Select**: adding / removing tracks updates the list and the auto-generated title; the first tap shows both tracks on the map, the second hides them (verified against the map and the `selected_gpx` preference: `[]` -> both files -> `[]`); the label flips between `Show - Kyiv_Loop +1` and `Hide - Kyiv_Loop +1`;
* **Always ask**: the tap opens the tracks dialog with per-track checkboxes;
* saved parameters are restored correctly when the action is reopened for editing.

Both selected tracks on the map after a single tap of the button:

<img src="https://github.com/user-attachments/assets/65c23797-89ab-4f6c-bab2-887c5d0b6573" width="420">

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Try to fix https://github.com/osmandapp/OsmAnd/issues/24990.
2. Start another emulator (the first one was busy with another task).

Decided by the agent, not requested explicitly:
- The two-mode design (`Always ask` / `Select`) was taken from the screenshot in the issue comment; `Always ask` reuses the existing tracks dialog, `Select` stores a list of track paths in the action parameters.
- A separate action was added instead of making the existing `Show / Hide - Tracks` editable, so that several per-track buttons can coexist (non-editable actions can only be added once).
- Renaming the existing action to `All tracks` to keep the two entries distinguishable.
- Wording of the four new strings, and the choice to store absolute track paths as a JSON array (same approach as `ShowHidePoiAction`).
