### PR TITLE
Keep OSM account state out of Global Settings

### DIFF
--- a/OsmAnd/src/net/osmand/plus/plugins/osmedit/OsmEditingPlugin.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/osmedit/OsmEditingPlugin.java
@@ -141,17 +141,17 @@ public class OsmEditingPlugin extends OsmandPlugin {
 	public OsmEditingPlugin(OsmandApplication app) {
 		super(app);
 
-		OSM_USER_NAME_OR_EMAIL = registerStringPreference("user_name", "").makeGlobal().makeShared();
-		OSM_USER_DISPLAY_NAME = registerStringPreference("user_display_name", "").makeGlobal().makeShared();
+		OSM_USER_NAME_OR_EMAIL = registerStringPreference("user_name", "").makeGlobal();
+		OSM_USER_DISPLAY_NAME = registerStringPreference("user_display_name", "").makeGlobal();
 		OSM_UPLOAD_VISIBILITY = registerEnumStringPreference("upload_visibility", UploadVisibility.getDefaultValue(), UploadVisibility.getAvailableValues(), UploadVisibility.class).makeGlobal().makeShared();
 
 		USER_OSM_BUG_NAME = registerStringPreference("user_osm_bug_name", "NoName/OsmAnd").makeGlobal().makeShared();
-		OSM_USER_PASSWORD = registerStringPreference("user_password", "").makeGlobal().makeShared();
+		OSM_USER_PASSWORD = registerStringPreference("user_password", "").makeGlobal();
 		OSM_USER_ACCESS_TOKEN = registerStringPreference("user_access_token", "").makeGlobal();
 		OSM_USER_ACCESS_TOKEN_SECRET = registerStringPreference("user_access_token_secret", "").makeGlobal();
 
 		OFFLINE_EDITION = registerBooleanPreference("offline_osm_editing", true).makeGlobal().makeShared();
-		OSM_USE_DEV_URL = registerBooleanPreference("use_dev_url", false).makeGlobal().makeShared();
+		OSM_USE_DEV_URL = registerBooleanPreference("use_dev_url", false).makeGlobal();
 
 		SHOW_OSM_BUGS = registerBooleanPreference("show_osm_bugs", false).makeProfile().cache();
 		SHOW_OSM_EDITS = registerBooleanPreference("show_osm_edits", true).makeProfile().cache();


### PR DESCRIPTION
## Summary

This change keeps OSM account state and the development OSM endpoint local to
the current device.

The affected preferences remain global, so they are still shared across
profiles on the same device. They are no longer marked as `shared`, therefore
they are excluded from `general_settings.json` and cannot advance the Global
Settings modification time.

## Changed preferences

- `OSM_USER_NAME_OR_EMAIL`
- `OSM_USER_DISPLAY_NAME`
- `OSM_USER_PASSWORD`
- `OSM_USE_DEV_URL`

## Rationale

Global Settings exports every global preference marked as `shared`, using its
stored string value. This previously included the OSM password in the Global
Settings payload.

The OAuth access token and secret are already device-local. Keeping the
username, password, and derived display name shared was inconsistent with that
model and could also create Global Settings changes when login validation
automatically updates or clears account state.

`OSM_USE_DEV_URL` is a development-only endpoint selection. It is
automatically reset when the Development plugin is disabled, so it must not be
treated as portable user intent.

## Not changed

The following OSM editing preferences remain shared because they represent
explicit editing behavior rather than account or device state:

- `OSM_UPLOAD_VISIBILITY`
- `USER_OSM_BUG_NAME`
- `OFFLINE_EDITION`

## Validation

- `git diff --check`
- `git diff --cached --check`

No Cloud Sync algorithm changes are included.