### PR TITLE
Reuse the map renderer across configuration changes

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/MapViewWithLayers.java
+++ b/OsmAnd/src/net/osmand/plus/views/MapViewWithLayers.java
@@ -2,7 +2,9 @@ package net.osmand.plus.views;
 
 import static net.osmand.plus.views.OsmandMapTileView.MIN_ALLOWED_ELEVATION_ANGLE;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.os.Bundle;
 import android.util.AttributeSet;
 import android.util.DisplayMetrics;
@@ -168,12 +170,30 @@ public class MapViewWithLayers extends FrameLayout {
 			NavigationSession carNavigationSession = app.getCarNavigationSession();
 			if (carNavigationSession == null || !carNavigationSession.hasStarted()) {
 				mapView.setMapRenderer(null, true);
-				resetMapRendererView();
-				atlasMapRendererView.handleOnDestroy();
+				if (isChangingConfigurations()) {
+					// The activity is relaunched right away, so keep the renderer and its EGL
+					// contexts alive instead of releasing rendering and initializing it anew.
+					// The recreated view picks the renderer up in setupAtlasMapRendererView().
+					atlasMapRendererView.suspendRenderer();
+				} else {
+					resetMapRendererView();
+					atlasMapRendererView.handleOnDestroy();
+				}
 			}
 		}
 		mapView.clearTouchDetectors();
 		app.getOsmandMap().removeRenderingViewSetupListener(getRenderingViewSetupListener());
+	}
+
+	private boolean isChangingConfigurations() {
+		Context context = getContext();
+		while (context instanceof ContextWrapper) {
+			if (context instanceof Activity) {
+				return ((Activity) context).isChangingConfigurations();
+			}
+			context = ((ContextWrapper) context).getBaseContext();
+		}
+		return false;
 	}
 
 	@NonNull


### PR DESCRIPTION
Part 2 of 2 for the `onPause`/`onRelease` ANR (OsmAnd-Issues#3229, 443 users).
**Merge order: osmandapp/OsmAnd-core#1104 first, this one after** — without it the recreated view
gets `null` from `suspendRenderer()` and builds a second renderer while the old one is still alive.

### Why

Every activity relaunch — screen rotation is the common one, and it is the entry point of the top
ANR cluster — released rendering and rebuilt everything: `releaseMapRendererView()` → `stopRenderer()`
tears down the `EGLThread` and its EGL contexts, and the recreated view then runs a full
`INITIALIZE_RENDERING`. All of that blocks the main thread, and re-uploading everything to the GPU
also makes the frames right after the rotation heavy, which lengthens the *next* rotation's pause.

On a configuration change a new activity comes immediately, so there is nothing to release.
`setupAtlasMapRendererView()` already knows how to take a suspended renderer over from the previous
view (the Android Auto path); it just needs the old view suspended rather than destroyed.

### Measured

Emulator, Android 15 arm64, software GPU, Bremen at z16, 16 rotations with a map swipe before each.
The fix was behind a system property so both arms come from one build.

| per rotation | before | after |
|---|---|---|
| `Release rendering...` | 16 | 0 |
| renderer built from scratch | 16 | 0 |
| renderer reused | 0 | 16 |

| main thread, ms | before (avg / max) | after (avg / max) |
|---|---|---|
| `performPause` | 172 / 353 | 50 / 95 |
| `performDestroy` | 134 / 272 | 18 / 57 |
| `performCreate` | 125 / 172 | 126 / 309 |
| `performResume` | 132 / 188 | 115 / 159 |

Pause + destroy per rotation: **306 ms → 68 ms (−78%)**. A quieter run (14 rotations, 6 s apart) gives
the same picture: pause 134 → 70 avg, destroy 114 → 12 avg.

The map renders identically after 16 rotations — no lost symbols, no black frame, no native crash,
same process. Verified again on a build with the property gate removed.

### What this does not fix

An ANR from one single stalled frame (the `GL_GenTextures` stall inside `libGLESv2_samsung.so` in the
Play traces) — `handleOnPause()` still waits for the frame in flight. With an artificial 3000 ms
per-frame stall the pause blocked 3083 ms before and 3048 ms after. This change removes the rest of
the per-rotation main-thread cost and the release/re-init churn that makes the following frames heavy.

Reproduction bench and full analysis: OsmAnd-Issues#3229.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Analyse the top Play Console crashes and ANRs, group them, and open a separate PR per group against
   the `r5.4` branch only.
2. Blind fixes are not acceptable — reproduce the ANR first, with a real ANR and a matching stack dump.
3. Post the analysis and the reproduction method as a comment on the internal issue, move it to the
   `5.4-map` milestone, then make the fix, verify it works, and push a draft PR if it fixes the problem.

Decided by the agent, not requested explicitly:
- Choice of fix. Bounding the blocking waits was rejected after reading the code: the EGL thread holds
  its monitor for the whole operation, so a `wait()` timeout cannot return early there.
- Splitting into a core change plus this app-side change, both drafts, because they must merge in order.
- Reading the activity out of the view's `Context` via `ContextWrapper` instead of changing the
  `onDestroy()` signature.
- The verification method: A/B behind a system property, and a build where only `MapRendererView` was
  recompiled and spliced into the released 5.4 AAR, so the SWIG bindings and the prebuilt `.so` stayed
  untouched.
- The scope note above.
