### PR TITLE
Add bounded pan gesture diagnostics for #25736

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/MapActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/MapActivity.java
@@ -597,6 +597,7 @@ public class MapActivity extends OsmandActionBarActivity implements DownloadEven
 	@Override
 	protected void onResume() {
 		super.onResume();
+		getMapView().getPanDiagnostics().onResume();
 		MapActivity mapViewMapActivity = getMapView().getMapActivity();
 		if (activityRestartNeeded || !getMapLayers().hasMapActivity()
 				|| (mapViewMapActivity != null && mapViewMapActivity != this)) {
@@ -1104,6 +1105,7 @@ public class MapActivity extends OsmandActionBarActivity implements DownloadEven
 	@Override
 	protected void onPause() {
 		super.onPause();
+		getMapView().getPanDiagnostics().onPause();
 		settings.LAST_MAP_ACTIVITY_PAUSED_TIME.set(System.currentTimeMillis());
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && isInMultiWindowMode()) {
 			pendingPause = true;
@@ -1458,6 +1460,14 @@ public class MapActivity extends OsmandActionBarActivity implements DownloadEven
 
 	@Override
 	public boolean dispatchTouchEvent(MotionEvent event) {
+		long startedAt = android.os.SystemClock.uptimeMillis();
+		getMapView().getPanDiagnostics().onActivityTouch(event, lockHelper.isScreenLocked());
+		boolean handled = dispatchMapTouchEvent(event);
+		getMapView().getPanDiagnostics().onActivityTouchFinished(event, startedAt, handled);
+		return handled;
+	}
+
+	private boolean dispatchMapTouchEvent(MotionEvent event) {
 		if (lockHelper.isScreenLocked()) {
 			return lockHelper.getLockGestureDetector(this).onTouchEvent(event);
 		}

--- a/OsmAnd/src/net/osmand/plus/base/MapViewTrackingUtilities.java
+++ b/OsmAnd/src/net/osmand/plus/base/MapViewTrackingUtilities.java
@@ -321,6 +321,7 @@ public class MapViewTrackingUtilities implements OsmAndLocationListener, IMapLoc
 				registerUnregisterSensor(location, smallSpeedForCompass);
 
 				if (!movingToMyLocation) {
+					mapView.getPanDiagnostics().onLocationCameraUpdate();
 					if (mapRenderer != null && !settings.USE_DISCRETE_AUTO_ZOOM.get()) {
 						setMyLocationV2(mapView, mapRenderer, location, predictedLocation, movingTime, rotation);
 					} else {
@@ -530,6 +531,7 @@ public class MapViewTrackingUtilities implements OsmAndLocationListener, IMapLoc
 	}
 
 	private void animateBackToLocation(@NonNull Location location, int zoom, boolean forceZoom) {
+		mapView.getPanDiagnostics().onRecenter();
 		AnimateDraggingMapThread thread = mapView.getAnimatedDraggingThread();
 		int targetZoom;
 		float targetZoomFloatPart;

--- a/OsmAnd/src/net/osmand/plus/views/MapPanDiagnostics.kt
+++ b/OsmAnd/src/net/osmand/plus/views/MapPanDiagnostics.kt
@@ -1,0 +1,223 @@
+package net.osmand.plus.views
+
+import android.os.SystemClock
+import android.view.MotionEvent
+import net.osmand.PlatformUtil
+import net.osmand.core.android.MapRendererView
+import kotlin.math.hypot
+
+/**
+ * Temporary diagnostics for #25736. No event interception, camera writes or location coordinates.
+ * MOVE events only update bounded counters; native camera snapshots are sampled at most every 100 ms.
+ * Keep enabled in this diagnostic branch: the reporter also tests self-built release variants.
+ */
+class MapPanDiagnostics @JvmOverloads constructor(
+	private val log: (String) -> Unit = { LOG.info(it) },
+	private val uptime: () -> Long = { SystemClock.uptimeMillis() }
+) {
+	private var gesture: Gesture? = null
+	private var resumedAt = -1L
+	private var recenteredAt = -1L
+
+	@Synchronized
+	fun onResume() {
+		finish("resume")
+		resumedAt = uptime()
+		log("PAN25736 resume uptimeMs=$resumedAt")
+	}
+
+	@Synchronized
+	fun onPause() {
+		finish("pause")
+		log("PAN25736 pause uptimeMs=${uptime()}")
+	}
+
+	@Synchronized
+	fun onRecenter() {
+		recenteredAt = uptime()
+		log("PAN25736 recenter uptimeMs=$recenteredAt")
+	}
+
+	@Synchronized
+	fun onActivityTouch(event: MotionEvent, screenLocked: Boolean) {
+		val current = getGesture(event)
+		current.activityEvents++
+		current.screenLocked = current.screenLocked || screenLocked
+		when (event.actionMasked) {
+			MotionEvent.ACTION_DOWN -> current.activityDown = true
+			MotionEvent.ACTION_MOVE -> current.activityMoves++
+		}
+		current.maxPointers = maxOf(current.maxPointers, event.pointerCount)
+		current.maxQueueMs = maxOf(current.maxQueueMs, uptime() - event.eventTime)
+		current.travelPx = maxOf(current.travelPx, hypot(event.rawX - current.x, event.rawY - current.y))
+	}
+
+	@Synchronized
+	fun onActivityTouchFinished(event: MotionEvent, startedAt: Long, handled: Boolean) {
+		val current = gesture ?: return
+		if (current.id != event.downTime) return
+		current.maxDispatchMs = maxOf(current.maxDispatchMs, uptime() - startedAt)
+		if (!handled) current.unhandledEvents++
+		if (event.actionMasked == MotionEvent.ACTION_UP || event.actionMasked == MotionEvent.ACTION_CANCEL) {
+			finish(MotionEvent.actionToString(event.actionMasked))
+		}
+	}
+
+	@Synchronized
+	fun onMapTouch(event: MotionEvent, view: OsmandMapTileView) {
+		val current = getGesture(event)
+		current.mapEvents++
+		when (event.actionMasked) {
+			MotionEvent.ACTION_DOWN -> {
+				current.mapDown = true
+				val settings = view.settings
+				val tracking = view.application.mapViewTrackingUtilities
+				log("PAN25736 mapDown id=${current.id} linked=${tracking.isMapLinkedToLocation}"
+						+ " returning=${tracking.isMovingToMyLocation} userInteraction=${view.isUserMapInteractionActive}"
+						+ " removeAnimations=${settings.DO_NOT_USE_ANIMATIONS.get()}"
+						+ " positionAnimation=${settings.ANIMATE_MY_LOCATION.get()} renderer=${view.hasMapRenderer()}"
+						+ " locationSource=${settings.LOCATION_SOURCE.get()} rotateMode=${settings.ROTATE_MAP.get()}")
+			}
+			MotionEvent.ACTION_MOVE -> current.mapMoves++
+			MotionEvent.ACTION_CANCEL -> current.mapCancels++
+		}
+		// getTarget() is the fixed gesture anchor, not the camera center. Sample target31 instead.
+		val renderer = view.mapRenderer ?: return
+		val now = uptime()
+		if (current.cameraSamples == 0 || now - current.sampledAt >= 100
+				|| event.actionMasked == MotionEvent.ACTION_UP || event.actionMasked == MotionEvent.ACTION_CANCEL) {
+			sampleCamera(current, renderer, now)
+		}
+	}
+
+	@Synchronized
+	fun onDetectorInput(event: MotionEvent, present: Boolean, zoom: Boolean, doubleTap: Boolean,
+			tilt: Boolean, rotation: Boolean) {
+		val current = gesture ?: return
+		if (current.id != event.downTime) return
+		if (!present) current.detectorMissing++
+		if (zoom) current.zoomBlocked++
+		if (doubleTap) current.doubleTapBlocked++
+		if (tilt) current.tiltEvents++
+		if (rotation) current.rotationEvents++
+		if (present && !zoom && !doubleTap) {
+			if (event.actionMasked == MotionEvent.ACTION_DOWN) current.detectorDown = true
+			if (event.actionMasked == MotionEvent.ACTION_MOVE) current.detectorMoves++
+		}
+	}
+
+	@Synchronized
+	fun onCallback(event: MotionEvent?, name: String) {
+		val current = gesture ?: return
+		if (event == null || event.downTime != current.id) current.otherDownTimeCallbacks++
+		current.callbacks[name] = (current.callbacks[name] ?: 0) + 1
+	}
+
+	@Synchronized
+	fun onNativePanResult(accepted: Boolean) {
+		val current = gesture ?: return
+		current.nativeCalls++
+		if (accepted) current.nativeAccepted++
+	}
+
+	@Synchronized
+	fun onAnchorResolved(found: Boolean) {
+		val current = gesture ?: return
+		current.anchorLookups++
+		if (!found) current.anchorMisses++
+	}
+
+	@Synchronized
+	fun onLocationCameraUpdate() {
+		val current = gesture ?: return
+		current.locationCameraUpdates++
+		if (current.callbacks["scroll"] == null) current.locationUpdatesBeforeScroll++
+	}
+
+	private fun getGesture(event: MotionEvent): Gesture {
+		gesture?.let { if (it.id == event.downTime) return it }
+		finish("nextDownTime")
+		val now = uptime()
+		return Gesture(event.downTime, event.rawX, event.rawY).also {
+			gesture = it
+			log("PAN25736 begin id=${it.id} afterResumeMs=${if (resumedAt < 0) -1 else now - resumedAt}"
+					+ " afterRecenterMs=${if (recenteredAt < 0) -1 else now - recenteredAt}")
+		}
+	}
+
+	private fun sampleCamera(current: Gesture, renderer: MapRendererView, now: Long) {
+		val target = renderer.state.target31
+		val frame = renderer.frameId
+		if (current.cameraSamples > 0) {
+			if (target.x != current.targetX || target.y != current.targetY) current.cameraChanges++
+			if (frame != current.frame) current.frameAdvances++
+		}
+		current.cameraSamples++
+		current.sampledAt = now
+		current.targetX = target.x
+		current.targetY = target.y
+		current.frame = frame
+	}
+
+	private fun finish(reason: String) {
+		val current = gesture ?: return
+		gesture = null
+		with(current) {
+			log("PAN25736 end id=$id reason=$reason durationMs=${uptime() - id}"
+					+ " activityDown=$activityDown mapDown=$mapDown detectorDown=$detectorDown"
+					+ " activityEvents=$activityEvents mapEvents=$mapEvents"
+					+ " activityMoves=$activityMoves mapMoves=$mapMoves detectorMoves=$detectorMoves"
+					+ " mapCancels=$mapCancels maxPointers=$maxPointers travelPx=${travelPx.toInt()}"
+					+ " maxQueueMs=$maxQueueMs maxDispatchMs=$maxDispatchMs unhandled=$unhandledEvents"
+					+ " screenLocked=$screenLocked detectorMissing=$detectorMissing"
+					+ " zoomBlocked=$zoomBlocked doubleTapBlocked=$doubleTapBlocked"
+					+ " tiltEvents=$tiltEvents rotationEvents=$rotationEvents callbacks=$callbacks"
+					+ " otherDownTimeCallbacks=$otherDownTimeCallbacks nativeCalls=$nativeCalls nativeAccepted=$nativeAccepted"
+					+ " anchorLookups=$anchorLookups anchorMisses=$anchorMisses"
+					+ " cameraSamples=$cameraSamples cameraChanges=$cameraChanges frameAdvances=$frameAdvances"
+					+ " locationCameraUpdates=$locationCameraUpdates locationUpdatesBeforeScroll=$locationUpdatesBeforeScroll")
+		}
+	}
+
+	private class Gesture(val id: Long, val x: Float, val y: Float) {
+		var activityDown = false
+		var mapDown = false
+		var detectorDown = false
+		var activityEvents = 0
+		var mapEvents = 0
+		var activityMoves = 0
+		var mapMoves = 0
+		var detectorMoves = 0
+		var mapCancels = 0
+		var maxPointers = 0
+		var travelPx = 0f
+		var maxQueueMs = 0L
+		var maxDispatchMs = 0L
+		var unhandledEvents = 0
+		var screenLocked = false
+		var detectorMissing = 0
+		var zoomBlocked = 0
+		var doubleTapBlocked = 0
+		var tiltEvents = 0
+		var rotationEvents = 0
+		val callbacks = linkedMapOf<String, Int>()
+		var otherDownTimeCallbacks = 0
+		var nativeCalls = 0
+		var nativeAccepted = 0
+		var anchorLookups = 0
+		var anchorMisses = 0
+		var cameraSamples = 0
+		var cameraChanges = 0
+		var frameAdvances = 0
+		var sampledAt = 0L
+		var targetX = 0
+		var targetY = 0
+		var frame = 0
+		var locationCameraUpdates = 0
+		var locationUpdatesBeforeScroll = 0
+	}
+
+	companion object {
+		private val LOG = PlatformUtil.getLog(MapPanDiagnostics::class.java)
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
+++ b/OsmAnd/src/net/osmand/plus/views/OsmandMapTileView.java
@@ -255,6 +255,12 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 	private float scrollDistanceX;
 	private float scrollDistanceY;
 	private boolean touchActive;
+	private final MapPanDiagnostics panDiagnostics = new MapPanDiagnostics();
+
+	@NonNull
+	public MapPanDiagnostics getPanDiagnostics() {
+		return panDiagnostics;
+	}
 
 	public OsmandMapTileView(@NonNull Context ctx, int width, int height) {
 		this.ctx = ctx;
@@ -2007,6 +2013,7 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 			PointI touchPosition = new PointI((int) touchPointX, (int) touchPointY);
 			PointI touchLocation31 = mapRenderer.getTarget();
 			float height = mapRenderer.getHeightAndLocationFromElevatedPoint(touchPosition, touchLocation31);
+			panDiagnostics.onAnchorResolved(height > NativeUtilities.MIN_ALTITUDE_VALUE);
 			firstTouchLocationX = touchLocation31.getX();
 			firstTouchLocationY = touchLocation31.getY();
 			firstTouchLocationHeight = height > NativeUtilities.MIN_ALTITUDE_VALUE ? height : 0.0f;
@@ -2026,6 +2033,7 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 	}
 
 	public boolean onTouchEvent(MotionEvent event) {
+		panDiagnostics.onMapTouch(event, this);
 		if (mapRenderer != null) {
 			if (event.getAction() == MotionEvent.ACTION_DOWN) {
 				mapRenderer.suspendSymbolsUpdate();
@@ -2049,6 +2057,7 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 			}
 		}
 		if (twoFingersTapDetector != null && twoFingersTapDetector.onTouchEvent(event)) {
+			panDiagnostics.onCallback(event, "twoFingerTap");
 			ContextMenuLayer contextMenuLayer = getLayerByClass(ContextMenuLayer.class);
 			if (contextMenuLayer != null) {
 				contextMenuLayer.onTouchEvent(event, getCurrentRotatedTileBox());
@@ -2120,6 +2129,11 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 				layers.get(i).onTouchEvent(event, getCurrentRotatedTileBox());
 			}
 		}
+		panDiagnostics.onDetectorInput(event, gestureDetector != null && doubleTapScaleDetector != null,
+				doubleTapScaleDetector != null && doubleTapScaleDetector.isInZoomMode(),
+				doubleTapScaleDetector != null && doubleTapScaleDetector.isDoubleTapping(),
+				multiTouchSupport != null && multiTouchSupport.isInTiltMode(),
+				multiTouchSupport != null && multiTouchSupport.isInZoomAndRotationMode());
 		if (doubleTapScaleDetector != null && !doubleTapScaleDetector.isInZoomMode()
 				&& !doubleTapScaleDetector.isDoubleTapping() && gestureDetector != null) {
 			gestureDetector.onTouchEvent(event);
@@ -2611,6 +2625,7 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 	private class MapTileViewOnGestureListener extends SimpleOnGestureListener {
 		@Override
 		public boolean onDown(MotionEvent e) {
+			panDiagnostics.onCallback(e, "down");
 			MapRendererView mapRenderer = getMapRenderer();
 			MapAnimator animator = mapRenderer != null ? mapRenderer.getMapAnimator() : null;
 			if (animator != null) {
@@ -2624,6 +2639,7 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 
 		@Override
 		public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
+			panDiagnostics.onCallback(e1, "fling");
 			if (e1 != null) {
 				animatedDraggingThread.startDragging(velocityX / 3, velocityY / 3,
 						e1.getX() + scrollDistanceX, e1.getY() + scrollDistanceY,
@@ -2634,6 +2650,7 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 
 		@Override
 		public void onLongPress(MotionEvent e) {
+			panDiagnostics.onCallback(e, "longPress");
 			if (multiTouchSupport != null && multiTouchSupport.isInZoomAndRotationMode()
 					|| doubleTapScaleDetector != null && doubleTapScaleDetector.isInZoomMode()
 					|| doubleTapScaleDetector != null && doubleTapScaleDetector.isDoubleTapping()) {
@@ -2661,6 +2678,7 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 
 		@Override
 		public boolean onScroll(MotionEvent e1, @NonNull MotionEvent e2, float distanceX, float distanceY) {
+			panDiagnostics.onCallback(e1, "scroll");
 			if (multiTouchSupport == null || (!multiTouchSupport.isInTiltMode() && !multiTouchSupport.isInZoomAndRotationMode())) {
 				MeasurementToolLayer layer = getMeasurementToolLayer();
 				MapRendererView mapRenderer = getMapRenderer();
@@ -2677,19 +2695,29 @@ public class OsmandMapTileView implements IMapDownloaderCallback {
 					scrollDistanceX = distanceX;
 					scrollDistanceY = distanceY;
 					PointI touchPoint = new PointI((int) (e2.getX() + scrollDistanceX), (int) (e2.getY() + scrollDistanceY));
-					mapRenderer.setMapTarget(touchPoint, new PointI(firstTouchLocationX, firstTouchLocationY));
+					boolean accepted = mapRenderer.setMapTarget(touchPoint,
+							new PointI(firstTouchLocationX, firstTouchLocationY));
+					panDiagnostics.onNativePanResult(accepted);
 					LatLon latLon = NativeUtilities.getLatLonFromElevatedPixel(mapRenderer, currentViewport, targetPixelX, targetPixelY);
 					currentViewport.setLatLonCenter(latLon.getLatitude(), latLon.getLongitude());
 					refreshMap();
 					notifyLocationListeners(getLatitude(), getLongitude());
-				} else
+				} else {
+					panDiagnostics.onCallback(e2, "fallbackPan");
 					dragToAnimate(e2.getX() + distanceX, e2.getY() + distanceY, e2.getX(), e2.getY(), true);
+				}
 			}
 			return true;
 		}
 
 		@Override
 		public void onShowPress(MotionEvent e) {
+		}
+
+		@Override
+		public boolean onDoubleTapEvent(MotionEvent e) {
+			panDiagnostics.onCallback(e, "frameworkDoubleTap");
+			return super.onDoubleTapEvent(e);
 		}
 
 		@Override

--- a/OsmAnd/test/java/net/osmand/plus/views/MapPanDiagnosticsTest.kt
+++ b/OsmAnd/test/java/net/osmand/plus/views/MapPanDiagnosticsTest.kt
@@ -1,0 +1,125 @@
+package net.osmand.plus.views
+
+import android.view.MotionEvent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MapPanDiagnosticsTest {
+	private val lines = mutableListOf<String>()
+	private var now = 1_000L
+	private val diagnostics = MapPanDiagnostics({ lines.add(it) }, { now })
+
+	@Test
+	fun activityOnlyGestureDoesNotClaimMapDelivery() {
+		event(MotionEvent.ACTION_DOWN) { diagnostics.onActivityTouch(it, false) }
+		event(MotionEvent.ACTION_MOVE, time = 1_100, x = 250f) { diagnostics.onActivityTouch(it, false) }
+		event(MotionEvent.ACTION_UP, time = 1_150) {
+			diagnostics.onActivityTouch(it, false)
+			diagnostics.onActivityTouchFinished(it, now, true)
+		}
+		val summary = summary()
+		assertTrue(summary.contains("activityDown=true mapDown=false detectorDown=false"))
+		assertTrue(summary.contains("activityMoves=1 mapMoves=0 detectorMoves=0"))
+		assertTrue(summary.contains("travelPx=150"))
+	}
+
+	@Test
+	fun suppressionAndFrameworkDoubleTapAreReportedSeparately() {
+		event(MotionEvent.ACTION_DOWN) {
+			diagnostics.onActivityTouch(it, false)
+			diagnostics.onDetectorInput(it, true, false, true, false, false)
+		}
+		event(MotionEvent.ACTION_MOVE, time = 1_050) {
+			diagnostics.onDetectorInput(it, true, false, false, false, false)
+			diagnostics.onCallback(it, "frameworkDoubleTap")
+		}
+		diagnostics.onPause()
+		val summary = summary()
+		assertTrue(summary.contains("detectorDown=false"))
+		assertTrue(summary.contains("detectorMoves=1"))
+		assertTrue(summary.contains("zoomBlocked=0 doubleTapBlocked=1"))
+		assertTrue(summary.contains("callbacks={frameworkDoubleTap=1}"))
+	}
+
+	@Test
+	fun nativeFalseIsNotReportedAsAnErrorOrAsCameraMovement() {
+		event(MotionEvent.ACTION_DOWN) { diagnostics.onActivityTouch(it, false) }
+		diagnostics.onNativePanResult(false)
+		diagnostics.onNativePanResult(true)
+		diagnostics.onPause()
+		val summary = summary()
+		assertTrue(summary.contains("nativeCalls=2 nativeAccepted=1"))
+		assertTrue(summary.contains("cameraSamples=0 cameraChanges=0 frameAdvances=0"))
+		assertFalse(summary.contains("error", ignoreCase = true))
+	}
+
+	@Test
+	fun locationUpdatesBeforeAndAfterScrollAreCounted() {
+		event(MotionEvent.ACTION_DOWN) { diagnostics.onActivityTouch(it, false) }
+		diagnostics.onLocationCameraUpdate()
+		event(MotionEvent.ACTION_MOVE, time = 1_050) { diagnostics.onCallback(it, "scroll") }
+		diagnostics.onLocationCameraUpdate()
+		diagnostics.onPause()
+		assertTrue(summary().contains("locationCameraUpdates=2 locationUpdatesBeforeScroll=1"))
+	}
+
+	@Test
+	fun cancellationAndNewDownTimeFinishOnlyTheirOwnGesture() {
+		event(MotionEvent.ACTION_DOWN) { diagnostics.onActivityTouch(it, false) }
+		event(MotionEvent.ACTION_CANCEL, time = 1_050) {
+			diagnostics.onActivityTouch(it, false)
+			diagnostics.onActivityTouchFinished(it, now, true)
+		}
+		event(MotionEvent.ACTION_DOWN, down = 2_000, time = 2_000) { diagnostics.onActivityTouch(it, false) }
+		event(MotionEvent.ACTION_UP, time = 2_010) {
+			// A late callback for the previous stream must not end the new stream.
+			diagnostics.onActivityTouchFinished(it, now, true)
+		}
+		event(MotionEvent.ACTION_DOWN, down = 3_000, time = 3_000) { diagnostics.onActivityTouch(it, false) }
+		diagnostics.onPause()
+		val summaries = lines.filter { it.startsWith("PAN25736 end") }
+		assertEquals(3, summaries.size)
+		assertTrue(summaries[0].contains("id=1000 reason=ACTION_CANCEL"))
+		assertTrue(summaries[1].contains("id=2000 reason=nextDownTime"))
+		assertTrue(summaries[2].contains("id=3000 reason=pause"))
+	}
+
+	@Test
+	fun movesDoNotProducePerEventLogsAndEventsAreNotModified() {
+		event(MotionEvent.ACTION_DOWN) { diagnostics.onActivityTouch(it, false) }
+		val initialLines = lines.size
+		repeat(1_000) { index ->
+			event(MotionEvent.ACTION_MOVE, time = 1_001L + index) {
+				val before = it.toString()
+				diagnostics.onActivityTouch(it, false)
+				diagnostics.onDetectorInput(it, true, false, false, false, false)
+				diagnostics.onCallback(it, "scroll")
+				diagnostics.onNativePanResult(true)
+				diagnostics.onActivityTouchFinished(it, now, true)
+				assertEquals(before, it.toString())
+			}
+		}
+		assertEquals(initialLines, lines.size)
+		diagnostics.onPause()
+		assertTrue(summary().contains("activityMoves=1000"))
+		assertTrue(summary().contains("callbacks={scroll=1000}"))
+	}
+
+	private fun summary() = lines.single { it.startsWith("PAN25736 end") }
+
+	private fun event(action: Int, down: Long = 1_000, time: Long = down, x: Float = 100f,
+			block: (MotionEvent) -> Unit) {
+		now = time
+		val event = MotionEvent.obtain(down, time, action, x, 100f, 0)
+		try {
+			block(event)
+		} finally {
+			event.recycle()
+		}
+	}
+}


### PR DESCRIPTION
## Purpose

Related to #25736. **Diagnostic only; this does not fix or close the issue.**

The reporter confirmed that #25814 did not improve either the occasional frozen pan after returning to My Location or the first pan immediately after foregrounding. That change was reverted, apart from the null `e1` guard. We still need to distinguish missing input, a recognizer suppressing the gesture, a camera update that is not applied, and a renderer that stops advancing frames.

This draft keeps gesture routing, return values, follow-location behavior, camera writes, animation settings and cancellation behavior unchanged.

## Instrumentation

- Correlate Activity input, map input and recognizer callbacks by `MotionEvent.downTime`.
- Record resume/recenter timing, maximum input-queue and Activity-dispatch delay, pointer count and maximum finger travel in pixels.
- Count missing/suppressed detector input, long presses, framework double-tap callbacks, anchor lookup misses, native pan calls and native return values.
- Count location-driven camera-update attempts during the gesture, including attempts before the first scroll callback.
- Sample the requested camera `target31` and renderer frame counter during map input, approximately every 100 ms plus the final input event. Do not use `getTarget()` as the camera-movement oracle: it can return the fixed gesture anchor.
- Flush a bounded summary on UP, CANCEL, pause/resume or a replacement input stream. MOVE events do not write individual log lines. No event objects are retained or modified, and no coordinates, routes or location-provider payloads are logged.

Diagnostics are intentionally enabled in this branch without requiring the Development plugin or a debug build, because the reporter builds their own variants and reported that enabling the plugin may affect reproducibility. Remove the instrumentation after collecting evidence; it is not a permanent telemetry feature.

## Capture and interpretation

Build this branch using the usual local development workflow. No separate APK download is required.

Capture the existing application log and filter lines containing `PAN25736`, or use:

```sh
adb logcat -v threadtime | rg PAN25736
```

Test the two scenarios separately:

1. With a valid Android API location fix, tap My Location, wait 1–5 seconds, and pan. On a failed attempt, keep moving the finger for several seconds before releasing it. Start with Remove animations enabled and Position animation disabled; then repeat with animations enabled.
2. Return from Home using the launcher shortcut and start panning within the first second. Do not insert an idle wait before the gesture.

Retain the `begin`, `mapDown`, and `end` lines for a failed attempt and the next successful attempt. Ordinary taps on map controls can legitimately have `mapDown=false`, so identify the actual failed pan rather than treating every Activity-only stream as a bug.

| Observation in the failed pan | Area to investigate |
| --- | --- |
| Activity receives movement but the map never receives DOWN | View/input dispatch or an overlay owning the stream |
| Map receives movement but the detector is missing/suppressed, or scroll callbacks are absent | Recognizer state, long press, double tap or multitouch |
| Scroll callbacks occur but sampled camera state never changes | Anchor resolution, camera setters and location-follow updates |
| Requested camera state changes but the sampled frame counter does not advance | Renderer/lifecycle path |

`nativeAccepted=0` is **not** an error count: native `setMapTarget()` can return false when nothing needs changing. `cameraChanges` counts changes observed between samples, not every setter call. `frameAdvances` counts samples with a changed frame counter, not rendered-frame totals. Neither counter proves that pixels were presented on the screen. Sampling can miss an intervening change that was subsequently undone. The summary is evidence for choosing the next investigation, not an automatic diagnosis.

## Validation

Environment: macOS arm64, JDK 17.0.17, the repository's Gradle 8.11.1 wrapper, existing Gradle caches, and Pixel 9a AVD / Android 15 (API 35) / arm64. Portrait, 1080 x 2424, light map theme, font scale 1.0, default LTR. Validated head: `8106d0c281fa26341c268f14644644f577fca341`, based on `6150fa10e3d81f39163ba6f1b5caad9148ea1364`.

Commands run with `JAVA_HOME` pointing to JDK 17 and `ANDROID_HOME` pointing to the installed Android SDK:

```sh
./gradlew assembleGplayFreeOpenglArm64Debug :OsmAnd:assembleGplayFreeOpenglArm64DebugAndroidTest --console=plain
./gradlew :OsmAnd:connectedGplayFreeOpenglArm64DebugAndroidTest \
  -Pandroid.testInstrumentationRunnerArguments.class=net.osmand.plus.views.MapPanDiagnosticsTest --console=plain
git diff --check
```

- Debug app and test APK build: successful. The connected task rebuilt the final source changes and passed all **6 tests**, with 0 failures/errors/skips. The build also ran the `OsmAnd-java` tests. Native code was not modified; the configured remote OsmAndCore `master-snapshot` artifacts were used, and the legacy native build reported `ANDROID_NDK is not set`.
- Installed and launched the debug APK on the AVD. A normal 700 ms pan produced 40 scroll callbacks, 40 accepted native calls, 7 sampled camera changes and 7 frame advances. A pan started 2.041 seconds after My Location had `linked=true` at DOWN and produced 41 scroll callbacks and 7 sampled camera changes.
- A subsequent five-second pan produced 258 scroll callbacks with bounded logging and continued camera/frame changes. Screenshots were inspected locally. No runtime crash was observed.
- Smoke tests used the fresh-install defaults: Remove animations off, Position animation on, Google Play Services location source. The reporter's Android API / animations-disabled configuration and a full gesture regression matrix remain untested. These are diagnostic checks, not a fix-verification result.

### Captured foreground-only failure

On this diagnostic build, bringing the Activity forward with `am start`, waiting 200 ms, then injecting a 700 ms swipe captured a failed pan. The relevant observations were:

```text
MapActivity onResume for MapActivity took 697 ms
PAN25736 begin id=26759325 afterResumeMs=711
PAN25736 end id=26759325 ... mapDown=true detectorDown=true
  activityMoves=2 mapMoves=2 detectorMoves=2 maxQueueMs=440 maxDispatchMs=9
  callbacks={down=1, longPress=1} nativeCalls=0 cameraChanges=0 frameAdvances=3
```

The following five-second gesture produced `callbacks={down=1, scroll=258}` and changed the camera. Thus, for this captured attempt, DOWN was delivered, rendering continued, and long-press recognition replaced scrolling. This is consistent with delayed input allowing Android's long-press timeout to expire before a scroll is recognized. It is not evidence of a native pan failure or location updates overwriting that gesture (`nativeCalls=0`, `locationCameraUpdates=0`).

This emulator case opened a context menu, used `am start` rather than the reporter's launcher shortcut, and has not had an uninstrumented A/B run. Do not generalize it to the original intermittent My Location report without a matching trace from the affected device.

The original intermittent My Location bug has not been reproduced or fixed by this PR. Human review and a failed-gesture trace from the affected device are still needed. Logging and periodic read-only native snapshots add some overhead and can affect timing; no claim is made that this diagnostic branch is timing-neutral.

## AI disclaimer

Produced with Codex (GPT-5).

Prompts used (summarised):
1. Analyze #25736 and suggest a fix, taking into account the reported location and animation settings and behavior with animations enabled.
2. Verify #25814, then revisit the analysis and propose next steps after it did not help.
3. Prepare a diagnostic PR instead of distributing an APK, and commit and push a separate branch.

Decided by the agent, not requested explicitly: use bounded per-gesture counters, sample camera state and frame progress separately, avoid logging geographic coordinates, add focused instrumentation tests, and keep the PR diagnostic and draft rather than claiming a fix.
