### PR TITLE
Keep paired device settings out of Global Settings

### DIFF
--- a/OsmAnd/src/net/osmand/plus/plugins/externalsensors/ExternalSensorsPlugin.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/externalsensors/ExternalSensorsPlugin.java
@@ -92,7 +92,7 @@ public class ExternalSensorsPlugin extends OsmandPlugin {
 		@NonNull
 		@Override
 		public CommonPreference<String> getPreference() {
-			return registerStringPref(DEVICES_SETTINGS_PREF_ID, "");
+			return registerStringPreference(DEVICES_SETTINGS_PREF_ID, "").makeGlobal();
 		}
 	};
 

--- a/OsmAnd/src/net/osmand/plus/plugins/odb/VehicleMetricsPlugin.kt
+++ b/OsmAnd/src/net/osmand/plus/plugins/odb/VehicleMetricsPlugin.kt
@@ -135,13 +135,9 @@ class VehicleMetricsPlugin(app: OsmandApplication) : OsmandPlugin(app), OBDReadS
 	private val deviceSettingsPreferenceProvider: CommonPreferenceProvider<String> =
 		object : CommonPreferenceProvider<String> {
 			override fun getPreference(): CommonPreference<String> {
-				return registerStringPref(OBD_DEVICES_SETTINGS_PREF_ID, "")
+				return registerStringPreference(OBD_DEVICES_SETTINGS_PREF_ID, "").makeGlobal()
 			}
 		}
-
-	fun registerStringPref(prefId: String, defValue: String?): CommonPreference<String> {
-		return registerStringPreference(prefId, defValue).makeGlobal().makeShared()
-	}
 
 	private val devicesHelper: DevicesHelper =
 		VehicleMetricsBLEDeviceHelper(this, app, deviceSettingsPreferenceProvider)


### PR DESCRIPTION
## Summary

This change keeps paired external-sensor and BLE OBD device configuration local
to the device where the hardware is configured.

`external_devices_settings` and `obd_devices_settings` contain hardware-bound
data such as BLE/ANT identifiers, device type, enabled state, UUID and device
parameters. These values are not portable Cloud user intent.

Both preferences remain global, so they are still persisted across profiles on
the same device. They are no longer `shared`, so their updates do not enter
Global Settings backup or advance the Global Settings sync timestamp.

## Scope

Changed:

- `external_devices_settings`
- `obd_devices_settings`

Not changed:

- `TRIP_RECORDING_VEHICLE_METRICS`, which remains a portable profile-level user
  choice;
- `SIMULATE_OBD_DATA`, which is a manually controlled development setting;
- profile-level sensor device-ID preferences, which require a separate audit.

## Validation

- `git diff --check` passes.
- Static tracing confirms that startup restores device settings by reading them
  only; pairing, enablement and device-property updates remain local writes.