### PR TITLE
Do not start the star map preview after the camera was closed (#25880)

### DIFF
--- a/OsmAnd/src/net/osmand/plus/plugins/astronomy/utils/StarMapCameraHelper.kt
+++ b/OsmAnd/src/net/osmand/plus/plugins/astronomy/utils/StarMapCameraHelper.kt
@@ -41,6 +41,7 @@ class StarMapCameraHelper(
 
 	private var cameraDevice: CameraDevice? = null
 	private var captureSession: CameraCaptureSession? = null
+	private var cameraOpenRequested = false
 	private var previewSize: Size? = null
 	private var baseTransformMatrix: Matrix? = null
 
@@ -131,6 +132,7 @@ class StarMapCameraHelper(
 			return
 		}
 
+		cameraOpenRequested = true
 		if (cameraTextureView.isAvailable) {
 			startCameraSession()
 		} else {
@@ -175,16 +177,25 @@ class StarMapCameraHelper(
 
 			manager.openCamera(cameraId, object : CameraDevice.StateCallback() {
 				override fun onOpened(camera: CameraDevice) {
+					if (!cameraOpenRequested) {
+						// The overlay was closed while the camera was still opening
+						camera.close()
+						return
+					}
 					cameraDevice = camera
 					createCaptureSession()
 				}
 				override fun onDisconnected(camera: CameraDevice) {
 					camera.close()
-					cameraDevice = null
+					if (cameraDevice === camera) {
+						cameraDevice = null
+					}
 				}
 				override fun onError(camera: CameraDevice, error: Int) {
 					camera.close()
-					cameraDevice = null
+					if (cameraDevice === camera) {
+						cameraDevice = null
+					}
 				}
 			}, null)
 		} catch (e: Exception) {
@@ -293,6 +304,7 @@ class StarMapCameraHelper(
 
 	private fun createCaptureSession() {
 		try {
+			val device = cameraDevice ?: return
 			val texture = cameraTextureView.surfaceTexture!!
 			if (previewSize != null) {
 				texture.setDefaultBufferSize(previewSize!!.width, previewSize!!.height)
@@ -301,14 +313,21 @@ class StarMapCameraHelper(
 			}
 			val surface = Surface(texture)
 
-			val builder = cameraDevice?.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW)
-			builder?.addTarget(surface)
+			val builder = device.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW)
+			builder.addTarget(surface)
 
-			cameraDevice?.createCaptureSession(listOf(surface), object : CameraCaptureSession.StateCallback() {
+			device.createCaptureSession(listOf(surface), object : CameraCaptureSession.StateCallback() {
 				override fun onConfigured(session: CameraCaptureSession) {
+					if (cameraDevice !== device) {
+						// The camera was closed or reopened while the session was being configured
+						session.close()
+						return
+					}
 					captureSession = session
-					builder?.build()?.let {
-						session.setRepeatingRequest(it, null, null)
+					try {
+						session.setRepeatingRequest(builder.build(), null, null)
+					} catch (e: Exception) {
+						log.error("Failed to start camera preview", e)
 					}
 				}
 				override fun onConfigureFailed(session: CameraCaptureSession) {}
@@ -319,6 +338,7 @@ class StarMapCameraHelper(
 	}
 
 	private fun closeCamera() {
+		cameraOpenRequested = false
 		captureSession?.close()
 		captureSession = null
 		cameraDevice?.close()

--- a/OsmAnd/test/java/net/osmand/test/junit/StarMapCameraOverlayRaceTest.kt
+++ b/OsmAnd/test/java/net/osmand/test/junit/StarMapCameraOverlayRaceTest.kt
@@ -1,0 +1,259 @@
+package net.osmand.test.junit
+
+import android.Manifest
+import android.content.Context
+import android.graphics.SurfaceTexture
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraManager
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.Looper
+import android.view.TextureView
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.fragment.app.Fragment
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.GrantPermissionRule
+import net.osmand.plus.OsmandApplication
+import net.osmand.plus.activities.MapActivity
+import net.osmand.plus.plugins.astronomy.utils.StarMapCameraHelper
+import net.osmand.plus.plugins.astronomy.views.StarView
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Regression test for issue #25880 - `IllegalStateException: CameraDevice was already closed`
+ * thrown from `StarMapCameraHelper.createCaptureSession$1.onConfigured()`.
+ *
+ * `StarMapCameraHelper.createCaptureSession()` blocks its looper thread inside the framework's
+ * `configureStreamsChecked()` and only then posts `onConfigured` back to that looper. Anything
+ * that closes the camera in the meantime - `onPause()`, or the overlay button being pressed
+ * again - is dispatched first, so `onConfigured()` then calls `setRepeatingRequest()` on a
+ * session whose device is already closed.
+ *
+ * The test drives [StarMapCameraHelper] directly instead of going through `StarMapFragment`:
+ * the star map is behind a paid feature, and the fragment adds nothing the race needs. The
+ * helper is given a fragment that is not attached to an activity, which keeps `configureTransform()`
+ * out of the way, and a real [TextureView] hosted by [MapActivity], because only an attached,
+ * hardware accelerated view produces the [SurfaceTexture] the capture session needs.
+ *
+ * The helper is resumed and paused on a dedicated looper thread rather than the main one. The
+ * ordering that produces the crash is identical - Camera2 delivers its callbacks to the looper of
+ * the thread that called `openCamera()`, because the helper passes a `null` handler - but an
+ * uncaught exception on that thread can be recorded and asserted on, instead of killing the
+ * process and reporting the whole instrumentation run as crashed.
+ *
+ * Each cycle waits for `onCameraUnavailable()`, which is the framework announcing that the device
+ * has just been opened, and then schedules the close a few milliseconds later, so it lands inside
+ * the configuration window. How long that window is depends on the device, so the cycles sweep a
+ * range of delays around it.
+ *
+ * Before the fix this fails on a Pixel 8 Pro / Android 17 within the first few cycles; after it,
+ * all cycles pass.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class StarMapCameraOverlayRaceTest {
+
+	companion object {
+		/**
+		 * Delay between the camera device being opened and the overlay being closed. The
+		 * configuration window is tens of milliseconds wide and its length differs per device,
+		 * so the cycles sweep across it.
+		 */
+		private val CLOSE_DELAYS_MS = longArrayOf(5, 10, 15, 20, 25, 30, 40, 50, 60, 80, 15, 25, 35, 45, 55)
+
+		private const val SURFACE_TIMEOUT_SEC = 10L
+		private const val CAMERA_OPEN_TIMEOUT_SEC = 10L
+		private const val SESSION_SETTLE_MS = 2500L
+		private const val CYCLE_SETTLE_MS = 1200L
+		private const val PREVIEW_SIZE_PX = 320
+		private const val APP_INIT_TIMEOUT_SEC = 120L
+	}
+
+	@get:Rule
+	val scenarioRule = ActivityScenarioRule(MapActivity::class.java)
+
+	@get:Rule
+	val cameraPermissionRule: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.CAMERA)
+
+	private val uncaught = AtomicReference<Throwable?>(null)
+
+	private var cameraThread: HandlerThread? = null
+	private var cameraHandler: Handler? = null
+	private var helper: StarMapCameraHelper? = null
+	private var textureView: TextureView? = null
+
+	private lateinit var app: OsmandApplication
+
+	@Before
+	fun setup() {
+		app = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as OsmandApplication
+		val deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(APP_INIT_TIMEOUT_SEC)
+		while (app.isApplicationInitializing && System.currentTimeMillis() < deadline) {
+			Thread.sleep(200)
+		}
+	}
+
+	@Test
+	fun sessionConfiguredAfterCameraClosedDoesNotCrash() {
+		val manager = app.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+		val cameraId = findBackCameraId(manager)
+		assumeTrue("no back camera on this device", cameraId != null)
+
+		startCameraThread()
+		createHelper()
+		armOverlay()
+
+		for ((cycle, closeDelayMs) in CLOSE_DELAYS_MS.withIndex()) {
+			runRaceCycle(manager, cameraId!!, cycle, closeDelayMs)
+
+			val throwable = uncaught.get()
+			if (throwable != null) {
+				fail("Camera callback threw after the camera was closed" +
+						" (cycle $cycle, close scheduled ${closeDelayMs}ms after the device was opened):\n" +
+						stackTraceOf(throwable))
+			}
+		}
+	}
+
+	@After
+	fun releaseCamera() {
+		val handler = cameraHandler
+		if (handler != null && cameraThread?.isAlive == true) {
+			runOnCameraThread(handler) { helper?.onPause() }
+		}
+		InstrumentationRegistry.getInstrumentation().runOnMainSync {
+			textureView?.let { (it.parent as? ViewGroup)?.removeView(it) }
+		}
+		cameraThread?.quitSafely()
+		cameraThread = null
+		cameraHandler = null
+	}
+
+	private fun findBackCameraId(manager: CameraManager): String? {
+		return manager.cameraIdList.firstOrNull { id ->
+			val lensFacing = manager.getCameraCharacteristics(id).get(CameraCharacteristics.LENS_FACING)
+			lensFacing == CameraCharacteristics.LENS_FACING_BACK
+		}
+	}
+
+	private fun startCameraThread() {
+		val thread = HandlerThread("star-map-camera-race")
+		thread.start()
+		thread.setUncaughtExceptionHandler { _, throwable -> uncaught.compareAndSet(null, throwable) }
+		cameraThread = thread
+		cameraHandler = Handler(thread.looper)
+	}
+
+	/**
+	 * Hosts a real [TextureView] in the activity and builds the helper around it. The fragment is
+	 * deliberately detached: the helper only needs a context from it, and a null activity keeps
+	 * `configureTransform()` - the one part that touches views - from running off the main thread.
+	 */
+	private fun createHelper() {
+		val surfaceReady = CountDownLatch(1)
+		scenarioRule.scenario.onActivity { activity ->
+			val view = TextureView(activity)
+			view.surfaceTextureListener = object : TextureView.SurfaceTextureListener {
+				override fun onSurfaceTextureAvailable(surface: SurfaceTexture, width: Int, height: Int) {
+					surfaceReady.countDown()
+				}
+
+				override fun onSurfaceTextureSizeChanged(surface: SurfaceTexture, width: Int, height: Int) {}
+				override fun onSurfaceTextureDestroyed(surface: SurfaceTexture): Boolean = true
+				override fun onSurfaceTextureUpdated(surface: SurfaceTexture) {}
+			}
+			val content = activity.findViewById<ViewGroup>(android.R.id.content)
+			content.addView(view, FrameLayout.LayoutParams(PREVIEW_SIZE_PX, PREVIEW_SIZE_PX))
+			textureView = view
+		}
+		assertTrue("the texture view never produced a surface",
+			surfaceReady.await(SURFACE_TIMEOUT_SEC, TimeUnit.SECONDS))
+
+		scenarioRule.scenario.onActivity { activity ->
+			val view = textureView!!
+			view.surfaceTextureListener = null
+			helper = StarMapCameraHelper(DetachedFragment(app), StarView(activity), view) {}
+		}
+	}
+
+	/**
+	 * Turns the overlay on once from the main thread so that `isCameraOverlayEnabled` is set, lets
+	 * that first session configure fully, then closes it. From here on the race is driven with
+	 * [StarMapCameraHelper.onResume] and [StarMapCameraHelper.onPause] on the camera thread.
+	 */
+	private fun armOverlay() {
+		InstrumentationRegistry.getInstrumentation().runOnMainSync { helper!!.toggleCameraOverlay() }
+		assertTrue("the overlay did not turn on", helper!!.isCameraOverlayEnabled)
+		Thread.sleep(SESSION_SETTLE_MS)
+		InstrumentationRegistry.getInstrumentation().runOnMainSync { helper!!.onPause() }
+		Thread.sleep(CYCLE_SETTLE_MS)
+	}
+
+	private fun runRaceCycle(manager: CameraManager, cameraId: String, cycle: Int, closeDelayMs: Long) {
+		val handler = cameraHandler!!
+		val deviceOpened = CountDownLatch(1)
+		val availabilityCallback = object : CameraManager.AvailabilityCallback() {
+			override fun onCameraUnavailable(id: String) {
+				if (id == cameraId) {
+					deviceOpened.countDown()
+				}
+			}
+		}
+		manager.registerAvailabilityCallback(availabilityCallback, Handler(Looper.getMainLooper()))
+		try {
+			handler.post { helper?.onResume() }
+			assertTrue("cycle $cycle: the camera was never opened",
+				deviceOpened.await(CAMERA_OPEN_TIMEOUT_SEC, TimeUnit.SECONDS))
+
+			handler.postDelayed({ helper?.onPause() }, closeDelayMs)
+			Thread.sleep(CYCLE_SETTLE_MS)
+		} finally {
+			manager.unregisterAvailabilityCallback(availabilityCallback)
+		}
+		if (cameraThread?.isAlive == true) {
+			runOnCameraThread(handler) { helper?.onPause() }
+		}
+	}
+
+	private fun runOnCameraThread(handler: Handler, action: () -> Unit) {
+		val done = CountDownLatch(1)
+		handler.post {
+			try {
+				action()
+			} finally {
+				done.countDown()
+			}
+		}
+		done.await(CAMERA_OPEN_TIMEOUT_SEC, TimeUnit.SECONDS)
+	}
+
+	private fun stackTraceOf(throwable: Throwable): String {
+		val writer = StringWriter()
+		throwable.printStackTrace(PrintWriter(writer))
+		return writer.toString()
+	}
+
+	/**
+	 * A fragment that hands out a context without ever being attached, so that
+	 * [Fragment.getActivity] stays null.
+	 */
+	private class DetachedFragment(private val ctx: Context) : Fragment() {
+		override fun getContext(): Context = ctx
+	}
+}


### PR DESCRIPTION
Fixes #25880.

## Problem

`StarMapCameraHelper` never checks that the camera a Camera2 callback is about is still the one it wants. Both `openCamera()` -> `onOpened()` and `createCaptureSession()` -> `onConfigured()` are registered with a `null` handler, so they run on the main looper — the same one on which `onPause()` -> `closeCamera()` runs.

The window is wide: `createCaptureSession()` blocks the main thread inside the framework's `configureStreamsChecked()` and only then posts `onConfigured`. Touch events arriving during that block are delivered from the input channel inside `nativePollOnce`, i.e. before the already posted `onConfigured` is dispatched. So leaving the star map while the session is configuring runs `closeCamera()` first, and `onConfigured` then calls `setRepeatingRequest()` on a session whose device is gone — `StarMapCameraHelper.kt:311` on `origin/r5.4` (36448bdd14):

```
java.lang.IllegalStateException: CameraDevice was already closed
	at android.hardware.camera2.impl.CameraDeviceImpl.checkIfCameraClosedOrInError(CameraDeviceImpl.java:2947)
	at android.hardware.camera2.impl.CameraCaptureSessionImpl.setRepeatingRequest(CameraCaptureSessionImpl.java:313)
	at net.osmand.plus.plugins.astronomy.utils.StarMapCameraHelper$createCaptureSession$1.onConfigured(StarMapCameraHelper.kt:311)
	at android.os.Looper.loop(Looper.java:363)
```

Three more consequences of the same cause:

1. After a fast off -> on toggle the helper holds a *second* device, so `cameraDevice` is not null when the first session's `onConfigured()` arrives — a plain null check would not stop the crash.
2. Leaving the screen before `onOpened()` closes nothing (`cameraDevice` is still null), and `onOpened()` then starts a preview for a screen that is gone: the camera keeps streaming until the next `closeCamera()`.
3. `onDisconnected()`/`onError()` null `cameraDevice` unconditionally, so a late callback about an old device drops the reference to the current one.

Introduced by 6a45ed6a99 ("Add camera overlay to star map view", 2025-12-12); 60cdee29cc only moved the code into this helper.

## Fix

Every callback acts on the device it was handed, and only while that device is still the one the helper holds:

- `createCaptureSession()` captures the device in a local `val device`, and `onConfigured()` compares it against the field — this covers the reported crash and 1, where comparing against `null` would not.
- `onOpened()` closes the device at once when no open is wanted any more, tracked by a new `cameraOpenRequested` flag (`isCameraOverlayEnabled` cannot serve: it deliberately survives `onPause()`). Covers 2.
- `onDisconnected()`/`onError()` clear `cameraDevice` only while it still points at that camera. Covers 3.
- `setRepeatingRequest()` is wrapped as a last resort — the framework can close the device from a binder thread between the check and the call. `catch (e: Exception)` matches the file's three existing handlers and also covers `CameraAccessException`.

Normal path unchanged: `cameraDevice === device`, and the preview starts as before.

## Verification

Pixel 8 Pro (husky), Android 17 (API 37), `nightlyFreeLegacyArm64Debug` (`net.osmand.dev`, 5.4.0 / 5399), built from `origin/r5.4` with and without the fix commit.

`StarMapCameraOverlayRaceTest` (second commit) drives the helper directly — no UI, so it needs neither the paid star map nor screen coordinates — on a dedicated looper, so the uncaught `IllegalStateException` is recorded there and asserted on instead of killing the process. Each of its 15 cycles waits for `onCameraUnavailable()` and schedules the close 5-80 ms later, sweeping the configuration window.

```
adb shell am instrument -w -e class net.osmand.test.junit.StarMapCameraOverlayRaceTest \
  net.osmand.dev.test/androidx.test.runner.AndroidJUnitRunner
```

| | without the fix commit | with it |
|---|---|---|
| the test | **failed 3 / 3 runs**, at cycle 1-2, in 9-10 s | **passed 3 / 3 runs**, all 15 cycles, ~24.5 s |
| race through the real UI (`monkey` script, 60 ms between the two taps) | process killed in **4 / 10** trials | **0 / 15**, and 20 races back to back survived |
| `dumpsys media.camera` afterwards | — | `Active Camera Clients: []`, 48 CONNECT / 48 DISCONNECT |

The failing run reports the reporter's stack, caught rather than fatal:

```
java.lang.AssertionError: Camera callback threw after the camera was closed
 (cycle 2, close scheduled 15ms after the device was opened):
java.lang.IllegalStateException: CameraDevice was already closed
	at android.hardware.camera2.impl.CameraCaptureSessionImpl.setRepeatingRequest(CameraCaptureSessionImpl.java:328)
	at net.osmand.plus.plugins.astronomy.utils.StarMapCameraHelper$createCaptureSession$1.onConfigured(StarMapCameraHelper.kt:311)
	at android.os.HandlerThread.run(HandlerThread.java:139)
```

The overlay still works: the camera opens, the preview streams, and toggling it off releases the camera. `git diff origin/r5.4 origin/master` for this file is empty, so `master` carries the identical defect and picks the fix up through the merge-up.

Not verified: consequences 2 and 3 are argued from the code, not reproduced; one device and one Android version only, and the test's close delays are tuned to a window that is device dependent; `legacy` core only; the test is skipped without a back camera.

## Known gap, not addressed here

- The test does not extend the shared `AndroidTest` base, whose `Espresso.onIdle()` fails on Android 17 with the Espresso 3.5.1 this branch pins: `NoSuchMethodException: android.hardware.input.InputManager.getInstance`. That breaks the existing UI tests on such a device too. `master` is already on Espresso 3.7.0, where the same base class works, so this is an r5.4-only limitation and backporting the bump does not belong in a crash fix.
- Pre-existing and left alone: the `Surface` built in `createCaptureSession()` is never released, `onConfigureFailed()` is silent, and the `SurfaceTextureListener` installed by `openCamera()` is never removed.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Analyse and fix the crash in issue #25880 autonomously, following every rule in the `AGENTS.md` files.
2. Use PR #25865 as the example to follow.
3. Also test the fix on the connected phone.
4. Can a test be added? — answered with the options and their costs; the maintainer chose this PR, without production-code changes.

Decided by the agent, not requested explicitly:
- Target `r5.4` rather than `master`: the report is against 5.4.0 nightlies, and a second PR into `master` would only duplicate the fix.
- Going beyond the fix suggested in the issue — the null check it proposes leaves consequences 1-3 open, and 3 combined with it turns the crash into a permanently black overlay after the camera is reopened.
- `catch (e: Exception)` rather than the proposed `IllegalStateException`.
- Naming 6a45ed6a99 as the origin, after checking that the later commit only moved the code.
- The design of the test, and keeping the fix and the test as separate commits.
- Building the APKs: `AGENTS.md` §9 on `r5.4` forbids Gradle, but on-device testing was explicitly asked for and is impossible without a build. Nothing was compiled outside Gradle.
- For the manual UI trials only, the Astronomy plugin was enabled and `billing_full_version_purchased` set in the app's `shared_prefs` on the device, because the star map is paid and `nightlyFree` is not a `~` build; that, the camera permission and `exception.log` were reverted afterwards. The instrumented test needs none of it.
