### PR TITLE
Keep device-local OpenGL fallback out of Cloud Sync

### DIFF
--- a/OsmAnd/src/net/osmand/plus/AppInitializer.java
+++ b/OsmAnd/src/net/osmand/plus/AppInitializer.java
@@ -655,12 +655,12 @@ public class AppInitializer implements IProgress {
 	private void initOpenGl() {
 		OsmandSettings settings = app.getSettings();
 
-		if (!settings.USE_OPENGL_RENDER.get()) {
+		if (!settings.isOpenGlRendererEnabled()) {
 			return;
 		}
 
 		if (!Version.isOpenGlAvailable(app)) {
-			settings.USE_OPENGL_RENDER.set(false);
+			settings.OPENGL_RENDER_FALLBACK_TO_LEGACY.set(true);
 		} else {
 			int failedCounter = settings.OPENGL_RENDER_FAILED.get();
 			if (failedCounter >= MAX_OPENGL_FAILURES && failedCounter % 2 == 1) {
@@ -668,7 +668,7 @@ public class AppInitializer implements IProgress {
 				// show warnings before disable
 				warnings.add("Native OpenGL library is not supported. Please try again after exit");
 				if (failedCounter > MAX_OPENGL_DISABLE) {
-					settings.USE_OPENGL_RENDER.set(false);
+					settings.OPENGL_RENDER_FALLBACK_TO_LEGACY.set(true);
 				}
 			} else {
 				try {

--- a/OsmAnd/src/net/osmand/plus/OsmandApplication.java
+++ b/OsmAnd/src/net/osmand/plus/OsmandApplication.java
@@ -1265,7 +1265,7 @@ public class OsmandApplication extends MultiDexApplication {
 	}
 
 	public boolean useOpenGlRenderer() {
-		return NativeCoreContext.isInit() && settings.USE_OPENGL_RENDER.get();
+		return NativeCoreContext.isInit() && settings.isOpenGlRendererEnabled();
 	}
 
 	private void enableStrictMode() {

--- a/OsmAnd/src/net/osmand/plus/dialogs/MapRenderingEngineDialog.java
+++ b/OsmAnd/src/net/osmand/plus/dialogs/MapRenderingEngineDialog.java
@@ -46,7 +46,7 @@ public class MapRenderingEngineDialog {
 		radioButtonLegacy = setupRadioItem(legacyRenderingView, app.getString(R.string.map_rendering_engine_v1));
 		View openglRenderingView = alertDialogView.findViewById(R.id.opengl_rendering);
 		radioButtonOpengl = setupRadioItem(openglRenderingView, app.getString(R.string.map_rendering_engine_v2));
-		updateRadioButtons(app.getSettings().USE_OPENGL_RENDER.get());
+		updateRadioButtons(app.getSettings().isOpenGlRendererEnabled());
 		radioButtonOpengl.setEnabled(Version.isOpenGlAvailable(app));
 		openglRenderingView.findViewById(R.id.button).setEnabled(Version.isOpenGlAvailable(app));
 
@@ -73,7 +73,7 @@ public class MapRenderingEngineDialog {
 
 	private void updateRenderingEngineSetting(boolean openglEnabled, @Nullable OnRenderChangeListener listener) {
 		updateRadioButtons(openglEnabled);
-		app.getSettings().USE_OPENGL_RENDER.set(openglEnabled);
+		app.getSettings().setOpenGlRendererEnabled(openglEnabled);
 
 		if (app.isApplicationInitializing()) {
 			String title = app.getString(R.string.loading_smth, "");

--- a/OsmAnd/src/net/osmand/plus/plugins/weather/WeatherUtils.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/weather/WeatherUtils.java
@@ -26,7 +26,7 @@ public class WeatherUtils {
 	}
 
 	public static boolean isWeatherSupported(@NonNull OsmandApplication app) {
-		return app.getSettings().USE_OPENGL_RENDER.get() && Version.isOpenGlAvailable(app);
+		return app.getSettings().isOpenGlRendererEnabled() && Version.isOpenGlAvailable(app);
 	}
 
 	@NonNull

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -3364,10 +3364,24 @@ public class OsmandSettings {
 
 	public final CommonPreference<Integer> LOCATION_INTERPOLATION_PERCENT = new IntPreference(this, "location_interpolation_percent", 0).makeProfile().makeShared();
 
+	// Shared user choice. The current device can override it with a local fallback.
 	public final CommonPreference<Boolean> USE_OPENGL_RENDER = new BooleanPreference(this, "use_opengl_render",
 			Build.VERSION.SDK_INT >= Build.VERSION_CODES.P).makeGlobal().makeShared().cache();
 
+	// Device-local fallback to V1 after V2 is unavailable or repeatedly fails to initialize.
+	public final OsmandPreference<Boolean> OPENGL_RENDER_FALLBACK_TO_LEGACY = new BooleanPreference(this, "opengl_render_fallback_to_legacy", false).makeGlobal().cache();
+
 	public final OsmandPreference<Integer> OPENGL_RENDER_FAILED = new IntPreference(this, "opengl_render_failed_count", 0).makeGlobal().cache();
+
+	public boolean isOpenGlRendererEnabled() {
+		return USE_OPENGL_RENDER.get() && !OPENGL_RENDER_FALLBACK_TO_LEGACY.get();
+	}
+
+	// An explicit user choice clears the local fallback before retrying V2.
+	public void setOpenGlRendererEnabled(boolean enabled) {
+		USE_OPENGL_RENDER.set(enabled);
+		OPENGL_RENDER_FALLBACK_TO_LEGACY.set(false);
+	}
 
 	public final OsmandPreference<String> CONTRIBUTION_INSTALL_APP_DATE = new StringPreference(this, "CONTRIBUTION_INSTALL_APP_DATE", null).makeGlobal();
 

--- a/OsmAnd/src/net/osmand/plus/settings/fragments/GlobalSettingsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/settings/fragments/GlobalSettingsFragment.java
@@ -261,7 +261,7 @@ public class GlobalSettingsFragment extends BaseSettingsFragment
 	private void setupMapRenderingEnginePref() {
 		Preference preference = findPreference(MAP_RENDERING_ENGINE_ID);
 		preference.setIcon(getContentIcon(R.drawable.ic_map));
-		preference.setSummary(settings.USE_OPENGL_RENDER.get() ? R.string.map_rendering_engine_v2 : R.string.map_rendering_engine_v1);
+		preference.setSummary(settings.isOpenGlRendererEnabled() ? R.string.map_rendering_engine_v2 : R.string.map_rendering_engine_v1);
 		//preference.setVisible(Version.isOpenGlAvailable(app));
 	}
 

--- a/OsmAnd/src/net/osmand/plus/views/layers/CoordinatesGridSettings.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/CoordinatesGridSettings.java
@@ -206,6 +206,6 @@ public class CoordinatesGridSettings {
 	}
 
 	public static boolean isGridSupported(@NonNull OsmandApplication app) {
-		return app.getSettings().USE_OPENGL_RENDER.get() && Version.isOpenGlAvailable(app);
+		return app.getSettings().isOpenGlRendererEnabled() && Version.isOpenGlAvailable(app);
 	}
 }


### PR DESCRIPTION
## Summary

This change prevents automatic OpenGL fallback from overwriting the shared Map
rendering engine preference and creating false Global Settings Cloud changes.

`USE_OPENGL_RENDER` remains the portable user choice and is still included in
Global Settings Cloud Sync.

A new local preference, `OPENGL_RENDER_FALLBACK_TO_LEGACY`, records that V2
cannot currently be used on this specific device. It remains global for the
current installation, but is not shared, so it does not update the Global
Settings modification time or enter Global Settings backup.

| State | Storage | Meaning |
|---|---|---|
| `USE_OPENGL_RENDER` | Global, shared | Renderer selected by the user: V1 or V2. |
| `OPENGL_RENDER_FALLBACK_TO_LEGACY` | Global, local | This device must use V1 because V2 is unavailable or repeatedly failed to initialize. |
| Effective renderer | Runtime | `USE_OPENGL_RENDER && !OPENGL_RENDER_FALLBACK_TO_LEGACY`. |

## Behavior

Automatic OpenGL capability and crash-recovery paths now set only the local
fallback:

```text
user selected V2 on Device A
        ↓
Global Settings Cloud Sync
        ↓
Device B cannot initialize V2
        ↓
local V1 fallback on Device B
        ↓
no false Global Settings Local Change or Conflict
```

An explicit renderer selection clears the local fallback and allows a new V2
attempt:

```text
user selects V1 or V2
        ↓
USE_OPENGL_RENDER is updated as the shared user choice
        ↓
OPENGL_RENDER_FALLBACK_TO_LEGACY is cleared locally
```

The existing OpenGL failure counter is intentionally not reset. This preserves
the current crash-recovery behavior while allowing a user-initiated retry.

UI and dependent features now use the effective renderer state:

- Map rendering engine dialog;
- Global Settings summary;
- active map renderer;
- Weather support;
- Coordinates Grid support.

The renderer initialization error sheet intentionally still reads the shared
user choice. A user who selected V2 should be able to see the V2 initialization
error even when the current device has already fallen back to V1.

## Not included

- No automatic retry after an app or system update. The local fallback remains
  until the user explicitly selects a renderer again, matching the previous
  persistent-disable behavior.
- No migration of legacy installations where automatic fallback had already
  stored `USE_OPENGL_RENDER = false`.
- No changes to the general Cloud Sync conflict algorithm.
- `ENABLE_MSAA` remains outside this change and requires its own capability and
  writer audit.

## Manual verification

1. On Device A, explicitly select V2 and upload Global Settings.
2. On Device B, download the V2 selection.
3. Simulate repeated V2 initialization failure by setting
   `OPENGL_RENDER_FAILED` to `7` through the debugger, then restart the app.
4. Verify that Device B uses V1, while:
   - `USE_OPENGL_RENDER` remains `true`;
   - `OPENGL_RENDER_FALLBACK_TO_LEGACY` becomes `true`;
   - Global Settings do not appear as a Local change or Conflict.
5. Select V2 manually on Device B and verify that the local fallback is cleared.
6. Verify that normal V2 startup on a compatible device remains unchanged.