### PR TITLE
Android Auto: generic widgets panel over the map (prototype)

### DIFF
--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -4269,6 +4269,8 @@ You need to activate the sensor so OsmAnd can find it.</string>
     <string name="map_marker_2nd">Second map marker</string>
     <string name="shared_string_toolbar">Toolbar</string>
     <string name="shared_string_widgets">Widgets</string>
+    <string name="aa_show_widgets_panel">Show widgets panel</string>
+    <string name="aa_show_widgets_panel_descr">Draw the selected widgets over the map on the car screen</string>
     <string name="shared_string_add_to_map_markers">Add to map markers</string>
     <string name="select_map_markers">Select map markers</string>
     <string name="shared_string_reverse_order">Reverse order</string>

--- a/OsmAnd/src/net/osmand/plus/auto/CarWidgetsPanel.java
+++ b/OsmAnd/src/net/osmand/plus/auto/CarWidgetsPanel.java
@@ -1,0 +1,295 @@
+package net.osmand.plus.auto;
+
+import android.graphics.Canvas;
+import android.graphics.Path;
+import android.graphics.Rect;
+import android.graphics.RectF;
+import android.view.View;
+import android.view.View.MeasureSpec;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.activities.MapActivity;
+import net.osmand.plus.settings.backend.ApplicationMode;
+import net.osmand.plus.settings.enums.ScreenLayoutMode;
+import net.osmand.plus.views.layers.base.OsmandMapLayer.DrawSettings;
+import net.osmand.plus.views.mapwidgets.MapWidgetInfo;
+import net.osmand.plus.views.mapwidgets.WidgetsInitializer;
+import net.osmand.plus.views.mapwidgets.WidgetsPanel;
+import net.osmand.plus.views.mapwidgets.appearance.ResolvedPanelAppearance;
+import net.osmand.plus.views.mapwidgets.widgets.MapWidget;
+
+import net.osmand.util.Algorithms;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Prototype of a generic widgets panel drawn over the Android Auto map surface.
+ * <p>
+ * The panel reuses the regular map widgets of the current profile ({@link WidgetsPanel#RIGHT}
+ * by default), so any widget - including the OBD II ones of the Vehicle metrics plugin - shows
+ * up in the car without a car-specific implementation. Widgets are drawn on the right side of
+ * the surface to keep the left part free for the navigation card of the head unit. When more
+ * widgets are enabled than fit on the screen, a click on the panel shows the next page.
+ * <p>
+ * Widget views are created and laid out by this class only and are never attached to a window,
+ * so the phone UI is not affected.
+ */
+public class CarWidgetsPanel {
+
+	/** Panel is drawn only when the visible area is at least that wide. */
+	private static final float MIN_SURFACE_WIDTH_DP = 400f;
+	private static final float PANEL_MARGIN_DP = 10f;
+	private static final float CORNER_RADIUS_DP = 8f;
+	/** Widgets are stacked without gaps, their own dividers separate the rows. */
+	private static final float WIDGET_SPACING_DP = 0f;
+	private static final float WIDGET_WIDTH_DP = 130f;
+	/**
+	 * Width of the panel in car dp. The car screen is viewed from about twice the distance of a
+	 * phone, so the widgets are drawn ~1.5 times bigger than the {@link #WIDGET_WIDTH_DP} used on
+	 * the phone, which keeps them slightly larger than a phone widget in angular size.
+	 */
+	private static final float PANEL_WIDTH_CAR_DP = 200f;
+	/** Safety net for narrow head units (800x480), the panel never takes more than this. */
+	private static final float MAX_PANEL_WIDTH_RATIO = 0.22f;
+	/** Fraction of the visible area height the panel is allowed to occupy. */
+	private static final float MAX_PANEL_HEIGHT_RATIO = 0.7f;
+
+	public static final String WIDGETS_SEPARATOR = ";";
+
+	private final OsmandApplication app;
+	private final WidgetsPanel panel;
+
+	private final List<MapWidget> widgets = new ArrayList<>();
+	private final RectF lastPanelBounds = new RectF();
+
+	private MapActivity cachedMapActivity;
+	private ApplicationMode cachedAppMode;
+	private Boolean cachedNightMode;
+	private String cachedWidgetIds;
+	private int firstVisibleWidget;
+	private int lastVisibleCount;
+
+	public CarWidgetsPanel(@NonNull OsmandApplication app) {
+		this(app, WidgetsPanel.RIGHT);
+	}
+
+	public CarWidgetsPanel(@NonNull OsmandApplication app, @NonNull WidgetsPanel panel) {
+		this.app = app;
+		this.panel = panel;
+	}
+
+	/**
+	 * @param topOffset constant offset from the top of the visible area, it only depends on the
+	 *                  speedometer, which does not appear and disappear while driving.
+	 * @param hiddenArea area covered by a transient widget (the alarm). Rows that fall into it are
+	 *                   hidden and their slots are kept, so that the panel never shifts.
+	 * @return height occupied by the panel in surface pixels.
+	 */
+	public float drawWidgets(@NonNull Canvas canvas, @NonNull Rect visibleArea,
+			@NonNull DrawSettings drawSettings, float carDensity, float topOffset,
+			@Nullable Rect hiddenArea) {
+		lastPanelBounds.setEmpty();
+		lastVisibleCount = 0;
+		if (!app.getSettings().AA_SHOW_WIDGETS_PANEL.get()
+				|| visibleArea.width() < MIN_SURFACE_WIDTH_DP * carDensity) {
+			return 0;
+		}
+		List<MapWidget> widgets = getWidgets(drawSettings.isNightMode());
+		if (widgets.isEmpty()) {
+			return 0;
+		}
+		if (firstVisibleWidget >= widgets.size()) {
+			firstVisibleWidget = 0;
+		}
+		// Widget views are inflated with the application resources, so they are measured in phone
+		// pixels and scaled while drawing. The panel is sized in car dp, the car screen is looked
+		// at from farther away than a phone, so the widgets are drawn bigger than on the phone.
+		float appDensity = app.getResources().getDisplayMetrics().density;
+		int widgetWidth = (int) (WIDGET_WIDTH_DP * appDensity);
+		float panelWidth = Math.min(PANEL_WIDTH_CAR_DP * carDensity,
+				visibleArea.width() * MAX_PANEL_WIDTH_RATIO);
+		float scale = panelWidth / widgetWidth;
+
+		// The panel is flush with the right edge and keeps a fixed top, so that it does not jump
+		// when the speedometer or the alarm widget appear or change size.
+		float right = visibleArea.right;
+		float left = right - panelWidth;
+		float top = visibleArea.top + topOffset;
+		float maxBottom = top + visibleArea.height() * MAX_PANEL_HEIGHT_RATIO;
+
+		List<View> views = new ArrayList<>();
+		List<Float> tops = new ArrayList<>();
+		List<Float> bottoms = new ArrayList<>();
+		float y = top;
+		for (int i = firstVisibleWidget; i < widgets.size(); i++) {
+			MapWidget widget = widgets.get(i);
+			widget.updateInfo(drawSettings);
+			View view = widget.getView();
+			if (view.getVisibility() != View.VISIBLE) {
+				lastVisibleCount++;
+				continue;
+			}
+			view.measure(MeasureSpec.makeMeasureSpec(widgetWidth, MeasureSpec.EXACTLY),
+					MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED));
+			int measuredWidth = view.getMeasuredWidth();
+			int measuredHeight = view.getMeasuredHeight();
+			if (measuredWidth <= 0 || measuredHeight <= 0) {
+				lastVisibleCount++;
+				continue;
+			}
+			float height = measuredHeight * scale;
+			if (y + height > maxBottom) {
+				break;
+			}
+			view.layout(0, 0, measuredWidth, measuredHeight);
+			// A row is dropped only when the transient widget really covers it, a small overlap
+			// on the edge is not worth losing a whole row for.
+			boolean covered = hiddenArea != null
+					&& Math.min(hiddenArea.bottom, y + height) > Math.max(hiddenArea.top, y)
+					&& Math.min(hiddenArea.right, right) - Math.max(hiddenArea.left, left)
+					> panelWidth / 2;
+			if (!covered) {
+				views.add(view);
+				tops.add(y);
+				bottoms.add(y + height);
+			}
+			// The slot is kept even for a hidden widget, the panel must not shift.
+			y += height + WIDGET_SPACING_DP * carDensity;
+			lastVisibleCount++;
+		}
+		if (views.isEmpty()) {
+			return 0;
+		}
+		float corner = CORNER_RADIUS_DP * carDensity;
+		// Rounded on the left, flush square on the right. Rows hidden by the reserved area split
+		// the panel into several blocks, each of them gets its own rounded outline.
+		int blockStart = 0;
+		for (int i = 1; i <= views.size(); i++) {
+			boolean endOfBlock = i == views.size()
+					|| bottoms.get(i - 1) + 1 < tops.get(i);
+			if (endOfBlock) {
+				drawBlock(canvas, views.subList(blockStart, i), tops.subList(blockStart, i),
+						left, right, bottoms.get(i - 1), corner, scale);
+				lastPanelBounds.union(left, tops.get(blockStart), right, bottoms.get(i - 1));
+				blockStart = i;
+			}
+		}
+		return lastPanelBounds.height();
+	}
+
+	private void drawBlock(@NonNull Canvas canvas, @NonNull List<View> views,
+			@NonNull List<Float> tops, float left, float right, float bottom, float corner,
+			float scale) {
+		Path path = new Path();
+		float top = tops.get(0);
+		path.addRoundRect(new RectF(left, top, right, bottom),
+				new float[] {corner, corner, 0, 0, 0, 0, corner, corner}, Path.Direction.CW);
+
+		canvas.save();
+		canvas.clipPath(path);
+		for (int i = 0; i < views.size(); i++) {
+			canvas.save();
+			canvas.translate(left, tops.get(i));
+			canvas.scale(scale, scale);
+			views.get(i).draw(canvas);
+			canvas.restore();
+		}
+		canvas.restore();
+	}
+
+	/**
+	 * @return true if the click was handled by the panel.
+	 */
+	public boolean onSurfaceClick(float x, float y) {
+		if (lastPanelBounds.isEmpty() || !lastPanelBounds.contains(x, y)) {
+			return false;
+		}
+		int next = firstVisibleWidget + Math.max(lastVisibleCount, 1);
+		firstVisibleWidget = next < widgets.size() ? next : 0;
+		return true;
+	}
+
+	@NonNull
+	private List<MapWidget> getWidgets(boolean nightMode) {
+		MapActivity mapActivity = app.getOsmandMap().getMapView().getMapActivity();
+		ApplicationMode appMode = app.getSettings().getApplicationMode();
+		if (mapActivity == null) {
+			// Widgets can only be created together with a map activity. Once created they stay
+			// valid and keep being updated even after the activity is gone.
+			return widgets;
+		}
+		String widgetIds = app.getSettings().AA_WIDGETS.getModeValue(appMode);
+		if (mapActivity != cachedMapActivity || appMode != cachedAppMode
+				|| !Boolean.valueOf(nightMode).equals(cachedNightMode)
+				|| !Algorithms.stringsEqual(widgetIds, cachedWidgetIds)) {
+			cachedMapActivity = mapActivity;
+			cachedAppMode = appMode;
+			cachedNightMode = nightMode;
+			cachedWidgetIds = widgetIds;
+			recreateWidgets(mapActivity, appMode, nightMode, widgetIds);
+		}
+		return widgets;
+	}
+
+	private void recreateWidgets(@NonNull MapActivity mapActivity, @NonNull ApplicationMode appMode,
+			boolean nightMode, @Nullable String widgetIds) {
+		widgets.clear();
+		firstVisibleWidget = 0;
+
+		List<String> selectedIds = getSelectedWidgetIds(widgetIds);
+		if (selectedIds.isEmpty()) {
+			return;
+		}
+		ScreenLayoutMode layoutMode = ScreenLayoutMode.getDefault(mapActivity);
+		Map<String, MapWidgetInfo> available = new HashMap<>();
+		for (MapWidgetInfo info : WidgetsInitializer.createAllControls(mapActivity, appMode, layoutMode)) {
+			// Custom copies of a widget share the type id, the first one is enough for the car.
+			available.putIfAbsent(info.getWidgetType().id, info);
+		}
+		float density = app.getResources().getDisplayMetrics().density;
+		ResolvedPanelAppearance appearance = app.getPanelAppearanceSettingsManager()
+				.resolveCommitted(panel, layoutMode, nightMode, false, density, true);
+		for (String id : selectedIds) {
+			MapWidgetInfo info = available.get(id);
+			if (info != null) {
+				MapWidget widget = info.widget;
+				widget.applyPanelAppearance(appearance);
+				widgets.add(widget);
+			}
+		}
+	}
+
+	/**
+	 * @return ids of the widgets selected for the car screen, in the order they are shown.
+	 */
+	@NonNull
+	public static List<String> getSelectedWidgetIds(@Nullable String widgetIds) {
+		if (Algorithms.isEmpty(widgetIds)) {
+			return Collections.emptyList();
+		}
+		List<String> ids = new ArrayList<>();
+		for (String id : widgetIds.split(WIDGETS_SEPARATOR)) {
+			if (!Algorithms.isEmpty(id) && !ids.contains(id)) {
+				ids.add(id);
+			}
+		}
+		return ids;
+	}
+
+	public void clearWidgets() {
+		widgets.clear();
+		lastPanelBounds.setEmpty();
+		lastVisibleCount = 0;
+		firstVisibleWidget = 0;
+		cachedMapActivity = null;
+		cachedAppMode = null;
+		cachedNightMode = null;
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/auto/SurfaceRenderer.java
+++ b/OsmAnd/src/net/osmand/plus/auto/SurfaceRenderer.java
@@ -17,6 +17,7 @@ import androidx.car.app.AppManager;
 import androidx.car.app.CarContext;
 import androidx.car.app.HostException;
 import androidx.car.app.SurfaceCallback;
+import androidx.car.app.annotations.RequiresCarApi;
 import androidx.car.app.SurfaceContainer;
 import androidx.lifecycle.DefaultLifecycleObserver;
 import androidx.lifecycle.Lifecycle;
@@ -93,6 +94,13 @@ public final class SurfaceRenderer implements DefaultLifecycleObserver, MapRende
 	public interface SurfaceRendererCallback {
 		void onFrameRendered(@NonNull Canvas canvas, @NonNull Rect visibleArea, @NonNull Rect stableArea);
 		void onElevationChanging(float angle);
+
+		/**
+		 * @return true if the click was consumed by the content drawn over the map.
+		 */
+		default boolean onSurfaceClick(float x, float y) {
+			return false;
+		}
 	}
 
 	private void setupSurfaceView(@NonNull SurfaceContainer surfaceContainer) {
@@ -206,6 +214,15 @@ public final class SurfaceRenderer implements DefaultLifecycleObserver, MapRende
 					getDisplayPositionManager().restoreMapRatio();
 					mapView.setupRenderingView();
 				}
+			}
+		}
+
+		@Override
+		@RequiresCarApi(5)
+		public void onClick(float x, float y) {
+			SurfaceRendererCallback callback = SurfaceRenderer.this.callback;
+			if (callback != null && callback.onSurfaceClick(x, y)) {
+				renderFrame();
 			}
 		}
 

