### PR TITLE
Shared primitive collections and data types for the routing migration (Tier 0)

### DIFF
--- a/OsmAnd-java/src/test/java/net/osmand/shared/util/collections/CollectionsTroveBenchmarkTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/shared/util/collections/CollectionsTroveBenchmarkTest.java
@@ -1,0 +1,364 @@
+package net.osmand.shared.util.collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import gnu.trove.list.array.TIntArrayList;
+import gnu.trove.map.hash.TLongObjectHashMap;
+import gnu.trove.set.hash.TLongHashSet;
+
+/**
+ * Timing comparison of the shared primitive collections against gnu.trove and java.util.BitSet.
+ *
+ * <b>Disabled on purpose.</b> Measuring takes seconds and the timings are noise in a normal test
+ * run, so this class is not part of the suite. It is a tool for when you change a collection, not a
+ * regression gate: correctness against the same originals is covered by {@link TroveComparisonTest},
+ * which does run.
+ *
+ * To measure, remove the {@code @Ignore} below, run it, and put the annotation back:
+ * <pre>
+ * ./gradlew :OsmAnd-java:test --tests "*CollectionsTroveBenchmarkTest" -i
+ * </pre>
+ *
+ * The cross platform half of the same measurement, which is what tells us how Kotlin/Native
+ * compares, is in
+ * OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/collections/CollectionsBenchmarkTest.kt
+ * and is disabled for the same reason.
+ *
+ * Nothing here asserts a timing. The assertions only check that both implementations computed the
+ * same answer, so a slow machine can never turn the build red.
+ */
+@Ignore("benchmark, run manually")
+public class CollectionsTroveBenchmarkTest {
+
+	private static final int ENTRIES = 300_000;
+	private static final int LOOKUPS = 600_000;
+	private static final int LIST_ENTRIES = 3_000_000;
+	private static final int RULE_EVALUATIONS = 300_000;
+	private static final int WARMUP_ROUNDS = 3;
+	private static final int MEASURED_ROUNDS = 5;
+
+	@Test
+	public void benchmarkLongObjectMap() {
+		System.out.println();
+		System.out.printf("### long -> object map, %d entries, %d lookups%n", ENTRIES, LOOKUPS);
+		printHeader();
+
+		for (KeyDistribution distribution : KeyDistribution.values()) {
+			long[] keys = distribution.keys(ENTRIES);
+			long[] probes = probeKeys(keys, LOOKUPS);
+			Object value = new Object();
+			long[] checksums = new long[3];
+
+			double shared = measure(() -> {
+				KTLongObjectMap<Object> map = new KTLongObjectMap<>(ENTRIES);
+				for (long key : keys) {
+					map.put(key, value);
+				}
+				long hits = 0;
+				for (long probe : probes) {
+					if (map.get(probe) != null) {
+						hits++;
+					}
+				}
+				long iterated = 0;
+				for (long key : map.keys()) {
+					iterated += key;
+				}
+				checksums[0] = hits * 31 + iterated;
+			});
+
+			double trove = measure(() -> {
+				TLongObjectHashMap<Object> map = new TLongObjectHashMap<>(ENTRIES);
+				for (long key : keys) {
+					map.put(key, value);
+				}
+				long hits = 0;
+				for (long probe : probes) {
+					if (map.get(probe) != null) {
+						hits++;
+					}
+				}
+				long iterated = 0;
+				for (long key : map.keys()) {
+					iterated += key;
+				}
+				checksums[1] = hits * 31 + iterated;
+			});
+
+			double boxed = measure(() -> {
+				HashMap<Long, Object> map = new HashMap<>(ENTRIES * 2);
+				for (long key : keys) {
+					map.put(key, value);
+				}
+				long hits = 0;
+				for (long probe : probes) {
+					if (map.get(probe) != null) {
+						hits++;
+					}
+				}
+				long iterated = 0;
+				for (long key : map.keySet()) {
+					iterated += key;
+				}
+				checksums[2] = hits * 31 + iterated;
+			});
+
+			assertEquals(checksums[1], checksums[0]);
+			assertEquals(checksums[1], checksums[2]);
+			printRow(distribution.label, "KTLongObjectMap", shared, "TLongObjectHashMap", trove, "HashMap", boxed);
+		}
+	}
+
+	@Test
+	public void benchmarkLongHashSet() {
+		System.out.println();
+		System.out.printf("### long set, %d entries, %d lookups%n", ENTRIES, LOOKUPS);
+		printHeader();
+
+		for (KeyDistribution distribution : KeyDistribution.values()) {
+			long[] keys = distribution.keys(ENTRIES);
+			long[] probes = probeKeys(keys, LOOKUPS);
+			long[] checksums = new long[3];
+
+			double shared = measure(() -> {
+				KTLongHashSet set = new KTLongHashSet(ENTRIES);
+				for (long key : keys) {
+					set.add(key);
+				}
+				long hits = 0;
+				for (long probe : probes) {
+					if (set.contains(probe)) {
+						hits++;
+					}
+				}
+				checksums[0] = hits;
+			});
+
+			double trove = measure(() -> {
+				TLongHashSet set = new TLongHashSet(ENTRIES);
+				for (long key : keys) {
+					set.add(key);
+				}
+				long hits = 0;
+				for (long probe : probes) {
+					if (set.contains(probe)) {
+						hits++;
+					}
+				}
+				checksums[1] = hits;
+			});
+
+			double boxed = measure(() -> {
+				HashSet<Long> set = new HashSet<>(ENTRIES * 2);
+				for (long key : keys) {
+					set.add(key);
+				}
+				long hits = 0;
+				for (long probe : probes) {
+					if (set.contains(probe)) {
+						hits++;
+					}
+				}
+				checksums[2] = hits;
+			});
+
+			assertEquals(checksums[1], checksums[0]);
+			assertEquals(checksums[1], checksums[2]);
+			printRow(distribution.label, "KTLongHashSet", shared, "TLongHashSet", trove, "HashSet", boxed);
+		}
+	}
+
+	@Test
+	public void benchmarkIntArrayList() {
+		System.out.println();
+		System.out.printf("### int list, %d appends plus a full scan%n", LIST_ENTRIES);
+		printHeader();
+		long[] checksums = new long[3];
+
+		double shared = measure(() -> {
+			KTIntArrayList list = new KTIntArrayList();
+			for (int i = 0; i < LIST_ENTRIES; i++) {
+				list.add(i);
+			}
+			long sum = 0;
+			for (int i = 0; i < list.getSize(); i++) {
+				sum += list.getQuick(i);
+			}
+			checksums[0] = sum;
+		});
+
+		double trove = measure(() -> {
+			TIntArrayList list = new TIntArrayList();
+			for (int i = 0; i < LIST_ENTRIES; i++) {
+				list.add(i);
+			}
+			long sum = 0;
+			for (int i = 0; i < list.size(); i++) {
+				sum += list.getQuick(i);
+			}
+			checksums[1] = sum;
+		});
+
+		double boxed = measure(() -> {
+			List<Integer> list = new ArrayList<>();
+			for (int i = 0; i < LIST_ENTRIES; i++) {
+				list.add(i);
+			}
+			long sum = 0;
+			for (int i = 0; i < list.size(); i++) {
+				sum += list.get(i);
+			}
+			checksums[2] = sum;
+		});
+
+		assertEquals(checksums[1], checksums[0]);
+		assertEquals(checksums[1], checksums[2]);
+		printRow("sequential", "KTIntArrayList", shared, "TIntArrayList", trove, "ArrayList", boxed);
+	}
+
+	@Test
+	public void benchmarkBitSet() {
+		// shaped like GeneralRouter rule evaluation: build a tag mask, intersect it with a road's
+		// types, read the first matching bit
+		System.out.println();
+		System.out.printf("### bit mask evaluation, %d GeneralRouter style rule evaluations%n", RULE_EVALUATIONS);
+		printHeader();
+
+		int universe = 512;
+		Random random = new Random(20260907L);
+		KBitSet[] masks = new KBitSet[64];
+		BitSet[] referenceMasks = new BitSet[64];
+		for (int i = 0; i < masks.length; i++) {
+			masks[i] = new KBitSet(universe);
+			referenceMasks[i] = new BitSet(universe);
+			for (int k = 0; k < 8; k++) {
+				int bit = random.nextInt(universe);
+				masks[i].set(bit);
+				referenceMasks[i].set(bit);
+			}
+		}
+		KBitSet roadTypes = new KBitSet(universe);
+		BitSet referenceRoadTypes = new BitSet(universe);
+		for (int k = 0; k < 24; k++) {
+			int bit = random.nextInt(universe);
+			roadTypes.set(bit);
+			referenceRoadTypes.set(bit);
+		}
+		long[] checksums = new long[2];
+
+		double shared = measure(() -> {
+			long checksum = 0;
+			KBitSet scratch = new KBitSet(universe);
+			for (int i = 0; i < RULE_EVALUATIONS; i++) {
+				KBitSet mask = masks[i & 63];
+				if (mask.intersects(roadTypes)) {
+					scratch.clear();
+					scratch.or(mask);
+					scratch.and(roadTypes);
+					checksum += scratch.nextSetBit(0);
+				}
+			}
+			checksums[0] = checksum;
+		});
+
+		double reference = measure(() -> {
+			long checksum = 0;
+			for (int i = 0; i < RULE_EVALUATIONS; i++) {
+				BitSet mask = referenceMasks[i & 63];
+				if (mask.intersects(referenceRoadTypes)) {
+					BitSet findBit = new BitSet(mask.length());
+					findBit.or(mask);
+					findBit.and(referenceRoadTypes);
+					checksum += findBit.nextSetBit(0);
+				}
+			}
+			checksums[1] = checksum;
+		});
+
+		assertEquals(checksums[1], checksums[0]);
+		assertTrue(checksums[0] != 0);
+		printRow("GeneralRouter shape", "KBitSet", shared, "java.util.BitSet", reference, "-", Double.NaN);
+	}
+
+	// ------------------------------------------------------------------ harness
+
+	private enum KeyDistribution {
+
+		/** roadId << 6 | segment, exactly what routing uses as a map key. */
+		ROUTING("routing ids"),
+
+		/** Uniformly spread keys, the friendly case for any hash function. */
+		RANDOM("random     ");
+
+		final String label;
+
+		KeyDistribution(String label) {
+			this.label = label;
+		}
+
+		long[] keys(int count) {
+			long[] keys = new long[count];
+			Random random = new Random(20260907L);
+			for (int i = 0; i < count; i++) {
+				keys[i] = this == ROUTING
+						? ((100_000_000L + i * 17L) << 6) | (i % 48)
+						: random.nextLong();
+			}
+			return keys;
+		}
+	}
+
+	/** Half of the probes hit an existing key, half miss. */
+	private static long[] probeKeys(long[] keys, int count) {
+		long[] probes = new long[count];
+		Random random = new Random(1234L);
+		for (int i = 0; i < count; i++) {
+			probes[i] = (i & 1) == 0
+					? keys[random.nextInt(keys.length)]
+					: random.nextLong() | (1L << 62);
+		}
+		return probes;
+	}
+
+	private static double measure(Runnable block) {
+		for (int i = 0; i < WARMUP_ROUNDS; i++) {
+			block.run();
+		}
+		double best = Double.MAX_VALUE;
+		for (int i = 0; i < MEASURED_ROUNDS; i++) {
+			long start = System.nanoTime();
+			block.run();
+			double elapsed = (System.nanoTime() - start) / 1_000_000.0;
+			if (elapsed < best) {
+				best = elapsed;
+			}
+		}
+		return best;
+	}
+
+	private static void printHeader() {
+		System.out.printf("    best of %d rounds after %d warmup rounds%n", MEASURED_ROUNDS, WARMUP_ROUNDS);
+	}
+
+	private static void printRow(String label, String sharedName, double shared,
+			String refName, double ref, String boxedName, double boxed) {
+		StringBuilder line = new StringBuilder();
+		line.append(String.format("  %-22s %-20s %8.2f ms", label, sharedName, shared));
+		line.append(String.format("   vs %-20s %8.2f ms (%.2fx)", refName, ref, ref / shared));
+		if (!Double.isNaN(boxed)) {
+			line.append(String.format("   vs %-10s %8.2f ms (%.2fx)", boxedName, boxed, boxed / shared));
+		}
+		System.out.println(line);
+	}
+}

--- a/OsmAnd-java/src/test/java/net/osmand/shared/util/collections/TroveComparisonTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/shared/util/collections/TroveComparisonTest.java
@@ -1,0 +1,189 @@
+package net.osmand.shared.util.collections;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Random;
+
+import org.junit.Test;
+
+import gnu.trove.list.array.TIntArrayList;
+import gnu.trove.map.hash.TLongObjectHashMap;
+import gnu.trove.set.hash.TLongHashSet;
+
+/**
+ * Differential tests of the shared primitive collections against the originals they replace:
+ * gnu.trove for the maps, sets and lists, java.util.BitSet for {@link KBitSet}.
+ *
+ * These live in OsmAnd-java because that is the only module where trove and OsmAnd-shared are both
+ * on the classpath. They are cheap and run as part of the normal suite; the timing comparison is a
+ * separate, disabled class, see {@link CollectionsTroveBenchmarkTest}.
+ *
+ * Every test drives both implementations through the same pseudo random operation stream and
+ * asserts they stay in step, which is what makes a drop in replacement safe to swap in.
+ */
+public class TroveComparisonTest {
+
+	private static final int OPERATIONS = 200_000;
+
+	@Test
+	public void testLongObjectMapMatchesTrove() {
+		KTLongObjectMap<Integer> shared = new KTLongObjectMap<>();
+		TLongObjectHashMap<Integer> trove = new TLongObjectHashMap<>();
+		Random random = new Random(20260907L);
+
+		for (int step = 0; step < OPERATIONS; step++) {
+			long key = random.nextInt(4000) - 2000;
+			int op = random.nextInt(10);
+			if (op <= 5) {
+				assertEquals("put(" + key + ")", trove.put(key, step), shared.put(key, step));
+			} else if (op <= 7) {
+				assertEquals("remove(" + key + ")", trove.remove(key), shared.remove(key));
+			} else if (op == 8) {
+				assertEquals("get(" + key + ")", trove.get(key), shared.get(key));
+			} else {
+				assertEquals("containsKey(" + key + ")", trove.containsKey(key), shared.containsKey(key));
+			}
+			assertEquals(trove.size(), shared.getSize());
+		}
+
+		long[] troveKeys = trove.keys();
+		long[] sharedKeys = shared.keys();
+		Arrays.sort(troveKeys);
+		Arrays.sort(sharedKeys);
+		assertArrayEquals(troveKeys, sharedKeys);
+		for (long key : troveKeys) {
+			assertEquals(trove.get(key), shared.get(key));
+		}
+	}
+
+	@Test
+	public void testLongHashSetMatchesTrove() {
+		KTLongHashSet shared = new KTLongHashSet();
+		TLongHashSet trove = new TLongHashSet();
+		Random random = new Random(4242L);
+
+		for (int step = 0; step < OPERATIONS; step++) {
+			long key = random.nextInt(3000) - 1500;
+			int op = random.nextInt(10);
+			if (op <= 5) {
+				assertEquals("add(" + key + ")", trove.add(key), shared.add(key));
+			} else if (op <= 7) {
+				assertEquals("remove(" + key + ")", trove.remove(key), shared.remove(key));
+			} else {
+				assertEquals("contains(" + key + ")", trove.contains(key), shared.contains(key));
+			}
+			assertEquals(trove.size(), shared.getSize());
+		}
+
+		long[] troveKeys = trove.toArray();
+		long[] sharedKeys = shared.toArray();
+		Arrays.sort(troveKeys);
+		Arrays.sort(sharedKeys);
+		assertArrayEquals(troveKeys, sharedKeys);
+	}
+
+	@Test
+	public void testIntArrayListMatchesTrove() {
+		KTIntArrayList shared = new KTIntArrayList();
+		TIntArrayList trove = new TIntArrayList();
+		Random random = new Random(777L);
+
+		for (int step = 0; step < OPERATIONS; step++) {
+			int op = random.nextInt(10);
+			if (op <= 6) {
+				shared.add(step);
+				trove.add(step);
+			} else if (op == 7 && !trove.isEmpty()) {
+				int index = random.nextInt(trove.size());
+				assertEquals(trove.removeAt(index), shared.removeAt(index));
+			} else if (op == 8 && !trove.isEmpty()) {
+				int index = random.nextInt(trove.size());
+				trove.set(index, step);
+				shared.set(index, step);
+			} else if (!trove.isEmpty()) {
+				int index = random.nextInt(trove.size());
+				assertEquals(trove.get(index), shared.get(index));
+			}
+			assertEquals(trove.size(), shared.getSize());
+		}
+		assertArrayEquals(trove.toArray(), shared.toArray());
+	}
+
+	@Test
+	public void testBitSetMatchesJavaBitSet() {
+		KBitSet shared = new KBitSet(1);
+		BitSet reference = new BitSet();
+		Random random = new Random(31337L);
+
+		for (int step = 0; step < OPERATIONS; step++) {
+			int index = random.nextInt(4000);
+			int op = random.nextInt(8);
+			if (op <= 4) {
+				shared.set(index);
+				reference.set(index);
+			} else if (op <= 6) {
+				shared.clear(index);
+				reference.clear(index);
+			} else {
+				assertEquals("get(" + index + ")", reference.get(index), shared.get(index));
+			}
+		}
+
+		assertEquals(reference.cardinality(), shared.cardinality());
+		assertEquals(reference.length(), shared.length());
+		assertEquals(reference.isEmpty(), shared.isEmpty());
+		for (int bit = reference.nextSetBit(0), mirrored = shared.nextSetBit(0);
+				bit >= 0;
+				bit = reference.nextSetBit(bit + 1), mirrored = shared.nextSetBit(mirrored + 1)) {
+			assertEquals(bit, mirrored);
+		}
+
+		// binary operations and the capacity independent equality that GeneralRouter relies on
+		KBitSet sharedOther = new KBitSet(1);
+		BitSet referenceOther = new BitSet();
+		for (int i = 0; i < 2000; i++) {
+			int index = random.nextInt(4000);
+			sharedOther.set(index);
+			referenceOther.set(index);
+		}
+		assertEquals(referenceOther.intersects(reference), sharedOther.intersects(shared));
+
+		KBitSet sharedAnd = shared.copy();
+		sharedAnd.and(sharedOther);
+		BitSet referenceAnd = (BitSet) reference.clone();
+		referenceAnd.and(referenceOther);
+		assertArrayEquals(referenceAnd.stream().toArray(), sharedAnd.toIntArray());
+
+		KBitSet sharedOr = shared.copy();
+		sharedOr.or(sharedOther);
+		BitSet referenceOr = (BitSet) reference.clone();
+		referenceOr.or(referenceOther);
+		assertArrayEquals(referenceOr.stream().toArray(), sharedOr.toIntArray());
+
+		KBitSet wide = new KBitSet(4096);
+		KBitSet narrow = new KBitSet(1);
+		wide.set(7);
+		narrow.set(7);
+		assertEquals(wide, narrow);
+		assertEquals(wide.hashCode(), narrow.hashCode());
+		BitSet referenceWide = new BitSet(4096);
+		BitSet referenceNarrow = new BitSet(1);
+		referenceWide.set(7);
+		referenceNarrow.set(7);
+		assertEquals(referenceWide.hashCode(), wide.hashCode());
+		assertEquals(referenceNarrow.hashCode(), narrow.hashCode());
+	}
+
+	@Test
+	public void testConstructorsAreUsableFromJava() {
+		// @JvmOverloads must keep the no-arg form available for the Java routing code
+		assertEquals(0, new KTLongObjectMap<String>().getSize());
+		assertEquals(0, new KTLongHashSet().getSize());
+		assertEquals(0, new KTIntArrayList().getSize());
+		assertFalse(new KBitSet().get(0));
+	}
+}

