### PR TITLE
Never show a purchase price that did not come from the store

### DIFF
--- a/OsmAnd/res/values/no_translate.xml
+++ b/OsmAnd/res/values/no_translate.xml
@@ -22,7 +22,6 @@
     <string name="android_api">Android API</string>
     <string name="github">GitHub</string>
     <string name="telegram">Telegram</string>
-    <string name="full_version_price">€24,99</string>
     <string name="srtm_plugin_price">€2,99</string>
     <string name="sea_depth_maps_price">€1,39</string>
     <string name="osm_live">OsmAnd Live</string>

--- a/OsmAnd/src-google/net/osmand/plus/inapp/InAppPurchasesImpl.java
+++ b/OsmAnd/src-google/net/osmand/plus/inapp/InAppPurchasesImpl.java
@@ -119,11 +119,6 @@ public class InAppPurchasesImpl extends InAppPurchases {
 		public boolean isLegacy() {
 			return false;
 		}
-
-		@Override
-		public String getDefaultPrice(Context ctx) {
-			return ctx.getString(R.string.full_version_price);
-		}
 	}
 
 	private static class InAppPurchaseDepthContoursFull extends InAppPurchaseDepthContours {

--- a/OsmAnd/src-huawei/net/osmand/plus/inapp/InAppPurchasesImpl.java
+++ b/OsmAnd/src-huawei/net/osmand/plus/inapp/InAppPurchasesImpl.java
@@ -93,11 +93,6 @@ public class InAppPurchasesImpl extends InAppPurchases {
 		public boolean isLegacy() {
 			return false;
 		}
-
-		@Override
-		public String getDefaultPrice(Context ctx) {
-			return ctx.getString(R.string.full_version_price);
-		}
 	}
 
 	private static class InAppPurchaseDepthContoursFree extends InAppPurchaseDepthContours {

--- a/OsmAnd/src/net/osmand/plus/chooseplan/BasePurchaseDialogFragment.java
+++ b/OsmAnd/src/net/osmand/plus/chooseplan/BasePurchaseDialogFragment.java
@@ -29,7 +29,6 @@ import net.osmand.plus.helpers.AndroidUiHelper;
 import net.osmand.plus.inapp.InAppPurchaseHelper;
 import net.osmand.plus.inapp.InAppPurchaseHelper.InAppPurchaseListener;
 import net.osmand.plus.inapp.InAppPurchaseHelper.InAppPurchaseTaskType;
-import net.osmand.plus.inapp.InAppPurchaseUtils;
 import net.osmand.plus.utils.AndroidUtils;
 import net.osmand.plus.utils.ColorUtilities;
 import net.osmand.plus.utils.UiUtilities;
@@ -177,7 +176,9 @@ public abstract class BasePurchaseDialogFragment extends BaseFullScreenDialogFra
 
 	@Override
 	public void onGetItems() {
-		if (isAdded() && InAppPurchaseUtils.isSubscribedToAny(app)) {
+		if (isAdded()) {
+			// Prices arrive with the inventory, so the screen must be redrawn for
+			// everyone, not only for users who already own a purchase.
 			updateContent(false);
 		}
 	}


### PR DESCRIPTION
Fixes #25870.

The purchase screen could show **€24,99** for the one-time Maps+ purchase while Google Play charged the real price at checkout. Reported with screenshots in Zendesk #91603, and by 11 other users since January 2026.

## What was wrong

**`onGetItems()` never refreshed the paywall for the people who see it.** It is the callback that fires once the billing inventory is loaded and `setPrice()` has been applied to every `InAppPurchase`, but it was guarded by `isSubscribedToAny(app)` — true only for users who already own a purchase. The paywall is shown to users who own nothing, so the real prices arrived and were never rendered. Guard added in c0f90bbdac (2021-06-24).

**What was rendered instead was a hardcoded price.** `getPrice()` falls back to `getDefaultPrice()`, which for the one-time full version returned `R.string.full_version_price` = `€24,99` from `no_translate.xml`, last correct in 2021 (3869935d46). `SelectedPlanFragment:253` renders it with no guard.

Display and checkout both resolve through `getSelectedOneTimePurchaseOffer()`, so this was never an offer-selection mismatch — only the stale fallback being shown.

Two failure modes reached users. With Play available, the app advertised a price it could not honour and Play then asked for the real one. Without Play (LineageOS, /e/OS, SailfishOS), the inventory never loads, so €24,99 was shown permanently and the purchase failed with `Cannot launch full version purchase!` — a price quoted for something that could not be bought at all (Zendesk #89261, #89905).

## Changes

- `BasePurchaseDialogFragment.onGetItems()` — drop the `isSubscribedToAny` guard so the screen redraws for everyone when prices arrive.
- `InAppPurchasesImpl` (`src-google`, `src-huawei`) — remove the `getDefaultPrice()` override on `InAppPurchaseFullVersion`, so a price the store did not return is never displayed. `updateContinueButton:318` already handles an empty price.
- `no_translate.xml` — delete the now unreferenced `full_version_price`, so the same value cannot go stale again.

Targeted at `r5.4` and deliberately kept small. The identical stale-fallback pattern remains for `srtm_plugin_price`, `sea_depth_maps_price`, `osm_pro_monthly_price`, `osm_pro_annual_price` and `osm_live_default_price`, all equally out of date; that is noted in the issue as follow-up rather than folded into a release-branch change.

## Testing

`compileAndroidFullLegacyArm64DebugJavaWithJavac` and `compileHuaweiLegacyArm64DebugJavaWithJavac` both succeed — the two variants that carry `src-google` and `src-huawei` respectively. Not verified on a device: reproducing the stale price needs either a build with no Play billing or the timing window on a fresh install.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Review the open/new Zendesk queue and say what needs an urgent reply and what can wait until Monday.
2. Explain where the flood of tickets titled "Purchases" comes from in the code.
3. Validate and fix the urgent tickets rather than just replying to them.
4. Decisions on each ticket: refund the FastSpring order, refund the second one if a transaction exists, send the templated replies, and — for the price bug — "we cannot release, show me where to change the price in Google Play".
5. How do we fix the price bug urgently?
6. Create the issue and the PR against r5.4, test it, and push.
7. Search Zendesk for how many such complaints there have been.

Decided by the agent, not requested explicitly:
- Which of the two defects to fix. The user asked about the wrong price; the missing redraw in `onGetItems()` was found while tracing why the stale value persisted, and is included because fixing only the fallback would leave the screen showing nothing where a price belongs.
- Deleting the `full_version_price` string rather than leaving it unreferenced.
- Leaving the other five stale fallback prices alone, to keep a release-branch change reviewable.
- Scope of testing: compile-only, for the reason given above.
