### PR TITLE
Add a regression test for the Send GPX sheet after process death (#25881)

### DIFF
--- a/OsmAnd/test/java/net/osmand/test/junit/SendGpxBottomSheetProcessDeathTest.kt
+++ b/OsmAnd/test/java/net/osmand/test/junit/SendGpxBottomSheetProcessDeathTest.kt
@@ -6,23 +6,20 @@ import androidx.fragment.app.FragmentManager
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import androidx.test.platform.app.InstrumentationRegistry
 import net.osmand.IndexConstants
-import net.osmand.plus.OsmandApplication
 import net.osmand.plus.activities.MapActivity
 import net.osmand.plus.plugins.osmedit.dialogs.SendGpxBottomSheetFragment
+import net.osmand.test.common.AndroidTest
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -46,26 +43,14 @@ import java.util.concurrent.atomic.AtomicReference
  */
 @LargeTest
 @RunWith(AndroidJUnit4::class)
-class SendGpxBottomSheetProcessDeathTest {
+class SendGpxBottomSheetProcessDeathTest : AndroidTest() {
 
 	companion object {
-		private const val APP_INIT_TIMEOUT_SEC = 120L
 		private const val TRACK_NAME = "send_gpx_process_death_test.gpx"
 	}
 
 	@get:Rule
 	val scenarioRule = ActivityScenarioRule(MapActivity::class.java)
-
-	private lateinit var app: OsmandApplication
-
-	@Before
-	fun setup() {
-		app = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as OsmandApplication
-		val deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(APP_INIT_TIMEOUT_SEC)
-		while (app.isApplicationInitializing && System.currentTimeMillis() < deadline) {
-			Thread.sleep(200)
-		}
-	}
 
 	@After
 	fun dismissSheet() {

--- a/OsmAnd/test/java/net/osmand/test/junit/SendGpxBottomSheetProcessDeathTest.kt
+++ b/OsmAnd/test/java/net/osmand/test/junit/SendGpxBottomSheetProcessDeathTest.kt
@@ -1,0 +1,168 @@
+package net.osmand.test.junit
+
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentManager
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import net.osmand.IndexConstants
+import net.osmand.plus.OsmandApplication
+import net.osmand.plus.activities.MapActivity
+import net.osmand.plus.plugins.osmedit.dialogs.SendGpxBottomSheetFragment
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Regression test for issue #25881 - `NullPointerException: Attempt to get length of null array`
+ * from `SendGpxBottomSheetFragment.getDefaultActivity()`, fixed by PR #25888.
+ *
+ * `showInstance()` used to assign the `File[]` straight to a field of the new fragment and rely on
+ * `setRetainInstance(true)`. That survives a configuration change but not process death: when the
+ * `FragmentManager` restores its state afterwards it builds a *fresh* fragment and gives it back
+ * only the persisted arguments, so `files` was null and the `for (File file : files)` loop in
+ * `getDefaultActivity()` threw while the dialog was rebuilding its view - which is why the reported
+ * stack starts in `MapActivity.onStart()`.
+ *
+ * The restore is reproduced the way the `FragmentManager` performs it, with a new instance carrying
+ * the arguments the original fragment had, because arguments are the only per-fragment state
+ * `showInstance()` can persist. The test deliberately asserts on behaviour rather than on the
+ * argument key: [showFromRealApi] goes through the production `showInstance()`, and whatever it
+ * leaves behind is what the restored fragment gets.
+ *
+ * Both tests fail with the reported `NullPointerException` on the code before PR #25888.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class SendGpxBottomSheetProcessDeathTest {
+
+	companion object {
+		private const val APP_INIT_TIMEOUT_SEC = 120L
+		private const val TRACK_NAME = "send_gpx_process_death_test.gpx"
+	}
+
+	@get:Rule
+	val scenarioRule = ActivityScenarioRule(MapActivity::class.java)
+
+	private lateinit var app: OsmandApplication
+
+	@Before
+	fun setup() {
+		app = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as OsmandApplication
+		val deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(APP_INIT_TIMEOUT_SEC)
+		while (app.isApplicationInitializing && System.currentTimeMillis() < deadline) {
+			Thread.sleep(200)
+		}
+	}
+
+	@After
+	fun dismissSheet() {
+		onMainThread { manager ->
+			(manager.findFragmentByTag(SendGpxBottomSheetFragment.TAG) as? DialogFragment)
+				?.dismissAllowingStateLoss()
+			manager.executePendingTransactions()
+		}
+	}
+
+	/**
+	 * The sheet is shown through the production API, then rebuilt from the state that outlives the
+	 * process: it must come back showing the same tracks instead of throwing.
+	 */
+	@Test
+	fun sheetRestoredAfterProcessDeathKeepsItsFiles() {
+		val arguments = showFromRealApi()
+		removeSheet()
+
+		val thrown = restoreWith(arguments)
+		assertNull("Restoring the sheet after process death threw:\n" + stackTraceOf(thrown), thrown)
+		assertTrue("The restored sheet dismissed itself, so the tracks to upload were lost"
+				+ " - showInstance() did not persist them", isSheetShown())
+	}
+
+	/**
+	 * The same restore when nothing at all was persisted, which is exactly what the code before
+	 * PR #25888 produced. Dismissing is acceptable, crashing is not.
+	 */
+	@Test
+	fun sheetRestoredWithoutArgumentsDismissesInsteadOfCrashing() {
+		val thrown = restoreWith(null)
+		assertNull("Restoring the sheet without arguments threw:\n" + stackTraceOf(thrown), thrown)
+		assertFalse("The sheet stayed up with no tracks to upload", isSheetShown())
+	}
+
+	/**
+	 * Shows the sheet the way the app does and returns the state the `FragmentManager` would keep
+	 * across process death.
+	 */
+	private fun showFromRealApi(): Bundle? {
+		var arguments: Bundle? = null
+		onMainThread { manager ->
+			SendGpxBottomSheetFragment.showInstance(manager, arrayOf(trackFile()), null)
+			manager.executePendingTransactions()
+			arguments = manager.findFragmentByTag(SendGpxBottomSheetFragment.TAG)?.arguments
+		}
+		return arguments
+	}
+
+	/**
+	 * Recreates the fragment the way the `FragmentManager` does when it restores its state: a new
+	 * instance that knows nothing but its arguments.
+	 */
+	private fun restoreWith(arguments: Bundle?): Throwable? {
+		val thrown = AtomicReference<Throwable?>(null)
+		onMainThread { manager ->
+			try {
+				val restored = SendGpxBottomSheetFragment()
+				restored.arguments = arguments
+				restored.show(manager, SendGpxBottomSheetFragment.TAG)
+				manager.executePendingTransactions()
+			} catch (error: Throwable) {
+				thrown.set(error)
+			}
+		}
+		return thrown.get()
+	}
+
+	private fun removeSheet() {
+		onMainThread { manager ->
+			(manager.findFragmentByTag(SendGpxBottomSheetFragment.TAG) as? DialogFragment)
+				?.dismissAllowingStateLoss()
+			manager.executePendingTransactions()
+		}
+	}
+
+	private fun isSheetShown(): Boolean {
+		var shown = false
+		onMainThread { manager ->
+			shown = manager.findFragmentByTag(SendGpxBottomSheetFragment.TAG)?.isAdded == true
+		}
+		return shown
+	}
+
+	private fun trackFile(): File = File(app.getAppPath(IndexConstants.GPX_INDEX_DIR), TRACK_NAME)
+
+	private fun onMainThread(action: (FragmentManager) -> Unit) {
+		scenarioRule.scenario.onActivity { activity -> action(activity.supportFragmentManager) }
+	}
+
+	private fun stackTraceOf(throwable: Throwable?): String {
+		if (throwable == null) {
+			return ""
+		}
+		val writer = StringWriter()
+		throwable.printStackTrace(PrintWriter(writer))
+		return writer.toString()
+	}
+}


### PR DESCRIPTION
Follow-up to #25888, already merged. That PR fixed the crash reported in #25881; this adds the regression test for it and records the verification on an emulator.

## Problem

`showInstance()` assigned the `File[]` straight to a field of the new fragment and relied on `setRetainInstance(true)`. That survives a configuration change but not process death: when the `FragmentManager` restores its state afterwards it builds a *fresh* fragment and hands it back only the persisted arguments, so `files` was null and the `for (File file : files)` loop in `getDefaultActivity()` threw while the dialog was rebuilding its view.

#25888 moved the paths into the arguments and dismisses the sheet when it ends up with none. Nothing covered that, so nothing stops the field from creeping back.

## The test

`SendGpxBottomSheetProcessDeathTest`, two cases, both reproducing the restore the way the `FragmentManager` performs it — a fresh instance carrying only the arguments the original fragment had, because arguments are the only per-fragment state `showInstance()` can persist:

- `sheetRestoredAfterProcessDeathKeepsItsFiles` shows the sheet through the production `showInstance()`, rebuilds it from what survived, and asserts it neither throws **nor dismisses itself** — that second half is what makes the test fail if the paths are dropped again rather than merely guarded.
- `sheetRestoredWithoutArgumentsDismissesInsteadOfCrashing` is the state the old code actually produced: nothing persisted at all. Dismissing is acceptable, crashing is not.

The test asserts behaviour rather than the private `file_paths_key`, so it does not pin the implementation to a particular argument layout. It extends the shared `AndroidTest` base like the other UI tests, which handles app initialisation, permissions and the animation settings.

## Verification

Emulator `sdk_gphone16k_x86_64`, **Android 17 (API 37)**, x86_64, variant `nightlyFreeLegacyX86Debug` (`net.osmand.dev`), built from `origin/master` (dc3f3a2a33) with and without the `SendGpxBottomSheetFragment` change from #25888.

```
adb shell am instrument -w -e class net.osmand.test.junit.SendGpxBottomSheetProcessDeathTest \
  net.osmand.dev.test/androidx.test.runner.AndroidJUnitRunner
```

| | with #25888 reverted | with it |
|---|---|---|
| the test | **2 / 2 cases failed**, three runs | **passed 5 / 5 runs**, 8-20 s |
| real process death through the UI | **crash** | sheet restored intact, crash buffer empty |

The failure is the reported one, same frames and same line numbers as in #25881:

```
java.lang.NullPointerException: Attempt to get length of null array
	at ...SendGpxBottomSheetFragment.getDefaultActivity(SendGpxBottomSheetFragment.java:107)
	at ...SendGpxBottomSheetFragment.getDefaultTags(SendGpxBottomSheetFragment.java:121)
	at ...SendGpxBottomSheetFragment.setupTagsRow(SendGpxBottomSheetFragment.java:101)
	at ...SendGpxBottomSheetFragment.createMenuItems(SendGpxBottomSheetFragment.java:83)
	at net.osmand.plus.base.MenuBottomSheetDialogFragment.onCreateView(MenuBottomSheetDialogFragment.java:88)
```

The end-to-end reproduction, which is also the recipe for checking this by hand: enable the OSM Editing plugin, set an OSM account, open *My Places → Tracks → ⋮ → Export* on any track to get the sheet up, then

```
adb shell input keyevent KEYCODE_HOME
adb shell am kill net.osmand.dev
adb shell input keyevent KEYCODE_APP_SWITCH     # return through Recents, not the launcher
```

Returning through Recents matters: relaunching from the launcher starts a fresh `MapActivity` and never restores the saved state, so the bug does not show. On the reverted build this dies in the restored process with the stack above; with #25888 the sheet comes back with its track, tags and account intact.

`Don't keep activities` is *not* enough to reproduce it — a retained fragment survives activity recreation inside the same process, which is exactly why the old code looked correct.

**Not verified:** one emulator and one Android version (API 37); `legacy` core only; the test does not cover the upload itself, only the restore.

## Known gap, not addressed here

- The restore is modelled with the arguments alone. `Fragment.SavedState` is not replayed, because `SendGpxBottomSheetFragment` puts nothing in `onSaveInstanceState()` — if it ever does, the test should be extended with `setInitialSavedState()`.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Test the fix in PR #25888 on an emulator and add a test to it.
2. Extend `AndroidTest`, as the other UI tests do.

Decided by the agent, not requested explicitly:
- A separate PR into `master` rather than a commit on #25888: that PR is already merged and came from a fork with `maintainer_can_modify` off, so its branch cannot be extended.
- No `Fixes #25881` keyword, so merging this does not close an issue whose fix shipped separately.
- Modelling process death with a fresh instance plus persisted arguments instead of killing the process from inside the test, and asserting behaviour rather than the private argument key.
- The second case (`restored with no arguments`), which pins the dismiss-instead-of-crash guard that #25888 added alongside the persistence.
- The end-to-end emulator reproduction, including the Recents detail, and reverting the emulator's plugin, account and developer settings afterwards.