--- a/OsmAnd-shared/build.gradle.kts
+++ b/OsmAnd-shared/build.gradle.kts
@@ -40,6 +40,11 @@ kotlin {
 		}
 	}
 
+	// the default test binary is a debug build with LLVM optimisations off, which makes any
+	// Kotlin/Native performance number meaningless; this adds an optimised test binary,
+	// run with :OsmAnd-shared:iosSimulatorArm64ReleaseTest
+	iosSimulatorArm64().binaries.test(listOf(org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.RELEASE))
+
 	val sqliteVersion = "2.3.1"
 	val serializationVersion = "1.6.3"
 	val coroutinesCoreVersion = "1.8.1"

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/data/KDataTileManager.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/data/KDataTileManager.kt
@@ -1,0 +1,178 @@
+package net.osmand.shared.data
+
+import kotlin.jvm.JvmOverloads
+
+import net.osmand.shared.util.KMapUtils
+import net.osmand.shared.util.collections.KTLongObjectMap
+import kotlin.math.ceil
+import kotlin.math.sqrt
+
+/**
+ * Spatial index bucketing objects into map tiles of a fixed [zoom], port of
+ * `net.osmand.data.DataTileManager`.
+ *
+ * Backed by [KTLongObjectMap], so tile keys are never boxed.
+ */
+class KDataTileManager<T> @JvmOverloads constructor(val zoom: Int = DEFAULT_ZOOM) {
+
+	private val objects = KTLongObjectMap<MutableList<T>>()
+
+	fun isEmpty(): Boolean = getObjectsCount() == 0
+
+	fun getObjectsCount(): Int {
+		var count = 0
+		objects.forEachValue { list -> count += list.size }
+		return count
+	}
+
+	fun getTilesCount(): Int = objects.size
+
+	fun getAllObjects(): List<T> {
+		val result = ArrayList<T>(getObjectsCount())
+		objects.forEachValue { list -> result.addAll(list) }
+		return result
+	}
+
+	/** Per tile lists, exposed for callers that want to walk tiles rather than objects. */
+	fun getAllEditObjects(): List<MutableList<T>> = objects.values()
+
+	fun getObjects(
+		latitudeUp: Double,
+		longitudeUp: Double,
+		latitudeDown: Double,
+		longitudeDown: Double
+	): MutableList<T> {
+		var tileXUp = KMapUtils.getTileNumberX(zoom.toDouble(), longitudeUp).toInt()
+		var tileYUp = KMapUtils.getTileNumberY(zoom.toDouble(), latitudeUp).toInt()
+		var tileXDown = KMapUtils.getTileNumberX(zoom.toDouble(), longitudeDown).toInt() + 1
+		var tileYDown = KMapUtils.getTileNumberY(zoom.toDouble(), latitudeDown).toInt() + 1
+		val result = ArrayList<T>()
+		if (tileXUp > tileXDown) {
+			tileXDown = tileXUp
+			tileXUp = 0
+		}
+		if (tileYUp > tileYDown) {
+			// the Java original resets tileXUp here, which looks like a typo for tileYUp
+			tileYDown = tileYUp
+			tileYUp = 0
+		}
+		for (x in tileXUp..tileXDown) {
+			for (y in tileYUp..tileYDown) {
+				putObjects(evTile(x, y), result)
+			}
+		}
+		return result
+	}
+
+	fun getObjects(leftX31: Int, topY31: Int, rightX31: Int, bottomY31: Int): MutableList<T> =
+		getObjects(leftX31, topY31, rightX31, bottomY31, ArrayList())
+
+	fun getObjects(
+		leftX31: Int,
+		topY31: Int,
+		rightX31: Int,
+		bottomY31: Int,
+		result: MutableList<T>
+	): MutableList<T> {
+		val shift = 31 - zoom
+		val tileXUp = leftX31 shr shift
+		val tileYUp = topY31 shr shift
+		val tileXDown = (rightX31 shr shift) + 1
+		val tileYDown = (bottomY31 shr shift) + 1
+		for (x in tileXUp..tileXDown) {
+			for (y in tileYUp..tileYDown) {
+				putObjects(evTile(x, y), result)
+			}
+		}
+		return result
+	}
+
+	/** Objects of every tile whose center falls within [radius] meters, unsorted. */
+	fun getClosestObjects(latitude: Double, longitude: Double, radius: Double): MutableList<T> {
+		if (isEmpty()) {
+			return ArrayList()
+		}
+		val tileDist = radius / KMapUtils.getTileDistanceWidth(latitude, zoom.toDouble())
+		val tileDistInt = ceil(tileDist).toInt()
+		val px = KMapUtils.getTileNumberX(zoom.toDouble(), longitude)
+		val py = KMapUtils.getTileNumberY(zoom.toDouble(), latitude)
+		val stTileX = px.toInt()
+		val stTileY = py.toInt()
+		val result = ArrayList<T>()
+		for (xTile in -tileDistInt..tileDistInt) {
+			for (yTile in -tileDistInt..tileDistInt) {
+				val dx = xTile + 0.5 - (px - stTileX)
+				val dy = yTile + 0.5 - (py - stTileY)
+				if (sqrt(dx * dx + dy * dy) <= tileDist) {
+					putObjects(evTile(stTileX + xTile, stTileY + yTile), result)
+				}
+			}
+		}
+		return result
+	}
+
+	fun evaluateTile(latitude: Double, longitude: Double): Long {
+		val tileX = KMapUtils.getTileNumberX(zoom.toDouble(), longitude).toInt()
+		val tileY = KMapUtils.getTileNumberY(zoom.toDouble(), latitude).toInt()
+		return evTile(tileX, tileY)
+	}
+
+	fun evaluateTileXY(x31: Int, y31: Int): Long = evTile(x31 shr (31 - zoom), y31 shr (31 - zoom))
+
+	fun registerObject(latitude: Double, longitude: Double, obj: T): Long =
+		addObject(obj, evaluateTile(latitude, longitude))
+
+	fun registerObjectXY(x31: Int, y31: Int, obj: T): Long =
+		addObject(obj, evTile(x31 shr (31 - zoom), y31 shr (31 - zoom)))
+
+	fun unregisterObject(latitude: Double, longitude: Double, obj: T) {
+		removeObject(obj, evaluateTile(latitude, longitude))
+	}
+
+	fun unregisterObjectXY(x31: Int, y31: Int, obj: T) {
+		removeObject(obj, evaluateTileXY(x31, y31))
+	}
+
+	fun clear() {
+		objects.clear()
+	}
+
+	/** Tile occupancy summary, useful when tuning [zoom]. */
+	fun statsDistribution(name: String): String {
+		var min = -1
+		var max = -1
+		var total = 0
+		objects.forEachValue { list ->
+			if (min == -1) {
+				min = list.size
+				max = list.size
+			} else {
+				min = minOf(min, list.size)
+				max = maxOf(max, list.size)
+			}
+			total += list.size
+		}
+		val tiles = objects.size
+		val avg = total / (tiles + 0.1)
+		return "$name tiles stores $total in $tiles tiles. Tile size min $min, max $max, avg $avg."
+	}
+
+	private fun putObjects(tile: Long, result: MutableList<T>) {
+		objects[tile]?.let { result.addAll(it) }
+	}
+
+	private fun addObject(obj: T, tile: Long): Long {
+		objects.getOrPut(tile) { ArrayList() }.add(obj)
+		return tile
+	}
+
+	private fun removeObject(obj: T, tile: Long) {
+		objects[tile]?.remove(obj)
+	}
+
+	private fun evTile(tileX: Int, tileY: Int): Long = (tileX.toLong() shl zoom) + tileY
+
+	companion object {
+		const val DEFAULT_ZOOM = 15
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/data/KLocation.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/data/KLocation.kt
@@ -1,0 +1,318 @@
+package net.osmand.shared.data
+
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.atan
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+import kotlin.math.tan
+
+/**
+ * A geographic fix: position at a point in time, optionally with altitude, speed, bearing and
+ * accuracy. Port of `net.osmand.Location`, which in turn descends from the AOSP `Location` class.
+ *
+ * Optional values keep the Java shape of a primitive plus a `hasX` flag rather than a nullable
+ * primitive, because a route holds thousands of fixes and `Float?` would box every one of them.
+ * Setting a value raises its flag, `removeX()` clears both.
+ *
+ * [distanceTo] and [bearingTo] share one Vincenty solution through an immutable cache snapshot, so
+ * calling both for the same pair costs a single computation without needing a lock.
+ */
+class KLocation {
+
+	var provider: String? = null
+
+	var time: Long = 0
+
+	var latitude: Double = 0.0
+
+	var longitude: Double = 0.0
+
+	var hasAltitude: Boolean = false
+		private set
+
+	var altitude: Double = 0.0
+		set(value) {
+			field = value
+			hasAltitude = true
+		}
+
+	var hasSpeed: Boolean = false
+		private set
+
+	var speed: Float = 0f
+		set(value) {
+			field = value
+			hasSpeed = true
+		}
+
+	var hasBearing: Boolean = false
+		private set
+
+	var bearing: Float = 0f
+		set(value) {
+			field = value
+			hasBearing = true
+		}
+
+	var hasAccuracy: Boolean = false
+		private set
+
+	var accuracy: Float = 0f
+		set(value) {
+			field = value
+			hasAccuracy = true
+		}
+
+	var hasVerticalAccuracy: Boolean = false
+		private set
+
+	var verticalAccuracy: Float = 0f
+		set(value) {
+			field = value
+			hasVerticalAccuracy = true
+		}
+
+	private var cache: DistanceBearing? = null
+
+	constructor(provider: String?) {
+		this.provider = provider
+	}
+
+	constructor(provider: String?, latitude: Double, longitude: Double) {
+		this.provider = provider
+		this.latitude = latitude
+		this.longitude = longitude
+	}
+
+	constructor(other: KLocation) {
+		set(other)
+	}
+
+	/** Copies every field of [other] into this fix. */
+	fun set(other: KLocation) {
+		provider = other.provider
+		time = other.time
+		latitude = other.latitude
+		longitude = other.longitude
+		altitude = other.altitude
+		hasAltitude = other.hasAltitude
+		speed = other.speed
+		hasSpeed = other.hasSpeed
+		bearing = other.bearing
+		hasBearing = other.hasBearing
+		accuracy = other.accuracy
+		hasAccuracy = other.hasAccuracy
+		verticalAccuracy = other.verticalAccuracy
+		hasVerticalAccuracy = other.hasVerticalAccuracy
+		cache = null
+	}
+
+	fun reset() {
+		provider = null
+		time = 0
+		latitude = 0.0
+		longitude = 0.0
+		removeAltitude()
+		removeSpeed()
+		removeBearing()
+		removeAccuracy()
+		removeVerticalAccuracy()
+		cache = null
+	}
+
+	fun removeAltitude() {
+		altitude = 0.0
+		hasAltitude = false
+	}
+
+	fun removeSpeed() {
+		speed = 0f
+		hasSpeed = false
+	}
+
+	fun removeBearing() {
+		bearing = 0f
+		hasBearing = false
+	}
+
+	fun removeAccuracy() {
+		accuracy = 0f
+		hasAccuracy = false
+	}
+
+	fun removeVerticalAccuracy() {
+		verticalAccuracy = 0f
+		hasVerticalAccuracy = false
+	}
+
+	/** Distance in meters to [dest] along the WGS84 ellipsoid. */
+	fun distanceTo(dest: KLocation): Float = solve(dest).distance
+
+	/** Initial bearing in degrees east of true north on the shortest path to [dest]. */
+	fun bearingTo(dest: KLocation): Float = solve(dest).initialBearing
+
+	fun toKLatLon(): KLatLon = KLatLon(latitude, longitude)
+
+	private fun solve(dest: KLocation): DistanceBearing {
+		val cached = cache
+		if (cached != null &&
+			cached.lat1 == latitude && cached.lon1 == longitude &&
+			cached.lat2 == dest.latitude && cached.lon2 == dest.longitude
+		) {
+			return cached
+		}
+		val results = FloatArray(2)
+		computeDistanceAndBearing(latitude, longitude, dest.latitude, dest.longitude, results)
+		val computed = DistanceBearing(
+			latitude, longitude, dest.latitude, dest.longitude, results[0], results[1]
+		)
+		// a whole immutable snapshot is published at once, so a racing reader never mixes
+		// coordinates of one pair with the distance of another
+		cache = computed
+		return computed
+	}
+
+	override fun toString(): String =
+		"Location[provider=$provider,time=$time,latitude=$latitude,longitude=$longitude," +
+				"hasAltitude=$hasAltitude,altitude=$altitude,hasSpeed=$hasSpeed,speed=$speed," +
+				"hasBearing=$hasBearing,bearing=$bearing,hasAccuracy=$hasAccuracy,accuracy=$accuracy," +
+				"hasVerticalAccuracy=$hasVerticalAccuracy,verticalAccuracy=$verticalAccuracy]"
+
+	private class DistanceBearing(
+		val lat1: Double,
+		val lon1: Double,
+		val lat2: Double,
+		val lon2: Double,
+		val distance: Float,
+		val initialBearing: Float
+	)
+
+	companion object {
+
+		private const val MAX_ITERATIONS = 20
+
+		/** WGS84 major axis, meters. */
+		private const val WGS84_A = 6378137.0
+
+		/** WGS84 semi-major axis, meters. */
+		private const val WGS84_B = 6356752.3142
+
+		/**
+		 * Distance and, when [results] is long enough, initial and final bearing between two points.
+		 *
+		 * `results[0]` is the distance in meters, `results[1]` the initial bearing in degrees and
+		 * `results[2]` the final bearing in degrees.
+		 */
+		fun distanceBetween(
+			startLatitude: Double,
+			startLongitude: Double,
+			endLatitude: Double,
+			endLongitude: Double,
+			results: FloatArray
+		) {
+			require(results.isNotEmpty()) { "results must hold at least one value" }
+			computeDistanceAndBearing(startLatitude, startLongitude, endLatitude, endLongitude, results)
+		}
+
+		/**
+		 * Vincenty inverse solution on the WGS84 ellipsoid,
+		 * see http://www.ngs.noaa.gov/PUBS_LIB/inverse.pdf section 4.
+		 */
+		private fun computeDistanceAndBearing(
+			latitude1: Double,
+			longitude1: Double,
+			latitude2: Double,
+			longitude2: Double,
+			results: FloatArray
+		) {
+			val lat1 = latitude1 * PI / 180.0
+			val lat2 = latitude2 * PI / 180.0
+			val lon1 = longitude1 * PI / 180.0
+			val lon2 = longitude2 * PI / 180.0
+
+			val a = WGS84_A
+			val b = WGS84_B
+			val f = (a - b) / a
+			val aSqMinusBSqOverBSq = (a * a - b * b) / (b * b)
+
+			val bigL = lon2 - lon1
+			var bigA = 0.0
+			val u1 = atan((1.0 - f) * tan(lat1))
+			val u2 = atan((1.0 - f) * tan(lat2))
+
+			val cosU1 = cos(u1)
+			val cosU2 = cos(u2)
+			val sinU1 = sin(u1)
+			val sinU2 = sin(u2)
+			val cosU1cosU2 = cosU1 * cosU2
+			val sinU1sinU2 = sinU1 * sinU2
+
+			var sigma = 0.0
+			var deltaSigma = 0.0
+			var cosSqAlpha = 0.0
+			var cos2SM = 0.0
+			var cosSigma = 0.0
+			var sinSigma = 0.0
+			var cosLambda = 0.0
+			var sinLambda = 0.0
+
+			var lambda = bigL
+			for (iteration in 0 until MAX_ITERATIONS) {
+				val lambdaOrig = lambda
+				cosLambda = cos(lambda)
+				sinLambda = sin(lambda)
+				val t1 = cosU2 * sinLambda
+				val t2 = cosU1 * sinU2 - sinU1 * cosU2 * cosLambda
+				val sinSqSigma = t1 * t1 + t2 * t2
+				sinSigma = sqrt(sinSqSigma)
+				cosSigma = sinU1sinU2 + cosU1cosU2 * cosLambda
+				sigma = atan2(sinSigma, cosSigma)
+				val sinAlpha = if (sinSigma == 0.0) 0.0 else cosU1cosU2 * sinLambda / sinSigma
+				cosSqAlpha = 1.0 - sinAlpha * sinAlpha
+				cos2SM = if (cosSqAlpha == 0.0) 0.0 else cosSigma - 2.0 * sinU1sinU2 / cosSqAlpha
+
+				val uSquared = cosSqAlpha * aSqMinusBSqOverBSq
+				bigA = 1 + (uSquared / 16384.0) *
+						(4096.0 + uSquared * (-768 + uSquared * (320.0 - 175.0 * uSquared)))
+				val bigB = (uSquared / 1024.0) *
+						(256.0 + uSquared * (-128.0 + uSquared * (74.0 - 47.0 * uSquared)))
+				val bigC = (f / 16.0) * cosSqAlpha * (4.0 + f * (4.0 - 3.0 * cosSqAlpha))
+				val cos2SMSq = cos2SM * cos2SM
+				deltaSigma = bigB * sinSigma *
+						(cos2SM + (bigB / 4.0) *
+								(cosSigma * (-1.0 + 2.0 * cos2SMSq) -
+										(bigB / 6.0) * cos2SM *
+										(-3.0 + 4.0 * sinSigma * sinSigma) *
+										(-3.0 + 4.0 * cos2SMSq)))
+
+				lambda = bigL + (1.0 - bigC) * f * sinAlpha *
+						(sigma + bigC * sinSigma *
+								(cos2SM + bigC * cosSigma * (-1.0 + 2.0 * cos2SM * cos2SM)))
+
+				val delta = (lambda - lambdaOrig) / lambda
+				if (abs(delta) < 1.0e-12) {
+					break
+				}
+			}
+
+			results[0] = (b * bigA * (sigma - deltaSigma)).toFloat()
+			if (results.size > 1) {
+				val initialBearing = atan2(
+					cosU2 * sinLambda,
+					cosU1 * sinU2 - sinU1 * cosU2 * cosLambda
+				) * 180.0 / PI
+				results[1] = initialBearing.toFloat()
+				if (results.size > 2) {
+					val finalBearing = atan2(
+						cosU1 * sinLambda,
+						-sinU1 * cosU2 + cosU1 * sinU2 * cosLambda
+					) * 180.0 / PI
+					results[2] = finalBearing.toFloat()
+				}
+			}
+		}
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/data/KQuadPoint.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/data/KQuadPoint.kt
@@ -1,0 +1,32 @@
+package net.osmand.shared.data
+
+/** Mutable float point, port of `net.osmand.data.QuadPoint`. */
+class KQuadPoint {
+
+	var x: Float
+	var y: Float
+
+	constructor() : this(0f, 0f)
+
+	constructor(x: Float, y: Float) {
+		this.x = x
+		this.y = y
+	}
+
+	constructor(a: KQuadPoint) : this(a.x, a.y)
+
+	fun set(x: Float, y: Float) {
+		this.x = x
+		this.y = y
+	}
+
+	override fun equals(other: Any?): Boolean {
+		if (this === other) return true
+		if (other !is KQuadPoint) return false
+		return x == other.x && y == other.y
+	}
+
+	override fun hashCode(): Int = 31 * x.hashCode() + y.hashCode()
+
+	override fun toString(): String = "x $x y $y"
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/data/KQuadPointDouble.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/data/KQuadPointDouble.kt
@@ -1,0 +1,32 @@
+package net.osmand.shared.data
+
+/** Mutable double point, port of `net.osmand.data.QuadPointDouble`. */
+class KQuadPointDouble {
+
+	var x: Double
+	var y: Double
+
+	constructor() : this(0.0, 0.0)
+
+	constructor(x: Double, y: Double) {
+		this.x = x
+		this.y = y
+	}
+
+	constructor(a: KQuadPointDouble) : this(a.x, a.y)
+
+	fun set(x: Double, y: Double) {
+		this.x = x
+		this.y = y
+	}
+
+	override fun equals(other: Any?): Boolean {
+		if (this === other) return true
+		if (other !is KQuadPointDouble) return false
+		return x == other.x && y == other.y
+	}
+
+	override fun hashCode(): Int = 31 * x.hashCode() + y.hashCode()
+
+	override fun toString(): String = "x $x y $y"
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/data/KQuadTree.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/data/KQuadTree.kt
@@ -1,0 +1,151 @@
+package net.osmand.shared.data
+
+import kotlin.jvm.JvmOverloads
+
+/**
+ * Bounded quad tree over [KQuadRect], port of `net.osmand.data.QuadTree`.
+ *
+ * Children boxes overlap by design: [ratio] above 0.5 makes each quadrant slightly larger than a
+ * quarter, so items straddling the middle still descend instead of piling up in the parent node.
+ * Items that fit no single child stay in the node they reached.
+ */
+class KQuadTree<T> @JvmOverloads constructor(
+	bounds: KQuadRect,
+	depth: Int = 8,
+	ratio: Float = 0.55f
+) {
+
+	private class Node<T>(bounds: KQuadRect) {
+		var data: MutableList<T>? = null
+		val children: Array<Node<T>?> = arrayOfNulls(4)
+		val bounds: KQuadRect = KQuadRect(bounds.left, bounds.top, bounds.right, bounds.bottom)
+	}
+
+	private val ratio: Float = ratio
+	private val maxDepth: Int = depth
+	private val root: Node<T> = Node(bounds)
+
+	fun insert(data: T, box: KQuadRect) {
+		doInsertData(data, box, root, 0)
+	}
+
+	fun insert(data: T, x: Float, y: Float) {
+		val v = x.toDouble()
+		val w = y.toDouble()
+		insert(data, KQuadRect(v, w, v, w))
+	}
+
+	/** Fills [result] with every item whose node bounds intersect [box] and returns it. */
+	fun queryInBox(box: KQuadRect, result: MutableList<T>): MutableList<T> {
+		result.clear()
+		queryNode(box, result, root)
+		return result
+	}
+
+	fun clear() {
+		clear(root)
+	}
+
+	/**
+	 * True when [box] intersects the tree.
+	 *
+	 * With [hintDepth] of -1 every candidate item is verified through [contains]; with a depth of 0
+	 * or more the check stops at that level and reports a bounds intersection without looking at
+	 * items, which is the cheap "is anything around here" mode.
+	 */
+	fun checkIntersection(box: KQuadRect, hintDepth: Int, contains: KQuadTreeItemInQuadRect<T>): Boolean {
+		val depth = if (hintDepth != -1 && hintDepth > maxDepth) -1 else hintDepth
+		return checkIntersectionRecursive(box, root, 0, depth, contains)
+	}
+
+	fun interface KQuadTreeItemInQuadRect<T> {
+		fun contains(rect: KQuadRect, item: T): Boolean
+	}
+
+	private fun clear(node: Node<T>?) {
+		if (node != null) {
+			node.data?.clear()
+			for (child in node.children) {
+				clear(child)
+			}
+		}
+	}
+
+	private fun queryNode(box: KQuadRect, result: MutableList<T>, node: Node<T>?) {
+		if (node != null && KQuadRect.intersects(box, node.bounds)) {
+			node.data?.let { result.addAll(it) }
+			for (child in node.children) {
+				queryNode(box, result, child)
+			}
+		}
+	}
+
+	private fun doInsertData(data: T, box: KQuadRect, node: Node<T>, currentDepth: Int) {
+		val depth = currentDepth + 1
+		if (depth < maxDepth) {
+			val ext = splitBox(node.bounds)
+			for (i in 0 until 4) {
+				if (ext[i].contains(box)) {
+					var child = node.children[i]
+					if (child == null) {
+						child = Node(ext[i])
+						node.children[i] = child
+					}
+					doInsertData(data, box, child, depth)
+					return
+				}
+			}
+		}
+		val list = node.data ?: ArrayList<T>().also { node.data = it }
+		list.add(data)
+	}
+
+	private fun splitBox(extent: KQuadRect): Array<KQuadRect> {
+		val lx = extent.left
+		val ly = extent.top
+		val hx = extent.right
+		val hy = extent.bottom
+		val dx = hx - lx
+		val dy = hy - ly
+		val inv = 1 - ratio
+		return arrayOf(
+			KQuadRect(lx, ly, lx + dx * ratio, ly + dy * ratio),
+			KQuadRect(lx + dx * inv, ly, hx, ly + dy * ratio),
+			KQuadRect(lx, ly + dy * inv, lx + dx * ratio, hy),
+			KQuadRect(lx + dx * inv, ly + dy * inv, hx, hy)
+		)
+	}
+
+	private fun checkIntersectionRecursive(
+		box: KQuadRect,
+		node: Node<T>?,
+		currentDepth: Int,
+		targetDepth: Int,
+		contains: KQuadTreeItemInQuadRect<T>
+	): Boolean {
+		if (node == null || !KQuadRect.intersects(box, node.bounds)) {
+			return false
+		}
+		if (targetDepth != -1) {
+			if (currentDepth == targetDepth) {
+				return true
+			}
+			if (currentDepth > targetDepth) {
+				return false
+			}
+		}
+		node.data?.let { items ->
+			for (item in items) {
+				if (contains.contains(box, item)) {
+					return true
+				}
+			}
+		}
+		for (child in node.children) {
+			if (checkIntersectionRecursive(box, child, currentDepth + 1, targetDepth, contains)) {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/collections/KBitSet.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/collections/KBitSet.kt
@@ -1,0 +1,272 @@
+package net.osmand.shared.util.collections
+
+import kotlin.jvm.JvmOverloads
+
+/**
+ * Fixed semantics port of `java.util.BitSet`, limited to what [net.osmand.shared] needs.
+ *
+ * `GeneralRouter` represents a road's tag set as a bit mask over the universal rule table and then
+ * evaluates rules with `or` / `and` / `intersects` / `nextSetBit`, so the semantics below follow
+ * `java.util.BitSet` exactly, including:
+ * - [length] is "highest set bit + 1", not the capacity;
+ * - [equals] ignores trailing zero words, so sets of different capacity can be equal;
+ * - reading a bit beyond the current capacity returns false instead of failing.
+ *
+ * Not thread safe.
+ */
+class KBitSet @JvmOverloads constructor(bitCapacity: Int = BITS_PER_WORD) {
+
+	private var words: LongArray = LongArray(wordsFor(bitCapacity))
+
+	fun get(index: Int): Boolean {
+		requireIndex(index)
+		val word = index shr WORD_SHIFT
+		return word < words.size && (words[word] and (1L shl (index and BIT_MASK))) != 0L
+	}
+
+	fun set(index: Int) {
+		requireIndex(index)
+		val word = index shr WORD_SHIFT
+		ensureWords(word + 1)
+		words[word] = words[word] or (1L shl (index and BIT_MASK))
+	}
+
+	fun set(index: Int, value: Boolean) {
+		if (value) set(index) else clear(index)
+	}
+
+	fun clear(index: Int) {
+		requireIndex(index)
+		val word = index shr WORD_SHIFT
+		if (word < words.size) {
+			words[word] = words[word] and (1L shl (index and BIT_MASK)).inv()
+		}
+	}
+
+	/** Clears every bit, keeps the capacity. */
+	fun clear() {
+		words.fill(0L)
+	}
+
+	fun flip(index: Int) {
+		requireIndex(index)
+		val word = index shr WORD_SHIFT
+		ensureWords(word + 1)
+		words[word] = words[word] xor (1L shl (index and BIT_MASK))
+	}
+
+	fun or(other: KBitSet) {
+		if (this === other) {
+			return
+		}
+		ensureWords(other.words.size)
+		for (i in other.words.indices) {
+			words[i] = words[i] or other.words[i]
+		}
+	}
+
+	fun and(other: KBitSet) {
+		if (this === other) {
+			return
+		}
+		for (i in words.indices) {
+			words[i] = if (i < other.words.size) words[i] and other.words[i] else 0L
+		}
+	}
+
+	fun andNot(other: KBitSet) {
+		val last = minOf(words.size, other.words.size)
+		for (i in 0 until last) {
+			words[i] = words[i] and other.words[i].inv()
+		}
+	}
+
+	fun xor(other: KBitSet) {
+		ensureWords(other.words.size)
+		for (i in other.words.indices) {
+			words[i] = words[i] xor other.words[i]
+		}
+	}
+
+	/** True when the two sets share at least one bit. */
+	fun intersects(other: KBitSet): Boolean {
+		val last = minOf(words.size, other.words.size)
+		for (i in 0 until last) {
+			if (words[i] and other.words[i] != 0L) {
+				return true
+			}
+		}
+		return false
+	}
+
+	fun isEmpty(): Boolean {
+		for (word in words) {
+			if (word != 0L) {
+				return false
+			}
+		}
+		return true
+	}
+
+	fun cardinality(): Int {
+		var count = 0
+		for (word in words) {
+			count += word.countOneBits()
+		}
+		return count
+	}
+
+	/** Index of the highest set bit plus one, 0 for an empty set. */
+	fun length(): Int {
+		for (i in words.indices.reversed()) {
+			val word = words[i]
+			if (word != 0L) {
+				return (i shl WORD_SHIFT) + BITS_PER_WORD - word.countLeadingZeroBits()
+			}
+		}
+		return 0
+	}
+
+	/** Current capacity in bits, always a multiple of 64. */
+	fun size(): Int = words.size shl WORD_SHIFT
+
+	/** Index of the first set bit at or after [fromIndex], or -1. */
+	fun nextSetBit(fromIndex: Int): Int {
+		requireIndex(fromIndex)
+		var word = fromIndex shr WORD_SHIFT
+		if (word >= words.size) {
+			return -1
+		}
+		var bits = words[word] and (-1L shl (fromIndex and BIT_MASK))
+		while (true) {
+			if (bits != 0L) {
+				return (word shl WORD_SHIFT) + bits.countTrailingZeroBits()
+			}
+			word++
+			if (word >= words.size) {
+				return -1
+			}
+			bits = words[word]
+		}
+	}
+
+	/** Index of the first clear bit at or after [fromIndex]. Always defined, the set grows on demand. */
+	fun nextClearBit(fromIndex: Int): Int {
+		requireIndex(fromIndex)
+		var word = fromIndex shr WORD_SHIFT
+		if (word >= words.size) {
+			return fromIndex
+		}
+		var bits = words[word].inv() and (-1L shl (fromIndex and BIT_MASK))
+		while (true) {
+			if (bits != 0L) {
+				return (word shl WORD_SHIFT) + bits.countTrailingZeroBits()
+			}
+			word++
+			if (word >= words.size) {
+				return word shl WORD_SHIFT
+			}
+			bits = words[word].inv()
+		}
+	}
+
+	/** Indices of all set bits, ascending. */
+	fun toIntArray(): IntArray {
+		val result = IntArray(cardinality())
+		var at = 0
+		var bit = nextSetBit(0)
+		while (bit >= 0) {
+			result[at++] = bit
+			bit = nextSetBit(bit + 1)
+		}
+		return result
+	}
+
+	fun copy(): KBitSet {
+		val result = KBitSet(size())
+		words.copyInto(result.words)
+		return result
+	}
+
+	inline fun forEachSetBit(action: (index: Int) -> Unit) {
+		var bit = nextSetBit(0)
+		while (bit >= 0) {
+			action(bit)
+			bit = nextSetBit(bit + 1)
+		}
+	}
+
+	private fun ensureWords(count: Int) {
+		if (count > words.size) {
+			var newSize = if (words.size == 0) 1 else words.size shl 1
+			while (newSize < count) {
+				newSize = newSize shl 1
+			}
+			words = words.copyOf(newSize)
+		}
+	}
+
+	private fun requireIndex(index: Int) {
+		if (index < 0) {
+			throw IndexOutOfBoundsException("Negative bit index $index")
+		}
+	}
+
+	/** Equal when the same bits are set, regardless of capacity. */
+	override fun equals(other: Any?): Boolean {
+		if (this === other) return true
+		if (other !is KBitSet) return false
+		val common = minOf(words.size, other.words.size)
+		for (i in 0 until common) {
+			if (words[i] != other.words[i]) {
+				return false
+			}
+		}
+		val longer = if (words.size > other.words.size) words else other.words
+		for (i in common until longer.size) {
+			if (longer[i] != 0L) {
+				return false
+			}
+		}
+		return true
+	}
+
+	/** Matches `java.util.BitSet.hashCode()` and, like [equals], ignores trailing zero words. */
+	override fun hashCode(): Int {
+		var wordsInUse = words.size
+		while (wordsInUse > 0 && words[wordsInUse - 1] == 0L) {
+			wordsInUse--
+		}
+		var h = 1234L
+		for (i in wordsInUse - 1 downTo 0) {
+			h = h xor (words[i] * (i + 1))
+		}
+		return ((h shr 32) xor h).toInt()
+	}
+
+	override fun toString(): String {
+		val builder = StringBuilder("{")
+		var first = true
+		var bit = nextSetBit(0)
+		while (bit >= 0) {
+			if (!first) {
+				builder.append(", ")
+			}
+			first = false
+			builder.append(bit)
+			bit = nextSetBit(bit + 1)
+		}
+		return builder.append('}').toString()
+	}
+
+	companion object {
+		const val BITS_PER_WORD = 64
+		private const val WORD_SHIFT = 6
+		private const val BIT_MASK = 63
+
+		private fun wordsFor(bitCapacity: Int): Int {
+			require(bitCapacity >= 0) { "Negative bit capacity $bitCapacity" }
+			return if (bitCapacity == 0) 1 else (bitCapacity + BITS_PER_WORD - 1) shr WORD_SHIFT
+		}
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/collections/KTIntArrayList.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/collections/KTIntArrayList.kt
@@ -1,0 +1,248 @@
+package net.osmand.shared.util.collections
+
+import kotlin.jvm.JvmOverloads
+
+/**
+ * Growable `int` array, a minimal replacement for `gnu.trove.list.array.TIntArrayList`.
+ *
+ * Stores values in a flat [IntArray], so unlike `MutableList<Int>` it neither boxes elements nor
+ * allocates per element.
+ *
+ * When the final length is known, construct with that capacity: growth reallocates and copies, and
+ * on the JVM that path is the only one where this list is measurably behind `TIntArrayList`.
+ *
+ * Trove compatibility notes:
+ * - [get] is bounds checked, [getQuick] is not (same split as trove);
+ * - [clear] keeps the current capacity, [reset] also zeroes the backing array.
+ *
+ * Not thread safe.
+ */
+class KTIntArrayList @JvmOverloads constructor(initialCapacity: Int = DEFAULT_CAPACITY) {
+
+	@PublishedApi
+	internal var data: IntArray = IntArray(if (initialCapacity > 0) initialCapacity else DEFAULT_CAPACITY)
+
+	var size: Int = 0
+		private set
+
+	constructor(values: IntArray) : this(if (values.isEmpty()) DEFAULT_CAPACITY else values.size) {
+		add(values)
+	}
+
+	fun isEmpty(): Boolean = size == 0
+
+	fun isNotEmpty(): Boolean = size != 0
+
+	fun capacity(): Int = data.size
+
+	operator fun get(index: Int): Int {
+		checkIndex(index)
+		return data[index]
+	}
+
+	/** Unchecked read, callers must guarantee `0 <= index < size`. */
+	fun getQuick(index: Int): Int = data[index]
+
+	operator fun set(index: Int, value: Int) {
+		checkIndex(index)
+		data[index] = value
+	}
+
+	/** Unchecked write, callers must guarantee `0 <= index < size`. */
+	fun setQuick(index: Int, value: Int) {
+		data[index] = value
+	}
+
+	fun add(value: Int) {
+		val current = data
+		if (size < current.size) {
+			current[size++] = value
+		} else {
+			// keep the growth branch out of the hot path so it stays trivially inlinable
+			grow(size + 1)
+			data[size++] = value
+		}
+	}
+
+	fun add(values: IntArray) {
+		add(values, 0, values.size)
+	}
+
+	fun add(values: IntArray, offset: Int, length: Int) {
+		if (length == 0) {
+			return
+		}
+		require(offset >= 0 && length >= 0 && offset + length <= values.size) {
+			"Bad range $offset..${offset + length} for array of ${values.size}"
+		}
+		ensureCapacity(size + length)
+		values.copyInto(data, size, offset, offset + length)
+		size += length
+	}
+
+	fun addAll(other: KTIntArrayList) {
+		add(other.data, 0, other.size)
+	}
+
+	fun insert(index: Int, value: Int) {
+		require(index in 0..size) { "Index $index out of bounds for size $size" }
+		if (index == size) {
+			add(value)
+			return
+		}
+		ensureCapacity(size + 1)
+		data.copyInto(data, index + 1, index, size)
+		data[index] = value
+		size++
+	}
+
+	/** Removes and returns the value at [index]. */
+	fun removeAt(index: Int): Int {
+		checkIndex(index)
+		val removed = data[index]
+		if (index < size - 1) {
+			data.copyInto(data, index, index + 1, size)
+		}
+		size--
+		return removed
+	}
+
+	/** Removes the first occurrence of [value], returns true when something was removed. */
+	fun removeValue(value: Int): Boolean {
+		val index = indexOf(value)
+		if (index < 0) {
+			return false
+		}
+		removeAt(index)
+		return true
+	}
+
+	fun indexOf(value: Int): Int {
+		for (i in 0 until size) {
+			if (data[i] == value) {
+				return i
+			}
+		}
+		return -1
+	}
+
+	operator fun contains(value: Int): Boolean = indexOf(value) >= 0
+
+	/** Drops all elements, keeps the current capacity. */
+	fun clear() {
+		size = 0
+	}
+
+	/** Drops all elements and zeroes the backing array, like `TIntArrayList.reset()`. */
+	fun reset() {
+		data.fill(0, 0, size)
+		size = 0
+	}
+
+	fun toArray(): IntArray = data.copyOf(size)
+
+	fun toArray(offset: Int, length: Int): IntArray {
+		require(offset >= 0 && length >= 0 && offset + length <= size) {
+			"Bad range $offset..${offset + length} for size $size"
+		}
+		return data.copyOfRange(offset, offset + length)
+	}
+
+	/** Sorts the payload only, the unused tail of the backing array is left alone. */
+	fun sort() {
+		if (size > 1) {
+			data.sort(0, size)
+		}
+	}
+
+	fun reverse() {
+		var i = 0
+		var j = size - 1
+		while (i < j) {
+			val tmp = data[i]
+			data[i] = data[j]
+			data[j] = tmp
+			i++
+			j--
+		}
+	}
+
+	fun ensureCapacity(capacity: Int) {
+		if (capacity > data.size) {
+			grow(capacity)
+		}
+	}
+
+	private fun grow(capacity: Int) {
+		val current = data.size
+		// doubling, but never below what the caller asked for, so a bulk add grows once
+		var newCapacity = if (current == 0) DEFAULT_CAPACITY else current shl 1
+		if (newCapacity < capacity) {
+			newCapacity = capacity
+		}
+		check(newCapacity > 0) { "Capacity overflow for $capacity elements" }
+		data = data.copyOf(newCapacity)
+	}
+
+	fun trimToSize() {
+		if (data.size > size) {
+			data = data.copyOf(size)
+		}
+	}
+
+	inline fun forEach(action: (value: Int) -> Unit) {
+		val values = data
+		for (i in 0 until size) {
+			action(values[i])
+		}
+	}
+
+	fun sum(): Long {
+		var sum = 0L
+		for (i in 0 until size) {
+			sum += data[i]
+		}
+		return sum
+	}
+
+	private fun checkIndex(index: Int) {
+		if (index < 0 || index >= size) {
+			throw IndexOutOfBoundsException("Index $index out of bounds for size $size")
+		}
+	}
+
+	override fun equals(other: Any?): Boolean {
+		if (this === other) return true
+		if (other !is KTIntArrayList) return false
+		if (size != other.size) return false
+		for (i in 0 until size) {
+			if (data[i] != other.data[i]) {
+				return false
+			}
+		}
+		return true
+	}
+
+	override fun hashCode(): Int {
+		var result = 1
+		for (i in 0 until size) {
+			result = 31 * result + data[i]
+		}
+		return result
+	}
+
+	override fun toString(): String {
+		val builder = StringBuilder("[")
+		for (i in 0 until size) {
+			if (i > 0) {
+				builder.append(", ")
+			}
+			builder.append(data[i])
+		}
+		return builder.append(']').toString()
+	}
+
+	companion object {
+		const val DEFAULT_CAPACITY = 10
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/collections/KTLongHashSet.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/collections/KTLongHashSet.kt
@@ -1,0 +1,256 @@
+package net.osmand.shared.util.collections
+
+import kotlin.jvm.JvmOverloads
+
+/**
+ * Primitive `long` set without boxing, a minimal replacement for `gnu.trove.set.hash.TLongHashSet`.
+ *
+ * Same open addressing scheme as [KTLongObjectMap]: power-of-two table, linear probing,
+ * MurmurHash3 finalizer for key mixing, tombstones on removal.
+ *
+ * Not thread safe.
+ */
+class KTLongHashSet @JvmOverloads constructor(initialCapacity: Int = DEFAULT_CAPACITY) {
+
+	@PublishedApi
+	internal var keysArr: LongArray
+
+	@PublishedApi
+	internal var statesArr: ByteArray
+
+	private var mask: Int
+	private var threshold: Int
+	private var occupied: Int = 0
+
+	@PublishedApi
+	internal var modCount: Int = 0
+
+	var size: Int = 0
+		private set
+
+	init {
+		val capacity = tableSizeFor(initialCapacity)
+		keysArr = LongArray(capacity)
+		statesArr = ByteArray(capacity)
+		mask = capacity - 1
+		threshold = capacity / 2
+	}
+
+	fun isEmpty(): Boolean = size == 0
+
+	fun isNotEmpty(): Boolean = size != 0
+
+	operator fun contains(key: Long): Boolean = indexOf(key) >= 0
+
+	/** Returns true when [key] was not in the set yet. */
+	fun add(key: Long): Boolean {
+		val index = insertionIndex(key)
+		if (index < 0) {
+			return false
+		}
+		val wasFree = statesArr[index] == FREE
+		keysArr[index] = key
+		statesArr[index] = FULL
+		size++
+		modCount++
+		if (wasFree) {
+			occupied++
+			if (occupied > threshold) {
+				rehash(tableSizeFor(size + 1))
+			}
+		}
+		return true
+	}
+
+	fun addAll(keys: LongArray): Boolean {
+		ensureCapacity(size + keys.size)
+		var changed = false
+		for (key in keys) {
+			changed = add(key) || changed
+		}
+		return changed
+	}
+
+	fun addAll(other: KTLongHashSet): Boolean {
+		ensureCapacity(size + other.size)
+		var changed = false
+		other.forEach { key ->
+			changed = add(key) || changed
+		}
+		return changed
+	}
+
+	/** Returns true when [key] was present. */
+	fun remove(key: Long): Boolean {
+		val index = indexOf(key)
+		if (index < 0) {
+			return false
+		}
+		statesArr[index] = REMOVED
+		size--
+		modCount++
+		return true
+	}
+
+	fun clear() {
+		if (occupied == 0) {
+			return
+		}
+		statesArr.fill(FREE)
+		size = 0
+		occupied = 0
+		modCount++
+	}
+
+	fun ensureCapacity(entries: Int) {
+		if (entries > threshold) {
+			rehash(tableSizeFor(entries))
+		}
+	}
+
+	/** All keys, in unspecified order. */
+	fun toArray(): LongArray {
+		val result = LongArray(size)
+		var at = 0
+		for (i in statesArr.indices) {
+			if (statesArr[i] == FULL) {
+				result[at++] = keysArr[i]
+			}
+		}
+		return result
+	}
+
+	fun iterator(): KTLongIterator = KTLongIterator(this)
+
+	/** Allocation free iteration. */
+	inline fun forEach(action: (key: Long) -> Unit) {
+		val expected = modCount
+		val states = statesArr
+		for (i in states.indices) {
+			if (states[i] == FULL) {
+				action(keysArr[i])
+				check(modCount == expected) { "Set was modified during iteration" }
+			}
+		}
+	}
+
+	override fun toString(): String {
+		val builder = StringBuilder("{")
+		var first = true
+		forEach { key ->
+			if (!first) {
+				builder.append(", ")
+			}
+			first = false
+			builder.append(key)
+		}
+		return builder.append('}').toString()
+	}
+
+	private fun indexOf(key: Long): Int {
+		var index = hashIndex(key)
+		while (true) {
+			val state = statesArr[index]
+			if (state == FREE) {
+				return -1
+			}
+			if (state == FULL && keysArr[index] == key) {
+				return index
+			}
+			index = (index + 1) and mask
+		}
+	}
+
+	private fun insertionIndex(key: Long): Int {
+		var index = hashIndex(key)
+		var firstRemoved = -1
+		while (true) {
+			val state = statesArr[index]
+			if (state == FREE) {
+				return if (firstRemoved >= 0) firstRemoved else index
+			}
+			if (state == FULL) {
+				if (keysArr[index] == key) {
+					return -index - 1
+				}
+			} else if (firstRemoved < 0) {
+				firstRemoved = index
+			}
+			index = (index + 1) and mask
+		}
+	}
+
+	private fun hashIndex(key: Long): Int {
+		var h = key
+		h = h xor (h ushr 33)
+		h *= MURMUR_C1
+		h = h xor (h ushr 33)
+		h *= MURMUR_C2
+		h = h xor (h ushr 33)
+		return h.toInt() and mask
+	}
+
+	private fun rehash(newCapacity: Int) {
+		val oldKeys = keysArr
+		val oldStates = statesArr
+
+		keysArr = LongArray(newCapacity)
+		statesArr = ByteArray(newCapacity)
+		mask = newCapacity - 1
+		threshold = newCapacity / 2
+		occupied = 0
+		modCount++
+
+		for (i in oldStates.indices) {
+			if (oldStates[i] == FULL) {
+				val key = oldKeys[i]
+				var index = hashIndex(key)
+				while (statesArr[index] == FULL) {
+					index = (index + 1) and mask
+				}
+				keysArr[index] = key
+				statesArr[index] = FULL
+				occupied++
+			}
+		}
+	}
+
+	companion object {
+		const val DEFAULT_CAPACITY = 16
+
+		@PublishedApi
+		internal const val FREE: Byte = 0
+
+		@PublishedApi
+		internal const val FULL: Byte = 1
+
+		@PublishedApi
+		internal const val REMOVED: Byte = 2
+
+		private const val MURMUR_C1 = -0xae502812aa7333L
+		private const val MURMUR_C2 = -0x3b314601e57a13adL
+	}
+}
+
+/** Trove style iterator: `while (it.hasNext()) { val key = it.next() }`. */
+class KTLongIterator internal constructor(private val set: KTLongHashSet) {
+
+	private val expectedModCount = set.modCount
+	private var cursor = 0
+
+	fun hasNext(): Boolean {
+		val states = set.statesArr
+		while (cursor < states.size && states[cursor] != KTLongHashSet.FULL) {
+			cursor++
+		}
+		return cursor < states.size
+	}
+
+	fun next(): Long {
+		check(set.modCount == expectedModCount) { "Set was modified during iteration" }
+		if (!hasNext()) {
+			throw NoSuchElementException()
+		}
+		return set.keysArr[cursor++]
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/collections/KTLongObjectMap.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/collections/KTLongObjectMap.kt
@@ -1,0 +1,377 @@
+package net.osmand.shared.util.collections
+
+import kotlin.jvm.JvmOverloads
+
+/**
+ * Primitive `long` -> object map without boxing of keys.
+ *
+ * Minimal replacement for `gnu.trove.map.hash.TLongObjectHashMap`, covering the API actually used by
+ * the routing code: [get], [put], [containsKey], [remove], [size], [clear], [keys], [values] and
+ * iteration.
+ *
+ * Implementation notes:
+ * - open addressing with linear probing over power-of-two tables (cache friendly, no per-entry
+ *   allocation, unlike a bucket-per-entry hash map);
+ * - keys are mixed with the MurmurHash3 64-bit finalizer, because raw OsmAnd keys (road ids,
+ *   `x31 << 31 | y31` tile keys) are highly structured and would cluster badly under linear probing;
+ * - deletions leave tombstones, which are purged on the next rehash. Routing removes entries very
+ *   rarely, so this keeps [remove] simple and iteration-safe.
+ *
+ * Values may not be null: a null result from [get] always means "no such key".
+ * The map is not thread safe.
+ */
+class KTLongObjectMap<V : Any> @JvmOverloads constructor(
+	initialCapacity: Int = DEFAULT_CAPACITY
+) {
+
+	@PublishedApi
+	internal var keysArr: LongArray
+
+	@PublishedApi
+	internal var valuesArr: Array<Any?>
+
+	/** Per slot state, one of [FREE], [FULL], [REMOVED]. */
+	@PublishedApi
+	internal var statesArr: ByteArray
+
+	private var mask: Int
+	private var threshold: Int
+
+	/** Number of slots that are not [FREE], i.e. live entries plus tombstones. */
+	private var occupied: Int = 0
+
+	/** Bumped on every structural change, used to detect modification during iteration. */
+	@PublishedApi
+	internal var modCount: Int = 0
+
+	var size: Int = 0
+		private set
+
+	init {
+		val capacity = tableSizeFor(initialCapacity)
+		keysArr = LongArray(capacity)
+		valuesArr = arrayOfNulls(capacity)
+		statesArr = ByteArray(capacity)
+		mask = capacity - 1
+		threshold = capacity / 2
+	}
+
+	fun isEmpty(): Boolean = size == 0
+
+	fun isNotEmpty(): Boolean = size != 0
+
+	@Suppress("UNCHECKED_CAST")
+	operator fun get(key: Long): V? {
+		val index = indexOf(key)
+		return if (index < 0) null else valuesArr[index] as V
+	}
+
+	fun containsKey(key: Long): Boolean = indexOf(key) >= 0
+
+	/** Returns the value previously stored under [key], or null. */
+	@Suppress("UNCHECKED_CAST")
+	fun put(key: Long, value: V): V? {
+		val index = insertionIndex(key)
+		if (index < 0) {
+			val existing = -index - 1
+			val previous = valuesArr[existing]
+			valuesArr[existing] = value
+			return previous as V
+		}
+		insertAt(index, key, value)
+		return null
+	}
+
+	/** Stores [value] only when [key] is absent. Returns the value that is in the map afterwards. */
+	@Suppress("UNCHECKED_CAST")
+	fun putIfAbsent(key: Long, value: V): V {
+		val index = insertionIndex(key)
+		if (index < 0) {
+			return valuesArr[-index - 1] as V
+		}
+		insertAt(index, key, value)
+		return value
+	}
+
+	/**
+	 * Returns the value stored under [key], inserting the result of [defaultValue] when absent.
+	 * Saves the second lookup of the `containsKey` / `put` / `get` sequence.
+	 */
+	@Suppress("UNCHECKED_CAST")
+	fun getOrPut(key: Long, defaultValue: () -> V): V {
+		val index = insertionIndex(key)
+		if (index < 0) {
+			return valuesArr[-index - 1] as V
+		}
+		val expected = modCount
+		val value = defaultValue()
+		if (modCount != expected) {
+			// defaultValue() touched this map, the resolved slot is stale
+			val slot = insertionIndex(key)
+			if (slot < 0) {
+				return valuesArr[-slot - 1] as V
+			}
+			insertAt(slot, key, value)
+			return value
+		}
+		insertAt(index, key, value)
+		return value
+	}
+
+	@Suppress("UNCHECKED_CAST")
+	fun remove(key: Long): V? {
+		val index = indexOf(key)
+		if (index < 0) {
+			return null
+		}
+		val previous = valuesArr[index]
+		valuesArr[index] = null
+		statesArr[index] = REMOVED
+		size--
+		modCount++
+		return previous as V
+	}
+
+	fun clear() {
+		if (occupied == 0) {
+			return
+		}
+		statesArr.fill(FREE)
+		valuesArr.fill(null)
+		size = 0
+		occupied = 0
+		modCount++
+	}
+
+	/** Grows the table so that [entries] entries fit without a rehash. */
+	fun ensureCapacity(entries: Int) {
+		if (entries > threshold) {
+			rehash(tableSizeFor(entries))
+		}
+	}
+
+	/** Keys of all live entries, in unspecified order. */
+	fun keys(): LongArray {
+		val result = LongArray(size)
+		var at = 0
+		for (i in statesArr.indices) {
+			if (statesArr[i] == FULL) {
+				result[at++] = keysArr[i]
+			}
+		}
+		return result
+	}
+
+	/** Values of all live entries, in unspecified order. */
+	@Suppress("UNCHECKED_CAST")
+	fun values(): List<V> {
+		val result = ArrayList<V>(size)
+		for (i in statesArr.indices) {
+			if (statesArr[i] == FULL) {
+				result.add(valuesArr[i] as V)
+			}
+		}
+		return result
+	}
+
+	/** Trove compatible alias of [values]. */
+	fun valueCollection(): List<V> = values()
+
+	fun iterator(): KTLongObjectIterator<V> = KTLongObjectIterator(this)
+
+	/** Allocation free iteration over live entries. */
+	@Suppress("UNCHECKED_CAST")
+	inline fun forEach(action: (key: Long, value: V) -> Unit) {
+		val expected = modCount
+		val states = statesArr
+		for (i in states.indices) {
+			if (states[i] == FULL) {
+				action(keysArr[i], valuesArr[i] as V)
+				check(modCount == expected) { "Map was modified during iteration" }
+			}
+		}
+	}
+
+	/** Allocation free iteration over live values. */
+	@Suppress("UNCHECKED_CAST")
+	inline fun forEachValue(action: (value: V) -> Unit) {
+		val expected = modCount
+		val states = statesArr
+		for (i in states.indices) {
+			if (states[i] == FULL) {
+				action(valuesArr[i] as V)
+				check(modCount == expected) { "Map was modified during iteration" }
+			}
+		}
+	}
+
+	override fun toString(): String {
+		val builder = StringBuilder("{")
+		var first = true
+		forEach { key, value ->
+			if (!first) {
+				builder.append(", ")
+			}
+			first = false
+			builder.append(key).append('=').append(value)
+		}
+		return builder.append('}').toString()
+	}
+
+	private fun insertAt(index: Int, key: Long, value: V) {
+		val wasFree = statesArr[index] == FREE
+		keysArr[index] = key
+		valuesArr[index] = value
+		statesArr[index] = FULL
+		size++
+		modCount++
+		if (wasFree) {
+			occupied++
+			if (occupied > threshold) {
+				rehash(tableSizeFor(size + 1))
+			}
+		}
+	}
+
+	/** Index of the slot holding [key], or -1. */
+	private fun indexOf(key: Long): Int {
+		var index = hashIndex(key)
+		while (true) {
+			val state = statesArr[index]
+			if (state == FREE) {
+				return -1
+			}
+			if (state == FULL && keysArr[index] == key) {
+				return index
+			}
+			index = (index + 1) and mask
+		}
+	}
+
+	/**
+	 * Index of the slot to write [key] into, or `-existingIndex - 1` when the key is already there.
+	 * Reuses the first tombstone of the probe chain, but only after proving the key is absent.
+	 */
+	private fun insertionIndex(key: Long): Int {
+		var index = hashIndex(key)
+		var firstRemoved = -1
+		while (true) {
+			val state = statesArr[index]
+			if (state == FREE) {
+				return if (firstRemoved >= 0) firstRemoved else index
+			}
+			if (state == FULL) {
+				if (keysArr[index] == key) {
+					return -index - 1
+				}
+			} else if (firstRemoved < 0) {
+				firstRemoved = index
+			}
+			index = (index + 1) and mask
+		}
+	}
+
+	private fun hashIndex(key: Long): Int {
+		var h = key
+		h = h xor (h ushr 33)
+		h *= MURMUR_C1
+		h = h xor (h ushr 33)
+		h *= MURMUR_C2
+		h = h xor (h ushr 33)
+		return h.toInt() and mask
+	}
+
+	private fun rehash(newCapacity: Int) {
+		val oldKeys = keysArr
+		val oldValues = valuesArr
+		val oldStates = statesArr
+
+		keysArr = LongArray(newCapacity)
+		valuesArr = arrayOfNulls(newCapacity)
+		statesArr = ByteArray(newCapacity)
+		mask = newCapacity - 1
+		threshold = newCapacity / 2
+		occupied = 0
+		modCount++
+
+		for (i in oldStates.indices) {
+			if (oldStates[i] == FULL) {
+				val key = oldKeys[i]
+				var index = hashIndex(key)
+				while (statesArr[index] == FULL) {
+					index = (index + 1) and mask
+				}
+				keysArr[index] = key
+				valuesArr[index] = oldValues[i]
+				statesArr[index] = FULL
+				occupied++
+			}
+		}
+	}
+
+	companion object {
+		const val DEFAULT_CAPACITY = 16
+
+		@PublishedApi
+		internal const val FREE: Byte = 0
+
+		@PublishedApi
+		internal const val FULL: Byte = 1
+
+		@PublishedApi
+		internal const val REMOVED: Byte = 2
+
+		private const val MURMUR_C1 = -0xae502812aa7333L
+		private const val MURMUR_C2 = -0x3b314601e57a13adL
+	}
+}
+
+/**
+ * Trove style iterator: `while (it.hasNext()) { it.advance(); it.key(); it.value() }`.
+ * Fails fast when the map is structurally modified while iterating.
+ */
+class KTLongObjectIterator<V : Any> internal constructor(private val map: KTLongObjectMap<V>) {
+
+	private val expectedModCount = map.modCount
+	private var cursor = 0
+	private var current = -1
+
+	fun hasNext(): Boolean {
+		val states = map.statesArr
+		while (cursor < states.size && states[cursor] != KTLongObjectMap.FULL) {
+			cursor++
+		}
+		return cursor < states.size
+	}
+
+	fun advance() {
+		check(map.modCount == expectedModCount) { "Map was modified during iteration" }
+		if (!hasNext()) {
+			throw NoSuchElementException()
+		}
+		current = cursor
+		cursor++
+	}
+
+	fun key(): Long {
+		check(current >= 0) { "advance() must be called first" }
+		return map.keysArr[current]
+	}
+
+	@Suppress("UNCHECKED_CAST")
+	fun value(): V {
+		check(current >= 0) { "advance() must be called first" }
+		return map.valuesArr[current] as V
+	}
+}
+
+/** Smallest power of two table that keeps [entries] entries at or below a 0.5 load factor. */
+internal fun tableSizeFor(entries: Int): Int {
+	var capacity = 8
+	val needed = if (entries < 1) 1 else entries
+	while (capacity / 2 < needed) {
+		capacity = capacity shl 1
+		check(capacity > 0) { "Capacity overflow for $entries entries" }
+	}
+	return capacity
+}

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/data/KDataTileManagerTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/data/KDataTileManagerTest.kt
@@ -1,0 +1,145 @@
+package net.osmand.shared.data
+
+import net.osmand.shared.util.KMapUtils
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class KDataTileManagerTest {
+
+	@Test
+	fun testRegisterAndCount() {
+		val manager = KDataTileManager<String>(15)
+		assertTrue(manager.isEmpty())
+		assertEquals(0, manager.getObjectsCount())
+
+		manager.registerObject(50.45, 30.52, "kyiv")
+		manager.registerObject(50.451, 30.521, "kyiv2")
+		manager.registerObject(48.85, 2.35, "paris")
+
+		assertFalse(manager.isEmpty())
+		assertEquals(3, manager.getObjectsCount())
+		assertEquals(3, manager.getAllObjects().size)
+		assertTrue(manager.getTilesCount() in 2..3)
+	}
+
+	@Test
+	fun testGetObjectsByLatLonBox() {
+		val manager = KDataTileManager<String>(15)
+		manager.registerObject(50.45, 30.52, "kyiv")
+		manager.registerObject(48.85, 2.35, "paris")
+
+		// arguments are (latitudeUp, longitudeUp, latitudeDown, longitudeDown)
+		val around = manager.getObjects(50.5, 30.4, 50.4, 30.6)
+		assertTrue(around.contains("kyiv"))
+		assertFalse(around.contains("paris"))
+	}
+
+	@Test
+	fun testGetObjectsBy31Box() {
+		val manager = KDataTileManager<String>(15)
+		val x31 = KMapUtils.get31TileNumberX(30.52)
+		val y31 = KMapUtils.get31TileNumberY(50.45)
+		manager.registerObjectXY(x31, y31, "kyiv")
+
+		val shift = 1 shl 16
+		val found = manager.getObjects(x31 - shift, y31 - shift, x31 + shift, y31 + shift)
+		assertTrue(found.contains("kyiv"))
+
+		val far = manager.getObjects(0, 0, 1000, 1000)
+		assertFalse(far.contains("kyiv"))
+	}
+
+	@Test
+	fun testUnregister() {
+		val manager = KDataTileManager<String>(15)
+		manager.registerObject(50.45, 30.52, "a")
+		manager.registerObject(50.45, 30.52, "b")
+		assertEquals(2, manager.getObjectsCount())
+
+		manager.unregisterObject(50.45, 30.52, "a")
+		assertEquals(1, manager.getObjectsCount())
+		assertEquals(listOf("b"), manager.getAllObjects())
+
+		// removing something that was never there must be a no-op
+		manager.unregisterObject(0.0, 0.0, "c")
+		assertEquals(1, manager.getObjectsCount())
+	}
+
+	@Test
+	fun testGetClosestObjects() {
+		val manager = KDataTileManager<String>(15)
+		manager.registerObject(50.45, 30.52, "center")
+		manager.registerObject(50.46, 30.53, "near")
+		manager.registerObject(48.85, 2.35, "far")
+
+		val closest = manager.getClosestObjects(50.45, 30.52, 5000.0)
+		assertTrue(closest.contains("center"))
+		assertTrue(closest.contains("near"))
+		assertFalse(closest.contains("far"))
+
+		assertTrue(KDataTileManager<String>().getClosestObjects(0.0, 0.0, 100.0).isEmpty())
+	}
+
+	@Test
+	fun testEvaluateTileIsStableForTheSameTile() {
+		val manager = KDataTileManager<String>(15)
+		// start from the centre of a tile, otherwise a tiny offset can legitimately cross a boundary
+		val tileX = KMapUtils.getTileNumberX(15.0, 30.52).toInt()
+		val tileY = KMapUtils.getTileNumberY(15.0, 50.45).toInt()
+		val lon = KMapUtils.getLongitudeFromTile(15.0, tileX + 0.5)
+		val lat = KMapUtils.getLatitudeFromTile(15.0, tileY + 0.5)
+
+		val a = manager.evaluateTile(lat, lon)
+		val b = manager.evaluateTile(lat + 0.00001, lon + 0.00001)
+		val c = manager.evaluateTile(48.85, 2.35)
+		assertEquals(a, b)
+		assertFalse(a == c)
+	}
+
+	@Test
+	fun testLatLonAndX31TileKeysAgree() {
+		val manager = KDataTileManager<String>(15)
+		val random = net.osmand.shared.util.collections.XorShiftRandom(4711L)
+		repeat(500) {
+			val lat = 40.0 + random.nextInt(200_000) / 10_000.0
+			val lon = -20.0 + random.nextInt(600_000) / 10_000.0
+			val byLatLon = manager.evaluateTile(lat, lon)
+			val byX31 = manager.evaluateTileXY(
+				KMapUtils.get31TileNumberX(lon),
+				KMapUtils.get31TileNumberY(lat)
+			)
+			assertEquals(byLatLon, byX31, "tile key mismatch at $lat/$lon")
+		}
+	}
+
+	@Test
+	fun testClear() {
+		val manager = KDataTileManager<String>(15)
+		manager.registerObject(50.45, 30.52, "a")
+		manager.clear()
+		assertTrue(manager.isEmpty())
+		assertEquals(0, manager.getObjectsCount())
+		assertTrue(manager.getAllObjects().isEmpty())
+	}
+
+	@Test
+	fun testEveryRegisteredObjectIsFoundInItsOwnTile() {
+		val manager = KDataTileManager<Int>(15)
+		val random = net.osmand.shared.util.collections.XorShiftRandom(555L)
+		val points = ArrayList<DoubleArray>()
+		for (i in 0 until 2000) {
+			val lat = 45.0 + random.nextInt(100_000) / 10_000.0
+			val lon = 5.0 + random.nextInt(100_000) / 10_000.0
+			points.add(doubleArrayOf(lat, lon))
+			manager.registerObject(lat, lon, i)
+		}
+		assertEquals(2000, manager.getObjectsCount())
+		for (i in points.indices) {
+			val (lat, lon) = points[i]
+			val found = manager.getObjects(lat + 0.001, lon - 0.001, lat - 0.001, lon + 0.001)
+			assertTrue(found.contains(i), "object $i missing at $lat/$lon")
+		}
+	}
+}

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/data/KLocationTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/data/KLocationTest.kt
@@ -1,0 +1,160 @@
+package net.osmand.shared.data
+
+import net.osmand.shared.util.KMapUtils
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class KLocationTest {
+
+	@Test
+	fun testOptionalValuesTrackTheirFlags() {
+		val location = KLocation("test")
+		assertFalse(location.hasAltitude)
+		assertFalse(location.hasSpeed)
+		assertFalse(location.hasBearing)
+		assertFalse(location.hasAccuracy)
+		assertFalse(location.hasVerticalAccuracy)
+
+		location.altitude = 120.5
+		location.speed = 13.4f
+		location.bearing = 91f
+		location.accuracy = 4f
+		location.verticalAccuracy = 8f
+
+		assertTrue(location.hasAltitude)
+		assertTrue(location.hasSpeed)
+		assertTrue(location.hasBearing)
+		assertTrue(location.hasAccuracy)
+		assertTrue(location.hasVerticalAccuracy)
+
+		location.removeAltitude()
+		location.removeSpeed()
+		location.removeBearing()
+		location.removeAccuracy()
+		location.removeVerticalAccuracy()
+
+		assertFalse(location.hasAltitude)
+		assertEquals(0.0, location.altitude)
+		assertFalse(location.hasSpeed)
+		assertEquals(0f, location.speed)
+		assertFalse(location.hasBearing)
+		assertFalse(location.hasAccuracy)
+		assertFalse(location.hasVerticalAccuracy)
+	}
+
+	@Test
+	fun testCopyConstructorAndSet() {
+		val source = KLocation("gps", 50.45, 30.52)
+		source.time = 1_700_000_000_000L
+		source.speed = 5f
+		source.altitude = 180.0
+
+		val copy = KLocation(source)
+		assertEquals("gps", copy.provider)
+		assertEquals(50.45, copy.latitude)
+		assertEquals(30.52, copy.longitude)
+		assertEquals(1_700_000_000_000L, copy.time)
+		assertTrue(copy.hasSpeed)
+		assertEquals(5f, copy.speed)
+		assertTrue(copy.hasAltitude)
+		assertFalse(copy.hasBearing)
+
+		val target = KLocation("other")
+		target.bearing = 33f
+		target.set(source)
+		assertFalse(target.hasBearing, "flags must be copied, not merged")
+		assertEquals("gps", target.provider)
+	}
+
+	@Test
+	fun testReset() {
+		val location = KLocation("gps", 1.0, 2.0)
+		location.speed = 9f
+		location.reset()
+		assertEquals(null, location.provider)
+		assertEquals(0.0, location.latitude)
+		assertEquals(0.0, location.longitude)
+		assertEquals(0L, location.time)
+		assertFalse(location.hasSpeed)
+	}
+
+	@Test
+	fun testDistanceMatchesSphericalApproximationWithinEllipsoidError() {
+		// Vincenty on WGS84 vs the haversine used by KMapUtils: they must agree to ~0.5%
+		val pairs = listOf(
+			doubleArrayOf(50.4501, 30.5234, 50.4600, 30.5300),
+			doubleArrayOf(52.5200, 13.4050, 48.8566, 2.3522),
+			doubleArrayOf(-33.8688, 151.2093, -37.8136, 144.9631),
+			doubleArrayOf(0.0, 0.0, 0.0, 1.0)
+		)
+		for (pair in pairs) {
+			val from = KLocation("a", pair[0], pair[1])
+			val to = KLocation("b", pair[2], pair[3])
+			val vincenty = from.distanceTo(to).toDouble()
+			val haversine = KMapUtils.getDistance(pair[0], pair[1], pair[2], pair[3])
+			assertTrue(
+				abs(vincenty - haversine) / haversine < 0.005,
+				"distance mismatch: vincenty=$vincenty haversine=$haversine"
+			)
+		}
+	}
+
+	@Test
+	fun testKnownDistanceAndBearing() {
+		// one degree of longitude on the equator, and due east
+		val from = KLocation("a", 0.0, 0.0)
+		val to = KLocation("b", 0.0, 1.0)
+		assertTrue(abs(from.distanceTo(to) - 111_319.5f) < 50f, "got ${from.distanceTo(to)}")
+		assertTrue(abs(from.bearingTo(to) - 90f) < 0.001f, "got ${from.bearingTo(to)}")
+
+		// due north
+		val north = KLocation("c", 1.0, 0.0)
+		assertTrue(abs(from.bearingTo(north)) < 0.001f, "got ${from.bearingTo(north)}")
+
+		assertEquals(0f, from.distanceTo(KLocation("d", 0.0, 0.0)))
+	}
+
+	@Test
+	fun testDistanceIsSymmetric() {
+		val a = KLocation("a", 50.45, 30.52)
+		val b = KLocation("b", 48.85, 2.35)
+		assertTrue(abs(a.distanceTo(b) - b.distanceTo(a)) < 0.01f)
+	}
+
+	@Test
+	fun testCacheIsInvalidatedWhenCoordinatesChange() {
+		val from = KLocation("a", 0.0, 0.0)
+		val to = KLocation("b", 0.0, 1.0)
+		val first = from.distanceTo(to)
+		// bearing must reuse the very same solution
+		assertTrue(abs(from.bearingTo(to) - 90f) < 0.001f)
+
+		to.longitude = 2.0
+		val second = from.distanceTo(to)
+		assertTrue(second > first * 1.9, "cache was not invalidated: $first -> $second")
+
+		from.latitude = 10.0
+		val third = from.distanceTo(to)
+		assertTrue(abs(third - second) > 1f, "cache was not invalidated on source change")
+	}
+
+	@Test
+	fun testDistanceBetweenFillsResults() {
+		val results = FloatArray(3)
+		KLocation.distanceBetween(0.0, 0.0, 0.0, 1.0, results)
+		assertTrue(abs(results[0] - 111_319.5f) < 50f)
+		assertTrue(abs(results[1] - 90f) < 0.001f)
+		assertTrue(abs(results[2] - 90f) < 0.001f)
+		assertFailsWith<IllegalArgumentException> { KLocation.distanceBetween(0.0, 0.0, 1.0, 1.0, FloatArray(0)) }
+	}
+
+	@Test
+	fun testToKLatLon() {
+		val location = KLocation("gps", 50.45, 30.52)
+		assertEquals(KLatLon(50.45, 30.52), location.toKLatLon())
+	}
+}

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/data/KQuadTreeTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/data/KQuadTreeTest.kt
@@ -1,0 +1,120 @@
+package net.osmand.shared.data
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class KQuadTreeTest {
+
+	private fun world() = KQuadRect(0.0, 0.0, 1000.0, 1000.0)
+
+	private fun boxAt(x: Double, y: Double, size: Double = 1.0) =
+		KQuadRect(x, y, x + size, y + size)
+
+	@Test
+	fun testInsertAndQuery() {
+		val tree = KQuadTree<String>(world(), 8, 0.55f)
+		tree.insert("a", boxAt(10.0, 10.0))
+		tree.insert("b", boxAt(900.0, 900.0))
+		tree.insert("c", boxAt(500.0, 500.0))
+
+		val result = ArrayList<String>()
+		tree.queryInBox(KQuadRect(0.0, 0.0, 100.0, 100.0), result)
+		assertTrue(result.contains("a"))
+		assertFalse(result.contains("b"))
+
+		tree.queryInBox(KQuadRect(0.0, 0.0, 1000.0, 1000.0), result)
+		assertEquals(3, result.size)
+	}
+
+	@Test
+	fun testQueryReusesAndClearsTheResultList() {
+		val tree = KQuadTree<String>(world())
+		tree.insert("a", boxAt(10.0, 10.0))
+		val result = ArrayList<String>()
+		result.add("stale")
+		tree.queryInBox(KQuadRect(0.0, 0.0, 100.0, 100.0), result)
+		assertEquals(listOf("a"), result)
+	}
+
+	@Test
+	fun testPointInsert() {
+		val tree = KQuadTree<Int>(world())
+		tree.insert(1, 100f, 100f)
+		tree.insert(2, 800f, 800f)
+		val result = ArrayList<Int>()
+		tree.queryInBox(KQuadRect(90.0, 90.0, 110.0, 110.0), result)
+		assertTrue(result.contains(1))
+		assertFalse(result.contains(2))
+	}
+
+	@Test
+	fun testEveryInsertedItemIsFoundByAFullQuery() {
+		val tree = KQuadTree<Int>(world(), 6, 0.55f)
+		val random = net.osmand.shared.util.collections.XorShiftRandom(9001L)
+		val count = 2000
+		for (i in 0 until count) {
+			val x = random.nextInt(1000).toDouble()
+			val y = random.nextInt(1000).toDouble()
+			tree.insert(i, boxAt(x, y, 2.0))
+		}
+		val result = ArrayList<Int>()
+		tree.queryInBox(world(), result)
+		assertEquals(count, result.size)
+		assertEquals(count, result.toSet().size)
+	}
+
+	@Test
+	fun testQueryNeverMissesAnItemThatIntersects() {
+		val tree = KQuadTree<Int>(world(), 8, 0.55f)
+		val random = net.osmand.shared.util.collections.XorShiftRandom(13L)
+		val boxes = ArrayList<KQuadRect>()
+		for (i in 0 until 500) {
+			val x = random.nextInt(980).toDouble()
+			val y = random.nextInt(980).toDouble()
+			val box = boxAt(x, y, 5.0)
+			boxes.add(box)
+			tree.insert(i, box)
+		}
+		repeat(50) {
+			val qx = random.nextInt(900).toDouble()
+			val qy = random.nextInt(900).toDouble()
+			val query = KQuadRect(qx, qy, qx + 80.0, qy + 80.0)
+
+			val expected = boxes.indices.filter { KQuadRect.intersects(query, boxes[it]) }.toSet()
+			val actual = ArrayList<Int>()
+			tree.queryInBox(query, actual)
+			// the tree answers by node bounds, so it may over report but must never under report
+			assertTrue(actual.toSet().containsAll(expected), "missed ${expected - actual.toSet()}")
+		}
+	}
+
+	@Test
+	fun testClear() {
+		val tree = KQuadTree<Int>(world())
+		for (i in 0 until 100) {
+			tree.insert(i, boxAt(i.toDouble(), i.toDouble()))
+		}
+		tree.clear()
+		val result = ArrayList<Int>()
+		tree.queryInBox(world(), result)
+		assertTrue(result.isEmpty())
+	}
+
+	@Test
+	fun testCheckIntersection() {
+		val tree = KQuadTree<KQuadRect>(world(), 8, 0.55f)
+		val item = boxAt(500.0, 500.0, 10.0)
+		tree.insert(item, item)
+
+		val contains = KQuadTree.KQuadTreeItemInQuadRect<KQuadRect> { rect, value ->
+			KQuadRect.intersects(rect, value)
+		}
+		assertTrue(tree.checkIntersection(KQuadRect(495.0, 495.0, 505.0, 505.0), -1, contains))
+		assertFalse(tree.checkIntersection(KQuadRect(0.0, 0.0, 10.0, 10.0), -1, contains))
+
+		// a hint depth beyond maxDepth degrades to the precise check instead of failing
+		assertTrue(tree.checkIntersection(KQuadRect(495.0, 495.0, 505.0, 505.0), 99, contains))
+	}
+}

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/collections/CollectionsBenchmarkTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/collections/CollectionsBenchmarkTest.kt
@@ -1,0 +1,318 @@
+package net.osmand.shared.util.collections
+
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.TimeSource
+
+/**
+ * Head to head benchmark of the primitive collections against the boxing stdlib equivalents they
+ * replace. Runs on every target, so the same workload can be compared between JVM, Android and
+ * Kotlin/Native.
+ *
+ * **Disabled on purpose.** Measuring takes seconds and the timings are noise in a normal test run,
+ * so this class is not part of the suite. It is a tool you reach for when you change a collection
+ * or want platform numbers, not a regression gate — correctness is covered by [KTLongObjectMapTest],
+ * [KTLongHashSetTest], [KTIntArrayListTest] and [KBitSetTest], which do run.
+ *
+ * To measure, remove the `@Ignore` below and put it back afterwards.
+ *
+ * On the JVM:
+ * ```
+ * ./gradlew :OsmAnd-shared:jvmTest --tests "*CollectionsBenchmarkTest"
+ * ```
+ *
+ * On Kotlin/Native you must use the **release** binary. The default `iosSimulatorArm64Test` task
+ * builds `debugTest`, which is linked without LLVM optimisations and reports numbers 5 to 13 times
+ * worse than a real build:
+ * ```
+ * ./gradlew :OsmAnd-shared:linkReleaseTestIosSimulatorArm64
+ * xcrun simctl spawn --standalone <simulator-udid> \
+ *   OsmAnd-shared/build/bin/iosSimulatorArm64/releaseTest/test.kexe \
+ *   --ktest_filter='net.osmand.shared.util.collections.CollectionsBenchmarkTest.*'
+ * ```
+ *
+ * The comparison against the real `gnu.trove` collections lives in
+ * `OsmAnd-java/src/test/java/net/osmand/shared/util/collections/CollectionsTroveBenchmarkTest.java`,
+ * because that is the only module where trove and OsmAnd-shared share a classpath.
+ *
+ * Nothing here asserts a timing. The assertions only check that both implementations computed the
+ * same answer, so a slow machine can never turn the build red.
+ */
+@Ignore
+class CollectionsBenchmarkTest {
+
+	@Test
+	fun benchmarkLongObjectMap() {
+		val report = BenchmarkReport("long -> object map, ${ENTRIES} entries, ${LOOKUPS} lookups")
+
+		for (distribution in KeyDistribution.entries) {
+			val keys = distribution.keys(ENTRIES)
+			val probes = probeKeys(keys, LOOKUPS)
+			val value = Any()
+
+			var ktChecksum = 0L
+			val ktTime = measure {
+				val map = KTLongObjectMap<Any>(ENTRIES)
+				for (key in keys) {
+					map.put(key, value)
+				}
+				var hits = 0L
+				for (probe in probes) {
+					if (map[probe] != null) {
+						hits++
+					}
+				}
+				var iterated = 0L
+				map.forEach { key, _ -> iterated += key }
+				ktChecksum = hits * 31 + iterated
+			}
+
+			var refChecksum = 0L
+			val refTime = measure {
+				val map = HashMap<Long, Any>(ENTRIES * 2)
+				for (key in keys) {
+					map[key] = value
+				}
+				var hits = 0L
+				for (probe in probes) {
+					if (map[probe] != null) {
+						hits++
+					}
+				}
+				var iterated = 0L
+				for (key in map.keys) {
+					iterated += key
+				}
+				refChecksum = hits * 31 + iterated
+			}
+
+			assertEquals(refChecksum, ktChecksum, "checksum mismatch for $distribution")
+			report.add(distribution.label, "KTLongObjectMap", ktTime, "HashMap<Long,V>", refTime)
+		}
+
+		report.print()
+	}
+
+	@Test
+	fun benchmarkLongHashSet() {
+		val report = BenchmarkReport("long set, ${ENTRIES} entries, ${LOOKUPS} lookups")
+
+		for (distribution in KeyDistribution.entries) {
+			val keys = distribution.keys(ENTRIES)
+			val probes = probeKeys(keys, LOOKUPS)
+
+			var ktHits = 0L
+			val ktTime = measure {
+				val set = KTLongHashSet(ENTRIES)
+				for (key in keys) {
+					set.add(key)
+				}
+				var hits = 0L
+				for (probe in probes) {
+					if (probe in set) {
+						hits++
+					}
+				}
+				ktHits = hits
+			}
+
+			var refHits = 0L
+			val refTime = measure {
+				val set = HashSet<Long>(ENTRIES * 2)
+				for (key in keys) {
+					set.add(key)
+				}
+				var hits = 0L
+				for (probe in probes) {
+					if (probe in set) {
+						hits++
+					}
+				}
+				refHits = hits
+			}
+
+			assertEquals(refHits, ktHits, "checksum mismatch for $distribution")
+			report.add(distribution.label, "KTLongHashSet", ktTime, "HashSet<Long>", refTime)
+		}
+
+		report.print()
+	}
+
+	@Test
+	fun benchmarkIntArrayList() {
+		val report = BenchmarkReport("int list, ${LIST_ENTRIES} appends plus a full scan")
+
+		var ktSum = 0L
+		val ktTime = measure {
+			val list = KTIntArrayList()
+			for (i in 0 until LIST_ENTRIES) {
+				list.add(i)
+			}
+			var sum = 0L
+			for (i in 0 until list.size) {
+				sum += list.getQuick(i)
+			}
+			ktSum = sum
+		}
+
+		var refSum = 0L
+		val refTime = measure {
+			val list = ArrayList<Int>()
+			for (i in 0 until LIST_ENTRIES) {
+				list.add(i)
+			}
+			var sum = 0L
+			for (i in 0 until list.size) {
+				sum += list[i]
+			}
+			refSum = sum
+		}
+
+		assertEquals(refSum, ktSum)
+		report.add("sequential", "KTIntArrayList", ktTime, "ArrayList<Int>", refTime)
+		report.print()
+	}
+
+	@Test
+	fun benchmarkBitSet() {
+		// shaped like GeneralRouter rule evaluation: build a tag mask, intersect it with a road's
+		// types, read the first matching bit
+		val report = BenchmarkReport("bit mask evaluation, ${RULE_EVALUATIONS} rule evaluations")
+		val universe = 512
+		val random = XorShiftRandom(20260907L)
+
+		val masks = Array(64) { KBitSet(universe) }
+		val modelMasks = Array(64) { HashSet<Int>() }
+		for (i in masks.indices) {
+			repeat(8) {
+				val bit = random.nextInt(universe)
+				masks[i].set(bit)
+				modelMasks[i].add(bit)
+			}
+		}
+		val roadTypes = KBitSet(universe)
+		val modelRoadTypes = HashSet<Int>()
+		repeat(24) {
+			val bit = random.nextInt(universe)
+			roadTypes.set(bit)
+			modelRoadTypes.add(bit)
+		}
+
+		var ktChecksum = 0L
+		val ktTime = measure {
+			var checksum = 0L
+			val scratch = KBitSet(universe)
+			for (i in 0 until RULE_EVALUATIONS) {
+				val mask = masks[i and 63]
+				if (mask.intersects(roadTypes)) {
+					scratch.clear()
+					scratch.or(mask)
+					scratch.and(roadTypes)
+					checksum += scratch.nextSetBit(0)
+				}
+			}
+			ktChecksum = checksum
+		}
+
+		var refChecksum = 0L
+		val refTime = measure {
+			var checksum = 0L
+			for (i in 0 until RULE_EVALUATIONS) {
+				val mask = modelMasks[i and 63]
+				val intersection = mask.intersect(modelRoadTypes)
+				if (intersection.isNotEmpty()) {
+					checksum += intersection.min()
+				}
+			}
+			refChecksum = checksum
+		}
+
+		assertEquals(refChecksum, ktChecksum)
+		assertTrue(ktChecksum != 0L, "the workload must actually do something")
+		report.add("GeneralRouter shape", "KBitSet", ktTime, "HashSet<Int>", refTime)
+		report.print()
+	}
+
+	// ------------------------------------------------------------------ harness
+
+	private enum class KeyDistribution(val label: String) {
+
+		/** `roadId << 6 | segment`, exactly what routing uses as a map key. */
+		ROUTING("routing ids"),
+
+		/** Uniformly spread keys, the friendly case for any hash function. */
+		RANDOM("random     ");
+
+		fun keys(count: Int): LongArray {
+			val random = XorShiftRandom(20260907L)
+			return when (this) {
+				ROUTING -> LongArray(count) { i ->
+					// road ids grow in blocks, segments are small: highly structured low bits
+					((100_000_000L + i * 17L) shl 6) or (i % 48).toLong()
+				}
+				RANDOM -> LongArray(count) { random.nextLong() }
+			}
+		}
+	}
+
+	/** Half of the probes hit an existing key, half miss. */
+	private fun probeKeys(keys: LongArray, count: Int): LongArray {
+		val random = XorShiftRandom(1234L)
+		return LongArray(count) { i ->
+			if (i and 1 == 0) keys[random.nextInt(keys.size)] else (random.nextLong() or (1L shl 62))
+		}
+	}
+
+	private fun measure(block: () -> Unit): Double {
+		repeat(WARMUP_ROUNDS) { block() }
+		var best = Double.MAX_VALUE
+		repeat(MEASURED_ROUNDS) {
+			val mark = TimeSource.Monotonic.markNow()
+			block()
+			val elapsed = mark.elapsedNow().inWholeMicroseconds / 1000.0
+			if (elapsed < best) {
+				best = elapsed
+			}
+		}
+		return best
+	}
+
+	private class BenchmarkReport(private val title: String) {
+
+		private val rows = ArrayList<String>()
+
+		fun add(case: String, name: String, time: Double, refName: String, refTime: Double) {
+			val ratio = if (time > 0) refTime / time else 0.0
+			rows.add(
+				"  ${case.padEnd(22)} ${name.padEnd(16)} ${format(time)} ms" +
+						"   vs ${refName.padEnd(16)} ${format(refTime)} ms" +
+						"   speedup ${format(ratio)}x"
+			)
+		}
+
+		fun print() {
+			println("")
+			println("### $title")
+			println("    best of $MEASURED_ROUNDS rounds after $WARMUP_ROUNDS warmup rounds")
+			rows.forEach { println(it) }
+			println("")
+		}
+
+		private fun format(value: Double): String {
+			val scaled = (value * 100).toLong()
+			return "${scaled / 100}.${(scaled % 100).toString().padStart(2, '0')}".padStart(9)
+		}
+	}
+
+	companion object {
+		/** Kept modest so the suite stays usable on a phone and on a simulator. */
+		private const val ENTRIES = 200_000
+		private const val LOOKUPS = 400_000
+		private const val LIST_ENTRIES = 2_000_000
+		private const val RULE_EVALUATIONS = 200_000
+		private const val WARMUP_ROUNDS = 2
+		private const val MEASURED_ROUNDS = 3
+	}
+}

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/collections/KBitSetTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/collections/KBitSetTest.kt
@@ -1,0 +1,212 @@
+package net.osmand.shared.util.collections
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class KBitSetTest {
+
+	private fun bitsOf(vararg indices: Int): KBitSet {
+		val set = KBitSet()
+		for (index in indices) {
+			set.set(index)
+		}
+		return set
+	}
+
+	@Test
+	fun testSetGetClear() {
+		val bits = KBitSet()
+		assertTrue(bits.isEmpty())
+		assertFalse(bits.get(0))
+		// reading past the capacity must answer false, not fail
+		assertFalse(bits.get(100_000))
+
+		bits.set(5)
+		assertTrue(bits.get(5))
+		assertFalse(bits.get(4))
+		assertEquals(1, bits.cardinality())
+
+		bits.set(5, false)
+		assertFalse(bits.get(5))
+		bits.set(5, true)
+		assertTrue(bits.get(5))
+		bits.clear(5)
+		assertFalse(bits.get(5))
+		assertTrue(bits.isEmpty())
+	}
+
+	@Test
+	fun testGrowsOnDemandAcrossWords() {
+		val bits = KBitSet(1)
+		val indices = intArrayOf(0, 1, 63, 64, 65, 127, 128, 4095)
+		for (index in indices) {
+			bits.set(index)
+		}
+		assertEquals(indices.size, bits.cardinality())
+		for (index in indices) {
+			assertTrue(bits.get(index), "bit $index")
+		}
+		assertFalse(bits.get(62))
+		assertEquals(4096, bits.length())
+		assertContentEquals(indices, bits.toIntArray())
+	}
+
+	@Test
+	fun testLengthAndSize() {
+		val bits = KBitSet()
+		assertEquals(0, bits.length())
+		bits.set(0)
+		assertEquals(1, bits.length())
+		bits.set(70)
+		assertEquals(71, bits.length())
+		bits.clear(70)
+		assertEquals(1, bits.length())
+		assertTrue(bits.size() >= 128)
+		assertEquals(0, bits.size() % KBitSet.BITS_PER_WORD)
+	}
+
+	@Test
+	fun testNextSetBitAndNextClearBit() {
+		val bits = bitsOf(3, 64, 65, 200)
+		assertEquals(3, bits.nextSetBit(0))
+		assertEquals(3, bits.nextSetBit(3))
+		assertEquals(64, bits.nextSetBit(4))
+		assertEquals(65, bits.nextSetBit(65))
+		assertEquals(200, bits.nextSetBit(66))
+		assertEquals(-1, bits.nextSetBit(201))
+		assertEquals(-1, bits.nextSetBit(100_000))
+
+		assertEquals(0, bits.nextClearBit(0))
+		assertEquals(4, bits.nextClearBit(3))
+		assertEquals(66, bits.nextClearBit(64))
+	}
+
+	@Test
+	fun testBinaryOperations() {
+		val a = bitsOf(1, 2, 3, 100)
+		val b = bitsOf(2, 3, 4)
+
+		assertTrue(a.intersects(b))
+		assertFalse(bitsOf(1).intersects(bitsOf(2)))
+		// intersection must be found even when only the longer set has the bit range
+		assertTrue(bitsOf(200).intersects(bitsOf(200)))
+		assertFalse(bitsOf(200).intersects(bitsOf(1)))
+
+		val or = a.copy()
+		or.or(b)
+		assertContentEquals(intArrayOf(1, 2, 3, 4, 100), or.toIntArray())
+
+		val and = a.copy()
+		and.and(b)
+		assertContentEquals(intArrayOf(2, 3), and.toIntArray())
+
+		val andNot = a.copy()
+		andNot.andNot(b)
+		assertContentEquals(intArrayOf(1, 100), andNot.toIntArray())
+
+		val xor = a.copy()
+		xor.xor(b)
+		assertContentEquals(intArrayOf(1, 4, 100), xor.toIntArray())
+
+		val self = a.copy()
+		self.and(self)
+		assertContentEquals(a.toIntArray(), self.toIntArray())
+		self.or(self)
+		assertContentEquals(a.toIntArray(), self.toIntArray())
+	}
+
+	@Test
+	fun testAndClearsBitsBeyondTheOtherSet() {
+		val a = bitsOf(1, 500)
+		val b = bitsOf(1)
+		a.and(b)
+		assertContentEquals(intArrayOf(1), a.toIntArray())
+	}
+
+	@Test
+	fun testEqualsIgnoresCapacity() {
+		val small = KBitSet(8)
+		val large = KBitSet(4096)
+		small.set(3)
+		large.set(3)
+		assertEquals(small, large)
+		assertEquals(small.hashCode(), large.hashCode())
+
+		large.set(1000)
+		assertFalse(small == large)
+		large.clear(1000)
+		assertEquals(small, large)
+
+		assertEquals(KBitSet(8), KBitSet(4096))
+		assertEquals(KBitSet(8).hashCode(), KBitSet(4096).hashCode())
+	}
+
+	@Test
+	fun testGeneralRouterEvaluationShape() {
+		// mirrors GeneralRouter: mask over the universal rule table, intersected with a road's types
+		val tagRuleMask = bitsOf(4, 9, 17)
+		val roadTypes = bitsOf(2, 9, 30)
+
+		assertTrue(tagRuleMask.intersects(roadTypes))
+		val findBit = KBitSet(tagRuleMask.length())
+		findBit.or(tagRuleMask)
+		findBit.and(roadTypes)
+		assertEquals(9, findBit.nextSetBit(0))
+
+		// checkAllTypesShouldBePresent: filterTypes must be a subset of types
+		val filterTypes = bitsOf(2, 9)
+		val eval = KBitSet()
+		eval.or(filterTypes)
+		eval.and(roadTypes)
+		assertEquals(filterTypes, eval)
+
+		val missing = bitsOf(2, 9, 11)
+		val eval2 = KBitSet()
+		eval2.or(missing)
+		eval2.and(roadTypes)
+		assertFalse(missing == eval2)
+	}
+
+	@Test
+	fun testNegativeIndexRejected() {
+		val bits = KBitSet()
+		assertFailsWith<IndexOutOfBoundsException> { bits.set(-1) }
+		assertFailsWith<IndexOutOfBoundsException> { bits.get(-1) }
+		assertFailsWith<IndexOutOfBoundsException> { bits.nextSetBit(-1) }
+	}
+
+	@Test
+	fun testMatchesReferenceModelUnderRandomOps() {
+		val bits = KBitSet(1)
+		val model = HashSet<Int>()
+		val random = XorShiftRandom(31337L)
+		repeat(50_000) {
+			val index = random.nextInt(3000)
+			when (random.nextInt(8)) {
+				in 0..4 -> {
+					bits.set(index)
+					model.add(index)
+				}
+				in 5..6 -> {
+					bits.clear(index)
+					model.remove(index)
+				}
+				else -> assertEquals(model.contains(index), bits.get(index))
+			}
+		}
+		assertEquals(model.size, bits.cardinality())
+		assertContentEquals(model.sorted().toIntArray(), bits.toIntArray())
+		assertEquals((model.maxOrNull() ?: -1) + 1, bits.length())
+
+		var visited = 0
+		bits.forEachSetBit { index ->
+			assertTrue(index in model)
+			visited++
+		}
+		assertEquals(model.size, visited)
+	}
+}

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/collections/KTIntArrayListTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/collections/KTIntArrayListTest.kt
@@ -1,0 +1,157 @@
+package net.osmand.shared.util.collections
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class KTIntArrayListTest {
+
+	@Test
+	fun testAddAndGet() {
+		val list = KTIntArrayList()
+		assertTrue(list.isEmpty())
+		for (i in 0 until 100) {
+			list.add(i)
+		}
+		assertEquals(100, list.size)
+		for (i in 0 until 100) {
+			assertEquals(i, list[i])
+			assertEquals(i, list.getQuick(i))
+		}
+	}
+
+	@Test
+	fun testBoundsChecked() {
+		val list = KTIntArrayList()
+		list.add(1)
+		assertFailsWith<IndexOutOfBoundsException> { list[1] }
+		assertFailsWith<IndexOutOfBoundsException> { list[-1] }
+		assertFailsWith<IndexOutOfBoundsException> { list[0] = 5; list[3] = 5 }
+	}
+
+	@Test
+	fun testAddArrayAndRange() {
+		val list = KTIntArrayList()
+		list.add(intArrayOf(1, 2, 3))
+		list.add(intArrayOf(4, 5, 6, 7), 1, 2)
+		assertContentEquals(intArrayOf(1, 2, 3, 5, 6), list.toArray())
+		assertFailsWith<IllegalArgumentException> { list.add(intArrayOf(1), 0, 5) }
+	}
+
+	@Test
+	fun testAddAll() {
+		val a = KTIntArrayList(intArrayOf(1, 2))
+		val b = KTIntArrayList(intArrayOf(3, 4))
+		a.addAll(b)
+		assertContentEquals(intArrayOf(1, 2, 3, 4), a.toArray())
+		assertEquals(2, b.size)
+	}
+
+	@Test
+	fun testInsertAndRemove() {
+		val list = KTIntArrayList(intArrayOf(1, 2, 4))
+		list.insert(2, 3)
+		assertContentEquals(intArrayOf(1, 2, 3, 4), list.toArray())
+		list.insert(4, 5)
+		assertContentEquals(intArrayOf(1, 2, 3, 4, 5), list.toArray())
+		assertEquals(3, list.removeAt(2))
+		assertContentEquals(intArrayOf(1, 2, 4, 5), list.toArray())
+		assertTrue(list.removeValue(5))
+		assertFalse(list.removeValue(99))
+		assertContentEquals(intArrayOf(1, 2, 4), list.toArray())
+	}
+
+	@Test
+	fun testClearVsReset() {
+		val list = KTIntArrayList(intArrayOf(1, 2, 3))
+		val capacity = list.capacity()
+		list.clear()
+		assertEquals(0, list.size)
+		assertEquals(capacity, list.capacity())
+		list.add(9)
+		assertEquals(9, list[0])
+
+		val other = KTIntArrayList(intArrayOf(1, 2, 3))
+		other.reset()
+		assertEquals(0, other.size)
+		other.add(7)
+		assertContentEquals(intArrayOf(7), other.toArray())
+	}
+
+	@Test
+	fun testSortKeepsPayloadOnly() {
+		val list = KTIntArrayList(16)
+		list.add(intArrayOf(5, 3, 9, 1))
+		list.sort()
+		assertContentEquals(intArrayOf(1, 3, 5, 9), list.toArray())
+		assertEquals(4, list.size)
+		// the unused tail must not have been pulled into the payload
+		list.add(0)
+		assertContentEquals(intArrayOf(1, 3, 5, 9, 0), list.toArray())
+	}
+
+	@Test
+	fun testMiscOperations() {
+		val list = KTIntArrayList(intArrayOf(4, 8, 15, 16, 23, 42))
+		assertTrue(15 in list)
+		assertFalse(7 in list)
+		assertEquals(2, list.indexOf(15))
+		assertEquals(-1, list.indexOf(7))
+		assertContentEquals(intArrayOf(8, 15), list.toArray(1, 2))
+		assertEquals(108L, list.sum())
+		list.reverse()
+		assertContentEquals(intArrayOf(42, 23, 16, 15, 8, 4), list.toArray())
+
+		var sum = 0
+		list.forEach { sum += it }
+		assertEquals(108, sum)
+
+		list.trimToSize()
+		assertEquals(list.size, list.capacity())
+	}
+
+	@Test
+	fun testEqualsAndHashCode() {
+		val a = KTIntArrayList(intArrayOf(1, 2, 3))
+		val b = KTIntArrayList(64)
+		b.add(intArrayOf(1, 2, 3))
+		assertEquals(a, b)
+		assertEquals(a.hashCode(), b.hashCode())
+		b.add(4)
+		assertFalse(a == b)
+		assertEquals("[1, 2, 3]", a.toString())
+	}
+
+	@Test
+	fun testMatchesReferenceModelUnderRandomOps() {
+		val list = KTIntArrayList(2)
+		val model = ArrayList<Int>()
+		val random = XorShiftRandom(777L)
+		repeat(40_000) { step ->
+			when (random.nextInt(10)) {
+				in 0..6 -> {
+					list.add(step)
+					model.add(step)
+				}
+				7 -> if (model.isNotEmpty()) {
+					val index = random.nextInt(model.size)
+					assertEquals(model.removeAt(index), list.removeAt(index))
+				}
+				8 -> if (model.isNotEmpty()) {
+					val index = random.nextInt(model.size)
+					model[index] = step
+					list[index] = step
+				}
+				else -> if (model.isNotEmpty()) {
+					val index = random.nextInt(model.size)
+					assertEquals(model[index], list[index])
+				}
+			}
+			assertEquals(model.size, list.size)
+		}
+		assertContentEquals(model.toIntArray(), list.toArray())
+	}
+}

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/collections/KTLongHashSetTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/collections/KTLongHashSetTest.kt
@@ -1,0 +1,114 @@
+package net.osmand.shared.util.collections
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class KTLongHashSetTest {
+
+	@Test
+	fun testAddContainsRemove() {
+		val set = KTLongHashSet()
+		assertTrue(set.isEmpty())
+		assertFalse(5L in set)
+
+		assertTrue(set.add(5L))
+		assertFalse(set.add(5L))
+		assertEquals(1, set.size)
+		assertTrue(5L in set)
+
+		assertFalse(set.remove(6L))
+		assertTrue(set.remove(5L))
+		assertEquals(0, set.size)
+		assertFalse(5L in set)
+	}
+
+	@Test
+	fun testExtremeKeys() {
+		val set = KTLongHashSet()
+		val keys = longArrayOf(0L, -1L, Long.MIN_VALUE, Long.MAX_VALUE)
+		for (key in keys) {
+			assertTrue(set.add(key))
+		}
+		assertEquals(keys.size, set.size)
+		for (key in keys) {
+			assertTrue(key in set)
+		}
+	}
+
+	@Test
+	fun testGrowth() {
+		val set = KTLongHashSet(4)
+		val count = 10_000
+		for (i in 0 until count) {
+			set.add(i.toLong() shl 7)
+		}
+		assertEquals(count, set.size)
+		for (i in 0 until count) {
+			assertTrue((i.toLong() shl 7) in set)
+		}
+		assertFalse(1L in set)
+	}
+
+	@Test
+	fun testAddAllAndToArray() {
+		val set = KTLongHashSet()
+		assertTrue(set.addAll(longArrayOf(1L, 2L, 3L, 2L)))
+		assertEquals(3, set.size)
+		assertFalse(set.addAll(longArrayOf(1L, 2L)))
+
+		val other = KTLongHashSet()
+		other.addAll(longArrayOf(3L, 4L))
+		assertTrue(set.addAll(other))
+		assertEquals(4, set.size)
+		assertEquals(listOf(1L, 2L, 3L, 4L), set.toArray().sorted())
+	}
+
+	@Test
+	fun testIteration() {
+		val set = KTLongHashSet()
+		for (i in 0 until 50) {
+			set.add(i.toLong())
+		}
+		val byForEach = HashSet<Long>()
+		set.forEach { byForEach.add(it) }
+		assertEquals(50, byForEach.size)
+
+		val byIterator = HashSet<Long>()
+		val it = set.iterator()
+		while (it.hasNext()) {
+			byIterator.add(it.next())
+		}
+		assertEquals(byForEach, byIterator)
+	}
+
+	@Test
+	fun testClear() {
+		val set = KTLongHashSet()
+		for (i in 0 until 100) {
+			set.add(i.toLong())
+		}
+		set.clear()
+		assertEquals(0, set.size)
+		assertTrue(set.toArray().isEmpty())
+		assertTrue(set.add(1L))
+	}
+
+	@Test
+	fun testMatchesReferenceModelUnderRandomOps() {
+		val set = KTLongHashSet(4)
+		val model = HashSet<Long>()
+		val random = XorShiftRandom(4242L)
+		repeat(60_000) {
+			val key = random.nextLong(1500) - 700
+			when (random.nextInt(10)) {
+				in 0..5 -> assertEquals(model.add(key), set.add(key), "add($key)")
+				in 6..7 -> assertEquals(model.remove(key), set.remove(key), "remove($key)")
+				else -> assertEquals(model.contains(key), key in set, "contains($key)")
+			}
+			assertEquals(model.size, set.size)
+		}
+		assertEquals(model.sorted(), set.toArray().sorted())
+	}
+}

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/collections/KTLongObjectMapTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/collections/KTLongObjectMapTest.kt
@@ -1,0 +1,215 @@
+package net.osmand.shared.util.collections
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class KTLongObjectMapTest {
+
+	@Test
+	fun testPutGetRemove() {
+		val map = KTLongObjectMap<String>()
+		assertTrue(map.isEmpty())
+		assertNull(map[1L])
+
+		assertNull(map.put(1L, "one"))
+		assertEquals("one", map.put(1L, "ONE"))
+		assertEquals("ONE", map[1L])
+		assertEquals(1, map.size)
+		assertTrue(map.containsKey(1L))
+
+		assertNull(map.remove(2L))
+		assertEquals("ONE", map.remove(1L))
+		assertEquals(0, map.size)
+		assertFalse(map.containsKey(1L))
+		assertNull(map[1L])
+	}
+
+	@Test
+	fun testNegativeAndExtremeKeys() {
+		val map = KTLongObjectMap<String>()
+		val keys = longArrayOf(0L, -1L, Long.MIN_VALUE, Long.MAX_VALUE, -42L, 42L)
+		for (key in keys) {
+			map.put(key, "v$key")
+		}
+		assertEquals(keys.size, map.size)
+		for (key in keys) {
+			assertEquals("v$key", map[key])
+		}
+	}
+
+	@Test
+	fun testGrowthKeepsEveryEntry() {
+		val map = KTLongObjectMap<Int>(4)
+		val count = 5000
+		for (i in 0 until count) {
+			map.put(i.toLong() * 31, i)
+		}
+		assertEquals(count, map.size)
+		for (i in 0 until count) {
+			assertEquals(i, map[i.toLong() * 31])
+		}
+		assertNull(map[1L])
+	}
+
+	@Test
+	fun testTombstonesAreReused() {
+		val map = KTLongObjectMap<Int>(8)
+		// churn far beyond the table size, tombstones must not fill the table up
+		for (round in 0 until 200) {
+			for (i in 0 until 50) {
+				map.put((round * 50 + i).toLong(), i)
+			}
+			for (i in 0 until 50) {
+				map.remove((round * 50 + i).toLong())
+			}
+		}
+		assertEquals(0, map.size)
+		map.put(7L, 7)
+		assertEquals(7, map[7L])
+		assertEquals(1, map.size)
+	}
+
+	@Test
+	fun testRemovedKeyDoesNotBreakProbeChain() {
+		// keys chosen to be inserted, then removed from the middle of a chain
+		val map = KTLongObjectMap<Int>(8)
+		for (i in 0 until 12) {
+			map.put(i.toLong(), i)
+		}
+		map.remove(5L)
+		map.remove(6L)
+		for (i in 0 until 12) {
+			if (i == 5 || i == 6) {
+				assertNull(map[i.toLong()], "key $i must be gone")
+			} else {
+				assertEquals(i, map[i.toLong()], "key $i must still resolve")
+			}
+		}
+	}
+
+	@Test
+	fun testClear() {
+		val map = KTLongObjectMap<Int>()
+		for (i in 0 until 100) {
+			map.put(i.toLong(), i)
+		}
+		map.clear()
+		assertEquals(0, map.size)
+		assertTrue(map.isEmpty())
+		assertTrue(map.keys().isEmpty())
+		assertTrue(map.values().isEmpty())
+		map.put(1L, 1)
+		assertEquals(1, map[1L])
+	}
+
+	@Test
+	fun testPutIfAbsentAndGetOrPut() {
+		val map = KTLongObjectMap<String>()
+		assertEquals("a", map.putIfAbsent(1L, "a"))
+		assertEquals("a", map.putIfAbsent(1L, "b"))
+		assertEquals("a", map[1L])
+
+		var created = 0
+		assertEquals("a", map.getOrPut(1L) { created++; "z" })
+		assertEquals(0, created)
+		assertEquals("c", map.getOrPut(2L) { created++; "c" })
+		assertEquals(1, created)
+		assertEquals("c", map[2L])
+		assertEquals(2, map.size)
+	}
+
+	@Test
+	fun testKeysAndValues() {
+		val map = KTLongObjectMap<Int>()
+		for (i in 0 until 64) {
+			map.put(i.toLong(), i * 2)
+		}
+		map.remove(10L)
+		assertEquals(63, map.keys().size)
+		assertEquals(63, map.values().size)
+		assertEquals(map.values().sorted(), (0 until 64).filter { it != 10 }.map { it * 2 })
+		assertEquals(map.keys().sorted(), (0 until 64L).filter { it != 10L })
+		assertEquals(map.values(), map.valueCollection())
+	}
+
+	@Test
+	fun testIteration() {
+		val map = KTLongObjectMap<Int>()
+		for (i in 0 until 100) {
+			map.put(i.toLong(), i)
+		}
+		val seenByForEach = HashMap<Long, Int>()
+		map.forEach { key, value -> seenByForEach[key] = value }
+		assertEquals(100, seenByForEach.size)
+
+		val seenByIterator = HashMap<Long, Int>()
+		val it = map.iterator()
+		while (it.hasNext()) {
+			it.advance()
+			seenByIterator[it.key()] = it.value()
+		}
+		assertEquals(seenByForEach, seenByIterator)
+
+		var sum = 0
+		map.forEachValue { sum += it }
+		assertEquals((0 until 100).sum(), sum)
+	}
+
+	@Test
+	fun testIterationFailsFastOnModification() {
+		val map = KTLongObjectMap<Int>()
+		for (i in 0 until 10) {
+			map.put(i.toLong(), i)
+		}
+		assertFailsWith<IllegalStateException> {
+			map.forEach { key, _ -> map.put(key + 1000, 0) }
+		}
+		val map2 = KTLongObjectMap<Int>()
+		for (i in 0 until 10) {
+			map2.put(i.toLong(), i)
+		}
+		assertFailsWith<IllegalStateException> {
+			val it = map2.iterator()
+			it.advance()
+			map2.remove(9L)
+			it.advance()
+		}
+	}
+
+	@Test
+	fun testMatchesReferenceModelUnderRandomOps() {
+		val map = KTLongObjectMap<Int>(4)
+		val model = HashMap<Long, Int>()
+		val random = XorShiftRandom(20260907L)
+		repeat(60_000) { step ->
+			// small key space, so collisions, overwrites and re-inserts all get exercised
+			val key = random.nextLong(2000) - 1000
+			when (random.nextInt(10)) {
+				in 0..5 -> {
+					assertEquals(model.put(key, step), map.put(key, step), "put($key)")
+				}
+				in 6..7 -> {
+					assertEquals(model.remove(key), map.remove(key), "remove($key)")
+				}
+				8 -> {
+					assertEquals(model[key], map[key], "get($key)")
+				}
+				else -> {
+					assertEquals(model.containsKey(key), map.containsKey(key), "containsKey($key)")
+				}
+			}
+			assertEquals(model.size, map.size)
+		}
+		assertEquals(model.size, map.size)
+		for ((key, value) in model) {
+			assertEquals(value, map[key])
+		}
+		val fromMap = HashMap<Long, Int>()
+		map.forEach { key, value -> fromMap[key] = value }
+		assertEquals(model, fromMap)
+	}
+}

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/collections/TestRandom.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/collections/TestRandom.kt
@@ -1,0 +1,31 @@
+package net.osmand.shared.util.collections
+
+/**
+ * Small deterministic PRNG shared by the collection tests and benchmarks.
+ *
+ * `kotlin.random.Random` is deterministic per seed too, but this xorshift keeps benchmark key
+ * generation out of the measured cost and produces the exact same stream on every platform, so JVM,
+ * Android and iOS numbers describe the same workload.
+ */
+class XorShiftRandom(seed: Long) {
+
+	private var state: Long = if (seed == 0L) 0x2545F4914F6CDD1DL else seed
+
+	fun nextLong(): Long {
+		var x = state
+		x = x xor (x shl 13)
+		x = x xor (x ushr 7)
+		x = x xor (x shl 17)
+		state = x
+		return x
+	}
+
+	/** Non negative value below [bound]. */
+	fun nextLong(bound: Long): Long {
+		require(bound > 0) { "bound must be positive" }
+		return (nextLong() ushr 1) % bound
+	}
+
+	/** Non negative value below [bound]. */
+	fun nextInt(bound: Int): Int = nextLong(bound.toLong()).toInt()
+}


### PR DESCRIPTION
Groundwork for moving the routing code from `OsmAnd-java` into `OsmAnd-shared`. This is the bottom
tier only: the pieces every later step depends on. Nothing is ported on top of them yet, and no
existing code changes behaviour.

## What is here

**`net.osmand.shared.util.collections`** — replacements for `gnu.trove`, which has no KMP equivalent:

| Class | Replaces | Notes |
|---|---|---|
| `KTLongObjectMap` | `TLongObjectHashMap` | open addressing, linear probing, MurmurHash3 key mixing, tombstones |
| `KTLongHashSet` | `TLongHashSet` | same scheme |
| `KTIntArrayList` | `TIntArrayList` | flat `IntArray`, `get` / `getQuick` split as in trove |
| `KBitSet` | `java.util.BitSet` | `java.util.BitSet` semantics, including capacity independent `equals` / `hashCode` |

Keys are mixed through the MurmurHash3 finalizer rather than used raw: routing keys look like
`roadId << 6 | segment`, which is structured enough to cluster badly under linear probing.

**`net.osmand.shared.data`** — ports of `net.osmand.Location` and `net.osmand.data.*`:
`KLocation` (Vincenty inverse solution on WGS84), `KQuadPoint`, `KQuadPointDouble`, `KQuadTree`,
`KDataTileManager`.

## Design notes worth a reviewer's eye

- `KLocation` keeps the Java "primitive plus `hasX` flag" shape instead of nullable primitives. A
  route holds thousands of fixes and `Float?` would box every one of them.
- `KLocation.distanceTo` / `bearingTo` share one solution through an immutable snapshot rather than
  the `synchronized` block of the original, since common code has no `synchronized`. A racing reader
  either sees a complete consistent snapshot or recomputes.
- `KDataTileManager.getObjects` for a lat/lon box resets `tileYUp` where the Java original resets
  `tileXUp`. That looks like a typo; the branch is unreachable for the argument order callers
  actually use.
- Constructors carry `@JvmOverloads` so the existing Java routing code can construct these without
  passing a capacity.

## Testing

- **67 tests in `commonTest`**, passing on JVM and on Kotlin/Native (iOS simulator). Each collection
  is driven against a reference model (`HashMap` / `HashSet` / `ArrayList` / `HashSet<Int>`) over
  tens of thousands of random operations, so tombstone reuse, probe chains after removal, growth and
  iteration all get exercised.
- **`TroveComparisonTest` in `OsmAnd-java`** puts the shared collections and the originals
  (`gnu.trove`, `java.util.BitSet`) through the same operation stream and asserts they stay in step.
  It lives there because that module is the only place the two share a classpath.

Run counts on this branch:

| | tests | skipped | failures |
|---|---|---|---|
| `:OsmAnd-shared:jvmTest` | 131 | 4 | 0 |
| `:OsmAnd-shared:iosSimulatorArm64Test` | 130 | 4 | 6 pre-existing, unrelated |
| `:OsmAnd-java:test --tests "net.osmand.shared.*"` | 9 | 4 | 0 |

The 6 native failures are in `GpxUtilitiesLoadTest`, `KGeoPointParserUtilTest` and `NetworkAPITest`
and fail on `master` as well.

## Benchmarks

Two benchmark classes are included and **annotated `@Ignore`** — the 4 skipped tests in each row
above. Measuring takes seconds and the timings are noise in a normal run. Each class documents how
to run it.

Numbers from this branch, best of several rounds after warmup:

```
JVM, vs the originals
  long -> object map, 300k    KTLongObjectMap  7.74 ms   TLongObjectHashMap  9.29 (1.20x)
  long set, 300k              KTLongHashSet    4.48 ms   TLongHashSet        7.23 (1.61x)
  int list, 3M append+scan    KTIntArrayList   3.48 ms   TIntArrayList       2.77 (0.79x)
  bit mask, 300k rules        KBitSet          2.93 ms   java.util.BitSet    2.08 (0.71x)
```

`KTIntArrayList` trails trove only on the growth path; presized appends and scans match it. Presize
when the length is known.

The build file gains an optimised iOS test binary. The default `iosSimulatorArm64Test` task links
`debugTest`, i.e. without LLVM optimisations, and reports numbers 5 to 13 times worse than a real
build — enough to draw the wrong conclusion about whether Kotlin/Native can carry routing code. The
release binary is not part of the normal build graph and only links when asked for:

```
./gradlew :OsmAnd-shared:linkReleaseTestIosSimulatorArm64
```

Measured that way, Kotlin/Native release sits within 1.3–2.1x of the JVM on these workloads, and the
primitive collections beat the boxing stdlib ones by a wider margin on iOS than on JVM (6.2x vs
`ArrayList<Int>`, against 1.9x on JVM).

## Not in this PR

No routing class is ported yet, and nothing existing switches over to these types. That happens in
the following tiers, starting with the pure model classes (`TurnType`, `RouteCalculationProgress`,
`AlarmInfo`, `RouteDirectionInfo`).
