### PR TITLE
Cache number formatters in OsmAndFormatter (GC ANR in QuickSearch list layout)

### DIFF
--- a/OsmAnd/src/net/osmand/plus/utils/OsmAndFormatter.java
+++ b/OsmAnd/src/net/osmand/plus/utils/OsmAndFormatter.java
@@ -46,14 +46,15 @@ import java.text.DateFormat;
 import java.text.DateFormatSymbols;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
-import java.text.MessageFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.TimeZone;
 
 public class OsmAndFormatter {
@@ -119,6 +120,18 @@ public class OsmAndFormatter {
 		Locale preferredLocale = localeHelper.getPreferredLocale();
 		return preferredLocale != null ? preferredLocale : localeHelper.getDefaultLocale();
 	}
+
+	/**
+	 * Creating a {@link DecimalFormat} resolves the locale through ICU ({@link DecimalFormatSymbols}
+	 * looks up the currency, which builds a {@code LocaleIDParser}), which is far too expensive for
+	 * code that runs for every visible list row on every compass update: the allocation churn showed
+	 * up as an ANR inside {@code art::gc::Heap::WaitForGcToComplete} during {@code ListView} layout.
+	 *
+	 * <p>The key covers everything that configures the instance, so a cached formatter is never
+	 * reconfigured after creation. {@link DecimalFormat} is mutable and not thread safe, hence one
+	 * cache per thread.
+	 */
+	private static final ThreadLocal<Map<String, DecimalFormat>> DECIMAL_FORMATS = new ThreadLocal<>();
 
 	@NonNull
 	private static DecimalFormat createDecimalFormat(@NonNull String pattern, int minFractionDigits,
@@ -803,22 +816,28 @@ public class OsmAndFormatter {
 		Locale preferredLocale = app.getLocaleHelper().getPreferredLocale();
 		Locale locale = preferredLocale != null ? preferredLocale : Locale.getDefault();
 
-		DecimalFormatSymbols decimalFormatSymbols = new DecimalFormatSymbols(locale);
-		decimalFormatSymbols.setGroupingSeparator(' ');
+		boolean groupThousands = Math.abs(value) >= 10_000;
+		Map<String, DecimalFormat> formats = DECIMAL_FORMATS.get();
+		if (formats == null) {
+			formats = new HashMap<>();
+			DECIMAL_FORMATS.set(formats);
+		}
+		String key = pattern + groupThousands + locale;
+		DecimalFormat decimalFormat = formats.get(key);
+		if (decimalFormat == null) {
+			DecimalFormatSymbols symbols = new DecimalFormatSymbols(locale);
+			symbols.setGroupingSeparator(' ');
 
-		DecimalFormat decimalFormat = new DecimalFormat(pattern);
-		decimalFormat.setDecimalFormatSymbols(decimalFormatSymbols);
-
-		boolean fiveOrMoreDigits = Math.abs(value) >= 10_000;
-		if (fiveOrMoreDigits) {
-			decimalFormat.setGroupingUsed(true);
-			decimalFormat.setGroupingSize(3);
+			decimalFormat = new DecimalFormat(pattern);
+			decimalFormat.setDecimalFormatSymbols(symbols);
+			if (groupThousands) {
+				decimalFormat.setGroupingUsed(true);
+				decimalFormat.setGroupingSize(3);
+			}
+			formats.put(key, decimalFormat);
 		}
 
-		MessageFormat messageFormat = new MessageFormat("{0}");
-		messageFormat.setFormatByArgumentIndex(0, decimalFormat);
-		String formattedValue = messageFormat.format(new Object[] {value})
-				.replace('\n', ' ');
+		String formattedValue = decimalFormat.format(value).replace('\n', ' ');
 		return new FormattedValue(value, formattedValue, unit, unitId, true);
 	}
 

--- a/OsmAnd/test/java/net/osmand/test/junit/OsmAndFormatterCachingTest.java
+++ b/OsmAnd/test/java/net/osmand/test/junit/OsmAndFormatterCachingTest.java
@@ -1,0 +1,151 @@
+package net.osmand.test.junit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.util.Log;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.utils.OsmAndFormatter;
+import net.osmand.plus.utils.FormattedValue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * {@code OsmAndFormatter.formatValue()} used to build a {@link DecimalFormat} (and with it a
+ * {@link DecimalFormatSymbols}, which resolves the locale currency through ICU) on every single
+ * call. It is called for every visible row of a list on every compass update, so the allocation
+ * churn kept the collector busy and showed up as a main-thread ANR inside
+ * {@code art::gc::Heap::WaitForGcToComplete} during {@code ListView.layoutChildren}.
+ *
+ * <p>These tests pin both halves of the fix: the formatting result must not change, and formatting
+ * must no longer pay for building a formatter on every call.
+ */
+@RunWith(AndroidJUnit4.class)
+public class OsmAndFormatterCachingTest {
+
+	private static final int WARMUP_ITERATIONS = 200;
+	private static final int MEASURED_ITERATIONS = 3000;
+
+	/** The cached path has to be at least this much cheaper than building a formatter per call. */
+	private static final int MIN_SPEEDUP = 5;
+
+	private OsmandApplication app;
+
+	@Before
+	public void setup() {
+		Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+		app = (OsmandApplication) targetContext.getApplicationContext();
+	}
+
+	/**
+	 * The cache must not change a single formatted string. The reference implementation below is
+	 * the code that stood in {@code formatValue()} before the fix.
+	 */
+	@Test
+	public void formattedValuesAreUnchanged() {
+		List<String> mismatches = new ArrayList<>();
+		for (float value : values()) {
+			for (int decimalPlaces : new int[] {0, 1, 2, 3}) {
+				for (boolean forceTrailingZeroes : new boolean[] {false, true}) {
+					FormattedValue actual = OsmAndFormatter.formatValue(value, "m",
+							forceTrailingZeroes, decimalPlaces, app);
+					String expected = formatValueBeforeFix(value, forceTrailingZeroes, decimalPlaces);
+					if (!expected.equals(actual.value)) {
+						mismatches.add(value + " places=" + decimalPlaces
+								+ " trailingZeroes=" + forceTrailingZeroes
+								+ ": expected '" + expected + "' but was '" + actual.value + "'");
+					}
+				}
+			}
+		}
+		assertEquals("formatted values changed", "", String.join("\n", mismatches));
+	}
+
+	/** Repeated formatting has to reuse the formatter instead of building a new one every time. */
+	@Test
+	public void repeatedFormattingDoesNotRebuildTheFormatter() {
+		// Warm up both paths so that class loading and ICU's own caches are not being measured.
+		measureCached(WARMUP_ITERATIONS);
+		measureFormatterPerCall(WARMUP_ITERATIONS);
+
+		long perCallNanos = measureFormatterPerCall(MEASURED_ITERATIONS);
+		long cachedNanos = measureCached(MEASURED_ITERATIONS);
+
+		String detail = "building a formatter per call: " + perCallNanos / 1_000_000f + " ms, "
+				+ "OsmAndFormatter.formatValue(): " + cachedNanos / 1_000_000f + " ms for "
+				+ MEASURED_ITERATIONS + " calls";
+		Log.i("OsmAndFormatterCachingTest", detail);
+		assertTrue("formatValue() still builds a DecimalFormat on every call - " + detail,
+				cachedNanos * MIN_SPEEDUP < perCallNanos);
+	}
+
+	private long measureCached(int iterations) {
+		long start = System.nanoTime();
+		for (int i = 0; i < iterations; i++) {
+			OsmAndFormatter.formatValue(i + 0.5f, "m", false, 1, app);
+		}
+		return System.nanoTime() - start;
+	}
+
+	private long measureFormatterPerCall(int iterations) {
+		long start = System.nanoTime();
+		for (int i = 0; i < iterations; i++) {
+			formatValueBeforeFix(i + 0.5f, false, 1);
+		}
+		return System.nanoTime() - start;
+	}
+
+	private static float[] values() {
+		return new float[] {
+				0f, 0.04f, 0.5f, 1f, 1.25f, 9.999f, 12f, 99.95f, 100f, 999.9f,
+				1000f, 9999.99f, 10_000f, 12_345.678f, 999_999f, 1_234_567f,
+				-0.5f, -12.34f, -10_000.5f
+		};
+	}
+
+	/** Verbatim copy of {@code OsmAndFormatter.formatValue()} as it was before the fix. */
+	private String formatValueBeforeFix(float value, boolean forceTrailingZeroes,
+	                                    int decimalPlacesNumber) {
+		String pattern = "0";
+		if (decimalPlacesNumber > 0) {
+			char fractionDigitPattern = forceTrailingZeroes ? '0' : '#';
+			char[] fractionDigitsPattern = new char[decimalPlacesNumber];
+			Arrays.fill(fractionDigitsPattern, fractionDigitPattern);
+			pattern += "." + String.valueOf(fractionDigitsPattern);
+		}
+
+		Locale preferredLocale = app.getLocaleHelper().getPreferredLocale();
+		Locale locale = preferredLocale != null ? preferredLocale : Locale.getDefault();
+
+		DecimalFormatSymbols decimalFormatSymbols = new DecimalFormatSymbols(locale);
+		decimalFormatSymbols.setGroupingSeparator(' ');
+
+		DecimalFormat decimalFormat = new DecimalFormat(pattern);
+		decimalFormat.setDecimalFormatSymbols(decimalFormatSymbols);
+
+		boolean fiveOrMoreDigits = Math.abs(value) >= 10_000;
+		if (fiveOrMoreDigits) {
+			decimalFormat.setGroupingUsed(true);
+			decimalFormat.setGroupingSize(3);
+		}
+
+		MessageFormat messageFormat = new MessageFormat("{0}");
+		messageFormat.setFormatByArgumentIndex(0, decimalFormat);
+		return messageFormat.format(new Object[] {value}).replace('\n', ' ');
+	}
+}


### PR DESCRIPTION
Fixes the third most frequent user-perceived stability issue on Play: the GC ANR at
`art::gc::Heap::WaitForGcToCompleteLocked` — **223 affected users / 407 events over 28 days**
(2.0% of ANRs), issue `8b5d4a20`.

## Root cause

The reported main thread is not doing anything unusual — it is laying out a `ListView`:

```
at java.text.DecimalFormat.<init> (DecimalFormat.java:459)
at net.osmand.plus.utils.OsmAndFormatter.formatValue (OsmAndFormatter.java:789)
at net.osmand.plus.utils.OsmAndFormatter.getFormattedDistanceValue (OsmAndFormatter.java:464)
at net.osmand.plus.utils.UpdateLocationUtils.updateLocationView (UpdateLocationUtils.java:55)
at net.osmand.plus.search.dialogs.QuickSearchListAdapter.updateCompass (QuickSearchListAdapter.java:651)
at net.osmand.plus.search.dialogs.QuickSearchListAdapter.getView (QuickSearchListAdapter.java:247)
at android.widget.ListView.layoutChildren (ListView.java:1802)
...
at android.view.ViewRootImpl.performLayout (ViewRootImpl.java:4175)
```

…and the frames above it are the allocation slow path:

```
art::gc::Heap::WaitForGcToCompleteLocked
art::gc::Heap::AllocateInternalWithGc
artAllocArrayFromCodeResolvedRegionTLAB
at java.lang.AbstractStringBuilder.<init>
at android.icu.impl.LocaleIDParser.<init>
at android.icu.util.Currency.getInstance
at java.text.DecimalFormatSymbols.initializeCurrency
at java.text.DecimalFormat.initPattern
```

`formatValue()` built a `DecimalFormat`, a `DecimalFormatSymbols` and a `MessageFormat` on every
call. Constructing `DecimalFormatSymbols` resolves the locale currency through ICU, which allocates
its way through `LocaleIDParser`.

`QuickSearchListAdapter.updateCompass()` formats the distance of every visible row on every compass
update, from inside `ListView.layoutChildren()`. So the app pays the ICU cost dozens of times per
second on the main thread, during layout.

Measured on an Android 15 arm64 emulator: **0.45 ms per formatted value.**

## Fix

Cache the formatter in `formatValue()`, keyed by everything that configures the instance — pattern,
thousands grouping, locale — so a cached instance is never reconfigured after creation. The key
cannot be the unit: the same `unitId` is formatted with different `decimalPlacesNumber` (see
`getFormattedDistanceValue()`, where km goes through both `decimalPrecision` and
`1 + decimalPrecision`), and the `String unit` overload passes `unitId = -1` for every caller. The
locale has to be part of the key because `preferredLocale` changes at runtime.

`DecimalFormat` is mutable and not thread safe, and formatting also happens off the main thread
(`RoutingHelper`, `SplitTrackAsyncTask`, voice announcements), so the cache is a `ThreadLocal`.

The `MessageFormat` wrapper is dropped too: `MessageFormat("{0}")` with the `DecimalFormat` as its
only subformat calls `DecimalFormat.format(Object)` on a boxed `Float`, which ends in the same
`format(double)` as calling the formatter directly.

## Test

New instrumented test `OsmAndFormatterCachingTest` (`OsmAnd/test/java/net/osmand/test/junit/`).

`formattedValuesAreUnchanged` formats a matrix of 19 values × 4 decimal places × trailing-zeroes
on/off and compares every result against a verbatim copy of the pre-fix implementation kept in the
test. This is the guard that the cache did not change a single output — it passes both before and
after the change.

`repeatedFormattingDoesNotRebuildTheFormatter` measures the production path against that same
reference implementation in the same run, so there is no absolute threshold to tune: the cached path
has to be at least 5× cheaper.

Run on `Claude_Phone_API_35` (Android 15, arm64), variant `nightlyFreeOpenglArm64Debug`, 3000 calls:

**Before the fix** — the production path costs exactly as much as building a formatter per call:

```
repeatedFormattingDoesNotRebuildTheFormatter FAILED
java.lang.AssertionError: formatValue() still builds a DecimalFormat on every call -
building a formatter per call: 816.00006 ms, OsmAndFormatter.formatValue(): 774.0576 ms
for 3000 calls
```

**After the fix** — 13.9× cheaper, both tests pass:

```
building a formatter per call: 1151.7996 ms, OsmAndFormatter.formatValue(): 83.15504 ms for 3000 calls

<testsuite name="net.osmand.test.junit.OsmAndFormatterCachingTest"
           tests="2" failures="0" errors="0" skipped="0" time="2.755">
  <testcase name="formattedValuesAreUnchanged" time="0.329" />
  <testcase name="repeatedFormattingDoesNotRebuildTheFormatter" time="1.302" />
</testsuite>
```

0.45 ms → 0.028 ms per formatted value.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Asked whether the most frequent crashes in Play Console could be fixed, with links to seven
   crash issues.
2. Asked to review the rest of the top crashes and ANRs, group anything similar, and open a separate
   pull request per issue against the 5.4 branch only (not master).
3. Asked to reproduce the first group with a test and open that pull request; then to file the
   internal task for it.
4. Asked to open the pull request for this group next, and to start studying the renderer ANR.
5. Objected that the fix was over-complicated and asked why it is not simply a cache map inside
   `formatValue()`; after the key and thread-safety constraints were explained, asked to keep the
   `ThreadLocal` and key by pattern.

Decided by the agent, not requested explicitly:
* Removing the `MessageFormat` wrapper.
* The test design: a verbatim pre-fix reference implementation used both as the correctness oracle
  and as the self-calibrating performance control, instead of an absolute time threshold.
