### PR TITLE
Turn lanes: tell an unmarked lane apart from "through"

### DIFF
--- a/OsmAnd-java/build.gradle
+++ b/OsmAnd-java/build.gradle
@@ -57,6 +57,7 @@ tasks.register('collectTestResources', Copy) {
 		include "*"
 		include "/search/*"
 		include "/routing/*"
+		include "/turn_lanes/*"
 		include "/approximation/*"
 	}
 	from("../../resources/poi") {

--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
@@ -266,6 +266,7 @@ public class RouteResultPreparation {
 			result.get(i).setTurnType(turnType);
 		}
 		
+		convertNoneLanes(result);
 		determineTurnsToMerge(ctx.leftSideNavigation, result);
 		ignorePrecedingStraightsOnSameIntersection(ctx.leftSideNavigation, result);
 		justifyUTurns(ctx.leftSideNavigation, result);
@@ -1280,15 +1281,6 @@ public class RouteResultPreparation {
 
 
 	private TurnType getTurnInfo(List<RouteSegmentResult> result, int i, boolean leftSide) {
-		TurnType t = calculateTurnInfo(result, i, leftSide);
-		if (t != null) {
-			// TurnType.NONE is an internal marker of an unmarked lane, it must not leave turn calculation
-			TurnType.convertNoneToStraight(t.getLanes());
-		}
-		return t;
-	}
-
-	private TurnType calculateTurnInfo(List<RouteSegmentResult> result, int i, boolean leftSide) {
 		if (i == 0) {
 			return TurnType.valueOf(TurnType.C, false);
 		}
@@ -2649,6 +2641,15 @@ public class RouteResultPreparation {
 			}
 		}
 		return false;
+	}
+
+	private void convertNoneLanes(List<RouteSegmentResult> result) {
+		for (int i = 0; i < result.size(); i ++) {
+			TurnType t = result.get(i).getTurnType();
+			if (t != null) {
+				TurnType.convertNoneToStraight(t.getLanes());
+			}
+		}
 	}
 
 }

