### PR TITLE
Add a regression test for the Android Auto renderer hand-over crash

### DIFF
--- a/OsmAnd/test/java/net/osmand/test/ui/map/RendererHandoverToPausedViewTest.java
+++ b/OsmAnd/test/java/net/osmand/test/ui/map/RendererHandoverToPausedViewTest.java
@@ -1,0 +1,124 @@
+package net.osmand.test.ui.map;
+
+import static net.osmand.test.common.OsmAndDialogInteractions.skipAppStartDialogs;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import net.osmand.core.android.AtlasMapRendererView;
+import net.osmand.core.android.MapRendererContext;
+import net.osmand.core.android.MapRendererView;
+import net.osmand.plus.activities.MapActivity;
+import net.osmand.plus.views.corenative.NativeCoreContext;
+import net.osmand.test.common.AndroidTest;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Reproduces the Android Auto crash "Swig::DirectorException: Attempt to invoke virtual method
+ * 'void android.opengl.GLSurfaceView$GLThread.requestRender()' on a null object reference".
+ * <p>
+ * When the car session stops, NavigationSession.onStop() calls setupRenderingView(), which hands
+ * the live renderer over to the map view of the phone activity and immediately updates the state
+ * of the renderer (setAzimuth(0) in MapViewWithLayers.setupAtlasMapRendererView()). If the phone
+ * activity is paused at that moment, setupRenderer() only creates the rendering view and leaves it
+ * without a GL renderer until the activity resumes, while the handed over renderer is already able
+ * to ask for a frame through IFrameUpdateRequestCallback. The callback then dereferences the
+ * unstarted rendering view, and the exception escapes the SWIG director into native code, which
+ * aborts the process.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class RendererHandoverToPausedViewTest extends AndroidTest {
+
+	private static final long FRAME_TIMEOUT_MS = 60000;
+
+	@Rule
+	public ActivityScenarioRule<MapActivity> scenarioRule = new ActivityScenarioRule<>(MapActivity.class);
+
+	@Test
+	public void frameRequestAfterHandoverToPausedView() throws Throwable {
+		skipAppStartDialogs(app);
+
+		MapRendererContext rendererContext = NativeCoreContext.getMapRendererContext();
+		assertNotNull("OpenGL rendering is not in use", rendererContext);
+
+		MapRendererView activeView = rendererContext.getMapRendererView();
+		assertNotNull("Map renderer view is not set up", activeView);
+		assertTrue("Renderer did not draw a frame", awaitFrame(activeView));
+		float activeAzimuth = onMainSync(activeView::getAzimuth);
+
+		// The activity was recreated while the car session was driving the map, so its map view has
+		// no renderer of its own, and it is paused while the car session is running.
+		AtlasMapRendererView pausedView = onMainSync(() -> {
+			AtlasMapRendererView view = new AtlasMapRendererView(app);
+			rendererContext.presetMapRendererOptions(view, false);
+			view.handleOnPause();
+			return view;
+		});
+
+		// NavigationSession.onStop() -> MapViewWithLayers.setupAtlasMapRendererView(): the renderer
+		// is handed over to the paused view and its state is updated right away.
+		onMainSync(() -> {
+			pausedView.setupRenderer(app, 0, 0, activeView);
+			// setAzimuth() has to change the state of the renderer, otherwise no frame is requested
+			pausedView.setAzimuth(activeAzimuth + 30);
+			return null;
+		});
+
+		// The handed over renderer keeps asking for frames from its own threads as well.
+		Thread.sleep(3000);
+
+		onMainSync(() -> {
+			pausedView.stopRenderer();
+			return null;
+		});
+	}
+
+	private boolean awaitFrame(@androidx.annotation.NonNull MapRendererView view) throws InterruptedException {
+		CountDownLatch latch = new CountDownLatch(1);
+		MapRendererView.MapRendererViewListener listener = new MapRendererView.MapRendererViewListener() {
+			@Override
+			public void onUpdateFrame(MapRendererView mapRenderer) {
+				latch.countDown();
+			}
+
+			@Override
+			public void onFrameReady(MapRendererView mapRenderer) {
+			}
+		};
+		view.addListener(listener);
+		try {
+			return latch.await(FRAME_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+		} finally {
+			view.removeListener(listener);
+		}
+	}
+
+	private <T> T onMainSync(@androidx.annotation.NonNull java.util.concurrent.Callable<T> callable) throws Throwable {
+		AtomicReference<T> result = new AtomicReference<>();
+		AtomicReference<Throwable> error = new AtomicReference<>();
+		InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> {
+			try {
+				result.set(callable.call());
+			} catch (Throwable t) {
+				error.set(t);
+			}
+		});
+		if (error.get() != null) {
+			throw error.get();
+		}
+		return result.get();
+	}
+}


### PR DESCRIPTION
Regression test for the Android Auto crash fixed by osmandapp/OsmAnd-core#1105 — Play `70daec1e`,
~96 affected users:

```
terminating due to uncaught exception of type Swig::DirectorException: Attempt to invoke virtual
method 'void android.opengl.GLSurfaceView$GLThread.requestRender()' on a null object reference
    ... SwigDirector_MapRendererSetupOptions_IFrameUpdateRequestCallback::operator()
    ... OsmAnd::MapRenderer::setAzimuth
    ... net.osmand.plus.views.MapViewWithLayers.setupAtlasMapRendererView
    ... net.osmand.plus.auto.NavigationSession.onStop
```

`RendererHandoverToPausedViewTest` reproduces the state the field trace crashes in: the live renderer
is handed over to a paused `AtlasMapRendererView` and its state is changed right away, exactly as
`setupAtlasMapRendererView()` does when the car session stops while the phone activity is in the
background. In that state `setupRenderer()` creates the rendering view but leaves `setRenderer()` for
`handleOnResume()`, so the frame-update callback dereferences a `GLSurfaceView` without a `GLThread`,
and the exception escaping the SWIG director aborts the process.

Emulator, Android 15 arm64, `nightlyFreeOpenglArm64Debug`:

| | before the core fix | after |
|---|---|---|
| `am instrument` | `INSTRUMENTATION_RESULT: shortMsg=Process crashed.` | `OK (1 test)` |
| abort message | the Play one, with the same director frame | none |

No app code changes — the fix is in `OsmAnd-core`.

Internal task: osmandapp/OsmAnd-Issues#3314

## Merge order

Draft on purpose: merge osmandapp/OsmAnd-core#1105 first and let it reach the 5.4
`OsmAndCore_android` snapshot. Until then this test crashes the instrumentation process by design.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Clean up the working state of the previous crash round and report what crash groups are left and
   what can be fixed.
2. D, H and G are the same memory problem — do not patch them, leave a short comment in the epic that
   they need a systemic approach; study and fix B instead.
3. B has to be reproduced as well.
4. If there is no internal issue for it, create one for 5.4-map in code review with the test and the
   description, and set the parent epic.

Decided by the agent, not requested explicitly:
- Putting the test in `net.osmand.test.ui.map` next to the other `MapActivity`-based tests.
- Driving the hand-over directly instead of emulating a car session: the crashing state is reachable
  with the same public API and needs no head unit.
- Keeping this PR as a draft until the core fix ships in the snapshot.
