### PR TITLE
Do not start the navigation foreground service from the background (#25861)

### DIFF
--- a/OsmAnd/src/net/osmand/plus/OsmandApplication.java
+++ b/OsmAnd/src/net/osmand/plus/OsmandApplication.java
@@ -1162,8 +1162,16 @@ public class OsmandApplication extends MultiDexApplication {
 					LOG.info(">>>> Failed APP startForegroundService = " + usageIntent + " {no location permission}");
 					return;
 				}
+				if (!isAppInForeground()) {
+					// A foreground service started from the background is denied the while-in-use
+					// location capability, so startForeground(.., TYPE_LOCATION) throws and the
+					// platform may kill the process for missing its startForegroundService()
+					// deadline. See #25861.
+					LOG.info(">>>> Failed APP startForegroundService = " + usageIntent + " {app in background}");
+					return;
+				}
 				try {
-					LOG.info(">>>> APP startForegroundService = " + usageIntent + " {foreground " + isAppInForeground() + "}");
+					LOG.info(">>>> APP startForegroundService = " + usageIntent);
 					context.startForegroundService(intent);
 				} catch (Exception e) {
 					// e.g. ForegroundServiceStartNotAllowedException (Android 12+) when the service

--- a/OsmAnd/test/java/net/osmand/test/junit/NavigationServiceBackgroundStartTest.java
+++ b/OsmAnd/test/java/net/osmand/test/junit/NavigationServiceBackgroundStartTest.java
@@ -1,0 +1,119 @@
+package net.osmand.test.junit;
+
+import static net.osmand.plus.NavigationService.USED_BY_GPX;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.Intent;
+
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import net.osmand.plus.OsmAndLocationProvider;
+import net.osmand.plus.OsmandApplication;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Regression test for issue #25861 - {@code ForegroundServiceDidNotStartInTimeException} /
+ * silently lost GPX track when the process is re-created in the background.
+ *
+ * <p>{@code OsmandApplication.onCreate()} unconditionally runs {@code AppInitializer}, whose
+ * {@code saveGPXTracks()} step calls {@code startNavigationService(USED_BY_GPX)} whenever
+ * {@code SAVE_GLOBAL_TRACK_TO_GPX} is set. That happens on <i>every</i> cold start of the
+ * process, including the ones Android triggers with no UI at all - a sticky service restart,
+ * a broadcast, a widget update - after the recording process was killed with the screen off.
+ *
+ * <p>Until commit 51c7ff78c9 ("Attempt navigation foreground service start even from
+ * background (A3)") {@code startNavigationService()} skipped the call in that case, because it
+ * was guarded by {@code isAppInForeground()}. Since that commit the call is attempted from the
+ * background too, and Android then refuses to grant the service the while-in-use location
+ * capability: {@code Service.startForeground(.., FOREGROUND_SERVICE_TYPE_LOCATION)} throws
+ * {@code SecurityException} ("Foreground service started from background can not have
+ * location/camera/microphone access"), the service never enters the foreground state and the
+ * recording does not resume - and where the platform does not clear its own
+ * {@code startForegroundService()} deadline the whole process is killed with
+ * {@code ForegroundServiceDidNotStartInTimeException}.
+ *
+ * <p>The instrumentation runs without an activity, so the application really is in the
+ * background here - exactly the state the crashing cold start is in.
+ */
+@RunWith(AndroidJUnit4.class)
+public class NavigationServiceBackgroundStartTest {
+
+	private OsmandApplication app;
+
+	@Before
+	public void setup() {
+		Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+		app = (OsmandApplication) targetContext.getApplicationContext();
+	}
+
+	/**
+	 * The precondition of the whole test: no activity has been started, so the application is
+	 * in the background and {@code startForegroundService()} cannot produce a working
+	 * foreground service.
+	 */
+	@Test
+	public void applicationIsInBackgroundDuringInstrumentation() {
+		assertFalse("the test needs the app to be in the background", app.isAppInForeground());
+	}
+
+	/**
+	 * A background cold start must not ask the system to start the navigation foreground
+	 * service. The system accepts the call (the app is exempt from the background-start
+	 * restriction), then denies the location capability the service needs, which both loses the
+	 * recording and leaves the platform's {@code startForegroundService()} deadline running.
+	 */
+	@Test
+	public void doesNotStartForegroundServiceWhileInBackground() {
+		assertFalse("the test needs the app to be in the background", app.isAppInForeground());
+		assertTrue("the test needs the location permission granted",
+				OsmAndLocationProvider.isLocationPermissionAvailable(app));
+
+		RecordingContext context = new RecordingContext(app);
+		app.startNavigationService(context, USED_BY_GPX);
+		waitForMainThread();
+
+		assertTrue("startForegroundService() was called while the app was in the background: "
+				+ context.startedForegroundServices, context.startedForegroundServices.isEmpty());
+	}
+
+	/** {@code startNavigationService()} posts the actual call, so let the main looper drain. */
+	private void waitForMainThread() {
+		InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> {
+		});
+	}
+
+	/** A {@link Context} that records service starts instead of performing them. */
+	private static class RecordingContext extends ContextWrapper {
+
+		final List<String> startedForegroundServices = new ArrayList<>();
+		final List<String> startedServices = new ArrayList<>();
+
+		RecordingContext(@NonNull Context base) {
+			super(base);
+		}
+
+		@Override
+		public ComponentName startForegroundService(Intent service) {
+			startedForegroundServices.add(String.valueOf(service.getComponent()));
+			return service.getComponent();
+		}
+
+		@Override
+		public ComponentName startService(Intent service) {
+			startedServices.add(String.valueOf(service.getComponent()));
+			return service.getComponent();
+		}
+	}
+}


### PR DESCRIPTION
Fixes #25861.

## Problem

`AppInitializer.saveGPXTracks()` calls `startNavigationService(USED_BY_GPX)` on **every** creation of the process, including the ones Android triggers with no UI at all — a sticky service restart, a broadcast, a widget update — after the recording process was killed with the screen off.

Commit 51c7ff78c9 ("Attempt navigation foreground service start even from background (A3)", 2026-06-03) removed the `isAppInForeground()` guard from `OsmandApplication.startNavigationService()`, so since then that call reaches `Context.startForegroundService()` while the app is in the background.

That start can never succeed. Android accepts it (an app exempt from battery optimisation is allowed to *start* an FGS from the background) but denies the service the while-in-use location capability, so `Service.startForeground(.., FOREGROUND_SERVICE_TYPE_LOCATION)` throws:

```
W/ActivityManager: Foreground service started from background can not have location/camera/microphone access:
                   service net.osmand/.plus.NavigationService
E/NavigationService: Failed to start NavigationService (usedBy=2)
java.lang.SecurityException: Starting FGS with type location ... requires ...
    and the app must be in the eligible state/exemptions to access the foreground only permission
	at net.osmand.plus.NavigationService.startForeground(NavigationService.java:183)
	at net.osmand.plus.NavigationService.onStartCommand(NavigationService.java:152)
```

`onStartCommand()` catches it, resets `usedBy` and returns `START_NOT_STICKY`, so:

1. **Always** — track recording silently does not resume, and a `startRequested=true`, non-foreground `ServiceRecord` is left behind. This is the "only ~19 m of the track was saved" half of the report.
2. **When the main thread cannot dispatch `onStartCommand()` within the platform's 10 s deadline** — which is what a real cold start under memory pressure looks like — the platform kills the whole process with `ForegroundServiceDidNotStartInTimeException`, pointing at the `startForegroundService()` call in this exact lambda. That exception cannot be caught by app code; it is delivered asynchronously after the call returned.

## Fix

Restore the guard the commit removed. A foreground service started from the background cannot get the location capability that track recording needs, so there is nothing to gain from attempting the start — it only trades a silent no-op for a process kill.

## Verification

Reproduced on emulators running Android 15 (API 35) and Android 16 (API 36), with the app added to the device-idle allowlist to mimic the reporter's "Unrestricted" battery setting.

Forcing a background cold start with recording enabled:

```
adb shell am force-stop net.osmand.dev
adb shell am broadcast -f 32 -a android.intent.action.CAMERA_BUTTON \
  -n net.osmand.dev/net.osmand.plus.plugins.audionotes.MediaRemoteControlReceiver
```

| | before this change | after |
|---|---|---|
| log | `>>>> APP startForegroundService = 2 {foreground false}` → `SecurityException`, recording does not resume | `>>>> Failed APP startForegroundService = 2 {app in background}`, no service started |
| `dumpsys activity services` | `startRequested=true`, not foreground | no `ServiceRecord` |

The `ForegroundServiceDidNotStartInTimeException` itself was reproduced by making the same background call and then blocking the main looper for 30 s, which is the shape of the cold start in the report. The resulting stack matches the reporter's `exception.log` line for line, including `Caused by: ... at net.osmand.plus.OsmandApplication.lambda$startNavigationService$1`. With this change the same scenario does not crash, because no call is made.

Starting recording normally from the UI is unaffected — the service still reaches `isForeground=true`.

The added instrumented test (`NavigationServiceBackgroundStartTest`) asserts both halves: that instrumentation really runs with the app in the background (no activity is started), and that `startForegroundService()` is not called in that state. It fails on the code before this change and passes after:

```
adb shell am instrument -w -e class net.osmand.test.junit.NavigationServiceBackgroundStartTest \
  net.osmand.dev.test/androidx.test.runner.AndroidJUnitRunner
```

## Known gap, not addressed here

This restores the pre-51c7ff78c9 behaviour, so it does not by itself make recording resume after the process was killed in the background. The only automatic retry today is `AppInitializer` at process start; there is no hook that retries when the app returns to the foreground, so if the process is already alive when the user opens the app, recording stays stopped. Closing that needs a separate change — a retry on `ProcessLifecycleOwner.onStart` — plus a `stopSelf()` in `NavigationService` when `startForeground()` fails, so a failed start cannot leave a non-foreground service behind. Kept out of this PR to keep the crash fix minimal.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Reproduce issue #25861 (OsmAnd crashed 6 times in a row after enabling track recording and turning the screen off; Pixel 8 Pro, OsmAnd 5.4.3, unlimited background battery granted); write a test, possibly on 5.4, and check whether that commit actually broke it — it is still unclear.
2. Restore the guard as the minimal fix and open the test + fix PR.

Decided by the agent, not requested explicitly:
- Branch target `r5.4` rather than `master`, since the regression is live in the released 5.4.x.
- Test placed in the existing `androidTest` source set (`OsmAnd/test/java/net/osmand/test/junit`) and driven through a recording `ContextWrapper`, so it is deterministic and does not depend on the platform's FGS restrictions.
- Dropped the now always-true `{foreground ...}` detail from the remaining log line.
- The "Known gap" section above: the analysis of what this fix deliberately leaves open was not requested, but the guard restore is not a complete answer to "recording is lost" without it.
- Correction to the analysis recorded in the issue: the primary, always-reproducible failure is the `SecurityException` from `startForeground()`, not the cold-start timing; the timing only decides whether the process is additionally killed.
