### PR TITLE
Remove wiki tags in other languages from a favorite point

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/data/Amenity.java
+++ b/OsmAnd-java/src/main/java/net/osmand/data/Amenity.java
@@ -8,6 +8,7 @@ import static net.osmand.osm.MapPoiTypes.ROUTE_ARTICLE;
 import static net.osmand.osm.MapPoiTypes.ROUTE_ARTICLE_POINT;
 import static net.osmand.osm.MapPoiTypes.ROUTE_TRACK;
 import static net.osmand.osm.MapPoiTypes.ROUTE_TRACK_POINT;
+import static net.osmand.osm.MapPoiTypes.WIKI_LANG;
 import static net.osmand.shared.gpx.GpxFile.XML_COLON;
 
 import java.util.ArrayList;
@@ -39,6 +40,7 @@ import net.osmand.osm.PoiType;
 import net.osmand.shared.wiki.WikiHelper;
 import net.osmand.shared.wiki.WikiImage;
 import net.osmand.util.Algorithms;
+import net.osmand.util.CollectionUtils;
 import net.osmand.util.MapUtils;
 
 
@@ -847,6 +849,11 @@ public class Amenity extends MapObject {
 	}
 
 	public Map<String, String> getAmenityExtensions(MapPoiTypes mapPoiTypes, boolean addPrefixes) {
+		return getAmenityExtensions(mapPoiTypes, addPrefixes, false, null);
+	}
+
+	public Map<String, String> getAmenityExtensions(MapPoiTypes mapPoiTypes, boolean addPrefixes,
+	                                                boolean excludeWikiContent, String preferredLang) {
 		Map<String, String> result = new HashMap<>();
 		Map<String, List<PoiType>> categories = new HashMap<>();
 
@@ -863,7 +870,8 @@ public class Amenity extends MapObject {
 			result.put(addPrefixes ? AMENITY_PREFIX + OPENING_HOURS : OPENING_HOURS, openingHours);
 		}
 		if (hasAdditionalInfo()) {
-			result.putAll(getAdditionalInfoAndCollectCategories(mapPoiTypes, categories, addPrefixes));
+			result.putAll(getAdditionalInfoAndCollectCategories(mapPoiTypes, categories, addPrefixes,
+					excludeWikiContent, preferredLang));
 
 			//join collected tags by category into one string
 			for (Map.Entry<String, List<PoiType>> entry : categories.entrySet()) {
@@ -886,9 +894,15 @@ public class Amenity extends MapObject {
 
 	public Map<String, String> getAdditionalInfoAndCollectCategories(MapPoiTypes mapPoiTypes,
 	                                                                 Map<String, List<PoiType>> categories,
-	                                                                 boolean addPrefixes) {
+	                                                                 boolean addPrefixes,
+	                                                                 boolean excludeWikiContent,
+	                                                                 String preferredLang) {
 		Map<String, String> result = new HashMap<>();
+		boolean hasDefaultShortDescription = getInternalAdditionalInfoMap().containsKey(SHORT_DESCRIPTION);
 		for (String key : getAdditionalInfoKeys()) {
+			if (excludeWikiContent && isWikiContentTag(key, preferredLang, hasDefaultShortDescription)) {
+				continue;
+			}
 			String value = getAdditionalInfo(key);
 			PoiType poiType = getPoiType(mapPoiTypes, key, value);
 			if (poiType != null && poiType.isFilterOnly()) {
@@ -918,6 +932,55 @@ public class Amenity extends MapObject {
 			result.put(key, value);
 		}
 		return result;
+	}
+
+	public static boolean isWikiContentTag(String key, String preferredLang,
+	                                       boolean hasDefaultShortDescription) {
+		if (isContentTag(key) || WIKI_CATEGORY.equals(key)
+				|| hasLangSuffix(key, WIKI_LANG) || hasLangSuffix(key, LANG_YES)) {
+			return true;
+		}
+		if (Algorithms.isEmpty(preferredLang) || !hasLangSuffix(key, SHORT_DESCRIPTION)) {
+			return false;
+		}
+		if (isTagWithLang(key, SHORT_DESCRIPTION, preferredLang)) {
+			return false;
+		}
+		if (isTagWithLang(key, SHORT_DESCRIPTION, "en")) {
+			// without the unsuffixed tag this is the only English copy left
+			return hasDefaultShortDescription;
+		}
+		return true;
+	}
+
+	private static boolean isTagWithLang(String key, String tag, String lang) {
+		return key.equals(tag + ":" + lang) || key.equals(tag + XML_COLON + lang);
+	}
+
+	public static Map<String, String> removeWikiContentTags(Map<String, String> extensions,
+	                                                       String preferredLang) {
+		boolean hasDefaultShortDescription = extensions.containsKey(SHORT_DESCRIPTION)
+				|| extensions.containsKey(OSM_PREFIX + SHORT_DESCRIPTION);
+		Map<String, String> result = new LinkedHashMap<>();
+		for (Entry<String, String> entry : extensions.entrySet()) {
+			if (!isWikiContentTag(stripOsmPrefix(entry.getKey()), preferredLang, hasDefaultShortDescription)) {
+				result.put(entry.getKey(), entry.getValue());
+			}
+		}
+		return result;
+	}
+
+	private static boolean isContentTag(String key) {
+		return CONTENT.equals(key) || CONTENT_JSON.equals(key)
+				|| hasLangSuffix(key, CONTENT) || hasLangSuffix(key, CONTENT_JSON);
+	}
+
+	private static boolean hasLangSuffix(String key, String tag) {
+		return CollectionUtils.startsWithAny(key, tag + ":", tag + XML_COLON);
+	}
+
+	private static String stripOsmPrefix(String key) {
+		return key.startsWith(OSM_PREFIX) ? key.substring(OSM_PREFIX.length()) : key;
 	}
 
 	private PoiType getPoiType(MapPoiTypes mapPoiTypes, String key, String value) {

--- a/OsmAnd/src/net/osmand/data/FavouritePoint.java
+++ b/OsmAnd/src/net/osmand/data/FavouritePoint.java
@@ -460,7 +460,7 @@ public class FavouritePoint implements LocationPoint, Linkable {
 		point.setDescription(wptPt.getDesc());
 		point.setComment(wptPt.getComment());
 		point.setAmenityOriginName(wptPt.getAmenityOriginName());
-		point.setAmenityExtensions(wptPt.getExtensionsToRead());
+		point.setAmenityExtensions(Amenity.removeWikiContentTags(wptPt.getExtensionsToRead(), null));
 		point.setLinks(wptPt.getLinks());
 
 		Map<String, String> extensions = wptPt.getExtensionsToWrite();
@@ -512,7 +512,8 @@ public class FavouritePoint implements LocationPoint, Linkable {
 			point.setCategory(getCategory());
 		}
 		Map<String, String> extensions = point.getExtensionsToWrite();
-		extensions.putAll(getAmenityExtensions());
+		OsmandApplication app = (OsmandApplication) ctx.getApplicationContext();
+		extensions.putAll(Amenity.removeWikiContentTags(getAmenityExtensions(), app.getLanguage()));
 		if (isVisible()) {
 			extensions.remove(HIDDEN);
 		} else {

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/editors/FavoritePointEditor.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/editors/FavoritePointEditor.java
@@ -108,7 +108,8 @@ public class FavoritePointEditor extends PointEditor {
 	private void setAmenity(@NonNull Amenity amenity) {
 		favorite.setAmenityOriginName(amenity.toStringEn());
 		favorite.setIconId(RenderingIcons.getPreselectedIconId(app, amenity));
-		favorite.setAmenityExtensions(amenity.getAmenityExtensions(app.getPoiTypes(), true));
+		favorite.setAmenityExtensions(amenity.getAmenityExtensions(app.getPoiTypes(), true, true,
+				app.getLanguage()));
 		setOsmUrl(amenity);
 	}
 

--- a/OsmAnd/src/net/osmand/plus/mapcontextmenu/editors/WptPtEditor.java
+++ b/OsmAnd/src/net/osmand/plus/mapcontextmenu/editors/WptPtEditor.java
@@ -147,7 +147,8 @@ public class WptPtEditor extends PointEditor {
 				wpt.setIconName(preselectedIconName);
 			}
 			wpt.setAmenityOriginName(amenity.toStringEn());
-			wpt.getExtensionsToWrite().putAll(amenity.getAmenityExtensions(app.getPoiTypes(), true));
+			wpt.getExtensionsToWrite().putAll(amenity.getAmenityExtensions(app.getPoiTypes(), true, true,
+					app.getLanguage()));
 		} else if (mapObject instanceof RenderedObject renderedObject) {
 			wpt.setAmenityOriginName(renderedObject.toStringEn());
 			if (renderedObject.getIconRes() != null) {


### PR DESCRIPTION
## Do not store Wikipedia translations in Favorites (#25111)

### Problem
Saving a POI to Favorites with an offline Wikipedia map installed copies the whole
multilingual article payload into the point: ~110 `osm_tag_wiki_*` tags and a 1.6 MB
export for a single Berlin point. `AdditionalInfoBundle.shouldDisplayKey()` hides most
of them anyway, so the data is written to disk but never shown.

### Solution
Added an opt-in `excludeWikiContent` mode to `Amenity.getAmenityExtensions()` that drops
the offline-Wikipedia tags:

- **dropped:** `content`, `content:<lang>`, `content_json`, `wiki_lang:<lang>`,
  `lang_yes:<lang>`, `wiki_category`
- **kept:** `description` in all languages, `wikipedia`, `wikidata`, `wiki_photo`
- **`short_description`:** only the reader's language and English — the unsuffixed tag
  is the English one, which makes an explicit `:en` copy redundant when it's present

This mirrors the fallback the UI already uses
(`AmenityUIHelper.getDescriptionWithPreferredLang`): reader's language if present,
English otherwise. `description` is kept in full so a GPX shared with someone who has no
offline Wikipedia map still shows text for the point.

### Changes
- `Amenity` — `isWikiContentTag()`, `removeWikiContentTags()`, and the
  `excludeWikiContent` / `preferredLang` parameters on `getAmenityExtensions()`
- `FavoritePointEditor`, `WptPtEditor` — enable the filter when creating a point
- `FavouritePoint.fromWpt()` / `toWpt()` — filter on load and write, so favorites already
  saved with the payload shrink on their next save without a migration

## AI disclaimer

Produced with Claude Code (Claude Opus 5).

Prompts used (summarised):
1. Asked where offline Wikipedia article content ends up when a POI is added to
   Favorites, and where else `Amenity.getAmenityExtensions()` is used.
2. Pointed to issue #25111 and asked to fix it after an earlier attempt was lost from
   the working tree; asked to restart from the issue text.
3. Asked to keep `description` (including localized copies) so a shared GPX still shows
   text to someone without the offline Wikipedia map.
4. Asked to keep `short_description` for the current user's language and for English.
5. Asked whether the plain (unsuffixed) `short_description` tag is itself English and
   whether the `:en` copy can be skipped when it is — leading to skipping the redundant
   `:en` copy only when the unsuffixed tag is present.
6. Asked whether an existing `CollectionUtils`/`Algorithms` helper covers the
   prefix-matching logic instead of hand-rolled checks.
7. Asked where an old 3-argument overload of
   `getAdditionalInfoAndCollectCategories` was still used, then asked to delete it once
   it was confirmed unused.

Decided by the agent, not requested explicitly:
- The exact set of tags classified as "offline Wikipedia content"
  (`content`, `content:<lang>`, `content_json`, `wiki_lang:<lang>`, `lang_yes:<lang>`,
  `wiki_category`) — derived from the issue report and the POI type schema
  (`poi_types.xml`), not enumerated by the user.
- The overload structure on `Amenity.getAmenityExtensions()` /
  `getAdditionalInfoAndCollectCategories()` (adding `excludeWikiContent` and
  `preferredLang` as new overloads to preserve existing call sites).
- Using `CollectionUtils.startsWithAny()` for the language-suffix checks after the user
  asked whether a shared helper existed.
- Removing a gzip-based heuristic that was tried during development, after confirming
  with the user that it misclassified non-Wikipedia content.
- An initial unit test (`AmenityExtensionsTest`) covering the new filter rules was
  written unprompted; the user later asked to shelve it rather than merge it, so it is
  not part of this PR.