### PR TITLE
Fix native tile provider lifetime (MapTiledCollectionProvider SIGSEGV / pure virtual crashes)

### DIFF
--- a/OsmAnd/src/net/osmand/plus/utils/NativeUtilities.java
+++ b/OsmAnd/src/net/osmand/plus/utils/NativeUtilities.java
@@ -31,6 +31,24 @@ public class NativeUtilities {
 
 	public static final int MIN_ALTITUDE_VALUE = -20_000;
 
+	/**
+	 * Passes a Java implemented tile provider to the native renderer.
+	 *
+	 * <p>The renderer keeps the returned proxy in its own state and calls back into the Java
+	 * provider from its worker threads, also for a while after {@code removeSymbolsProvider()}.
+	 * {@code swigReleaseOwnership()} makes the native director hold a strong JNI reference to the
+	 * Java object and become responsible for its own lifetime, so the provider cannot be collected
+	 * while the renderer still uses it; {@code instantiateProxy(true)} destroys the director once
+	 * the last native reference to the proxy is gone, so nothing is leaked either.
+	 */
+	@NonNull
+	public static MapTiledCollectionProvider instantiateNativeProvider(
+			@NonNull interface_MapTiledCollectionProvider provider) {
+		MapTiledCollectionProvider providerInstance = provider.instantiateProxy(true);
+		provider.swigReleaseOwnership();
+		return providerInstance;
+	}
+
 	public static SingleSkImage createSkImageFromBitmap(@NonNull Bitmap bitmap) {
 		return createSkImage(bitmap.getWidth(), bitmap.getHeight(), AndroidUtils.getByteArrayFromBitmap(bitmap));
 	}

--- a/OsmAnd/src/net/osmand/plus/views/layers/core/AidlTileProvider.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/core/AidlTileProvider.java
@@ -74,14 +74,18 @@ public class AidlTileProvider extends interface_MapTiledCollectionProvider {
 		this.smallIconBg = aidlMapLayer.getSmallIconBg();
 		this.offset = new PointI(0, 0);
 		this.bigIconOffset = new PointI(0, (int) yOffset);
-		this.swigTakeOwnership();
+	}
+
+	@NonNull
+	public MapTiledCollectionProvider getProviderInstance() {
+		if (providerInstance == null) {
+			providerInstance = NativeUtilities.instantiateNativeProvider(this);
+		}
+		return providerInstance;
 	}
 
 	public void drawSymbols(@NonNull MapRendererView mapRenderer) {
-		if (providerInstance == null) {
-			providerInstance = instantiateProxy();
-		}
-		mapRenderer.addSymbolsProvider(providerInstance);
+		mapRenderer.addSymbolsProvider(getProviderInstance());
 	}
 
 	public void clearSymbols(@NonNull MapRendererView mapRenderer) {

--- a/OsmAnd/src/net/osmand/plus/views/layers/core/AudioNotesTileProvider.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/core/AudioNotesTileProvider.java
@@ -50,14 +50,18 @@ public class AudioNotesTileProvider extends interface_MapTiledCollectionProvider
         textStyle = new TextRasterizer.Style();
         this.density = density;
         this.offset = new PointI(0, 0);
-        this.swigTakeOwnership();
+    }
+
+    @NonNull
+    public MapTiledCollectionProvider getProviderInstance() {
+        if (providerInstance == null) {
+            providerInstance = NativeUtilities.instantiateNativeProvider(this);
+        }
+        return providerInstance;
     }
 
     public void drawSymbols(@NonNull MapRendererView mapRenderer) {
-        if (providerInstance == null) {
-            providerInstance = instantiateProxy();
-        }
-        mapRenderer.addSymbolsProvider(providerInstance);
+        mapRenderer.addSymbolsProvider(getProviderInstance());
     }
 
     public void clearSymbols(@NonNull MapRendererView mapRenderer) {

--- a/OsmAnd/src/net/osmand/plus/views/layers/core/FavoritesTileProvider.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/core/FavoritesTileProvider.java
@@ -45,14 +45,18 @@ public class FavoritesTileProvider extends interface_MapTiledCollectionProvider 
 		this.textStyle = textStyle;
 		this.density = density;
 		this.offset = new PointI(0, 0);
-		this.swigTakeOwnership();
+	}
+
+	@NonNull
+	public MapTiledCollectionProvider getProviderInstance() {
+		if (providerInstance == null) {
+			providerInstance = NativeUtilities.instantiateNativeProvider(this);
+		}
+		return providerInstance;
 	}
 
 	public void drawSymbols(@NonNull MapRendererView mapRenderer) {
-		if (providerInstance == null) {
-			providerInstance = instantiateProxy();
-		}
-		mapRenderer.addSymbolsProvider(FAVORITES_SECTION, providerInstance);
+		mapRenderer.addSymbolsProvider(FAVORITES_SECTION, getProviderInstance());
 	}
 
 	public void clearSymbols(@NonNull MapRendererView mapRenderer) {

--- a/OsmAnd/src/net/osmand/plus/views/layers/core/LocationPointsTileProvider.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/core/LocationPointsTileProvider.java
@@ -39,14 +39,18 @@ public class LocationPointsTileProvider extends interface_MapTiledCollectionProv
       }
       skPointBitmap = pointBitmap;
       this.offset = new PointI(0, 0);
-      this.swigTakeOwnership();
+   }
+
+   @NonNull
+   public MapTiledCollectionProvider getProviderInstance() {
+      if (providerInstance == null) {
+         providerInstance = NativeUtilities.instantiateNativeProvider(this);
+      }
+      return providerInstance;
    }
 
    public void drawPoints(@NonNull MapRendererView mapRenderer) {
-      if (providerInstance == null) {
-         providerInstance = instantiateProxy();
-      }
-      mapRenderer.addSymbolsProvider(providerInstance);
+      mapRenderer.addSymbolsProvider(getProviderInstance());
    }
 
    public void clearPoints(@NonNull MapRendererView mapRenderer) {

--- a/OsmAnd/src/net/osmand/plus/views/layers/core/OsmBugsTileProvider.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/core/OsmBugsTileProvider.java
@@ -130,15 +130,18 @@ public class OsmBugsTileProvider extends interface_MapTiledCollectionProvider {
 		this.showClosed = showClosed;
 		this.minZoom = minZoom;
 		this.offset = new PointI(0, -BACKGROUND_TYPE.getOffsetY(context, textScale));
-		this.swigTakeOwnership();
+	}
+
+	@NonNull
+	public MapTiledCollectionProvider getProviderInstance() {
+		if (providerInstance == null) {
+			providerInstance = NativeUtilities.instantiateNativeProvider(this);
+		}
+		return providerInstance;
 	}
 
 	public void drawSymbols(@NonNull MapRendererView mapRenderer) {
-		if (providerInstance == null) {
-			providerInstance = instantiateProxy();
-		}
-
-		mapRenderer.addSymbolsProvider(providerInstance);
+		mapRenderer.addSymbolsProvider(getProviderInstance());
 	}
 
 	public void clearSymbols(@NonNull MapRendererView mapRenderer) {

--- a/OsmAnd/src/net/osmand/plus/views/layers/core/POITileProvider.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/core/POITileProvider.java
@@ -141,14 +141,18 @@ public class POITileProvider extends interface_MapTiledCollectionProvider {
 		this.textScale = textScale;
 		this.density = density;
 		this.offset = new PointI(0, 0);
-		this.swigTakeOwnership();
+	}
+
+	@NonNull
+	public MapTiledCollectionProvider getProviderInstance() {
+		if (providerInstance == null) {
+			providerInstance = NativeUtilities.instantiateNativeProvider(this);
+		}
+		return providerInstance;
 	}
 
 	public void drawSymbols(@NonNull MapRendererView mapRenderer) {
-		if (providerInstance == null) {
-			providerInstance = instantiateProxy();
-		}
-		mapRenderer.addSymbolsProvider(POI_SYMBOL_SECTION, providerInstance);
+		mapRenderer.addSymbolsProvider(POI_SYMBOL_SECTION, getProviderInstance());
 	}
 
 	public void clearSymbols(@NonNull MapRendererView mapRenderer) {

--- a/OsmAnd/src/net/osmand/plus/views/layers/core/TilePointsProvider.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/core/TilePointsProvider.java
@@ -106,14 +106,18 @@ public class TilePointsProvider<T extends TilePointsProvider.ICollectionPoint> e
 		this.minZoom = minZoom;
 		this.maxZoom = maxZoom;
 		this.offset = new PointI(0, 0);
-		this.swigTakeOwnership();
+	}
+
+	@NonNull
+	public MapTiledCollectionProvider getProviderInstance() {
+		if (providerInstance == null) {
+			providerInstance = NativeUtilities.instantiateNativeProvider(this);
+		}
+		return providerInstance;
 	}
 
 	public void drawSymbols(@NonNull MapRendererView mapRenderer) {
-		if (providerInstance == null) {
-			providerInstance = instantiateProxy();
-		}
-		mapRenderer.addSymbolsProvider(providerInstance);
+		mapRenderer.addSymbolsProvider(getProviderInstance());
 	}
 
 	public void clearSymbols(@NonNull MapRendererView mapRenderer) {

--- a/OsmAnd/src/net/osmand/plus/views/layers/core/TransportStopsTileProvider.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/core/TransportStopsTileProvider.java
@@ -61,14 +61,18 @@ public class TransportStopsTileProvider extends interface_MapTiledCollectionProv
 		this.textStyle = new TextRasterizer.Style();
 		this.textScale = textScale;
 		offset = new PointI(0, 0);
-		this.swigTakeOwnership();
+	}
+
+	@NonNull
+	public MapTiledCollectionProvider getProviderInstance() {
+		if (providerInstance == null) {
+			providerInstance = NativeUtilities.instantiateNativeProvider(this);
+		}
+		return providerInstance;
 	}
 
 	public void drawSymbols(@NonNull MapRendererView mapRenderer) {
-		if (providerInstance == null) {
-			providerInstance = instantiateProxy();
-		}
-		mapRenderer.addSymbolsProvider(providerInstance);
+		mapRenderer.addSymbolsProvider(getProviderInstance());
 	}
 
 	public void clearSymbols(@NonNull MapRendererView mapRenderer) {

--- a/OsmAnd/src/net/osmand/plus/views/layers/core/WptPtTileProvider.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/core/WptPtTileProvider.java
@@ -46,14 +46,18 @@ public class WptPtTileProvider extends interface_MapTiledCollectionProvider {
       this.textStyle = textStyle != null ? textStyle : new TextRasterizer.Style();
       this.density = density;
       offset = new PointI(0,0);
-      this.swigTakeOwnership();
+   }
+
+   @NonNull
+   public MapTiledCollectionProvider getProviderInstance() {
+      if (providerInstance == null) {
+         providerInstance = NativeUtilities.instantiateNativeProvider(this);
+      }
+      return providerInstance;
    }
 
    public void drawSymbols(@NonNull MapRendererView mapRenderer) {
-      if (providerInstance == null) {
-         providerInstance = instantiateProxy();
-      }
-      mapRenderer.addSymbolsProvider(providerInstance);
+      mapRenderer.addSymbolsProvider(getProviderInstance());
    }
 
    public void clearSymbols(@NonNull MapRendererView mapRenderer) {

--- a/OsmAnd/test/java/net/osmand/test/junit/TileProviderNativeOwnershipTest.java
+++ b/OsmAnd/test/java/net/osmand/test/junit/TileProviderNativeOwnershipTest.java
@@ -1,0 +1,251 @@
+package net.osmand.test.junit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import net.osmand.core.android.NativeCore;
+import net.osmand.core.jni.MapTiledCollectionProvider;
+import net.osmand.core.jni.interface_MapTiledCollectionProvider;
+import net.osmand.data.DataTileManager;
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.views.corenative.NativeCoreContext;
+import net.osmand.plus.views.layers.core.AudioNotesTileProvider;
+import net.osmand.plus.views.layers.core.FavoritesTileProvider;
+import net.osmand.plus.views.layers.core.LocationPointsTileProvider;
+import net.osmand.plus.views.layers.core.OsmBugsTileProvider;
+import net.osmand.plus.views.layers.core.POITileProvider;
+import net.osmand.plus.views.layers.core.TilePointsProvider;
+import net.osmand.plus.views.layers.core.TransportStopsTileProvider;
+import net.osmand.plus.views.layers.core.WptPtTileProvider;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+/**
+ * Guards the ownership contract between a Java tile-symbols provider and the native renderer.
+ *
+ * <p>Every {@code *TileProvider} extends the SWIG director class
+ * {@code interface_MapTiledCollectionProvider} and hands a native proxy of itself to
+ * {@code MapRendererView.addSymbolsProvider()}. From that moment the renderer keeps the proxy in
+ * its own state and calls back into the Java object from its worker threads, also for a while
+ * after {@code removeSymbolsProvider()}, so the Java object has to stay alive for as long as the
+ * native side holds the proxy.
+ *
+ * <p>The SWIG default (and {@code swigTakeOwnership()}) gives the opposite semantics: the director
+ * keeps only a JNI <em>weak</em> global reference to the Java object, and the Java finalizer
+ * deletes the native director. Once the map layer drops its field, the Java object becomes
+ * collectable, the finalizer frees the director, and every later renderer callback dereferences
+ * freed memory - the {@code MapTiledCollectionProvider} SIGSEGV and {@code __cxa_pure_virtual}
+ * crashes.
+ *
+ * <p>The correct idiom, already used elsewhere in the code base (see
+ * {@code NativeCore.load(interface_ICoreResourcesProvider, String)} and the per-point providers in
+ * {@code TransportStopsTileProvider#getTilePoints}), is {@code instantiateProxy(true)} plus
+ * {@code swigReleaseOwnership()}: native takes a strong global reference and destroys the director
+ * once the last native reference to the proxy is gone.
+ */
+@RunWith(AndroidJUnit4.class)
+public class TileProviderNativeOwnershipTest {
+
+	private static final long GC_TIMEOUT_MS = 15_000;
+	private static final String SENTINEL = "sentinel";
+
+	private OsmandApplication app;
+
+	private final ReferenceQueue<Object> refQueue = new ReferenceQueue<>();
+	private final Map<Reference<?>, String> refNames = new HashMap<>();
+
+	@Before
+	public void setup() {
+		Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+		app = (OsmandApplication) targetContext.getApplicationContext();
+
+		NativeCoreContext.init(app);
+		assumeTrue("OsmAndCore native library is not available on this device",
+				NativeCore.isAvailable());
+	}
+
+	/**
+	 * Reproduces the crash: after a provider has been handed to the renderer, dropping the last
+	 * Java reference to it must not make the Java object collectable.
+	 */
+	@Test
+	public void javaProviderSurvivesGcWhileNativeHoldsProxy() throws Exception {
+		List<Handle> handles = new ArrayList<>();
+		for (Callable<Handle> provider : providers().values()) {
+			handles.add(provider.call());
+		}
+
+		Set<String> collected = collectGarbage();
+
+		List<String> lost = new ArrayList<>();
+		for (Handle handle : handles) {
+			if (collected.contains(handle.name)) {
+				lost.add(handle.name);
+			}
+		}
+		assertTrue("Java tile providers were garbage collected while the native renderer still"
+				+ " holds a proxy to them - the renderer would call into freed memory: "
+				+ lost, lost.isEmpty());
+
+		// This is what a renderer worker thread does with the proxy it still holds.
+		for (Handle handle : handles) {
+			assertNotNull(handle.name, handle.nativeProxy.getMinZoom());
+		}
+	}
+
+	/**
+	 * The mirror image of the test above: once the native side releases the proxy, the Java object
+	 * must become collectable again, otherwise the crash is merely traded for a leak.
+	 */
+	@Test
+	public void javaProviderIsReleasedWhenNativeProxyIsDestroyed() {
+		Handle handle = favoritesProvider();
+
+		// The renderer released the provider (removeSymbolsProvider() plus collection of the Java
+		// wrapper), so the last native reference to the proxy is gone.
+		handle.nativeProxy.delete();
+
+		assertTrue("Java tile provider is still pinned by native after the proxy was destroyed",
+				collectGarbage().contains(handle.name));
+	}
+
+	private Map<String, Callable<Handle>> providers() {
+		Map<String, Callable<Handle>> providers = new LinkedHashMap<>();
+		providers.put("FavoritesTileProvider", this::favoritesProvider);
+		providers.put("WptPtTileProvider", () -> {
+			WptPtTileProvider provider = new WptPtTileProvider(app, 0, false, null, 1f);
+			return handOverToNative("WptPtTileProvider", provider, provider.getProviderInstance());
+		});
+		providers.put("AudioNotesTileProvider", () -> {
+			AudioNotesTileProvider provider = new AudioNotesTileProvider(app, 0, 1f);
+			return handOverToNative("AudioNotesTileProvider", provider, provider.getProviderInstance());
+		});
+		providers.put("TransportStopsTileProvider", () -> {
+			TransportStopsTileProvider provider = new TransportStopsTileProvider(app, null, 0, 1f);
+			return handOverToNative("TransportStopsTileProvider", provider, provider.getProviderInstance());
+		});
+		providers.put("POITileProvider", () -> {
+			POITileProvider provider = new POITileProvider(app, null, 0, false, null, 1f, 1f);
+			return handOverToNative("POITileProvider", provider, provider.getProviderInstance());
+		});
+		providers.put("OsmBugsTileProvider", () -> {
+			OsmBugsTileProvider provider = new OsmBugsTileProvider(app, null, 0, false, 0, 1f);
+			return handOverToNative("OsmBugsTileProvider", provider, provider.getProviderInstance());
+		});
+		providers.put("TilePointsProvider", () -> {
+			TilePointsProvider<?> provider = new TilePointsProvider<>(app, new DataTileManager<>(),
+					0, false, null, 1f, 1f, 0, 22);
+			return handOverToNative("TilePointsProvider", provider, provider.getProviderInstance());
+		});
+		providers.put("LocationPointsTileProvider", () -> {
+			LocationPointsTileProvider provider = new LocationPointsTileProvider(0,
+					Collections.emptyList(), Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888));
+			return handOverToNative("LocationPointsTileProvider", provider, provider.getProviderInstance());
+		});
+		return providers;
+	}
+
+	private Handle favoritesProvider() {
+		FavoritesTileProvider provider = new FavoritesTileProvider(app, 0, false, null, 1f);
+		return handOverToNative("FavoritesTileProvider", provider, provider.getProviderInstance());
+	}
+
+	/**
+	 * Registers the Java provider for garbage collection watching and then forgets it, exactly like
+	 * a map layer that nulls its provider field after the renderer got the proxy.
+	 *
+	 * <p>Every provider is created inside its own lambda on purpose: this is a debuggable build,
+	 * where ART keeps every local of a running method alive until the method returns.
+	 */
+	private Handle handOverToNative(String name, interface_MapTiledCollectionProvider provider,
+	                                MapTiledCollectionProvider nativeProxy) {
+		WeakReference<Object> ref = new WeakReference<>(provider, refQueue);
+		refNames.put(ref, name);
+		return new Handle(name, nativeProxy, ref);
+	}
+
+	/**
+	 * Runs the garbage collector until it proves it reclaimed a weakly reachable object, and
+	 * returns the names of the tile providers it collected along the way.
+	 *
+	 * <p>Reclamation is observed through the {@link ReferenceQueue} rather than through
+	 * {@code WeakReference.get()}: under ART's concurrent copying collector a {@code get()} call
+	 * marks the referent, so polling with {@code get()} can keep the object alive indefinitely.
+	 */
+	private Set<String> collectGarbage() {
+		WeakReference<Object> sentinel = newSentinel(refQueue);
+		refNames.put(sentinel, SENTINEL);
+
+		Set<String> collected = new HashSet<>();
+		long deadline = System.currentTimeMillis() + GC_TIMEOUT_MS;
+		while (System.currentTimeMillis() < deadline) {
+			allocateGarbage();
+			System.gc();
+			System.runFinalization();
+			try {
+				Reference<?> ref = refQueue.remove(200);
+				while (ref != null) {
+					collected.add(refNames.get(ref));
+					ref = refQueue.poll();
+				}
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				break;
+			}
+			if (collected.remove(SENTINEL)) {
+				return collected;
+			}
+		}
+		fail("GC did not reclaim a weakly reachable object within " + GC_TIMEOUT_MS
+				+ " ms, the test is inconclusive");
+		return Collections.emptySet();
+	}
+
+	private static WeakReference<Object> newSentinel(ReferenceQueue<Object> queue) {
+		return new WeakReference<>(new Object(), queue);
+	}
+
+	private static void allocateGarbage() {
+		// Nudge ART into an actual collection instead of a no-op System.gc().
+		assertEquals(512 * 1024, new byte[512 * 1024].length);
+	}
+
+	private static final class Handle {
+
+		final String name;
+		final MapTiledCollectionProvider nativeProxy;
+		@SuppressWarnings("unused") // kept reachable so that it can be enqueued
+		final WeakReference<Object> javaProvider;
+
+		Handle(String name, MapTiledCollectionProvider nativeProxy,
+		       WeakReference<Object> javaProvider) {
+			this.name = name;
+			this.nativeProxy = nativeProxy;
+			this.javaProvider = javaProvider;
+		}
+	}
+}


### PR DESCRIPTION
Internal issue: https://github.com/osmandapp/OsmAnd-Issues/issues/2857 (epic https://github.com/osmandapp/OsmAnd-Issues/issues/3062)

Fixes the largest crash cluster in Play vitals: **4 issues, ~557 affected users over the last 28 days** (user-perceived, 5.3.10/5.4.x), all with the same root cause.

| Play issue | Signal | Top frame | Affected users |
|---|---|---|---|
| `c7d893ec` | SIGABRT | `__cxa_pure_virtual` ← `MapTiledCollectionProvider::obtainData` | 233 |
| `77d87005` | SIGSEGV | `OsmAnd::interface_MapTiledCollectionProvider::getMaxZoom() const+8` | 123/113/88 |
| `d758b5d4` | SIGSEGV | `OsmAnd::interface_MapTiledCollectionProvider::getPinIconOffset() const+8` | (same three rows) |
| `62a9c6f6` | SIGSEGV | `OsmAnd::MapTiledCollectionProvider::obtainData` | |

All four crash on a `Concurrent::WorkerPool` thread, through
`MapRendererResourcesManager::ResourceRequestTask::execute()` →
`MapRendererTiledSymbolsResource::obtainData()` →
`IMapTiledSymbolsProvider::obtainTiledSymbols()`.

## Root cause

Every `*TileProvider` extends the SWIG director class
`interface_MapTiledCollectionProvider` and hands a native proxy of itself to
`MapRendererView.addSymbolsProvider()`. The renderer keeps that proxy and calls back into
the Java object from its worker threads — also for a while after
`removeSymbolsProvider()`, because `MapRenderer::removeSymbolsProvider()` only drops the
provider from `_requestedState`; the published state and the already queued
`ResourceRequestTask`s still hold it.

The providers called `swigTakeOwnership()`, which means the opposite of what is needed
(and is also the SWIG default, so the call was a no-op):

* the director keeps only a JNI **weak** global reference to the Java object, and
* `swigCMemOwn == true`, so the Java finalizer runs
  `delete_interface_MapTiledCollectionProvider` → `delete arg1` on the native director.

The proxy returned by `instantiateProxy()` holds a **raw** `_instance` pointer to that
director (`CommonSWIG.h`). So as soon as a map layer nulls its provider field — e.g.
`FavouritesLayer.clearFavorites()`, or `showFavorites()` which rebuilds the provider on
every refresh and does not draw it when `SHOW_FAVORITES` is off — the Java object becomes
collectable, the finalizer frees the director, and the next renderer callback runs on
freed memory: SIGSEGV in a director thunk, or `__cxa_pure_virtual` when it lands during
the destructor.

## Fix

Use the idiom the code base already uses everywhere else an object is passed to native —
`NativeCore.load(interface_ICoreResourcesProvider, String)` and the per-point providers in
`TransportStopsTileProvider#getTilePoints`:

```java
MapTiledCollectionProvider providerInstance = provider.instantiateProxy(true);
provider.swigReleaseOwnership();
```

`swigReleaseOwnership()` turns the director's JNI reference into a strong global one and
makes native responsible for the director's lifetime; `instantiateProxy(true)` destroys the
director when the last native reference to the proxy is gone. The provider is therefore
neither collected while the renderer still uses it, nor leaked afterwards.

The hand-off is extracted into `NativeUtilities.instantiateNativeProvider()` (one place
documenting the contract) and into a per-provider `getProviderInstance()`, so the test can
exercise the production path. All 9 providers are converted.

## Test

New instrumented test `TileProviderNativeOwnershipTest` (`OsmAnd/test/java/net/osmand/test/junit/`):

* `javaProviderSurvivesGcWhileNativeHoldsProxy` — creates all 8 constructible providers,
  takes the native proxy through `getProviderInstance()`, drops the Java reference, forces
  GC, and asserts none of them was collected; then calls `getMinZoom()` on each proxy,
  which is what a renderer worker thread does.
* `javaProviderIsReleasedWhenNativeProxyIsDestroyed` — the mirror image: after the native
  proxy is destroyed the Java object must become collectable again, so the crash is not
  traded for a leak.

Collection is observed through a `ReferenceQueue`, not `WeakReference.get()`: under ART's
concurrent copying collector a `get()` call marks the referent, so polling with `get()`
keeps the object alive. A sentinel reference on the same queue makes the test fail loudly
("inconclusive") instead of passing when the GC did not actually run.

Run on `Claude_Phone_API_35` (Android 15, arm64), variant `nightlyFreeOpenglArm64Debug`:

**Before the fix** — the crash reproduces for every provider:

```
javaProviderSurvivesGcWhileNativeHoldsProxy FAILED
java.lang.AssertionError: Java tile providers were garbage collected while the native
renderer still holds a proxy to them - the renderer would call into freed memory:
[FavoritesTileProvider, WptPtTileProvider, AudioNotesTileProvider,
 TransportStopsTileProvider, POITileProvider, OsmBugsTileProvider, TilePointsProvider,
 LocationPointsTileProvider]
```

**After the fix:**

```
<testsuite name="net.osmand.test.junit.TileProviderNativeOwnershipTest"
           tests="2" failures="0" errors="0" skipped="0" time="6.036">
  <testcase name="javaProviderIsReleasedWhenNativeProxyIsDestroyed" time="4.568" />
  <testcase name="javaProviderSurvivesGcWhileNativeHoldsProxy" time="0.146" />
</testsuite>
```

`AidlTileProvider` is fixed as well but not covered by the test — its constructor needs a
live `AidlMapLayer`.

## Relation to #25009

#25009 ("Fix crash during rendering release", merged into `r5.3` on 2026-05-05) is what added
`this.swigTakeOwnership()` to these same 9 providers, with exactly the right intent — *"Hold Java
provider objects in memory while rendering is still active"*. The primitive is the opposite of that
intent, and it is also a no-op:

* `swigTakeOwnership()` means **Java** takes ownership of the C++ director, i.e. native keeps only a
  weak reference and the Java finalizer deletes the director;
* the SWIG director constructor already does `director_connect(this, swigCPtr, true, true)` —
  `mem_own = true`, `weak_global = true` — so calling it again changes nothing.

`swigReleaseOwnership()` is the call that actually holds the Java object from native. This PR
replaces the `swigTakeOwnership()` lines added by #25009.

The Play data says the earlier fix did not take effect: #25009 is in `r5.3` (merged 2026-05-05,
branch tip 2026-05-13) and therefore in the 5.3.10 build, and 5.3.10 is where **211 of the 233**
affected users of `c7d893ec` sit — 95.5% of that issue. The 5.4.x numbers are single digits per
version simply because 5.4 has only been rolling out for about three weeks, so they say nothing
either way yet.

## Notes for review

* No native rebuild needed: `instantiateProxy(boolean)` and `swigReleaseOwnership()` are
  already part of the generated JNI wrapper.
* `swigTakeOwnership()` was removed rather than replaced: it only re-asserted the SWIG
  default, so keeping it next to a `swigReleaseOwnership()` in the hand-off would be
  contradictory.
* The ownership release deliberately sits in `getProviderInstance()` and not in the
  constructor. A provider that is constructed but never handed to the renderer (e.g.
  `showFavorites()` when favourites are hidden) would otherwise be pinned by the global
  reference forever, with no proxy to ever release it.
* `clearSymbols()` still just nulls `providerInstance`; that breaks the
  Java → wrapper → proxy → director → global-ref → Java cycle, after which the wrapper is
  finalized and the director destroyed.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Asked whether the most frequent crashes in Play Console could be fixed, with links to
   seven crash issues.
2. Asked to review the rest of the top crashes and ANRs, group anything similar, and open a
   separate pull request per issue against the 5.4 branch only (not master).
3. Asked to reproduce group A with a test — stated as very important — and open the pull
   request.

Decided by the agent, not requested explicitly:
* Choice of fix (`instantiateProxy(true)` + `swigReleaseOwnership()`) over the alternatives
  of keeping a strong Java reference in a registry or releasing ownership in the
  constructor.
* Extracting `NativeUtilities.instantiateNativeProvider()` and the per-provider
  `getProviderInstance()` — needed so the test can drive the production code path rather
  than re-implementing the hand-off.
* The test design (`ReferenceQueue` instead of `WeakReference.get()`, the GC sentinel, the
  second leak-guard test) and its placement in the existing `androidTest` source set.
* Converting `AidlTileProvider` too, although it is not covered by the test.
