### PR TITLE
Alternative routes on short city routes: absolute stretch allowance and a fallback to the detailed graph

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/HHAlternativeRoutes.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHAlternativeRoutes.java
@@ -43,9 +43,9 @@ import net.osmand.router.HHRouteDataStructure.NetworkDBSegment;
  * expands candidates one by one and checks the real road segments, stopping as soon as
  * ALT_MAX_COUNT routes are accepted.
  *
- * A route short enough that the two last-mile searches meet each other never uses a hub-graph edge
- * at all, so none of the above can produce anything. {@link #calcDetailedAlternatives} then applies
- * the very same plateau idea one level down, on the detailed road trees - see its comment.
+ * A route short enough that the two last-mile searches meet each other uses no hub-graph edge at all,
+ * or so few that none of the above can produce anything. {@link #calcDetailedAlternatives} then
+ * applies the very same plateau idea one level down, on the detailed road trees - see its comment.
  *
  * One instance serves one routing call - the plateau maps and the expansion budget below are the
  * state of that call.
@@ -99,16 +99,28 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 		if (optCost <= 0 || cfg.ALT_MAX_COUNT <= 0) {
 			return;
 		}
-		maxCost = optCost * (1 + cfg.ALT_STRETCH);
+		maxCost = stretchLimit(optCost);
 		// Distinctness is measured against the main route and against the alternatives already
 		// accepted alike - an alternative has to be worth proposing next to each of them.
 		accepted.add(roadSegments(detailedSegments(route)));
 		setDistinctnessThresholds(totalLength(accepted.get(0)));
-		if (usesHubGraph(route)) {
+		boolean hub = usesHubGraph(route);
+		if (hub) {
 			calcHubAlternatives(route, start, end, progress, rrp);
-		} else {
+		}
+		// A route of a kilometre or two can touch the hub graph and still give the method nothing to
+		// work with - measured on a 1.7 km route: three hub segments, six hub points settled by both
+		// trees, no candidate. The detailed graph is then the only place left to look, as long as the
+		// route is short enough for that search to be cheap (a route that uses no hub graph at all is
+		// short by construction).
+		if (route.altRoutes.isEmpty() && (!hub || optCost <= cfg.ALT_DETAILED_MAX_COST)) {
 			calcDetailedAlternatives(route, rrp);
 		}
+	}
+
+	/** the most an alternative may cost, rule 1 of the three in HHRoutingConfig */
+	private double stretchLimit(double cost) {
+		return cost * (1 + cfg.ALT_STRETCH) + cfg.ALT_STRETCH_ABS;
 	}
 
 	/**
@@ -304,11 +316,12 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 	// ---------------------------------------------------------------------------------------------
 
 	/**
-	 * A city route of a few kilometres never reaches the hub graph: the two last-mile searches meet
-	 * each other first, the route is assembled from two detailed segments and the hub method above
-	 * has no edge to build a plateau on (measured on a 4 km route: 6 hub points settled by both
-	 * trees, none of them usable). Everything that makes such a route interesting - the parallel
-	 * street one block away - lives in the detailed graph, and both trees of it are already there.
+	 * A city route of a few kilometres does not reach the hub graph, or barely touches it: the two
+	 * last-mile searches meet each other first, and the hub method above has no edge to build a
+	 * plateau on (measured on a 4 km route: 6 hub points settled by both trees, none of them usable,
+	 * and the same six on a 1.7 km route that does have three hub segments). Everything that makes
+	 * such a route interesting - the parallel street one block away - lives in the detailed graph,
+	 * and both trees of it are already there.
 	 *
 	 * So the plateau method is applied one level down. A via node is a road point settled by both
 	 * detailed trees, its route costs f(v) + b(v), and its plateau is the maximal stretch around it
@@ -371,7 +384,7 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 		rctx.config.MAX_VISITED = HHRoutePlanner.MAX_POINTS_CLUSTER_ROUTING;
 		rctx.config.planRoadDirection = 0;
 		rctx.config.heuristicCoefficient = 0; // dijkstra: the queue cost is the distance from the start
-		rctx.config.altHorizon = cfg.ALT_STRETCH;
+		rctx.config.altHorizon = stretchLimit(optCost) / optCost - 1;
 		// the road segments of the route already found carry the routing state of that search
 		rctx.unloadAllData();
 		try {
@@ -415,7 +428,7 @@ public class HHAlternativeRoutes<T extends NetworkDBPoint> {
 			best = Math.min(best, c.cost);
 			all.add(c);
 		}
-		double limit = Math.min(optCost, best) * (1 + cfg.ALT_STRETCH);
+		double limit = stretchLimit(Math.min(optCost, best));
 		List<DetailedCandidate> within = new ArrayList<>();
 		for (DetailedCandidate c : all) {
 			if (c.cost <= limit) {

--- a/OsmAnd-java/src/main/java/net/osmand/router/HHRouteDataStructure.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHRouteDataStructure.java
@@ -64,13 +64,17 @@ public class HHRouteDataStructure {
 		// A candidate route goes through a "via node" v settled by both search trees: sp(s,v) + sp(v,t).
 		// Its plateau is the maximal chain of hub-graph edges around v that belongs to BOTH trees, i.e.
 		// the stretch the alternative drives as its own optimal road. Three explicit admissibility rules:
-		//   1) stretch    cost(alt) <= (1 + ALT_STRETCH) * cost(opt)
+		//   1) stretch    cost(alt) <= (1 + ALT_STRETCH) * cost(opt) + ALT_STRETCH_ABS
 		//   2) plateau    plateau(v) >= ALT_MIN_PLATEAU * cost(alt)          (local optimality)
 		//   3) distinct   own roads >= max(ALT_MIN_DISTINCT_FLOOR, ALT_MIN_DISTINCT_REL * len(opt))
 		// ALT_STRETCH also bounds the search horizon, so it directly trades quality for speed.
 		public int ALT_MAX_COUNT = 2; // how many alternatives to return
 		public double ALT_STRETCH = 0.4; // hard limit of relative cost overhead (and search bound)
 		public double ALT_STRETCH_PREFERRED = 0.15; // alternatives below this limit are proposed first
+		// A relative limit alone is harsh on a short route: on a 7 minute drive it rejects everything
+		// that is not within 3 minutes of the fastest way, and the only other way through a city block
+		// rarely is. On a route long enough for ALT_STRETCH to mean minutes this allowance is nothing.
+		public double ALT_STRETCH_ABS = 180; // seconds allowed on top of ALT_STRETCH
 		public double ALT_MIN_PLATEAU = 0.1; // min share of the route driven as its own optimal road
 		public double ALT_MAX_SHARING = 0.6; // coarse hub-graph pre-filter (stage 1)
 		public double ALT_MIN_DISTINCT_REL = 0.2; // exact geometry filter (stage 2), share of main length
@@ -82,6 +86,10 @@ public class HHRouteDataStructure {
 		// disagree with the detailed roads count against it, so this is not "number of candidates".
 		public int ALT_MAX_EXPAND = 8;
 		public double ALT_MAX_RETRACED = 100; // meters an alternative may drive twice (u-turn tolerance)
+		// The detailed graph is searched again when the hub graph offers nothing, and that search grows
+		// with the route: measured 44 ms at 423 s of cost, 197 ms at 645 s, 274 ms at 978 s and 700 ms
+		// on a 140 km route that had no alternative to find anyway. Beyond a city hop it is not worth it.
+		public double ALT_DETAILED_MAX_COST = 900; // seconds, above this only the hub graph is searched
 		public double ALT_RANK_COST_WEIGHT = 3; // rank: (1 - shared) - weight * stretch
 
 		double MAX_COST;

--- a/OsmAnd-java/src/test/java/net/osmand/router/AlternativeRoutesTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/router/AlternativeRoutesTest.java
@@ -126,7 +126,8 @@ public class AlternativeRoutesTest {
 	private void assertSaneAlternatives(List<Route> routes, Route main) {
 		Map<Long, Double> mainRoads = roads(main);
 		double mainLength = length(mainRoads);
-		double maxCost = main.cost * (1 + new HHRoutingConfig().ALT_STRETCH) + 1;
+		HHRoutingConfig limits = new HHRoutingConfig();
+		double maxCost = main.cost * (1 + limits.ALT_STRETCH) + limits.ALT_STRETCH_ABS + 1;
 		for (int i = 1; i < routes.size(); i++) {
 			Route alt = routes.get(i);
 			String id = "alternative " + i;

--- a/OsmAnd-java/src/test/resources/alternatives/test_alternative_routes.json
+++ b/OsmAnd-java/src/test/resources/alternatives/test_alternative_routes.json
@@ -120,5 +120,19 @@
         "toleranceMeters": 1000
       }
     ]
+  },
+  {
+    "testName": "Kyiv, a 1.7 km hop where the only other way costs 50% more",
+    "description": "The route uses three hub segments, but only six hub points are settled by both trees and none of them carries a plateau, so the hub method returns nothing. The one distinct way round (2.5 km, +49.6%) is out of reach of a purely relative stretch limit",
+    "map": "Ukraine_kyiv-city_europe_2.obf",
+    "startPoint": {
+      "latitude": 50.427112,
+      "longitude": 30.470581
+    },
+    "endPoint": {
+      "latitude": 50.416448,
+      "longitude": 30.47719
+    },
+    "minAlternatives": 1
   }
 ]


### PR DESCRIPTION
Follow-up to #25815. A 1.7 km route in Kyiv (`50.427112,30.470581 -> 50.416448,30.477190`, [on the map](https://test.osmand.net/map/navigate/?start=50.427112,30.470581&end=50.416448,30.477190&profile=car#15/50.4168/30.4760)) still comes back with no alternative. Reproduced locally on `Ukraine_kyiv-city_europe_2.obf` — cost 423.10, exactly the `routingTime` the server reports — and there are two independent reasons.

### 1. The detailed method was never reached

Instrumented run of the merged code:

```
optCost=423.1  maxCost=592.3  segments=3  hub=true
queueAdded=253  settled(via)=6  candidates=0   -> returns after 1 ms
```

The route touches the hub graph (three segments), so `usesHubGraph()` sends it down the hub branch. Six hub points are settled by both trees, none of them carries a plateau, no candidate survives — and because the switch was an either/or, the detailed method added in #25815 was never tried.

It now runs whenever the hub graph produced nothing. That search is not free and grows with the route — 44 ms at 423 s of cost, 197 ms at 645 s, 274 ms at 978 s, and 700 ms on a 140 km route that has no alternative to find — so it is bounded by `ALT_DETAILED_MAX_COST` (900 s). A route that uses no hub graph at all keeps the unconditional path it has today; it is short by construction.

### 2. A relative stretch limit is harsh on a short route

Here the fallback alone changes nothing: the only candidates inside the band are near-twins of the main route (own roads 0.0 km). The one genuinely distinct way round costs **+49.6%** — 2.5 km / 633 s against 1.7 km / 423 s — and `ALT_STRETCH` cannot reach it. On a seven-minute drive the relative limit allows three minutes, and the next street through the block rarely fits into that.

`ALT_STRETCH_ABS = 180` seconds is allowed on top of the relative limit. On any route long enough for `ALT_STRETCH` to mean minutes the allowance disappears into it.

Rule 1 of the three in `HHRoutingConfig` becomes `cost(alt) <= (1 + ALT_STRETCH) * cost(opt) + ALT_STRETCH_ABS`, and the same limit is used for the search horizon of the detailed Dijkstra and for the meeting-point filter, so the band the search settles and the band a candidate is admitted from stay one and the same.

### Measurements

12-route benchmark (Munich x4, Berlin, San Francisco x2, Paris x2, Tuscany, Amstelveen, Kyiv), before vs after:

- the alternatives offered are **byte-identical** — same routes, same costs, same order;
- time spent on alternatives is unchanged within noise (e.g. Munich→Rosenheim 278 → 288 ms, Tuscany 223 → 223 ms);
- the 140 km Kyiv→Zhytomyr route, which finds nothing either way, still spends **11 ms** on alternatives, not the 700 ms it would take without the `ALT_DETAILED_MAX_COST` guard;
- the reported route now returns one alternative (2.5 km, +49.6%) in 12 ms.

`AlternativeRoutesTest` passes with 7/7 cases, including the new one for this route. Its cost bound had to follow the production rule, or no case beyond `ALT_STRETCH` could ever pass.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Why does this route on test.osmand.net show no alternatives, all maps are available locally.
2. Is the request good, does it break anything, is it strictly by the code conventions I have written for years, is there anything superfluous.
3. The tests passed, what do you mean it breaks something.
4. There is still no alternative here although I already merged it — <the link above>.
5. Do it as one pull request and put a link to it in the issue.

Decided by the agent, not requested explicitly:
- the choice between the two possible fixes: an absolute allowance on top of the relative limit rather than raising `ALT_STRETCH` again (measured: raising the constant to 0.4 had degraded Munich→Rosenheim from +16.0% to +32.6% and SF urban from +23.9% to +33.8%, an absolute allowance changes nothing on the benchmark);
- the value 180 s and the guard `ALT_DETAILED_MAX_COST = 900 s`, both picked from the measurements quoted above;
- extending the fallback to every route that finds nothing on the hub graph, rather than only the reported one;
- the test case, and the change of the test's own cost bound so that it mirrors the production rule.
