### PR TITLE
Routing to OsmAnd-shared, step 4: RouteTypeRule

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/binary/BinaryMapRouteReaderAdapter.java
+++ b/OsmAnd-java/src/main/java/net/osmand/binary/BinaryMapRouteReaderAdapter.java
@@ -14,15 +14,13 @@ import net.osmand.binary.OsmandOdb.OsmAndRoutingIndex.RouteEncodingRule;
 import net.osmand.binary.OsmandOdb.RestrictionData;
 import net.osmand.binary.OsmandOdb.RouteData;
 import net.osmand.binary.RouteDataObject.RestrictionInfo;
-import net.osmand.util.Algorithms;
 import net.osmand.util.MapUtils;
-import net.osmand.shared.util.OpeningHoursParser;
+import net.osmand.shared.routing.RouteTypeRule;
 
 import org.apache.commons.logging.Log;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -39,289 +37,9 @@ public class BinaryMapRouteReaderAdapter {
 	protected static final Log LOG = PlatformUtil.getLog(BinaryMapRouteReaderAdapter.class);
 	private static final int SHIFT_COORDINATES = 4;
 
-	private static class RouteTypeCondition implements StringExternalizable<RouteDataBundle> {
-		String condition = "";
-		OpeningHoursParser.OpeningHours hours = null;
-		String value;
-		int ruleid;
-
-		@Override
-		public void writeToBundle(RouteDataBundle bundle) {
-			bundle.putString("c", condition);
-			bundle.putString("v", value);
-			bundle.putInt("id", ruleid);
-		}
-
-		@Override
-		public void readFromBundle(RouteDataBundle bundle) {
-
-		}
-	}
-
-	public static class RouteTypeRule implements StringExternalizable<RouteDataBundle> {
-		private final static int ACCESS = 1;
-		private final static int ONEWAY = 2;
-		private final static int HIGHWAY_TYPE = 3;
-		private final static int MAXSPEED = 4;
-		private final static int ROUNDABOUT = 5;
-		public final static int TRAFFIC_SIGNALS = 6;
-		public final static int RAILWAY_CROSSING = 7;
-		private final static int LANES = 8;
-		
-		public final static int PROFILE_NONE = 0;
-		public final static int PROFILE_TRUCK = 1000;
-		public final static int PROFILE_CAR = 1001;
-		
-		private String t;
-		private String v;
-		private int intValue;
-		private float floatValue;
-		private int type;
-		private List<RouteTypeCondition> conditions = null;
-		private int forward;
-
-		public RouteTypeRule() {
-		}
-
-		public RouteTypeRule(String t, String v) {
-			this.t = t.intern();
-			if ("true".equals(v)) {
-				v = "yes";
-			}
-			if ("false".equals(v)) {
-				v = "no";
-			}
-			this.v = v == null ? null : v.intern();
-			try {
-				analyze();
-			} catch(RuntimeException e) {
-				System.err.println("Error analyzing tag/value = " + t + "/" +v);
-				throw e;
-			}
-		}
-
-		@Override
-		public int hashCode() {
-			final int prime = 31;
-			int result = 1;
-			result = prime * result + ((t == null) ? 0 : t.hashCode());
-			result = prime * result + ((v == null) ? 0 : v.hashCode());
-			return result;
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj) {
-				return true;
-			}
-			if (obj == null || getClass() != obj.getClass()) {
-				return false;
-			}
-			RouteTypeRule other = (RouteTypeRule) obj;
-			return Algorithms.objectEquals(other.t, t) && Algorithms.objectEquals(other.v, v);
-		}
-
-		@Override
-		public void writeToBundle(RouteDataBundle bundle) {
-			bundle.putString("t", t);
-			if (v != null) {
-				bundle.putString("v", v);
-			}
-		}
-
-		@Override
-		public void readFromBundle(RouteDataBundle bundle) {
-			t = bundle.getString("t", null);
-			v = bundle.getString("v", null);
-			try {
-				analyze();
-			} catch(RuntimeException e) {
-				System.err.println("Error analyzing tag/value = " + t + "/" +v);
-				throw e;
-			}
-		}
-
-		@Override
-		public String toString() {
-			return t + "=" + v;
-		}
-
-		public int isForward() {
-			return forward;
-		}
-
-		public String getTag() {
-			return t;
-		}
-		
-		public String getValue(){
-			return v;
-		}
-
-		public boolean roundabout(){
-			return type == ROUNDABOUT;
-		}
-
-		public int getType() {
-			return type;
-		}
-
-		public boolean conditional() {
-			return conditions != null;
-		}
-		
-		public String getNonConditionalTag() {
-			String tag = getTag();
-			if(tag != null && tag.endsWith(":conditional")) {
-				tag = tag.substring(0, tag.length() - ":conditional".length());
-			}
-			return tag;
-		}
-		
-		public int onewayDirection(){
-			if(type == ONEWAY){
-				return intValue;
-			}
-			return 0;
-		}
-
-		public int conditionalValue(long time) {
-			if (conditional()) {
-				for (RouteTypeCondition c : conditions) {
-					if (c.hours != null && c.hours.isOpenedForTime(time)) {
-						return c.ruleid;
-					}
-				}
-			}
-			return 0;
-		}
-
-		public Integer getMaxIntegerConditionalValue() {
-			if (conditional()) {
-				int maxValue = Integer.MIN_VALUE;
-				for (RouteTypeCondition c : conditions) {
-					try {
-						int value = Integer.parseInt(c.value);
-						if (value > maxValue) {
-							maxValue = value;
-						}
-					} catch(NumberFormatException e) {
-						continue;
-					}
-				}
-				return maxValue > Integer.MIN_VALUE ? maxValue : null;
-			}
-			return null;
-		}
-
-		public float maxSpeed(int profile) {
-			if (type == (MAXSPEED + profile)) {
-				return floatValue;
-			}
-			return -1;
-		}
-
-		public int lanes() {
-			if (type == LANES) {
-				return intValue;
-			}
-			return -1;
-		}
-
-		public String highwayRoad() {
-			if (type == HIGHWAY_TYPE) {
-				return v;
-			}
-			return null;
-		}
-
-		private void analyze() {
-			if (t.equalsIgnoreCase("oneway")) {
-				type = ONEWAY;
-				if ("-1".equals(v) || "reverse".equals(v)) {
-					intValue = -1;
-				} else if("1".equals(v) || "yes".equals(v)) {
-					intValue = 1;
-				} else {
-					intValue = 0;
-				}
-			} else if(t.equalsIgnoreCase("highway") && "traffic_signals".equals(v)){
-				type = TRAFFIC_SIGNALS;
-			} else if(t.equalsIgnoreCase("railway") && ("crossing".equals(v) || "level_crossing".equals(v))){
-				type = RAILWAY_CROSSING;
-			} else if(t.equalsIgnoreCase("roundabout") && v != null){
-				type = ROUNDABOUT;
-			} else if(t.equalsIgnoreCase("junction") && "roundabout".equalsIgnoreCase(v)){
-				type = ROUNDABOUT;
-			} else if(t.equalsIgnoreCase("highway") && v != null){
-				type = HIGHWAY_TYPE;
-			} else if(t.endsWith(":conditional") && v != null){
-				conditions = new ArrayList<RouteTypeCondition>();
-				String[] cts = v.split("\\);");
-				for(String c : cts) {
-					int ch = c.indexOf('@');
-					if (ch > 0) {
-						RouteTypeCondition cond = new RouteTypeCondition();
-						cond.value = c.substring(0, ch).trim();
-						cond.condition = c.substring(ch + 1).trim();
-						if (cond.condition.startsWith("(")) {
-							cond.condition = cond.condition.substring(1, cond.condition.length()).trim();
-						}
-						if(cond.condition.endsWith(")")) {
-							cond.condition = cond.condition.substring(0, cond.condition.length() - 1).trim();
-						}
-						cond.hours = OpeningHoursParser.parseOpenedHours(cond.condition);
-						conditions.add(cond);
-					}
-				}
-				// we don't set type for condtiional so they are not used directly
-//				if(t.startsWith("maxspeed")) {
-//					type = MAXSPEED;
-//				} else if(t.startsWith("oneway")) {
-//					type = ONEWAY;
-//				} else if(t.startsWith("lanes")) {
-//					type = LANES;
-//				} else if(t.startsWith("access")) {
-//					type = ACCESS;
-//				}
-			} else if (t.startsWith("access") && v != null) {
-				type = ACCESS;
-			} else if (t.startsWith("maxspeed") && v != null) {
-				String tg = t;
-				if (t.endsWith(":forward")) {
-					tg = t.substring(0, t.length() - ":forward".length());
-					forward = 1;
-				} else if (t.endsWith(":backward")) {
-					tg = t.substring(0, t.length() - ":backward".length());
-					forward = -1;
-				} else {
-					forward = 0;
-				}
-				floatValue = RouteDataObject.parseSpeed(v, 0);
-				if (tg.equalsIgnoreCase("maxspeed")) {
-					type = MAXSPEED;
-				} else if (tg.equalsIgnoreCase("maxspeed:hgv")) {
-					type = MAXSPEED + PROFILE_TRUCK;
-				} else if (tg.equalsIgnoreCase("maxspeed:motorcar")) {
-					type = MAXSPEED + PROFILE_CAR;
-				}
-			} else if (t.equalsIgnoreCase("lanes") && v != null) {
-				intValue = -1;
-				int i = 0;
-				type = LANES;
-				while (i < v.length() && Character.isDigit(v.charAt(i))) {
-					i++;
-				}
-				if (i > 0) {
-					intValue = Integer.parseInt(v.substring(0, i));
-				}
-			}
-		}
-	}
-
 	public static class RouteRegion extends BinaryIndexPart {
 		public int regionsRead;
-		public List<RouteTypeRule> routeEncodingRules = new ArrayList<BinaryMapRouteReaderAdapter.RouteTypeRule>();
+		public List<RouteTypeRule> routeEncodingRules = new ArrayList<RouteTypeRule>();
 		public int routeEncodingRulesBytes = 0;
 		Map<String, Integer> decodingRules = null;
 		List<RouteSubregion> subregions = new ArrayList<RouteSubregion>();
@@ -432,9 +150,9 @@ public class BinaryMapRouteReaderAdapter {
 				RouteTypeRule rtr = routeEncodingRules.get(i);
 				if (rtr != null && rtr.conditional()) {
 					String tag = rtr.getNonConditionalTag();
-					for (RouteTypeCondition c : rtr.conditions) {
-						if (tag != null && c.value != null) {
-							c.ruleid = findOrCreateRouteType(tag, c.value);
+					for (RouteTypeRule.RouteTypeCondition c : rtr.getConditions()) {
+						if (c.getValue() != null) {
+							c.setRuleId(findOrCreateRouteType(tag, c.getValue()));
 						}
 					}
 

--- a/OsmAnd-java/src/main/java/net/osmand/binary/RouteDataObject.java
+++ b/OsmAnd-java/src/main/java/net/osmand/binary/RouteDataObject.java
@@ -3,9 +3,10 @@ package net.osmand.binary;
 import gnu.trove.map.hash.TIntObjectHashMap;
 import net.osmand.Location;
 import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteRegion;
-import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteTypeRule;
 import net.osmand.data.LatLon;
 import net.osmand.shared.routing.GeneralRouterProfile;
+import net.osmand.shared.routing.RouteDataUtils;
+import net.osmand.shared.routing.RouteTypeRule;
 import net.osmand.util.Algorithms;
 import net.osmand.util.MapUtils;
 import net.osmand.util.TransliterationHelper;
@@ -33,7 +34,7 @@ public class RouteDataObject {
 	public int[][] pointNameTypes;
 	public long id;
 	public TIntObjectHashMap<String> names;
-	public final static float NONE_MAX_SPEED = 40f;
+	public final static float NONE_MAX_SPEED = RouteDataUtils.NONE_MAX_SPEED;
 	public int[] nameIds;
 	// mixed array [0, height, cumulative_distance height, cumulative_distance, height, ...] - length is length(points)*2
 	public float[] heightDistanceArray = null;
@@ -552,20 +553,7 @@ public class RouteDataObject {
 	}
 
 	public static float parseSpeed(String v, float def) {
-		if (v.equals("none")) {
-			return RouteDataObject.NONE_MAX_SPEED;
-		} else {
-			int i = Algorithms.findFirstNumberEndIndex(v);
-			if (i > 0) {
-				float f = Float.parseFloat(v.substring(0, i));
-				f /= 3.6; // km/h -> m/s
-				if (v.contains("mph")) {
-					f *= 1.6;
-				}
-				return f;
-			}
-		}
-		return def;
+		return RouteDataUtils.parseSpeed(v, def);
 	}
 
 	public static float parseLength(String v, float def) {

--- a/OsmAnd-java/src/main/java/net/osmand/router/GeneralRouter.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/GeneralRouter.java
@@ -1,7 +1,7 @@
 package net.osmand.router;
 
 import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteRegion;
-import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteTypeRule;
+import net.osmand.shared.routing.RouteTypeRule;
 import net.osmand.binary.RouteDataObject;
 import net.osmand.router.BinaryRoutePlanner.RouteSegment;
 import net.osmand.shared.routing.GeneralRouterProfile;

--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteConditionalHelper.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteConditionalHelper.java
@@ -1,6 +1,6 @@
 package net.osmand.router;
 
-import net.osmand.binary.BinaryMapRouteReaderAdapter;
+import net.osmand.shared.routing.RouteTypeRule;
 import net.osmand.binary.RouteDataObject;
 
 import java.util.HashMap;
@@ -15,7 +15,7 @@ public class RouteConditionalHelper {
 		// Find corresponding non-conditional tags and save their existing int-values.
 		// Example: maxspeed:conditional (RULE_INT_MAX) will save the value of maxspeed.
 		for (int type : rdo.types) {
-			BinaryMapRouteReaderAdapter.RouteTypeRule r = rdo.region.quickGetEncodingRule(type);
+			RouteTypeRule r = rdo.region.quickGetEncodingRule(type);
 			if (r != null && !r.conditional()) {
 				String key = r.getTag() + ":conditional";
 				String rule = ambiguousConditionalTags.get(key);
@@ -37,7 +37,7 @@ public class RouteConditionalHelper {
 		// Example: access:conditional ("yes") will always set "access" = "yes"
 		// Example: maxspeed:conditional (RULE_INT_MAX) might set maxspeed = max(existing, conditional)
 		for (int type : rdo.types) {
-			BinaryMapRouteReaderAdapter.RouteTypeRule r = rdo.region.quickGetEncodingRule(type);
+			RouteTypeRule r = rdo.region.quickGetEncodingRule(type);
 			if (r != null && r.conditional()) {
 				String key = r.getTag();
 				String rule = ambiguousConditionalTags.get(key);
@@ -57,7 +57,7 @@ public class RouteConditionalHelper {
 	public void processConditionalTags(RouteDataObject rdo, long conditionalTime) {
 		int sz = rdo.types.length;
 		for (int i = 0; i < sz; i++) {
-			BinaryMapRouteReaderAdapter.RouteTypeRule r = rdo.region.quickGetEncodingRule(rdo.types[i]);
+			RouteTypeRule r = rdo.region.quickGetEncodingRule(rdo.types[i]);
 			if (r != null && r.conditional()) {
 				int vl = r.conditionalValue(conditionalTime);
 				if (vl != 0) {
@@ -74,15 +74,15 @@ public class RouteConditionalHelper {
 					int pSz = pTypes.length;
 					if (pSz > 0) {
 						for (int j = 0; j < pSz; j++) {
-							BinaryMapRouteReaderAdapter.RouteTypeRule r = rdo.region.quickGetEncodingRule(pTypes[j]);
+							RouteTypeRule r = rdo.region.quickGetEncodingRule(pTypes[j]);
 							if (r != null && r.conditional()) {
 								int vl = r.conditionalValue(conditionalTime);
 								if (vl != 0) {
-									BinaryMapRouteReaderAdapter.RouteTypeRule rtr = rdo.region.quickGetEncodingRule(vl);
+									RouteTypeRule rtr = rdo.region.quickGetEncodingRule(vl);
 									String nonCondTag = rtr.getTag();
 									int ks;
 									for (ks = 0; ks < rdo.pointTypes[i].length; ks++) {
-										BinaryMapRouteReaderAdapter.RouteTypeRule toReplace = rdo.region.quickGetEncodingRule(rdo.pointTypes[i][ks]);
+										RouteTypeRule toReplace = rdo.region.quickGetEncodingRule(rdo.pointTypes[i][ks]);
 										if (toReplace != null && toReplace.getTag().contentEquals(nonCondTag)) {
 											break;
 										}
@@ -117,7 +117,7 @@ public class RouteConditionalHelper {
 		if (ruleId > 0) {
 			int ks;
 			for (ks = 0; ks < rdo.types.length; ks++) {
-				BinaryMapRouteReaderAdapter.RouteTypeRule toReplace = rdo.region.quickGetEncodingRule(rdo.types[ks]);
+				RouteTypeRule toReplace = rdo.region.quickGetEncodingRule(rdo.types[ks]);
 				if (toReplace != null && toReplace.getTag().equals(tag)) {
 					break;
 				}

--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteDataResources.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteDataResources.java
@@ -1,7 +1,7 @@
 package net.osmand.router;
 
 import net.osmand.Location;
-import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteTypeRule;
+import net.osmand.shared.routing.RouteTypeRule;
 import net.osmand.binary.RouteDataObject;
 
 import java.util.ArrayList;

--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteExporter.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteExporter.java
@@ -1,7 +1,7 @@
 package net.osmand.router;
 
 import net.osmand.Location;
-import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteTypeRule;
+import net.osmand.shared.routing.RouteTypeRule;
 import net.osmand.binary.RouteDataBundle;
 import net.osmand.binary.StringBundle;
 import net.osmand.shared.gpx.GpxFile;
@@ -89,7 +89,10 @@ public class RouteExporter {
 		Map<RouteTypeRule, Integer> rules = resources.getRules();
 		for (RouteTypeRule rule : rules.keySet()) {
 			RouteDataBundle typeBundle = new RouteDataBundle(resources);
-			rule.writeToBundle(typeBundle);
+			typeBundle.putString("t", rule.getTag());
+			if (rule.getValue() != null) {
+				typeBundle.putString("v", rule.getValue());
+			}
 			typeList.add(typeBundle);
 		}
 

--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteResultPreparation.java
@@ -5,7 +5,7 @@ import gnu.trove.set.hash.TIntHashSet;
 import net.osmand.PlatformUtil;
 import net.osmand.binary.BinaryMapIndexReader;
 import net.osmand.binary.ObfConstants;
-import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteTypeRule;
+import net.osmand.shared.routing.RouteTypeRule;
 import net.osmand.binary.RouteDataObject;
 import net.osmand.data.LatLon;
 import net.osmand.osm.MapRenderingTypes;

--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteSegmentResult.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteSegmentResult.java
@@ -4,7 +4,7 @@ package net.osmand.router;
 import net.osmand.shared.routing.TurnType;
 import net.osmand.Location;
 import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteRegion;
-import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteTypeRule;
+import net.osmand.shared.routing.RouteTypeRule;
 import net.osmand.binary.RouteDataBundle;
 import net.osmand.binary.RouteDataObject;
 import net.osmand.binary.StringExternalizable;

--- a/OsmAnd-java/src/main/java/net/osmand/router/RouteStatisticsHelper.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RouteStatisticsHelper.java
@@ -1,7 +1,7 @@
 package net.osmand.router;
 
 import net.osmand.PlatformUtil;
-import net.osmand.binary.BinaryMapRouteReaderAdapter;
+import net.osmand.shared.routing.RouteTypeRule;
 import net.osmand.binary.RouteDataObject;
 import net.osmand.render.RenderingRuleSearchRequest;
 import net.osmand.render.RenderingRulesStorage;
@@ -403,7 +403,7 @@ public class RouteStatisticsHelper {
 							+ ", rules=" + encodingRulesSize);
 					continue;
 				}
-				BinaryMapRouteReaderAdapter.RouteTypeRule tp = routeObject.region.quickGetEncodingRule(type);
+				RouteTypeRule tp = routeObject.region.quickGetEncodingRule(type);
 				if (tp.getTag().equals("highway") || tp.getTag().equals("route")
 						|| tp.getTag().equals("railway") || tp.getTag().equals("aeroway")
 						|| tp.getTag().equals("aerialway") || tp.getTag().equals("piste:type")) {

--- a/OsmAnd-java/src/main/java/net/osmand/router/network/NetworkRouteSelector.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/network/NetworkRouteSelector.java
@@ -3,7 +3,7 @@ package net.osmand.router.network;
 
 import net.osmand.binary.BinaryMapDataObject;
 import net.osmand.binary.BinaryMapIndexReader;
-import net.osmand.binary.BinaryMapRouteReaderAdapter;
+import net.osmand.shared.routing.RouteTypeRule;
 import net.osmand.binary.RouteDataObject;
 import net.osmand.osm.OsmRouteType;
 import net.osmand.shared.gpx.GpxFile;
@@ -31,13 +31,13 @@ public class NetworkRouteSelector {
 		for (int i = 0; obj.nameIds != null && i < obj.nameIds.length; i++) {
 			int nameId = obj.nameIds[i];
 			String value = obj.names.get(nameId);
-			BinaryMapRouteReaderAdapter.RouteTypeRule rt = obj.region.quickGetEncodingRule(nameId);
+			RouteTypeRule rt = obj.region.quickGetEncodingRule(nameId);
 			if (rt != null) {
 				tags.put(rt.getTag(), value);
 			}
 		}
 		for (int i = 0; obj.types != null && i < obj.types.length; i++) {
-			BinaryMapRouteReaderAdapter.RouteTypeRule rt = obj.region.quickGetEncodingRule(obj.types[i]);
+			RouteTypeRule rt = obj.region.quickGetEncodingRule(obj.types[i]);
 			if (rt != null) {
 				tags.put(rt.getTag(), rt.getValue());
 			}

--- a/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/util/PlatformStrings.kt
+++ b/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/util/PlatformStrings.kt
@@ -1,0 +1,3 @@
+package net.osmand.shared.util
+
+actual fun internString(value: String): String = value.intern()

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteDataUtils.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteDataUtils.kt
@@ -1,0 +1,33 @@
+package net.osmand.shared.routing
+
+import net.osmand.shared.util.KAlgorithms
+import kotlin.jvm.JvmStatic
+
+/** Helpers shared by the routing data model. */
+object RouteDataUtils {
+
+	/** Speed reported for roads tagged `maxspeed=none`, in m/s. */
+	const val NONE_MAX_SPEED = 40f
+
+	/**
+	 * Converts an osm `maxspeed` value to m/s, [def] if the value carries no number.
+	 */
+	@JvmStatic
+	fun parseSpeed(v: String, def: Float): Float {
+		if (v == "none") {
+			return NONE_MAX_SPEED
+		}
+		val i = KAlgorithms.findFirstNumberEndIndex(v)
+		if (i > 0) {
+			// the arithmetic runs in double and narrows once, the way the java original did, so the
+			// speeds that reach the router are bit for bit the ones it saw before
+			var f = v.substring(0, i).toFloat()
+			f = (f / 3.6).toFloat() // km/h -> m/s
+			if (v.contains("mph")) {
+				f = (f * 1.6).toFloat()
+			}
+			return f
+		}
+		return def
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteTypeRule.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteTypeRule.kt
@@ -1,0 +1,232 @@
+package net.osmand.shared.routing
+
+import net.osmand.shared.util.KAlgorithms
+import net.osmand.shared.util.LoggerFactory
+import net.osmand.shared.util.OpeningHoursParser
+import net.osmand.shared.util.internString
+
+/**
+ * One tag/value pair of the routing section of an obf file.
+ *
+ * Rules are read once per region and then looked up by index for every road of that region,
+ * so everything the router asks for later is precomputed in [analyze].
+ */
+class RouteTypeRule(t: String, v: String?) {
+
+	private val t: String
+	private val v: String?
+	private var intValue = 0
+	private var floatValue = 0f
+	private var type = 0
+	private var conditions: MutableList<RouteTypeCondition>? = null
+	private var forward = 0
+
+	init {
+		this.t = internString(t)
+		var value = v
+		if ("true" == value) {
+			value = "yes"
+		}
+		if ("false" == value) {
+			value = "no"
+		}
+		this.v = if (value == null) null else internString(value)
+		try {
+			analyze()
+		} catch (e: RuntimeException) {
+			LOG.error("Error analyzing tag/value = ${this.t}/${this.v}")
+			throw e
+		}
+	}
+
+	/** A single `value @ (opening hours)` alternative of a `*:conditional` tag. */
+	class RouteTypeCondition internal constructor(val value: String?, val condition: String) {
+
+		internal val hours: OpeningHoursParser.OpeningHours? =
+			OpeningHoursParser.parseOpenedHours(condition)
+
+		/** Index of the rule this condition resolves to, assigned by the owning route region. */
+		var ruleId: Int = 0
+	}
+
+	override fun hashCode(): Int {
+		val prime = 31
+		var result = 1
+		result = prime * result + (t.hashCode())
+		result = prime * result + (v?.hashCode() ?: 0)
+		return result
+	}
+
+	override fun equals(other: Any?): Boolean {
+		if (this === other) {
+			return true
+		}
+		if (other == null || other !is RouteTypeRule) {
+			return false
+		}
+		return KAlgorithms.stringsEqual(other.t, t) && KAlgorithms.stringsEqual(other.v, v)
+	}
+
+	override fun toString(): String = "$t=$v"
+
+	fun isForward(): Int = forward
+
+	fun getTag(): String = t
+
+	fun getValue(): String? = v
+
+	fun roundabout(): Boolean = type == ROUNDABOUT
+
+	fun getType(): Int = type
+
+	fun conditional(): Boolean = conditions != null
+
+	fun getConditions(): List<RouteTypeCondition>? = conditions
+
+	fun getNonConditionalTag(): String {
+		var tag = getTag()
+		if (tag.endsWith(":conditional")) {
+			tag = tag.substring(0, tag.length - ":conditional".length)
+		}
+		return tag
+	}
+
+	fun onewayDirection(): Int {
+		if (type == ONEWAY) {
+			return intValue
+		}
+		return 0
+	}
+
+	fun conditionalValue(time: Long): Int {
+		conditions?.let {
+			for (c in it) {
+				if (c.hours != null && c.hours.isOpenedForTime(time)) {
+					return c.ruleId
+				}
+			}
+		}
+		return 0
+	}
+
+	fun getMaxIntegerConditionalValue(): Int? {
+		val conditions = this.conditions ?: return null
+		var maxValue = Int.MIN_VALUE
+		for (c in conditions) {
+			val value = c.value?.toIntOrNull() ?: continue
+			if (value > maxValue) {
+				maxValue = value
+			}
+		}
+		return if (maxValue > Int.MIN_VALUE) maxValue else null
+	}
+
+	fun maxSpeed(profile: Int): Float {
+		if (type == MAXSPEED + profile) {
+			return floatValue
+		}
+		return -1f
+	}
+
+	fun lanes(): Int {
+		if (type == LANES) {
+			return intValue
+		}
+		return -1
+	}
+
+	fun highwayRoad(): String? {
+		if (type == HIGHWAY_TYPE) {
+			return v
+		}
+		return null
+	}
+
+	private fun analyze() {
+		if (t.equals("oneway", ignoreCase = true)) {
+			type = ONEWAY
+			intValue = if ("-1" == v || "reverse" == v) {
+				-1
+			} else if ("1" == v || "yes" == v) {
+				1
+			} else {
+				0
+			}
+		} else if (t.equals("highway", ignoreCase = true) && "traffic_signals" == v) {
+			type = TRAFFIC_SIGNALS
+		} else if (t.equals("railway", ignoreCase = true) && ("crossing" == v || "level_crossing" == v)) {
+			type = RAILWAY_CROSSING
+		} else if (t.equals("roundabout", ignoreCase = true) && v != null) {
+			type = ROUNDABOUT
+		} else if (t.equals("junction", ignoreCase = true) && "roundabout".equals(v, ignoreCase = true)) {
+			type = ROUNDABOUT
+		} else if (t.equals("highway", ignoreCase = true) && v != null) {
+			type = HIGHWAY_TYPE
+		} else if (t.endsWith(":conditional") && v != null) {
+			val parsed = ArrayList<RouteTypeCondition>()
+			for (c in v.split(");")) {
+				val ch = c.indexOf('@')
+				if (ch > 0) {
+					var condition = c.substring(ch + 1).trim()
+					if (condition.startsWith("(")) {
+						condition = condition.substring(1).trim()
+					}
+					if (condition.endsWith(")")) {
+						condition = condition.substring(0, condition.length - 1).trim()
+					}
+					parsed.add(RouteTypeCondition(c.substring(0, ch).trim(), condition))
+				}
+			}
+			conditions = parsed
+			// we don't set type for conditional so they are not used directly
+		} else if (t.startsWith("access") && v != null) {
+			type = ACCESS
+		} else if (t.startsWith("maxspeed") && v != null) {
+			var tg = t
+			if (t.endsWith(":forward")) {
+				tg = t.substring(0, t.length - ":forward".length)
+				forward = 1
+			} else if (t.endsWith(":backward")) {
+				tg = t.substring(0, t.length - ":backward".length)
+				forward = -1
+			} else {
+				forward = 0
+			}
+			floatValue = RouteDataUtils.parseSpeed(v, 0f)
+			if (tg.equals("maxspeed", ignoreCase = true)) {
+				type = MAXSPEED
+			} else if (tg.equals("maxspeed:hgv", ignoreCase = true)) {
+				type = MAXSPEED + PROFILE_TRUCK
+			} else if (tg.equals("maxspeed:motorcar", ignoreCase = true)) {
+				type = MAXSPEED + PROFILE_CAR
+			}
+		} else if (t.equals("lanes", ignoreCase = true) && v != null) {
+			intValue = -1
+			var i = 0
+			type = LANES
+			while (i < v.length && KAlgorithms.isDigit(v[i])) {
+				i++
+			}
+			if (i > 0) {
+				intValue = v.substring(0, i).toInt()
+			}
+		}
+	}
+
+	companion object {
+		private val LOG = LoggerFactory.getLogger("RouteTypeRule")
+
+		private const val ACCESS = 1
+		private const val ONEWAY = 2
+		private const val HIGHWAY_TYPE = 3
+		private const val MAXSPEED = 4
+		private const val ROUNDABOUT = 5
+		const val TRAFFIC_SIGNALS = 6
+		const val RAILWAY_CROSSING = 7
+		private const val LANES = 8
+
+		const val PROFILE_NONE = 0
+		const val PROFILE_TRUCK = 1000
+		const val PROFILE_CAR = 1001
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/KAlgorithms.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/KAlgorithms.kt
@@ -93,6 +93,50 @@ object KAlgorithms {
 		}
 	}
 
+	fun isDigit(c: Char): Boolean {
+		return c in '0'..'9'
+	}
+
+	/**
+	 * Index right after the leading decimal number of [value], -1 when it does not start with one.
+	 * A trailing dot is not part of the number, so "40." reports 2.
+	 */
+	fun findFirstNumberEndIndex(value: String): Int {
+		var i = 0
+		if (value.isNotEmpty() && value[0] == '-') {
+			i++
+		}
+		var state = 0 // 0 - no number, 1 - 1st digits, 2 - dot, 3 - last digits
+		while (i < value.length && (isDigit(value[i]) || value[i] == '.')) {
+			if (value[i] == '.') {
+				if (state == 2) {
+					return i - 1
+				}
+				if (state != 1) {
+					return -1
+				}
+				state = 2
+			} else {
+				if (state == 2) {
+					// last digits
+					state = 3
+				} else if (state == 0) {
+					// first digits started
+					state = 1
+				}
+			}
+			i++
+		}
+		if (state == 2) {
+			// invalid number like 40. correct to -> '40'
+			return i - 1
+		}
+		if (state == 0) {
+			return -1
+		}
+		return i
+	}
+
 	fun colorToString(color: Int): String {
 		return if ((0xFF000000.toInt() and color) == 0xFF000000.toInt()) {
 			"#%06X".format(color and 0x00FFFFFF)

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/OpeningHoursTime.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/OpeningHoursTime.kt
@@ -3,6 +3,7 @@ package net.osmand.shared.util
 import kotlin.jvm.JvmStatic
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.IllegalTimeZoneException
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
@@ -75,6 +76,20 @@ class OpeningHoursTime(var dateTime: LocalDateTime) {
 		fun ofEpochMillis(epochMillis: Long): OpeningHoursTime = OpeningHoursTime(
 			Instant.fromEpochMilliseconds(epochMillis).toLocalDateTime(TimeZone.currentSystemDefault())
 		)
+
+		/**
+		 * [epochMillis] read in [timeZoneId], the equivalent of `Calendar.getInstance(TimeZone)`.
+		 * An unknown zone falls back to UTC, the way `TimeZone.getTimeZone` falls back to GMT.
+		 */
+		@JvmStatic
+		fun ofEpochMillis(epochMillis: Long, timeZoneId: String): OpeningHoursTime {
+			val zone = try {
+				TimeZone.of(timeZoneId)
+			} catch (e: IllegalTimeZoneException) {
+				TimeZone.UTC
+			}
+			return OpeningHoursTime(Instant.fromEpochMilliseconds(epochMillis).toLocalDateTime(zone))
+		}
 
 		/** Explicit wall clock reading, mostly useful in tests. */
 		@JvmStatic

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/PlatformStrings.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/PlatformStrings.kt
@@ -1,0 +1,9 @@
+package net.osmand.shared.util
+
+/**
+ * Returns a shared instance of [value] where the platform keeps a string pool.
+ *
+ * Every loaded region repeats the same routing tags and values, so pooling them keeps
+ * one copy per tag instead of one per region.
+ */
+expect fun internString(value: String): String

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/routing/RouteTypeRuleTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/routing/RouteTypeRuleTest.kt
@@ -1,0 +1,177 @@
+package net.osmand.shared.routing
+
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RouteTypeRuleTest {
+
+	private fun assertSpeed(expected: Float, actual: Float) {
+		assertTrue(abs(expected - actual) < 1e-4f, "expected $expected but was $actual")
+	}
+
+	@Test
+	fun testOneway() {
+		assertEquals(1, RouteTypeRule("oneway", "yes").onewayDirection())
+		assertEquals(1, RouteTypeRule("oneway", "1").onewayDirection())
+		assertEquals(-1, RouteTypeRule("oneway", "-1").onewayDirection())
+		assertEquals(-1, RouteTypeRule("oneway", "reverse").onewayDirection())
+		assertEquals(0, RouteTypeRule("oneway", "no").onewayDirection())
+		// the tag is matched case insensitively
+		assertEquals(1, RouteTypeRule("OneWay", "yes").onewayDirection())
+		// a rule of another type never reports a direction
+		assertEquals(0, RouteTypeRule("highway", "primary").onewayDirection())
+	}
+
+	@Test
+	fun testBooleanValuesAreNormalized() {
+		// "true"/"false" come from a few third party sources, osm itself uses yes/no
+		assertEquals("yes", RouteTypeRule("oneway", "true").getValue())
+		assertEquals("no", RouteTypeRule("oneway", "false").getValue())
+		assertEquals(1, RouteTypeRule("oneway", "true").onewayDirection())
+		assertEquals(0, RouteTypeRule("oneway", "false").onewayDirection())
+	}
+
+	@Test
+	fun testHighwayAndRoundabout() {
+		val primary = RouteTypeRule("highway", "primary")
+		assertEquals("primary", primary.highwayRoad())
+		assertFalse(primary.roundabout())
+
+		assertTrue(RouteTypeRule("junction", "roundabout").roundabout())
+		assertTrue(RouteTypeRule("roundabout", "any").roundabout())
+		assertNull(RouteTypeRule("junction", "roundabout").highwayRoad())
+		// a highway without a value is not a highway type rule
+		assertNull(RouteTypeRule("highway", null).highwayRoad())
+	}
+
+	@Test
+	fun testTrafficSignalsAndRailwayCrossing() {
+		assertEquals(RouteTypeRule.TRAFFIC_SIGNALS, RouteTypeRule("highway", "traffic_signals").getType())
+		assertEquals(RouteTypeRule.RAILWAY_CROSSING, RouteTypeRule("railway", "crossing").getType())
+		assertEquals(RouteTypeRule.RAILWAY_CROSSING, RouteTypeRule("railway", "level_crossing").getType())
+		assertNotEquals(RouteTypeRule.RAILWAY_CROSSING, RouteTypeRule("railway", "rail").getType())
+	}
+
+	@Test
+	fun testMaxSpeed() {
+		// values are stored in m/s
+		assertSpeed(50 / 3.6f, RouteTypeRule("maxspeed", "50").maxSpeed(RouteTypeRule.PROFILE_NONE))
+		assertSpeed(30 / 3.6f * 1.6f, RouteTypeRule("maxspeed", "30 mph").maxSpeed(RouteTypeRule.PROFILE_NONE))
+		assertSpeed(RouteDataUtils.NONE_MAX_SPEED, RouteTypeRule("maxspeed", "none").maxSpeed(RouteTypeRule.PROFILE_NONE))
+		// an unparseable value keeps the default passed to parseSpeed, which is 0
+		assertSpeed(0f, RouteTypeRule("maxspeed", "walk").maxSpeed(RouteTypeRule.PROFILE_NONE))
+		// asking for the wrong profile reports no limit
+		assertSpeed(-1f, RouteTypeRule("maxspeed", "50").maxSpeed(RouteTypeRule.PROFILE_TRUCK))
+	}
+
+	@Test
+	fun testMaxSpeedProfiles() {
+		val hgv = RouteTypeRule("maxspeed:hgv", "60")
+		assertSpeed(60 / 3.6f, hgv.maxSpeed(RouteTypeRule.PROFILE_TRUCK))
+		assertSpeed(-1f, hgv.maxSpeed(RouteTypeRule.PROFILE_NONE))
+
+		val motorcar = RouteTypeRule("maxspeed:motorcar", "90")
+		assertSpeed(90 / 3.6f, motorcar.maxSpeed(RouteTypeRule.PROFILE_CAR))
+		assertSpeed(-1f, motorcar.maxSpeed(RouteTypeRule.PROFILE_NONE))
+	}
+
+	@Test
+	fun testMaxSpeedDirection() {
+		val forward = RouteTypeRule("maxspeed:forward", "70")
+		assertEquals(1, forward.isForward())
+		assertSpeed(70 / 3.6f, forward.maxSpeed(RouteTypeRule.PROFILE_NONE))
+
+		val backward = RouteTypeRule("maxspeed:backward", "70")
+		assertEquals(-1, backward.isForward())
+		assertSpeed(70 / 3.6f, backward.maxSpeed(RouteTypeRule.PROFILE_NONE))
+
+		assertEquals(0, RouteTypeRule("maxspeed", "70").isForward())
+	}
+
+	@Test
+	fun testLanes() {
+		assertEquals(3, RouteTypeRule("lanes", "3").lanes())
+		// osm sometimes carries a suffix, the leading digits still count
+		assertEquals(2, RouteTypeRule("lanes", "2 lanes").lanes())
+		assertEquals(-1, RouteTypeRule("lanes", "unknown").lanes())
+		assertEquals(-1, RouteTypeRule("highway", "primary").lanes())
+	}
+
+	@Test
+	fun testConditional() {
+		val rule = RouteTypeRule("maxspeed:conditional", "30 @ (Mo-Fr 07:00-19:00); 50 @ (Sa-Su)")
+		assertTrue(rule.conditional())
+		assertEquals("maxspeed", rule.getNonConditionalTag())
+		// a conditional rule is never used directly, so it stays untyped
+		assertEquals(0, rule.getType())
+
+		val conditions = rule.getConditions()
+		assertEquals(2, conditions?.size)
+		assertEquals("30", conditions?.get(0)?.value)
+		assertEquals("50", conditions?.get(1)?.value)
+	}
+
+	@Test
+	fun testConditionalValueResolvesToRuleId() {
+		val rule = RouteTypeRule("access:conditional", "no @ (24/7)")
+		rule.getConditions()!![0].ruleId = 42
+		assertEquals(42, rule.conditionalValue(0L))
+
+		// an unconditional rule has nothing to resolve
+		assertFalse(RouteTypeRule("access", "no").conditional())
+		assertEquals(0, RouteTypeRule("access", "no").conditionalValue(0L))
+	}
+
+	@Test
+	fun testMaxIntegerConditionalValue() {
+		val rule = RouteTypeRule("maxspeed:conditional", "30 @ (Mo-Fr 07:00-19:00); 50 @ (Sa-Su)")
+		assertEquals(50, rule.getMaxIntegerConditionalValue())
+
+		// non numeric values are skipped, and a rule with none at all reports nothing
+		val weight = RouteTypeRule("maxweight:conditional", "delivery @ (Mo-Fr 07:00-19:00)")
+		assertNull(weight.getMaxIntegerConditionalValue())
+		assertNull(RouteTypeRule("highway", "primary").getMaxIntegerConditionalValue())
+	}
+
+	@Test
+	fun testNonConditionalTagOfPlainTag() {
+		assertEquals("maxspeed", RouteTypeRule("maxspeed", "50").getNonConditionalTag())
+	}
+
+	@Test
+	fun testEqualsAndHashCode() {
+		// rules are used as map keys when a route is exported
+		val a = RouteTypeRule("highway", "primary")
+		val b = RouteTypeRule("highway", "primary")
+		assertEquals(a, b)
+		assertEquals(a.hashCode(), b.hashCode())
+
+		assertNotEquals(a, RouteTypeRule("highway", "secondary"))
+		assertNotEquals(a, RouteTypeRule("route", "primary"))
+		assertNotEquals<Any?>(a, "highway=primary")
+
+		val noValue = RouteTypeRule("name", null)
+		assertEquals(noValue, RouteTypeRule("name", null))
+		assertNotEquals(noValue, RouteTypeRule("name", "Main street"))
+	}
+
+	@Test
+	fun testToString() {
+		assertEquals("highway=primary", RouteTypeRule("highway", "primary").toString())
+		assertEquals("name=null", RouteTypeRule("name", null).toString())
+	}
+
+	@Test
+	fun testParseSpeed() {
+		assertSpeed(RouteDataUtils.NONE_MAX_SPEED, RouteDataUtils.parseSpeed("none", 1f))
+		assertSpeed(50 / 3.6f, RouteDataUtils.parseSpeed("50", 1f))
+		assertSpeed(50 / 3.6f, RouteDataUtils.parseSpeed("50 km/h", 1f))
+		assertSpeed(50 / 3.6f * 1.6f, RouteDataUtils.parseSpeed("50mph", 1f))
+		assertSpeed(7.5f, RouteDataUtils.parseSpeed("no number", 7.5f))
+	}
+}

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/KAlgorithmsTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/KAlgorithmsTest.kt
@@ -1,0 +1,46 @@
+package net.osmand.shared.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class KAlgorithmsTest {
+
+	@Test
+	fun testIsDigit() {
+		assertTrue(KAlgorithms.isDigit('0'))
+		assertTrue(KAlgorithms.isDigit('9'))
+		assertFalse(KAlgorithms.isDigit('.'))
+		assertFalse(KAlgorithms.isDigit('a'))
+		// only ascii digits count, the same as the java original
+		assertFalse(KAlgorithms.isDigit('٣'))
+	}
+
+	@Test
+	fun testFindFirstNumberEndIndex() {
+		assertEquals(2, KAlgorithms.findFirstNumberEndIndex("50"))
+		assertEquals(2, KAlgorithms.findFirstNumberEndIndex("50 km/h"))
+		assertEquals(4, KAlgorithms.findFirstNumberEndIndex("12.5 t"))
+		assertEquals(2, KAlgorithms.findFirstNumberEndIndex("-5"))
+		assertEquals(4, KAlgorithms.findFirstNumberEndIndex("-3.5m"))
+	}
+
+	@Test
+	fun testFindFirstNumberEndIndexWithoutNumber() {
+		assertEquals(-1, KAlgorithms.findFirstNumberEndIndex(""))
+		assertEquals(-1, KAlgorithms.findFirstNumberEndIndex("none"))
+		assertEquals(-1, KAlgorithms.findFirstNumberEndIndex("-"))
+		// a value that opens with a dot carries no number
+		assertEquals(-1, KAlgorithms.findFirstNumberEndIndex(".5"))
+	}
+
+	@Test
+	fun testFindFirstNumberEndIndexDropsTrailingDot() {
+		// "40." is corrected to "40"
+		assertEquals(2, KAlgorithms.findFirstNumberEndIndex("40."))
+		assertEquals(2, KAlgorithms.findFirstNumberEndIndex("40. t"))
+		// a second dot makes the whole value unusable
+		assertEquals(-1, KAlgorithms.findFirstNumberEndIndex("40.5.1"))
+	}
+}

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/OpeningHoursTimeTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/OpeningHoursTimeTest.kt
@@ -1,0 +1,31 @@
+package net.osmand.shared.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OpeningHoursTimeTest {
+
+	// 2024-06-01T12:00:00Z
+	private val instant = 1717243200000L
+
+	@Test
+	fun testOfEpochMillisInZone() {
+		val utc = OpeningHoursTime.ofEpochMillis(instant, "UTC")
+		assertEquals(2024, utc.year)
+		assertEquals(5, utc.month) // zero based, June
+		assertEquals(1, utc.dayOfMonth)
+		assertEquals(12, utc.hourOfDay)
+
+		assertEquals(15, OpeningHoursTime.ofEpochMillis(instant, "Europe/Moscow").hourOfDay)
+		// summer time is applied, New York is at UTC-4 in June
+		assertEquals(8, OpeningHoursTime.ofEpochMillis(instant, "America/New_York").hourOfDay)
+	}
+
+	@Test
+	fun testOfEpochMillisFallsBackToUtc() {
+		// TimeZone.getTimeZone answers GMT for an unknown id, this keeps that behaviour
+		val unknown = OpeningHoursTime.ofEpochMillis(instant, "Not/AZone")
+		assertEquals(12, unknown.hourOfDay)
+		assertEquals(1, unknown.dayOfMonth)
+	}
+}

--- a/OsmAnd-shared/src/iosMain/kotlin/net/osmand/shared/util/PlatformStrings.kt
+++ b/OsmAnd-shared/src/iosMain/kotlin/net/osmand/shared/util/PlatformStrings.kt
@@ -1,0 +1,4 @@
+package net.osmand.shared.util
+
+// Kotlin/Native has no string pool, strings stay as they were read.
+actual fun internString(value: String): String = value

--- a/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/util/PlatformStrings.kt
+++ b/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/util/PlatformStrings.kt
@@ -1,0 +1,3 @@
+package net.osmand.shared.util
+
+actual fun internString(value: String): String = value.intern()

--- a/OsmAnd/src/net/osmand/plus/helpers/WaypointHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/WaypointHelper.java
@@ -19,7 +19,7 @@ import net.osmand.Location;
 import net.osmand.OnCompleteCallback;
 import net.osmand.StateChangedListener;
 import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteRegion;
-import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteTypeRule;
+import net.osmand.shared.routing.RouteTypeRule;
 import net.osmand.binary.RouteDataObject;
 import net.osmand.data.Amenity;
 import net.osmand.data.Amenity.AmenityRoutePoint;

--- a/OsmAnd/src/net/osmand/plus/render/MapRenderRepositories.java
+++ b/OsmAnd/src/net/osmand/plus/render/MapRenderRepositories.java
@@ -18,7 +18,7 @@ import net.osmand.binary.BinaryMapIndexReader.SearchRequest;
 import net.osmand.binary.BinaryMapIndexReader.TagValuePair;
 import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteRegion;
 import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteSubregion;
-import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteTypeRule;
+import net.osmand.shared.routing.RouteTypeRule;
 import net.osmand.binary.RouteDataObject;
 import net.osmand.data.QuadPointDouble;
 import net.osmand.data.QuadRect;

--- a/OsmAnd/src/net/osmand/plus/routing/AlarmInfo.java
+++ b/OsmAnd/src/net/osmand/plus/routing/AlarmInfo.java
@@ -19,7 +19,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import net.osmand.Location;
-import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteTypeRule;
+import net.osmand.shared.routing.RouteTypeRule;
 import net.osmand.data.LocationPoint;
 import net.osmand.data.PointDescription;
 

--- a/OsmAnd/src/net/osmand/plus/routing/RouteCalculationResult.java
+++ b/OsmAnd/src/net/osmand/plus/routing/RouteCalculationResult.java
@@ -10,7 +10,7 @@ import androidx.annotation.Nullable;
 import net.osmand.Location;
 import net.osmand.PlatformUtil;
 import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteRegion;
-import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteTypeRule;
+import net.osmand.shared.routing.RouteTypeRule;
 import net.osmand.binary.RouteDataObject;
 import net.osmand.data.LatLon;
 import net.osmand.data.LocationPoint;

--- a/OsmAnd/src/net/osmand/plus/settings/backend/ApplicationMode.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/ApplicationMode.java
@@ -1,7 +1,5 @@
 package net.osmand.plus.settings.backend;
 
-import static net.osmand.binary.BinaryMapRouteReaderAdapter.RouteTypeRule;
-
 import androidx.annotation.ColorInt;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
@@ -19,6 +17,7 @@ import net.osmand.plus.profiles.ProfileIconColors;
 import net.osmand.plus.routing.RouteService;
 import net.osmand.plus.settings.backend.OsmAndAppCustomization.OsmAndAppCustomizationListener;
 import net.osmand.plus.settings.enums.MarkerDisplayOption;
+import net.osmand.shared.routing.RouteTypeRule;
 import net.osmand.util.Algorithms;
 
 import java.util.*;

--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/widgets/StreetNameWidget.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/widgets/StreetNameWidget.java
@@ -25,7 +25,7 @@ import androidx.appcompat.content.res.AppCompatResources;
 import androidx.fragment.app.FragmentActivity;
 
 import net.osmand.Location;
-import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteTypeRule;
+import net.osmand.shared.routing.RouteTypeRule;
 import net.osmand.binary.RouteDataObject;
 import net.osmand.plus.OsmAndLocationProvider;
 import net.osmand.plus.OsmandApplication;


### PR DESCRIPTION
Fourth step of moving the routing model into `OsmAnd-shared`. Stacked on #25903, review that one first.

## What moves

`RouteTypeRule` and its `RouteTypeCondition` leave `BinaryMapRouteReaderAdapter` for `net.osmand.shared.routing`. It is the leaf of the routing data model — `RouteDataObject`, `RouteRegion` and `RouteSegmentResult` all read encoding rules through it — and, unlike every other class in that cluster, the C++ core does not bind it by name, so this step needs **no paired `core-legacy` PR**.

## Why this is smaller than the plan in #25903

That PR said step 4 would take `RouteTypeRule`, `RouteRegion` and `RouteSubregion` together. Looking at the code, those three cannot go in one step:

- `RouteRegion.adopt()` builds `RouteDataObject`s and `RouteSubregion` holds a `List<RouteDataObject>`, while `RouteDataObject` holds a `RouteRegion` — the three are mutually dependent and have to move in one commit with `RouteDataObject`.
- `RouteRegion extends BinaryIndexPart`, and `java_wrap.cpp` reads the inherited package-private `length` and `filePointer` fields off it. Its `getFieldNumber()` returns a protobuf-generated constant. Neither survives a move to a module that has no protobuf and no `BinaryIndexPart`.

So the cluster is one large step of its own, and `RouteTypeRule` is the part that can be separated cleanly.

## Details that changed shape

- **`parseSpeed` / `NONE_MAX_SPEED`** live on `RouteDataObject`, which is still Java. They move to a shared `RouteDataUtils` that `RouteDataObject` delegates to, so the maxspeed parsing is not duplicated while that class waits its turn. `NONE_MAX_SPEED` stays a compile-time constant — verified with `javap -v`. `Algorithms.findFirstNumberEndIndex` gets a `KAlgorithms` twin for the same reason.
- **`String.intern`** has no common equivalent. `internString` keeps the pooling on jvm and android and is a no-op on ios, where Kotlin/Native has no string pool. Route encoding rules repeat the same tags across every loaded region, so this is worth keeping.
- **`StringExternalizable` is dropped.** `readFromBundle` was dead code — `RouteImporter` reads the two keys itself and calls `initRouteEncodingRule`. `writeToBundle` had one caller, `RouteExporter`, which now writes the keys directly. Keeping the interface would have pulled `RouteDataBundle` and `RouteDataResources` into the shared module.
- **`RouteRegion.completeRouteEncodingRules`** reached into a rule's private `conditions` list, which only worked while both classes were nested in `BinaryMapRouteReaderAdapter`. It goes through `getConditions()` and `setRuleId()` now.
- **`OpeningHoursTime.ofEpochMillis(millis, zoneId)`** is new. See below.

## The tools repository was broken by steps 2 and 3

`OsmAnd-tools` builds `OsmAnd-java` and `OsmAnd-shared` from source (`java-tools/settings.gradle` points at `../../android/`). Steps 2 and 3 moved `TurnType` and `OpeningHoursParser` without updating it, so two files there stopped compiling; this step breaks another twelve.

osmandapp/OsmAnd-tools#1680 fixes all of them. It needs the zone-aware `OpeningHoursTime` factory added here, because `SearchResultConverter` evaluates opening hours in the *client's* time zone, which the device-zone factories cannot express. **Merge order: this stack first, then the tools PR.**

## Verification

- `:OsmAnd-shared:jvmTest` — green, 19 new tests covering rule parsing, the two new `KAlgorithms` helpers and the new factory
- `:OsmAnd-java:test` — green
- `:OsmAnd-shared:iosSimulatorArm64Test` — 176 tests, the same 6 failures as master (`GpxUtilitiesLoadTest`, `KGeoPointParserUtilTest`, `NetworkAPITest`)
- Android app compiles
- `OsmAnd-tools`: all four java-tools projects compile against this branch

## Next

Step 5 is the `RouteRegion` / `RouteSubregion` / `RouteDataObject` cluster, which does need a paired `core-legacy` PR and a rethink of the `BinaryIndexPart` inheritance.
