### PR TITLE
Fix NullPointerException in MapTransparencyHelper.hideParameterBar()

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/layers/MapTransparencyHelper.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/MapTransparencyHelper.java
@@ -177,7 +177,7 @@ public class MapTransparencyHelper {
 	}
 
 	public void hideParameterBar() {
-		parameterBarLayout.setVisibility(View.GONE);
+		AndroidUiHelper.updateVisibility(parameterBarLayout, false);
 		parameterMinSetting = null;
 		parameterMaxSetting = null;
 		parameterStepSetting = null;


### PR DESCRIPTION
### Summary
Fixes #25862 - a NullPointerException in MapTransparencyHelper.hideParameterBar() when the raster-map parameter bar's LinearLayout view is null.

### How it works
hideParameterBar() called parameterBarLayout.setVisibility(View.GONE) directly, with no null check. If the map view/activity has already been torn down (e.g. a raster-map-overlay selection dialog callback fires after a configuration change destroyed the view) parameterBarLayout is null and the app crashes.

The sibling method hideTransparencyBar() had the exact same crash pattern and was already fixed for it in commit 54576ed2ae ("Fix several possible exceptions", #23889), switching to the null-safe AndroidUiHelper.updateVisibility() helper. hideParameterBar() was missed in that fix. This PR applies the same one-line fix to hideParameterBar(), for consistency with its sibling method.

### Status of this PR
Ready for review. This is a minimal, low-risk fix mirroring an existing, already-shipped null-safety pattern in the same class - not a new behavior.

### Testing
Verified the change compiles (./gradlew :OsmAnd:compileNightlyFreeOpenglFatDebugJavaWithJavac - BUILD SUCCESSFUL). The fix is a direct mirror of the already-merged and released fix for the sibling hideTransparencyBar() method, so the same approach is already proven in production.

*Idea and testing plan by @EugeneZmeuk. Code implementation and testing by Claude AI.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)