--- a/OsmAnd/src/net/osmand/plus/auto/screens/CarWidgetsScreen.java
+++ b/OsmAnd/src/net/osmand/plus/auto/screens/CarWidgetsScreen.java
@@ -1,0 +1,97 @@
+package net.osmand.plus.auto.screens;
+
+import androidx.annotation.NonNull;
+import androidx.car.app.CarContext;
+import androidx.car.app.model.Action;
+import androidx.car.app.model.CarIcon;
+import androidx.car.app.model.ItemList;
+import androidx.car.app.model.ListTemplate;
+import androidx.car.app.model.Row;
+import androidx.car.app.model.Template;
+import androidx.car.app.model.Toggle;
+import androidx.core.graphics.drawable.IconCompat;
+
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.R;
+import net.osmand.plus.auto.CarWidgetsPanel;
+import net.osmand.plus.settings.backend.ApplicationMode;
+import net.osmand.plus.settings.backend.OsmandSettings;
+import net.osmand.plus.settings.backend.WidgetsAvailabilityHelper;
+import net.osmand.plus.views.mapwidgets.WidgetType;
+import net.osmand.plus.views.mapwidgets.WidgetsPanel;
+import net.osmand.util.Algorithms;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Lets the driver pick which widgets are drawn over the map on the car screen. The selection is
+ * kept per profile in {@link OsmandSettings#AA_WIDGETS} and is independent of the widgets
+ * configured for the phone panels.
+ */
+public class CarWidgetsScreen extends BaseAndroidAutoScreen {
+
+	@NonNull
+	private final OsmandSettings settings;
+
+	public CarWidgetsScreen(@NonNull CarContext carContext) {
+		super(carContext);
+		settings = ((OsmandApplication) carContext.getApplicationContext()).getSettings();
+	}
+
+	@NonNull
+	@Override
+	public Template getTemplate() {
+		OsmandApplication app = getApp();
+		ApplicationMode appMode = settings.getApplicationMode();
+		List<String> selected = CarWidgetsPanel.getSelectedWidgetIds(settings.AA_WIDGETS.getModeValue(appMode));
+
+		ItemList.Builder listBuilder = new ItemList.Builder();
+		int count = 0;
+		for (WidgetType widgetType : getAvailableWidgets(app, appMode)) {
+			if (count++ >= getContentLimit()) {
+				break;
+			}
+			boolean checked = selected.contains(widgetType.id);
+			listBuilder.addItem(new Row.Builder()
+					.setTitle(app.getString(widgetType.titleId))
+					.setImage(new CarIcon.Builder(IconCompat.createWithResource(app, widgetType.dayIconId)).build())
+					.setToggle(new Toggle.Builder(value -> onWidgetToggled(appMode, widgetType, value))
+							.setChecked(checked)
+							.build())
+					.build());
+		}
+		return new ListTemplate.Builder()
+				.setSingleList(listBuilder.build())
+				.setHeaderAction(Action.BACK)
+				.setTitle(app.getString(R.string.shared_string_widgets))
+				.build();
+	}
+
+	private void onWidgetToggled(@NonNull ApplicationMode appMode, @NonNull WidgetType widgetType,
+			boolean enabled) {
+		List<String> ids = new ArrayList<>(
+				CarWidgetsPanel.getSelectedWidgetIds(settings.AA_WIDGETS.getModeValue(appMode)));
+		ids.remove(widgetType.id);
+		if (enabled) {
+			ids.add(widgetType.id);
+		}
+		settings.AA_WIDGETS.setModeValue(appMode,
+				Algorithms.encodeCollection(ids, CarWidgetsPanel.WIDGETS_SEPARATOR));
+	}
+
+	@NonNull
+	private List<WidgetType> getAvailableWidgets(@NonNull OsmandApplication app,
+			@NonNull ApplicationMode appMode) {
+		List<WidgetsPanel> panels = Collections.singletonList(WidgetsPanel.RIGHT);
+		List<WidgetType> widgets = new ArrayList<>();
+		for (WidgetType widgetType : WidgetType.values()) {
+			if (widgetType.isAllowed() && widgetType.isPanelsAllowed(panels)
+					&& WidgetsAvailabilityHelper.isWidgetAvailable(app, widgetType.id, appMode)) {
+				widgets.add(widgetType);
+			}
+		}
+		return widgets;
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/auto/screens/NavigationScreen.java
+++ b/OsmAnd/src/net/osmand/plus/auto/screens/NavigationScreen.java
@@ -31,6 +31,7 @@ import androidx.lifecycle.LifecycleOwner;
 import net.osmand.data.ValueHolder;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.R;
+import net.osmand.plus.auto.CarWidgetsPanel;
 import net.osmand.plus.auto.NavigationListener;
 import net.osmand.plus.auto.NavigationSession;
 import net.osmand.plus.auto.SurfaceRenderer;
@@ -78,10 +79,14 @@ public final class NavigationScreen extends BaseAndroidAutoScreen implements Sur
 
 	private final AlarmWidget alarmWidget;
 	private final SpeedometerWidget speedometerWidget;
+	private final CarWidgetsPanel widgetsPanel;
 	@DrawableRes
 	private int compassResId = R.drawable.ic_compass_niu;
 
 	private boolean panMode;
+
+	/** Compensates the 0.77 factor SpeedometerWidget applies for Android Auto. */
+	private static final float SPEEDOMETER_CAR_SCALE = 2f;
 
 	public NavigationScreen(
 			@NonNull CarContext carContext,
@@ -94,6 +99,7 @@ public final class NavigationScreen extends BaseAndroidAutoScreen implements Sur
 		OsmandApplication app = getApp();
 		alarmWidget = new AlarmWidget(app, null);
 		speedometerWidget = new SpeedometerWidget(app, ThemeUsageContext.MAP);
+		widgetsPanel = new CarWidgetsPanel(app);
 		updateUse3DButton();
 		getLifecycle().addObserver(this);
 	}
@@ -130,6 +136,7 @@ public final class NavigationScreen extends BaseAndroidAutoScreen implements Sur
 	@Override
 	public void onDestroy(@NonNull LifecycleOwner owner) {
 		super.onDestroy(owner);
+		widgetsPanel.clearWidgets();
 		adjustMapPosition(false);
 		getApp().getRoutingHelper().removeListener(this);
 		getLifecycle().removeObserver(this);
@@ -139,22 +146,44 @@ public final class NavigationScreen extends BaseAndroidAutoScreen implements Sur
 	public void onFrameRendered(@NonNull Canvas canvas, @NonNull Rect visibleArea, @NonNull Rect stableArea) {
 		SurfaceRenderer surfaceRenderer = getSurfaceRenderer();
 		if (surfaceRenderer != null) {
-			DrawSettings drawSettings = new DrawSettings(isNightMode(), false, surfaceRenderer.getDensity());
+			float density = surfaceRenderer.getDensity();
+			DrawSettings drawSettings = new DrawSettings(isNightMode(), false, density);
+			// SpeedometerWidget shrinks itself by 0.77 for Android Auto, which leaves it much
+			// smaller than the alarm widget next to it - unlike on the phone, where the two are
+			// about the same size. The alarm widget already has a car sized layout.
+			DrawSettings speedometerSettings = new DrawSettings(drawSettings.isNightMode(), false,
+					density * SPEEDOMETER_CAR_SCALE);
 
 			alarmWidget.updateInfo(drawSettings, true);
-			speedometerWidget.updateInfo(drawSettings, drawSettings.isNightMode());
+			speedometerWidget.updateInfo(speedometerSettings, drawSettings.isNightMode());
 
 			Bitmap alarmBitmap = alarmWidget.getWidgetBitmap();
 			Bitmap speedometerBitmap = speedometerWidget.getWidgetBitmap();
 
+			Rect area = visibleArea;
 			if (speedometerBitmap != null) {
-				canvas.drawBitmap(speedometerBitmap, visibleArea.right - speedometerBitmap.getWidth() - 10, visibleArea.top + 10, new Paint());
+				canvas.drawBitmap(speedometerBitmap, area.right - speedometerBitmap.getWidth() - 10, area.top + 10, new Paint());
 			}
 			if (alarmBitmap != null) {
 				int offset = speedometerBitmap != null ? speedometerBitmap.getWidth() : 0;
-				canvas.drawBitmap(alarmBitmap, visibleArea.right - alarmBitmap.getWidth() - 10 - offset, visibleArea.top + 10, new Paint());
+				canvas.drawBitmap(alarmBitmap, area.right - alarmBitmap.getWidth() - 10 - offset, area.top + 10, new Paint());
 			}
+			// The speedometer is always there while driving, so the panel simply starts below it.
+			// The alarm comes and goes, hiding the rows it covers keeps the panel from jumping.
+			float topOffset = speedometerBitmap != null ? speedometerBitmap.getHeight() + 20 : 10;
+			Rect alarmArea = null;
+			if (alarmBitmap != null) {
+				int offset = speedometerBitmap != null ? speedometerBitmap.getWidth() : 0;
+				alarmArea = new Rect(area.right - alarmBitmap.getWidth() - 10 - offset, area.top,
+						area.right - offset, area.top + alarmBitmap.getHeight() + 20);
+			}
+			widgetsPanel.drawWidgets(canvas, area, drawSettings, density, topOffset, alarmArea);
 		}
+	}
+
+	@Override
+	public boolean onSurfaceClick(float x, float y) {
+		return widgetsPanel.onSurfaceClick(x, y);
 	}
 
 	@Nullable

--- a/OsmAnd/src/net/osmand/plus/auto/screens/SettingsScreen.java
+++ b/OsmAnd/src/net/osmand/plus/auto/screens/SettingsScreen.java
@@ -84,6 +84,21 @@ public final class SettingsScreen extends BaseAndroidAutoScreen {
 		ItemList.Builder configureMapBuilder = new ItemList.Builder();
 		configureMapBuilder.addItem(mapModeRowBuilder.build());
 		configureMapBuilder.addItem(magnifierRowBuilder.build());
+		configureMapBuilder.addItem(new Row.Builder()
+				.setTitle(getApp().getString(R.string.aa_show_widgets_panel))
+				.addText(getApp().getString(R.string.aa_show_widgets_panel_descr))
+				.setToggle(
+						new Toggle.Builder(osmandSettings.AA_SHOW_WIDGETS_PANEL::set)
+								.setChecked(osmandSettings.AA_SHOW_WIDGETS_PANEL.get())
+								.build())
+				.build()
+		);
+		configureMapBuilder.addItem(new Row.Builder()
+				.setTitle(getApp().getString(R.string.shared_string_widgets))
+				.setBrowsable(true)
+				.setOnClickListener(() -> getScreenManager().push(new CarWidgetsScreen(getCarContext())))
+				.build()
+		);
 
 		templateBuilder.addSectionedList(
 				SectionedItemList.create(

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -1493,6 +1493,9 @@ public class OsmandSettings {
 	public final CommonPreference<Float> AA_MAP_DENSITY = new FloatPreference(this, "aa_map_density_n", 1f).makeProfile().cache();
 	public final CommonPreference<AndroidAutoMapMode> AA_MAP_NIGHT_MODE =
 			new EnumStringPreference<>(this, "aa_map_mode", AndroidAutoMapMode.AUTOMATIC, AndroidAutoMapMode.values()).makeProfile().cache();
+	public final OsmandPreference<Boolean> AA_SHOW_WIDGETS_PANEL = new BooleanPreference(this, "aa_show_widgets_panel", true).makeProfile().cache();
+	/** Widget ids shown on the Android Auto widgets panel, separated by {@code ;}. */
+	public final CommonPreference<String> AA_WIDGETS = new StringPreference(this, "aa_widgets", "speed;altitude").makeProfile().cache();
 
 	public final OsmandPreference<Boolean> SHOW_POI_LABEL = new BooleanPreference(this, "show_poi_label", false).makeProfile();
 


### PR DESCRIPTION
Prototype for #23336 — an OBD II (and any other) widgets panel on the Android Auto screen.

## What it does

Instead of a car-specific implementation per widget, the panel reuses the regular OsmAnd map widgets and draws their views on the car surface, so **any** widget works — OBD II speed / RPM from the Vehicle metrics plugin as well as speed, altitude, GPS info, time, battery, max speed.

- `CarWidgetsPanel` measures, lays out and draws the widget views on the car canvas. The views are created and owned by the panel and never attached to a window, so the phone UI is untouched.
- The widget set is stored per profile in `AA_WIDGETS`, independent of the phone panels.
- The panel is flush with the right edge, under the speedometer, so the navigation card on the left stays free. Rounded on the left, square on the right.
- The panel never moves: its top only depends on the speedometer (always present while driving); rows that the transient alarm widget covers are hidden and their slot is kept, instead of pushing the panel down.
- `SpeedometerWidget` compensates the `* 0.77` factor it applies for Android Auto, which left it much smaller than the alarm widget next to it — on the phone the two are about the same size.

Sizing is done in **car dp**, not in a share of the pixel width: the panel is 200 dp wide (~1.5× the 130 dp phone widget, the car screen is looked at from roughly twice the distance), clamped to 22 % of the visible area so it still fits a 800×480 head unit.

## Verified

Tested on a real phone (Pixel 9 Pro XL, `net.osmand.dev`) driving the Desktop Head Unit at 1920×1080, 1280×720 and 800×480. Six widgets render correctly under the speedometer at 1280×720.

## Not done yet

1. **Widget selection must move into the phone app.** This prototype adds a "Widgets" screen to the Android Auto settings (`CarWidgetsScreen`); per review feedback the configuration belongs in the app, next to the other widget settings, and the Android Auto screen should be dropped.
2. **Paging must be removed.** The current prototype pages through the widgets on a tap (`SurfaceCallback.onClick`, car API level 5). The decision is to drop it and simply cut off the widgets that do not fit — this also removes the open question of whether a tappable surface area passes Google review.
3. Requires a live `MapActivity` on the phone: `MapWidget` needs one to inflate its views, so with the phone activity destroyed the panel stays empty. Needs a headless widget factory (or keeping the widgets alive with the car session) before this is shippable.
4. Not measured: the drawing cost per frame (`measure`/`layout`/`draw` of every row on every rendered frame) and the behaviour on a real head unit — everything above is from the DHU.
5. No tests.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Look at what the Android project backlog contains and take a task from "In progress / Fixing / Ready to do".
2. Make a prototype for #23336 (Android Auto OBD II widgets panel).
3. Make the UI generic so that any widget works; Dima suggested a panel on the left where there is space.
4. No — the panel must be on the right, so it does not cover the navigation card; 3–4 widgets seem to fit on some screens.
5. Paging on tap is possible, but think about whether it passes Google review; a prototype is fine.
6. Let's look at the UI and the simulator; install the dev nightly on the phone, do not touch production.
7. Separate widget set for Android Auto rather than reusing the phone right panel.
8. Fix the sizes: think about the proportions of a tablet-sized screen and of the DHU; the speedometer is suspiciously small; the alert is now huge, on the phone it is not like that.
9. No right margin for the widgets, never shift the panel — hide the widgets that would be shifted; neat rounded corners on top, bottom and left.
10. Run a smaller DHU to check how paging works with 5–6 widgets.
11. Widget configuration must be in the app, not in Android Auto; drop paging entirely and just cut off what does not fit.
12. Open a draft pull request and write down what is not finished.

Decided by the agent, not requested explicitly:
- Reusing the existing `MapWidget` views and drawing them on the car canvas, instead of writing car-specific widget rendering.
- The `AA_WIDGETS` / `AA_SHOW_WIDGETS_PANEL` preferences and their defaults (`speed;altitude`, panel on).
- The dp-based sizing rule (200 car dp, 22 % clamp, 400 dp minimum surface width, 70 % maximum height) and the 8 dp corner radius.
- Rounding on the left only, and splitting the panel into separate rounded blocks when the alarm hides a row in the middle.
- Scaling the speedometer by 2× to cancel its Android Auto `0.77` factor, while leaving the alarm widget untouched.
- Adding a default `onSurfaceClick` to `SurfaceRendererCallback` and `SurfaceCallback.onClick` in `SurfaceRenderer` (only needed for the paging that is to be removed).