--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
@@ -1485,35 +1485,11 @@ public class RouteResultPreparation {
 		int activeTurn = act[2];
 		if (activeBeginIndex == -1 || activeEndIndex == -1 || activeBeginIndex > activeEndIndex) {
 			TurnType simple = createSimpleKeepLeftRightTurn(leftSide, prevSegm, currentSegm, rs);
-			if (hasNoneLanes(rawLanes)) {
-				// turn:lanes doesn't declare a direction for every road of the junction, so the
-				// directions couldn't be matched to the roads by their position. The lanes themselves
-				// are still usable: activate the ones that allow the direction the route takes,
-				// instead of dropping the tag and building the lanes from the geometry alone.
-				double deviation = MapUtils.degreesDiff(prevSegm.getBearingEnd(), currentSegm.getBearingBegin());
-				int laneTurnType = getTurnByAngle(deviation);
-				int baseTurnType = simple != null ? simple.getValue() : laneTurnType;
-				boolean activated = setAllowedLanes(laneTurnType, rawLanes);
-				if (!activated) {
-					// the geometry matches no lane: a tag that declares a single direction
-					// on the same side describes the turn better than the raw angle does
-					int[] declared = getUniqTurnTypes(turnLanes);
-					if (declared.length == 1 && sameTurnSide(declared[0], laneTurnType)
-							&& setAllowedLanes(declared[0], rawLanes)) {
-						activated = true;
-						baseTurnType = declared[0];
-					}
-				}
-				if (activated) {
-					t = getActiveTurnType(rawLanes, leftSide, TurnType.valueOf(baseTurnType, leftSide));
-					if (simple != null) {
-						t.setSkipToSpeak(simple.isSkipToSpeak());
-					}
-					t.setLanes(rawLanes);
-					t.setPossibleLeftTurn(possiblyLeftTurn);
-					t.setPossibleRightTurn(possiblyRightTurn);
-					return t;
-				}
+			TurnType unmarked = createTurnFromUnmarkedLanes(prevSegm, currentSegm, rawLanes, turnLanes, leftSide, simple);
+			if (unmarked != null) {
+				unmarked.setPossibleLeftTurn(possiblyLeftTurn);
+				unmarked.setPossibleRightTurn(possiblyRightTurn);
+				return unmarked;
 			}
 			// something went wrong
 			return simple;
@@ -1529,7 +1505,7 @@ public class RouteResultPreparation {
 					if (TurnType.getSecondaryTurn(rawLanes[i]) == tp) {
 						TurnType.setSecondaryToPrimary(rawLanes, i);
 						rawLanes[i] |= 1;
-					} else if (isPrimaryDirection(rawLanes[i], tp)) {
+					} else if (TurnType.isPrimaryDirection(rawLanes[i], tp)) {
 						rawLanes[i] |= 1;
 					}
 				}
@@ -1555,18 +1531,32 @@ public class RouteResultPreparation {
 		return t;
 	}
 
-	private boolean sameTurnSide(int t1, int t2) {
-		return (TurnType.isLeftTurn(t1) && TurnType.isLeftTurn(t2))
-				|| (TurnType.isRightTurn(t1) && TurnType.isRightTurn(t2));
-	}
-
-	private boolean hasNoneLanes(int[] rawLanes) {
-		for (int lane : rawLanes) {
-			if (TurnType.hasNoneTurnLane(lane)) {
-				return true;
+	private TurnType createTurnFromUnmarkedLanes(RouteSegmentResult prevSegm, RouteSegmentResult currentSegm,
+			int[] rawLanes, String turnLanes, boolean leftSide, TurnType simple) {
+		if (!TurnType.hasNoneTurnLane(rawLanes)) {
+			return null;
+		}
+		double deviation = MapUtils.degreesDiff(prevSegm.getBearingEnd(), currentSegm.getBearingBegin());
+		int laneTurnType = getTurnByAngle(deviation);
+		int baseTurnType = simple != null ? simple.getValue() : laneTurnType;
+		boolean activated = setAllowedLanes(laneTurnType, rawLanes);
+		if (!activated) {
+			int[] declared = getUniqTurnTypes(turnLanes);
+			if (declared.length == 1 && TurnType.isSameTurnSide(declared[0], laneTurnType)
+					&& setAllowedLanes(declared[0], rawLanes)) {
+				activated = true;
+				baseTurnType = declared[0];
 			}
 		}
-		return false;
+		if (!activated) {
+			return null;
+		}
+		TurnType t = getActiveTurnType(rawLanes, leftSide, TurnType.valueOf(baseTurnType, leftSide));
+		if (simple != null) {
+			t.setSkipToSpeak(simple.isSkipToSpeak());
+		}
+		t.setLanes(rawLanes);
+		return t;
 	}
 
 	private void setActiveLanesRange(int[] rawLanes, int activeBeginIndex, int activeEndIndex, int activeTurn) {
@@ -2403,49 +2393,55 @@ public class RouteResultPreparation {
 	private void findActiveIndexByUniqueDirections(int[] pair, int[] directions, RoadSplitStructure rs, int[] rawLanes) {
 		int startDirection = directions[rs.roadsOnLeft];
 		int endDirection = directions[directions.length - rs.roadsOnRight - 1];
+
+		int beginIndex = firstLaneWithDirection(rawLanes, startDirection);
+		int endIndex = lastLaneWithDirection(rawLanes, endDirection);
+		if (beginIndex >= 0) {
+			pair[2] = startDirection;
+		}
+		if (beginIndex >= 0 && endIndex >= beginIndex) {
+			endIndex = includeTrailingUnmarkedLanes(rawLanes, endIndex);
+		}
+		if (beginIndex >= 0 && !isStartDirectionTrusted(rawLanes, beginIndex, startDirection, rs)) {
+			beginIndex = -1;
+		}
+		pair[0] = beginIndex;
+		pair[1] = endIndex;
+	}
+
+	private int firstLaneWithDirection(int[] rawLanes, int direction) {
 		for (int i = 0; i < rawLanes.length; i++) {
-			if (laneHasDirection(rawLanes[i], startDirection)) {
-				pair[0] = i;
-				pair[2] = startDirection;
-				break;
+			if (TurnType.laneHasDirection(rawLanes[i], direction)) {
+				return i;
 			}
 		}
+		return -1;
+	}
+
+	private int lastLaneWithDirection(int[] rawLanes, int direction) {
 		for (int i = rawLanes.length - 1; i >= 0; i--) {
-			if (laneHasDirection(rawLanes[i], endDirection)) {
-				pair[1] = i;
-				break;
+			if (TurnType.laneHasDirection(rawLanes[i], direction)) {
+				return i;
 			}
 		}
-		if (pair[0] >= 0 && pair[1] >= pair[0]) {
-			// Unmarked lanes next to the matched range are claimed by no road of the junction,
-			// so they belong to the direction the route takes - keep them in the active range.
-			while (pair[1] + 1 < rawLanes.length
-					&& TurnType.getPrimaryTurn(rawLanes[pair[1] + 1]) == TurnType.NONE) {
-				pair[1]++;
-			}
-		}
-		if (pair[0] >= 0 && rs.roadsOnLeft > 0 && hasNoneLanes(rawLanes)
-				&& !TurnType.isSlightTurn(startDirection)
-				&& !isPrimaryDirection(rawLanes[pair[0]], startDirection)) {
-			// The roads here are within TURN_DEGREE_MIN of each other, so a sharp direction is already
-			// at odds with the geometry. With an incomplete tag (unmarked lanes) the directions can't be
-			// matched to the roads by position either, so accept it only as the main direction of its lane.
-			pair[0] = -1;
-		}
+		return -1;
 	}
 
-	private boolean isPrimaryDirection(int lane, int direction) {
-		int primary = TurnType.getPrimaryTurn(lane);
-		return primary == direction || (direction == TurnType.C && primary == TurnType.NONE);
+	private int includeTrailingUnmarkedLanes(int[] rawLanes, int endIndex) {
+		while (endIndex + 1 < rawLanes.length
+				&& TurnType.getPrimaryTurn(rawLanes[endIndex + 1]) == TurnType.NONE) {
+			endIndex++;
+		}
+		return endIndex;
 	}
 
-	private boolean laneHasDirection(int lane, int direction) {
-		if (direction == TurnType.C && TurnType.getPrimaryTurn(lane) == TurnType.NONE) {
-			// an unmarked lane keeps the direction of the road
+	private boolean isStartDirectionTrusted(int[] rawLanes, int beginIndex, int startDirection,
+			RoadSplitStructure rs) {
+		if (rs.roadsOnLeft == 0 || !TurnType.hasNoneTurnLane(rawLanes)) {
 			return true;
 		}
-		return TurnType.getPrimaryTurn(lane) == direction || TurnType.getSecondaryTurn(lane) == direction
-				|| TurnType.getTertiaryTurn(lane) == direction;
+		return TurnType.isSlightTurn(startDirection)
+				|| TurnType.isPrimaryDirection(rawLanes[beginIndex], startDirection);
 	}
 
 	private boolean findActiveIndexByLanes(int[] pair, int[] directions, RoadSplitStructure rs, int[] rawLanes,

--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
@@ -1280,6 +1280,15 @@ public class RouteResultPreparation {
 
 
 	private TurnType getTurnInfo(List<RouteSegmentResult> result, int i, boolean leftSide) {
+		TurnType t = calculateTurnInfo(result, i, leftSide);
+		if (t != null) {
+			// TurnType.NONE is an internal marker of an unmarked lane, it must not leave turn calculation
+			TurnType.convertNoneToStraight(t.getLanes());
+		}
+		return t;
+	}
+
+	private TurnType calculateTurnInfo(List<RouteSegmentResult> result, int i, boolean leftSide) {
 		if (i == 0) {
 			return TurnType.valueOf(TurnType.C, false);
 		}
@@ -1308,7 +1317,7 @@ public class RouteResultPreparation {
 					int[] lanes = getTurnLanesInfo(prev, rr, t.getValue());
 					t = getActiveTurnType(lanes, leftSide, t);
 					t.setLanes(lanes);
-				} else if (fromTag != TurnType.C) {
+				} else if (fromTag != TurnType.C && fromTag != TurnType.NONE) {
 					t = attachKeepLeftInfoAndLanes(leftSide, prev, rr, twiceRoadPresent);
 					if (t != null) {
 						TurnType mainTurnType = TurnType.valueOf(fromTag, leftSide);
@@ -1414,6 +1423,15 @@ public class RouteResultPreparation {
 				turnSet = true;
 			}
 		}
+		if (mainTurnType == TurnType.C) {
+			// unmarked lanes are the ones that keep the direction of the road
+			for (int i = 0; i < lanesArray.length; i++) {
+				if (TurnType.getPrimaryTurn(lanesArray[i]) == TurnType.NONE) {
+					lanesArray[i] |= 1;
+					turnSet = true;
+				}
+			}
+		}
 		return turnSet;
 	}
 
@@ -1466,8 +1484,39 @@ public class RouteResultPreparation {
 		int activeEndIndex = act[1];
 		int activeTurn = act[2];
 		if (activeBeginIndex == -1 || activeEndIndex == -1 || activeBeginIndex > activeEndIndex) {
+			TurnType simple = createSimpleKeepLeftRightTurn(leftSide, prevSegm, currentSegm, rs);
+			if (hasNoneLanes(rawLanes)) {
+				// turn:lanes doesn't declare a direction for every road of the junction, so the
+				// directions couldn't be matched to the roads by their position. The lanes themselves
+				// are still usable: activate the ones that allow the direction the route takes,
+				// instead of dropping the tag and building the lanes from the geometry alone.
+				double deviation = MapUtils.degreesDiff(prevSegm.getBearingEnd(), currentSegm.getBearingBegin());
+				int laneTurnType = getTurnByAngle(deviation);
+				int baseTurnType = simple != null ? simple.getValue() : laneTurnType;
+				boolean activated = setAllowedLanes(laneTurnType, rawLanes);
+				if (!activated) {
+					// the geometry matches no lane: a tag that declares a single direction
+					// on the same side describes the turn better than the raw angle does
+					int[] declared = getUniqTurnTypes(turnLanes);
+					if (declared.length == 1 && sameTurnSide(declared[0], laneTurnType)
+							&& setAllowedLanes(declared[0], rawLanes)) {
+						activated = true;
+						baseTurnType = declared[0];
+					}
+				}
+				if (activated) {
+					t = getActiveTurnType(rawLanes, leftSide, TurnType.valueOf(baseTurnType, leftSide));
+					if (simple != null) {
+						t.setSkipToSpeak(simple.isSkipToSpeak());
+					}
+					t.setLanes(rawLanes);
+					t.setPossibleLeftTurn(possiblyLeftTurn);
+					t.setPossibleRightTurn(possiblyRightTurn);
+					return t;
+				}
+			}
 			// something went wrong
-			return createSimpleKeepLeftRightTurn(leftSide, prevSegm, currentSegm, rs);
+			return simple;
 		}
 		boolean leftOrRightKeep = (rs.keepLeft && !rs.keepRight) || (!rs.keepLeft && rs.keepRight);
 		if (leftOrRightKeep) {
@@ -1480,7 +1529,7 @@ public class RouteResultPreparation {
 					if (TurnType.getSecondaryTurn(rawLanes[i]) == tp) {
 						TurnType.setSecondaryToPrimary(rawLanes, i);
 						rawLanes[i] |= 1;
-					} else if(TurnType.getPrimaryTurn(rawLanes[i]) == tp) {
+					} else if (isPrimaryDirection(rawLanes[i], tp)) {
 						rawLanes[i] |= 1;
 					}
 				}
@@ -1504,6 +1553,20 @@ public class RouteResultPreparation {
 		t.setPossibleLeftTurn(possiblyLeftTurn);
 		t.setPossibleRightTurn(possiblyRightTurn);
 		return t;
+	}
+
+	private boolean sameTurnSide(int t1, int t2) {
+		return (TurnType.isLeftTurn(t1) && TurnType.isLeftTurn(t2))
+				|| (TurnType.isRightTurn(t1) && TurnType.isRightTurn(t2));
+	}
+
+	private boolean hasNoneLanes(int[] rawLanes) {
+		for (int lane : rawLanes) {
+			if (TurnType.hasNoneTurnLane(lane)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private void setActiveLanesRange(int[] rawLanes, int activeBeginIndex, int activeEndIndex, int activeTurn) {
@@ -1969,7 +2032,10 @@ public class RouteResultPreparation {
 		if(turnLanes == null) {
 			return null;
 		}
-		return calculateRawTurnLanes(turnLanes, 0);
+		int[] lanes = calculateRawTurnLanes(turnLanes, 0);
+		// public entry point (used by the lanes widget in free drive), it must not expose TurnType.NONE
+		TurnType.convertNoneToStraight(lanes);
+		return lanes;
 	}
 	
 	public static int[] parseLanes(RouteDataObject ro, double dirToNorthEastPi) {
@@ -2061,7 +2127,10 @@ public class RouteResultPreparation {
 		for (int i = 0; i < oLanes.length; i++) {
 			// Nothing is in the list to compare to, so add the first elements
 			upossibleTurns.clear();
-			upossibleTurns.add(TurnType.getPrimaryTurn(oLanes[i]));
+			// an unmarked lane offers the direction of the road, i.e. the same slot as "through":
+			// it must stay in the count, otherwise "several directions are possible" turns into a turn
+			int primary = TurnType.getPrimaryTurn(oLanes[i]);
+			upossibleTurns.add(primary == TurnType.NONE ? TurnType.C : primary);
 			if (!onlyPrimary && TurnType.getSecondaryTurn(oLanes[i]) != 0) {
 				upossibleTurns.add(TurnType.getSecondaryTurn(oLanes[i]));
 			}
@@ -2286,7 +2355,10 @@ public class RouteResultPreparation {
 			String[] laneOptions = splitLaneOptions[i].split(";");
 			for (int j = 0; j < laneOptions.length; j++) {
 				int turn = TurnType.convertType(laneOptions[j]);
-				turnTypes.add(turn);
+				if (turn != TurnType.NONE) {
+					// an unmarked lane declares no direction, it must not be matched to a road at the junction
+					turnTypes.add(turn);
+				}
 			}
 		}
 		Iterator<Integer> it = turnTypes.iterator();
@@ -2332,24 +2404,48 @@ public class RouteResultPreparation {
 		int startDirection = directions[rs.roadsOnLeft];
 		int endDirection = directions[directions.length - rs.roadsOnRight - 1];
 		for (int i = 0; i < rawLanes.length; i++) {
-			int p = TurnType.getPrimaryTurn(rawLanes[i]);
-			int s = TurnType.getSecondaryTurn(rawLanes[i]);
-			int t = TurnType.getTertiaryTurn(rawLanes[i]);
-			if (p == startDirection || s == startDirection || t == startDirection) {
+			if (laneHasDirection(rawLanes[i], startDirection)) {
 				pair[0] = i;
 				pair[2] = startDirection;
 				break;
 			}
 		}
 		for (int i = rawLanes.length - 1; i >= 0; i--) {
-			int p = TurnType.getPrimaryTurn(rawLanes[i]);
-			int s = TurnType.getSecondaryTurn(rawLanes[i]);
-			int t = TurnType.getTertiaryTurn(rawLanes[i]);
-			if (p == endDirection || s == endDirection || t == endDirection) {
+			if (laneHasDirection(rawLanes[i], endDirection)) {
 				pair[1] = i;
 				break;
 			}
 		}
+		if (pair[0] >= 0 && pair[1] >= pair[0]) {
+			// Unmarked lanes next to the matched range are claimed by no road of the junction,
+			// so they belong to the direction the route takes - keep them in the active range.
+			while (pair[1] + 1 < rawLanes.length
+					&& TurnType.getPrimaryTurn(rawLanes[pair[1] + 1]) == TurnType.NONE) {
+				pair[1]++;
+			}
+		}
+		if (pair[0] >= 0 && rs.roadsOnLeft > 0 && hasNoneLanes(rawLanes)
+				&& !TurnType.isSlightTurn(startDirection)
+				&& !isPrimaryDirection(rawLanes[pair[0]], startDirection)) {
+			// The roads here are within TURN_DEGREE_MIN of each other, so a sharp direction is already
+			// at odds with the geometry. With an incomplete tag (unmarked lanes) the directions can't be
+			// matched to the roads by position either, so accept it only as the main direction of its lane.
+			pair[0] = -1;
+		}
+	}
+
+	private boolean isPrimaryDirection(int lane, int direction) {
+		int primary = TurnType.getPrimaryTurn(lane);
+		return primary == direction || (direction == TurnType.C && primary == TurnType.NONE);
+	}
+
+	private boolean laneHasDirection(int lane, int direction) {
+		if (direction == TurnType.C && TurnType.getPrimaryTurn(lane) == TurnType.NONE) {
+			// an unmarked lane keeps the direction of the road
+			return true;
+		}
+		return TurnType.getPrimaryTurn(lane) == direction || TurnType.getSecondaryTurn(lane) == direction
+				|| TurnType.getTertiaryTurn(lane) == direction;
 	}
 
 	private boolean findActiveIndexByLanes(int[] pair, int[] directions, RoadSplitStructure rs, int[] rawLanes,
@@ -2481,7 +2577,9 @@ public class RouteResultPreparation {
 			if ((ln & 1) > 0) {
 				int[] oneActiveLane = {lanes[k]};
 				if (hasAllowedLanes(oldTurnType.getValue(), oneActiveLane, 0, 0)) {
-					tp = TurnType.getPrimaryTurn(lanes[k]);
+					int primary = TurnType.getPrimaryTurn(lanes[k]);
+					// an unmarked lane carries no direction of its own, keep the calculated one
+					tp = primary == TurnType.NONE ? oldTurnType.getValue() : primary;
 					if (isOldTurnTypeSharp && TurnType.isSharpOrReverse(tp)) {
 						break;
 					}

--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
@@ -2109,8 +2109,6 @@ public class RouteResultPreparation {
 		for (int i = 0; i < oLanes.length; i++) {
 			// Nothing is in the list to compare to, so add the first elements
 			upossibleTurns.clear();
-			// an unmarked lane offers the direction of the road, i.e. the same slot as "through":
-			// it must stay in the count, otherwise "several directions are possible" turns into a turn
 			int primary = TurnType.getPrimaryTurn(oLanes[i]);
 			upossibleTurns.add(primary == TurnType.NONE ? TurnType.C : primary);
 			if (!onlyPrimary && TurnType.getSecondaryTurn(oLanes[i]) != 0) {
@@ -2121,14 +2119,6 @@ public class RouteResultPreparation {
 			}
 			if (!uniqueFromActive) {
 				possibleTurns.addAll(upossibleTurns);
-//				if (!possibleTurns.isEmpty()) {
-//					possibleTurns.retainAll(upossibleTurns);
-//					if(possibleTurns.isEmpty()) {
-//						break;
-//					}
-//				} else {
-//					possibleTurns.addAll(upossibleTurns);
-//				}
 			} else if ((oLanes[i] & 1) == 1) {
 				if (!possibleTurns.isEmpty()) {
 					possibleTurns.retainAll(upossibleTurns);

--- a/OsmAnd-java/src/main/java/net/osmand/router/TurnType.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/TurnType.java
@@ -509,6 +509,31 @@ public class TurnType {
 		return getPrimaryTurn(lane) == NONE || getSecondaryTurn(lane) == NONE || getTertiaryTurn(lane) == NONE;
 	}
 
+	public static boolean hasNoneTurnLane(int[] lanes) {
+		if (lanes != null) {
+			for (int lane : lanes) {
+				if (hasNoneTurnLane(lane)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	public static boolean isPrimaryDirection(int lane, int direction) {
+		int primary = getPrimaryTurn(lane);
+		return primary == direction || (direction == C && primary == NONE);
+	}
+
+	public static boolean laneHasDirection(int lane, int direction) {
+		return isPrimaryDirection(lane, direction) || getSecondaryTurn(lane) == direction
+				|| getTertiaryTurn(lane) == direction;
+	}
+
+	public static boolean isSameTurnSide(int t1, int t2) {
+		return (isLeftTurn(t1) && isLeftTurn(t2)) || (isRightTurn(t1) && isRightTurn(t2));
+	}
+
 	// NONE exists only while turns are calculated: replace it with C before the lanes are
 	// shown in the widget or used for voice prompts
 	public static void convertNoneToStraight(int[] lanes) {

--- a/OsmAnd-java/src/main/java/net/osmand/router/TurnType.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/TurnType.java
@@ -534,8 +534,6 @@ public class TurnType {
 		return (isLeftTurn(t1) && isLeftTurn(t2)) || (isRightTurn(t1) && isRightTurn(t2));
 	}
 
-	// NONE exists only while turns are calculated: replace it with C before the lanes are
-	// shown in the widget or used for voice prompts
 	public static void convertNoneToStraight(int[] lanes) {
 		if (lanes == null) {
 			return;

--- a/OsmAnd-java/src/main/java/net/osmand/router/TurnType.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/TurnType.java
@@ -22,11 +22,7 @@ public class TurnType {
 	public static final int OFFR = 12; // Off route //$NON-NLS-1$
 	public static final int RNDB = 13; // Roundabout
 	public static final int RNLB = 14; // Roundabout left
-	// Lane without a turn marking ("none" or an empty value in turn:lanes). It is not the same as
-	// C ("through"): such a lane declares no direction at all, so it must not be matched to a road
-	// of the junction. NONE exists only while turns are calculated, it is converted to C before it
-	// reaches voice prompts and the lanes widget (see convertNoneToStraight).
-	public static final int NONE = 15;
+	public static final int NONE = 15; // NONE lanes using only during calculating !
 	private static final int[] TURNS_ORDER = {TU, TSHL, TL, TSLL, C, TSLR, TR, TSHR, TRU};
 
 	public static TurnType straight() {
@@ -646,7 +642,7 @@ public class TurnType {
 		} else if (lane.equals("reverse")) {
 			turn = TurnType.TU;
 		} else {
-			// Unknown string (mistagged values such as "straight" are common), assume it keeps the direction
+			// Unknown string
 			turn = TurnType.C;
 //			continue;
 		}

--- a/OsmAnd-java/src/main/java/net/osmand/router/TurnType.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/TurnType.java
@@ -22,6 +22,11 @@ public class TurnType {
 	public static final int OFFR = 12; // Off route //$NON-NLS-1$
 	public static final int RNDB = 13; // Roundabout
 	public static final int RNLB = 14; // Roundabout left
+	// Lane without a turn marking ("none" or an empty value in turn:lanes). It is not the same as
+	// C ("through"): such a lane declares no direction at all, so it must not be matched to a road
+	// of the junction. NONE exists only while turns are calculated, it is converted to C before it
+	// reaches voice prompts and the lanes widget (see convertNoneToStraight).
+	public static final int NONE = 15;
 	private static final int[] TURNS_ORDER = {TU, TSHL, TL, TSLL, C, TSLR, TR, TSHR, TRU};
 
 	public static TurnType straight() {
@@ -70,6 +75,8 @@ public class TurnType {
 			return "RNDB"+exitOut;
 		case RNLB:
 			return "RNLB"+exitOut;
+		case NONE:
+			return "NONE";
 		}
 		return "C";
 	}
@@ -100,6 +107,8 @@ public class TurnType {
 			t = TurnType.valueOf(TRU, leftSide);
 		} else if ("OFFR".equals(s)) {
 			t = TurnType.valueOf(OFFR, leftSide);
+		} else if ("NONE".equals(s)) {
+			t = TurnType.valueOf(NONE, leftSide);
 		} else if (s != null && (s.startsWith("EXIT") ||
 				s.startsWith("RNDB") || s.startsWith("RNLB"))) {
 			try {
@@ -489,11 +498,34 @@ public class TurnType {
 	}
 
 	public static boolean isSlightTurn(int type) {
-		return type == TSLL || type == TSLR || type == C || type == KL || type == KR;
+		return type == TSLL || type == TSLR || type == C || type == KL || type == KR || type == NONE;
 	}
 	
 	public static boolean isKeepDirectionTurn(int type) {
-		return type == C || type == KL || type == KR;
+		return type == C || type == KL || type == KR || type == NONE;
+	}
+
+	public static boolean hasNoneTurnLane(int lane) {
+		return getPrimaryTurn(lane) == NONE || getSecondaryTurn(lane) == NONE || getTertiaryTurn(lane) == NONE;
+	}
+
+	// NONE exists only while turns are calculated: replace it with C before the lanes are
+	// shown in the widget or used for voice prompts
+	public static void convertNoneToStraight(int[] lanes) {
+		if (lanes == null) {
+			return;
+		}
+		for (int i = 0; i < lanes.length; i++) {
+			if (getPrimaryTurn(lanes[i]) == NONE) {
+				setPrimaryTurn(lanes, i, C);
+			}
+			if (getSecondaryTurn(lanes[i]) == NONE) {
+				setSecondaryTurn(lanes, i, C);
+			}
+			if (getTertiaryTurn(lanes[i]) == NONE) {
+				setTertiaryTurn(lanes, i, C);
+			}
+		}
 	}
 
 	public static boolean isSharpOrReverse(int type) {
@@ -522,16 +554,17 @@ public class TurnType {
 	}
 
 	public static void collectTurnTypes(int lane, LinkedHashSet<Integer> set) {
+		// NONE is not collected: an unmarked lane declares no turn
 		int pt = TurnType.getPrimaryTurn(lane);
-		if(pt != 0) {
+		if(pt != 0 && pt != NONE) {
 			set.add(pt);
 		}
 		pt = TurnType.getSecondaryTurn(lane);
-		if(pt != 0) {
+		if(pt != 0 && pt != NONE) {
 			set.add(pt);
 		}		
 		pt = TurnType.getTertiaryTurn(lane);
-		if(pt != 0) {
+		if(pt != 0 && pt != NONE) {
 			set.add(pt);
 		}		
 	}
@@ -571,8 +604,10 @@ public class TurnType {
 			turn = TurnType.C;
 		} else if(lane.equals("merge_to_right")) {
 			turn = TurnType.C;
-		} else if (lane.equals("none") || lane.equals("through")) {
+		} else if (lane.equals("through")) {
 			turn = TurnType.C;
+		} else if (lane.equals("none") || lane.isEmpty()) {
+			turn = TurnType.NONE;
 		} else if (lane.equals("slight_right")) {
 			turn = TurnType.TSLR;
 		} else if (lane.equals("slight_left") ) {
@@ -588,7 +623,7 @@ public class TurnType {
 		} else if (lane.equals("reverse")) {
 			turn = TurnType.TU;
 		} else {
-			// Unknown string
+			// Unknown string (mistagged values such as "straight" are common), assume it keeps the direction
 			turn = TurnType.C;
 //			continue;
 		}

--- a/OsmAnd-java/src/test/java/net/osmand/router/RouteResultPreparationTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/router/RouteResultPreparationTest.java
@@ -95,18 +95,32 @@ public class RouteResultPreparationTest {
             }
         }
         
-        String fileName = "src/test/resources/Turn_lanes_test.obf";
-        File fl = new File(fileName);
-    
+        Map<String, String> params = te.getParams();
+        if (params == null) {
+            params = new HashMap<>();
+        }
+
+        File fl = new File("src/test/resources/Turn_lanes_test.obf");
         RandomAccessFile raf = new RandomAccessFile(fl, "r");
         fe = new RoutePlannerFrontEnd();
         RoutingConfiguration.Builder builder = RoutingConfiguration.getDefault();
         if (useNative) {
             Objects.requireNonNull(nativeLibrary).initMapFile(fl.getAbsolutePath(), true);
         }
-        Map<String, String> params = te.getParams();
-        if (params == null) {
-            params = new HashMap<>();
+        BinaryMapIndexReader[] binaryMapIndexReaders;
+        if (params.containsKey("map")) {
+            // a case that needs its own small map instead of growing the shared one
+            File fl1 = new File("src/test/resources/turn_lanes/" + params.get("map"));
+            RandomAccessFile raf1 = new RandomAccessFile(fl1, "r");
+            binaryMapIndexReaders = new BinaryMapIndexReader[] {
+                    new BinaryMapIndexReader(raf1, fl1),
+                    new BinaryMapIndexReader(raf, fl)
+            };
+            if (useNative) {
+                Objects.requireNonNull(nativeLibrary).initMapFile(fl1.getAbsolutePath(), true);
+            }
+        } else {
+            binaryMapIndexReaders = new BinaryMapIndexReader[] {new BinaryMapIndexReader(raf, fl)};
         }
         params.put("car", "true");
         RoutingMemoryLimits memoryLimit = new RoutingMemoryLimits(
@@ -114,7 +128,6 @@ public class RouteResultPreparationTest {
                 RoutingConfiguration.DEFAULT_NATIVE_MEMORY_LIMIT
         );
         RoutingConfiguration config = builder.build("car", memoryLimit, params);
-        BinaryMapIndexReader[] binaryMapIndexReaders = {new BinaryMapIndexReader(raf, fl)};
         
         if (useNative) {
             ctx = fe.buildRoutingContext(config, nativeLibrary, binaryMapIndexReaders,

--- a/OsmAnd-java/src/test/resources/.gitignore
+++ b/OsmAnd-java/src/test/resources/.gitignore
@@ -2,6 +2,7 @@
 /osm_live/*.json
 /search/*
 /routing/*
+/turn_lanes/*
 *.obf
 *.osm
 phrases.xml


### PR DESCRIPTION
Fixes #21373, #19726, #22964 and the lane highlighting of #23922.

Needs osmandapp/OsmAnd-resources#1450 for the regression tests (94/95/96).

The second commit teaches `RouteResultPreparationTest` the `params.map` parameter that `RouteTestingTest` already has, so a turn-lanes case can bring its own small map in `test-resources/turn_lanes/` instead of being appended to the shared 10 MB `turn_lanes_test.osm`. A case with its own map also needs no coordinate translation into the shared synthetic area, so it uses the real coordinates from the report.

## The bug

`TurnType.convertType()` mapped the `turn:lanes` values `none` and `""` to `TurnType.C`, so an unmarked lane was indistinguishable from a lane explicitly marked `through`. Two consequences follow from that single line:

* `getUniqTurnTypes()` counted the unmarked lane as a **declared direction**, and `findActiveIndexByUniqueDirections()` hands the leftmost `roadsOnLeft` directions to the roads on the left and takes the next one for the route. On `||right` with one road on the left, `C` was given away to that road and `right` was left for us — so OsmAnd announced **"turn right" on a road that goes straight**. On the reported Hindmarsh Drive route (Canberra) that happened at four junctions, two of them unmuted:

  ```
  id=546709128  turn=TR  ang=  0.8  lanes=C|C|+TR      mute=false  turn:lanes=||right
  id=184970438  turn=TR  ang= -0.2  lanes=C|C|C|+TR|+TR mute=false turn:lanes=|||right|right
  ```

* When the tag did not cover every road of the junction the match failed altogether and the tag was **discarded**, the lanes being rebuilt from the junction geometry. On `left|left|||` (Irvine Center Drive, two carriageways converging) that turned an explicit `left` into a geometric `TSLL`:

  ```
  id=402248307  turn=TSLL  lanes=+TSLL|+TSLL,TSLR|TSLR|TSLR|TSLR   (nothing is tagged that way)
  ```

## The change

`TurnType.NONE` is introduced for a lane without a turn marking. It **declares no direction**: it is not matched to a road of the junction (`getUniqTurnTypes`), it never becomes the value of a turn (`getActiveTurnType`), and it is not collected as a declared turn (`collectTurnTypes`). At the same time it **keeps the direction of the road**: it is activated for a straight move (`setAllowedLanes`, `laneHasDirection`), it stays in the "how many directions are possible" count of `inferSlightTurnFromActiveLanes()`, and unmarked lanes next to the matched range are kept in the active range because no road of the junction claimed them.

`NONE` never leaves the turn calculation — it is converted back to `C` in `getTurnInfo()` and in `parseTurnLanes()` (the public entry point the lanes widget uses in free drive), so the widget, the voice prompts and the route serialisation are untouched. There is no UI change in this PR.

When the tag does not declare a direction for every road of the junction, the positional matching is impossible, but the tag itself is still worth something: instead of falling back to fully synthetic lanes, the lanes of the tag are kept and the ones that allow the direction the route takes are activated. If the geometry matches no lane and the tag declares a single direction on the same side, that direction is used — this is what turns the Irvine `TSLL` back into the tagged `TL`.

Unknown values keep mapping to `C`: `turn:lanes=left|left|straight;right` is a common mistag and `straight` has to stay a through lane. (This is the difference from the earlier attempt in #21190, where mapping unknown values to a new type broke test 32.)

## Result

```
#21373 Canberra   4 wrong instructions gone, 2 of them unmuted "turn right" on a straight road
#19726 Perth      unmuted "turn right" at a 0.9° angle on Leach Highway gone
#22964 Irvine     TSLL:+TSLL|+TSLL,TSLR|...  ->  TL:+TL|+TL|C|C|C
#23922 Los Angeles  TL|+TL|C|C  ->  TL|TL|+C|C   (the "left" lane is no longer lit on a straight move)
```

Verified byte-for-byte unchanged on nine further lane-related reports that turned out not to be about unmarked lanes: #21055, #21874, #25360, #21543, #21245, #20302, #24996, #23471, #21764. Their root causes are elsewhere — mostly service roads not being counted in the junction structure (#25360, #21422) and connectivity relations (#20302, #18853).

563 tests green in `:OsmAnd-java:test`, including both the plain and the native variants of `RouteResultPreparationTest` and `RouteTestingTest`. The three new cases fail on master with exactly the symptom of the corresponding issue.

## Note on #21190

The earlier attempt did not fail because of the new type. Reproduced on its own head: the base was 111/111 green, the PR head failed tests 32 and 79.2. Removing only the two new `hasAllowedLanes()` clauses that let a `left`/`right` lane at the edge count as allowed for a straight move makes 79.2 pass again, and additionally reverting `unknown -> NONE` makes 32 pass — 111/111. In that PR `none` and `""` still mapped to `C`, so the idea was never actually exercised.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Fix "C. none == through" (#21373, #22964, #21055, part of #21874): `TurnType.convertType` maps `none` and the empty string to `C`, which is wrong for the AU/US markings `||right` and `left|left||||`; a separate NONE type is needed, an earlier attempt in #21190 hit test 79.2, this is architectural rather than quick.
2. Explain why that earlier attempt got stuck.
3. How many bugs does this fix and how many tests will be added?
4. Do all the issues found have the turn-lanes epic as their parent?
5. Create draft pull requests.

Decided by the agent, not requested explicitly:
- Keeping unknown `turn:lanes` values mapped to `C` instead of the new type, unlike #21190.
- Confining NONE to the turn calculation and converting it back to `C` before it reaches the widget or the voice prompts, so that no UI change is needed.
- Keeping the tag's lanes when the tag is incomplete instead of falling back to synthetic geometry lanes, and the "single declared direction on the same side" rule.
- Sweeping 14 lane-related reports rather than only the four named ones. That sweep caught a regression of the first version on #21422 (it announced "turn left" on a straight road, the same failure mode as test 79.2), which is fixed here: #21422 now behaves exactly as on master.
- Adding the committed regression tests and the map data in osmandapp/OsmAnd-resources#1450.
- Adding `params.map` support to the turn-lanes test and the `/turn_lanes/*` entry in `collectTestResources`, after the shared-map approach was measured against it (18 125 lines and 211 KB added to shared files, versus 129 KB in three isolated maps).
