### PR TITLE
Keep accuracy circle and view angle sector on the location marker

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/layers/PointLocationLayer.java
+++ b/OsmAnd/src/net/osmand/plus/views/layers/PointLocationLayer.java
@@ -258,7 +258,21 @@ public class PointLocationLayer extends OsmandMapLayer
 		} else if (isMapLinkedToLocation() && !isMovingToMyLocation()) {
 			updateMarker(getPointLocation(), null, 0);
 		}
+		updateMyLocationCirclePosition(mapRenderer);
 		lastMarkerLocation = getCurrentMarkerLocation();
+	}
+
+	/**
+	 * Accuracy circle and view angle sector are drawn by the renderer itself at its own
+	 * "my location" position, which is a state separate from the marker position. That state is
+	 * not updated while the marker position is animated (unless the accuracy circle is visible),
+	 * so the sector could be left behind the location icon. Keep both in sync on every frame.
+	 */
+	private void updateMyLocationCirclePosition(@NonNull MapRendererView mapRenderer) {
+		CoreMapMarker locMarker = getCurrentMarker();
+		if (locMarker != null && locMarker.marker != null) {
+			mapRenderer.setMyLocationCirclePosition(locMarker.marker.getPosition());
+		}
 	}
 
 	private boolean setMarkerState(MarkerState markerState, boolean showHeading, boolean forceUpdate) {

--- a/OsmAnd/test/java/net/osmand/test/ui/map/MyLocationSectorPositionTest.java
+++ b/OsmAnd/test/java/net/osmand/test/ui/map/MyLocationSectorPositionTest.java
@@ -1,0 +1,181 @@
+package net.osmand.test.ui.map;
+
+import static net.osmand.plus.simulation.SimulationProvider.SIMULATED_PROVIDER;
+import static net.osmand.test.common.OsmAndDialogInteractions.skipAppStartDialogs;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import net.osmand.Location;
+import net.osmand.core.android.MapRendererView;
+import net.osmand.core.jni.PointI;
+import net.osmand.data.LatLon;
+import net.osmand.plus.activities.MapActivity;
+import net.osmand.plus.base.MapViewTrackingUtilities;
+import net.osmand.plus.simulation.SimulatedLocation;
+import net.osmand.plus.settings.enums.MarkerDisplayOption;
+import net.osmand.plus.views.OsmandMapTileView;
+import net.osmand.plus.views.layers.PointLocationLayer;
+import net.osmand.test.common.AndroidTest;
+import net.osmand.test.common.ResourcesImporter;
+import net.osmand.util.MapUtils;
+
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The location icon is a map marker, while the accuracy circle and the view angle sector are drawn
+ * by the renderer at its own "my location" position. Both have to point at the same place: once
+ * they diverge, the view angle sector is left behind the location icon and the gap grows with every
+ * meter driven (the sector ends up kilometres away from the arrow).
+ * <p>
+ * The divergence used to happen when the accuracy circle was hidden and the map was not following
+ * my location, because in that case the renderer position was updated neither by the layer (it does
+ * it only for non-animated moves) nor by the markers animator (it did it only while the accuracy
+ * circle was visible).
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class MyLocationSectorPositionTest extends AndroidTest {
+
+	private static final float SPEED_KM_PER_HOUR = 120;
+
+	private static final long DRIVE_TIME_MS = 25000;
+	private static final long CHECK_INTERVAL_MS = 500;
+	private static final long RENDERER_WAIT_TIME_MS = 15000;
+
+	// One simulated step at the speed above is ~50 m, so anything above a couple of steps
+	// means the renderer position stopped following the marker.
+	private static final int MAX_DEVIATION_M = 150;
+	private static final int MIN_TRAVELLED_DISTANCE_M = 300;
+
+	private static final LatLon PATH_START = new LatLon(45.92051, 35.20653);
+	private static final LatLon PATH_END = new LatLon(45.92051, 35.24653);
+	private static final int PATH_ZOOM = 13;
+
+	@Rule
+	public ActivityScenarioRule<MapActivity> scenarioRule = new ActivityScenarioRule<>(MapActivity.class);
+
+	@Before
+	@Override
+	public void setup() {
+		super.setup();
+		enableSimulation(SPEED_KM_PER_HOUR);
+		settings.setPreferenceForAllModes(settings.ANIMATE_MY_LOCATION.getId(), true);
+		settings.setPreferenceForAllModes(settings.LOCATION_RADIUS_VISIBILITY.getId(), MarkerDisplayOption.OFF);
+		settings.setPreferenceForAllModes(settings.VIEW_ANGLE_VISIBILITY.getId(), MarkerDisplayOption.RESTING_NAVIGATION);
+		try {
+			ResourcesImporter.importObfAssets(app, Collections.singletonList("alarm_test.obf"));
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@After
+	public void cleanUp() {
+		super.cleanUp();
+		app.getLocationProvider().getLocationSimulation().stop();
+	}
+
+	@Test
+	public void testMyLocationCircleFollowsLocationMarker() throws Throwable {
+		skipAppStartDialogs(app);
+
+		OsmandMapTileView mapView = app.getOsmandMap().getMapView();
+		MapRendererView mapRenderer = awaitMapRenderer(mapView);
+		Assume.assumeTrue("Applicable to the OpenGL map renderer only", mapRenderer != null);
+
+		PointLocationLayer locationLayer = app.getOsmandMap().getMapLayers().getLocationLayer();
+		MapViewTrackingUtilities trackingUtilities = app.getMapViewTrackingUtilities();
+
+		// Keep the whole simulated path on the screen without following my location: while the map
+		// follows it, the layer re-sets the renderer position on every frame anyway.
+		app.runInUIThread(() -> {
+			trackingUtilities.setMapLinkedToLocation(false);
+			mapView.setIntZoom(PATH_ZOOM);
+			mapView.setLatLon(PATH_START.getLatitude(),
+					(PATH_START.getLongitude() + PATH_END.getLongitude()) / 2);
+		});
+		app.getLocationProvider().getLocationSimulation()
+				.startSimulationThread(app, simulatedPath(), false, 1);
+
+		LatLon firstMarkerLocation = null;
+		LatLon markerLocation = null;
+		long finishTime = System.currentTimeMillis() + DRIVE_TIME_MS;
+		while (System.currentTimeMillis() < finishTime) {
+			Thread.sleep(CHECK_INTERVAL_MS);
+
+			markerLocation = locationLayer.getLastMarkerLocation();
+			if (markerLocation == null) {
+				continue;
+			}
+			if (firstMarkerLocation == null) {
+				firstMarkerLocation = markerLocation;
+			}
+			if (trackingUtilities.isMapLinkedToLocation()) {
+				throw new IllegalStateException("Map started following my location, "
+						+ "the divergence can't be detected anymore");
+			}
+			LatLon circleLocation = getMyLocationCirclePosition(mapRenderer);
+			double deviation = MapUtils.getDistance(markerLocation, circleLocation);
+			if (deviation > MAX_DEVIATION_M) {
+				throw new AssertionError("Accuracy circle and view angle sector are drawn "
+						+ (int) deviation + " m away from the location marker "
+						+ "(marker " + markerLocation + ", renderer " + circleLocation + ")");
+			}
+		}
+
+		if (markerLocation == null) {
+			throw new IllegalStateException("My location was never shown on the map");
+		}
+		double travelled = MapUtils.getDistance(firstMarkerLocation, markerLocation);
+		if (travelled < MIN_TRAVELLED_DISTANCE_M) {
+			throw new IllegalStateException("My location moved " + (int) travelled
+					+ " m only, the simulation did not run as expected");
+		}
+	}
+
+	@Nullable
+	private MapRendererView awaitMapRenderer(@NonNull OsmandMapTileView mapView) throws InterruptedException {
+		long finishTime = System.currentTimeMillis() + RENDERER_WAIT_TIME_MS;
+		MapRendererView mapRenderer = mapView.getMapRenderer();
+		while (mapRenderer == null && System.currentTimeMillis() < finishTime) {
+			Thread.sleep(CHECK_INTERVAL_MS);
+			mapRenderer = mapView.getMapRenderer();
+		}
+		return mapRenderer;
+	}
+
+	@NonNull
+	private LatLon getMyLocationCirclePosition(@NonNull MapRendererView mapRenderer) {
+		PointI position31 = mapRenderer.getState().getMyLocation31();
+		return new LatLon(MapUtils.get31LatitudeY(position31.getY()),
+				MapUtils.get31LongitudeX(position31.getX()));
+	}
+
+	@NonNull
+	private List<SimulatedLocation> simulatedPath() {
+		List<SimulatedLocation> locations = new ArrayList<>();
+		locations.add(simulatedLocation(PATH_START));
+		locations.add(simulatedLocation(PATH_END));
+		return locations;
+	}
+
+	@NonNull
+	private SimulatedLocation simulatedLocation(@NonNull LatLon latLon) {
+		Location location = new Location(SIMULATED_PROVIDER, latLon.getLatitude(), latLon.getLongitude());
+		return new SimulatedLocation(location, SIMULATED_PROVIDER);
+	}
+}


### PR DESCRIPTION
Internal issue: osmandapp/OsmAnd-Issues#3325

### Problem

While driving, the view angle sector was left behind the location icon and the gap kept growing —
on a real drive the sector ended up about 20 km away from the arrow.

Reproduced on an emulator (OpenGL renderer, simulated positions) with three conditions:

1. Profile appearance: **Location radius = Off**, **View angle** shown for the current state.
2. **Animate my location = on** (default).
3. The map is **not** following my location (panned away).

Pixel centroids over a screenshot series (7 s apart, ~180 px per 100 m): the arrow moved
591 → 779 → 958 px while the sector stayed at 526 px, i.e. the gap grew 66 → 253 → 431 px in
15 seconds. With `Location radius = Resting and navigation`, or with the map following my location,
the sector stays on the arrow.

### Cause

The location icon is a `MapMarker`, but the accuracy circle and the view angle sector are drawn by
the renderer at `MapRendererState::myLocation31`, which is separate state:

- `PointLocationLayer.updateMarkerPosition()` pushes it only for non-animated moves;
- during an animated move it was pushed by the core markers animator, but only while the accuracy
  circle was visible (see osmandapp/OsmAnd-core#1109);
- `onUpdateFrame()` re-set the position on every frame only while the map was following my location,
  which is why a panned map was needed to see it.

### Fix

`PointLocationLayer.onUpdateFrame()` now syncs the renderer position with the current marker
position on every frame, so the two cannot drift apart even when the position is animated or an
animation is cancelled. The root cause is fixed in core as well (osmandapp/OsmAnd-core#1109), which
also covers iOS; this change makes the app correct with any core build.

### Test

`MyLocationSectorPositionTest` (instrumented, `OsmAnd/test/java/net/osmand/test/ui/map/`) drives a
simulated path at 120 km/h with the accuracy circle switched off and the map not following my
location, and asserts every 500 ms that the renderer's "my location" position stays on the location
marker; it also checks that my location really moved, so the test cannot pass vacuously.

Verified on `Claude_Phone_API_35` (arm64 emulator, `nightlyFreeOpenglArm64Debug`): the test fails
without this change and passes with it.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Help me reproduce the bug where the location icon and the view angle get separated (screenshot
   from a real drive).
2. Create a pull request for 5.5 and, if possible, a test that catches this regression or similar
   bugs.
3. Also create a bug on the 5.5-map milestone.

Decided by the agent, not requested explicitly:
- Reproducing with the development plugin's position simulation instead of `adb emu geo fix`
  (emulator fixes carry no timestamp, so the location animation never starts and the bug stays
  hidden).
- Fixing the root cause in core (separate PR) in addition to the app-side per-frame sync, so that
  iOS is covered and the app does not depend on the core snapshot for the fix.
- Writing the test as an instrumented UI test driven by the location simulation, next to the
  existing tests in `net.osmand.test.ui`, instead of adding a new unit-test seam to the layer.
