### PR TITLE
Keep default plugin activation out of Cloud Sync

### DIFF
--- a/OsmAnd/src/net/osmand/plus/plugins/PluginsHelper.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/PluginsHelper.java
@@ -198,7 +198,6 @@ public class PluginsHelper {
 					&& !enabledPlugins.contains(plugin.getId())
 					&& !isPluginDisabledManually(app, plugin)) {
 				enabledPlugins.add(plugin.getId());
-				app.getSettings().enablePlugin(plugin.getId(), true);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Default plugins are initialized on every app start. Previously, this runtime
activation also persisted their IDs in the shared `enabled_plugins` preference.

That write advanced the Global Settings modification time and could turn a
device- or build-specific default into a Cloud Sync change without an explicit
user action.

This change keeps default plugins active for the current device without
persisting the default state. Explicit plugin enablement and manual disablement
remain shared:

```text
Default plugin
→ active locally, not stored in Global Settings

User explicitly enables a plugin
→ stored in `enabled_plugins`, synced through Cloud

User explicitly disables a default plugin
→ `-plugin_id` remains stored and prevents automatic activation
```

No migration is included. Existing positive entries may represent an explicit
user choice, so they cannot be safely removed as legacy defaults.

## Scope

This PR does not change:

- explicit plugin toggles in the Plugins UI;
- user-triggered activation from plugin features or quick actions;
- custom-plugin restore behavior;
- external customization or AIDL plugin-state changes.

Those flows need separate semantics review where required.

## Validation

- `git diff --check`
- Manual verification to perform:
  1. Restore Global Settings without a default plugin entry and restart the app.
  2. Confirm the default plugin is active locally without a new Global Settings
     Local Change.
  3. Confirm `-plugin_id` keeps a default plugin disabled after restart.
  4. Confirm an explicit plugin toggle still creates a Global Settings change.

## AI disclaimer

Produced with Codex (GPT-5.6).

Prompts used (summarised):
1. Investigate false Global Settings Cloud changes caused by automatic writes.
2. Audit plugin activation paths and distinguish runtime defaults from explicit
   user choices.
3. Prepare a focused uncommitted fix and review its historical intent.

Decided by the agent, not requested explicitly: default plugin activation is
recomputed during plugin initialization and therefore does not need to persist
as shared user intent; no legacy migration was added because existing positive
plugin entries cannot be distinguished safely from explicit user choices.