### PR TITLE
Fix OBD BLE reconnect race and VIN read corruption

### DIFF
--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/obd/OBDCommand.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/obd/OBDCommand.kt
@@ -26,7 +26,7 @@ enum class OBDCommand(
 	OBD_ENGINE_COOLANT_TEMP_COMMAND(0x01, 0x05, 1, OBDUtils::parseTempResponse, "vm_ctemp"),
 	OBD_FUEL_CONSUMPTION_RATE_COMMAND(0x01, 0x5E, 2, OBDUtils::parseFuelConsumptionRateResponse, "vm_fcons"),
 	OBD_FUEL_TYPE_COMMAND(0x01, 0x51, 1, OBDUtils::parseFuelTypeResponse, null, isStale = true),
-	OBD_VIN_COMMAND(0x09, 0x02, 1, OBDUtils::parseVINResponse, null,  IDENTIFICATION, true),
+	OBD_VIN_COMMAND(0x09, 0x02, 18, OBDUtils::parseVINResponse, null,  IDENTIFICATION, true),
 	OBD_FUEL_LEVEL_COMMAND(0x01, 0x2F, 1, OBDUtils::parsePercentResponse, "vm_fuel");
 
 	fun parseResponse(response: IntArray): OBDDataField<Any> {

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/obd/Obd2Connection.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/obd/Obd2Connection.kt
@@ -116,9 +116,9 @@ class Obd2Connection(
 					hexValues[0] != commandType.code ||
 					hexValues[1] != commandCode) {
 					log("Incorrect answer data (size ${hexValues.size}) for $fullCommand")
-				} else {
-					hexValues = hexValues.copyOfRange(2, hexValues.size)
+					return OBDResponse.ERROR
 				}
+				hexValues = hexValues.copyOfRange(2, hexValues.size)
 				return OBDResponse(hexValues)
 			} else {
 				return OBDResponse(

--- a/OsmAnd/src/net/osmand/plus/plugins/externalsensors/devices/ble/BLEAbstractDevice.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/externalsensors/devices/ble/BLEAbstractDevice.java
@@ -149,14 +149,20 @@ public abstract class BLEAbstractDevice extends AbstractDevice<BLEAbstractSensor
 		LOG.debug("currentState: " + getCurrentState());
 		if (status == GATT_SUCCESS) {
 			if (newState == BluetoothProfile.STATE_CONNECTED) {
+				// some OEM Bluetooth stacks (observed on Samsung devices) deliver the
+				// STATE_CONNECTED callback more than once for a single physical connection;
+				// re-running discovery/MTU/connect-event handling for a duplicate callback
+				// races a second GATT operation against the first and corrupts the session
+				if (getCurrentState() == DeviceConnectionState.CONNECTED) {
+					LOG.debug("Ignoring duplicate STATE_CONNECTED callback");
+					return;
+				}
 				int bondState = device.getBondState();
 
 				if (bondState == BOND_NONE || bondState == BOND_BONDED) {
-					LOG.debug("Discovering services");
-					boolean result = gatt.discoverServices();
-
-					if (!result) {
-						LOG.error("DiscoverServices failed to start");
+					boolean mtuRequested = gatt.requestMtu(247);
+					if (!mtuRequested) {
+						discoverServicesOnGatt(gatt);
 					}
 				} else if (bondState == BOND_BONDING) {
 					LOG.debug("Waiting for bonding to complete");
@@ -164,6 +170,10 @@ public abstract class BLEAbstractDevice extends AbstractDevice<BLEAbstractSensor
 				setCurrentState(DeviceConnectionState.CONNECTED);
 				fireDeviceConnectedEvent();
 			} else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+				if (getCurrentState() == DeviceConnectionState.DISCONNECTED) {
+					LOG.debug("Ignoring duplicate STATE_DISCONNECTED callback");
+					return;
+				}
 				fireDeviceDisconnectedEvent();
 				gatt.close();
 				LOG.debug("GATT disconnected (newState == BluetoothProfile.STATE_DISCONNECTED)");
@@ -171,11 +181,22 @@ public abstract class BLEAbstractDevice extends AbstractDevice<BLEAbstractSensor
 				setCurrentState(DeviceConnectionState.DISCONNECTED);
 			}
 		} else {
+			if (getCurrentState() == DeviceConnectionState.DISCONNECTED) {
+				LOG.debug("Ignoring duplicate disconnect (status != GATT_SUCCESS)");
+				return;
+			}
 			LOG.debug("GATT disconnected (status != GATT_SUCCESS)");
 			fireDeviceDisconnectedEvent();
 			gatt.close();
 			bluetoothGatt = null;
 			setCurrentState(DeviceConnectionState.DISCONNECTED);
+		}
+	}
+
+	@SuppressLint("MissingPermission")
+	private void discoverServicesOnGatt(BluetoothGatt gatt) {
+		if (!gatt.discoverServices()) {
+			LOG.error("DiscoverServices failed to start");
 		}
 	}
 
@@ -269,6 +290,12 @@ public abstract class BLEAbstractDevice extends AbstractDevice<BLEAbstractSensor
 			super.onDescriptorWrite(gatt, descriptor, status);
 			onDescriptorWriteCompleted();
 
+		}
+
+		@Override
+		public void onMtuChanged(BluetoothGatt gatt, int mtu, int status) {
+			super.onMtuChanged(gatt, mtu, status);
+			discoverServicesOnGatt(gatt);
 		}
 	};
 

--- a/OsmAnd/src/net/osmand/plus/plugins/externalsensors/devices/ble/BLEOBDDevice.kt
+++ b/OsmAnd/src/net/osmand/plus/plugins/externalsensors/devices/ble/BLEOBDDevice.kt
@@ -148,7 +148,7 @@ class BLEOBDDevice(bluetoothAdapter: BluetoothAdapter, deviceId: String) :
 						log.debug("lastSensorData == ${lastSensorData.response}")
 					}
 					lastSensorDataList.remove()
-					bufferToRead = lastSensorData.response
+					bufferToRead = (bufferToRead ?: "") + lastSensorData.response
 				} catch (error: Exception) {
 					log.debug("lastSensorData error")
 				}

--- a/OsmAnd/src/net/osmand/plus/plugins/odb/VehicleMetricsPlugin.kt
+++ b/OsmAnd/src/net/osmand/plus/plugins/odb/VehicleMetricsPlugin.kt
@@ -96,6 +96,9 @@ class VehicleMetricsPlugin(app: OsmandApplication) : OsmandPlugin(app), OBDReadS
 	private var currentReconnectAttempt = 0
 
 	private var connectionState = OBDConnectionState.DISCONNECTED
+	private var explicitBleDisconnectDeviceId: String? = null
+	private var bleConnectingAddress: String? = null
+
 	val OBD_DEVICES_SETTINGS_PREF_ID: String = "obd_devices_settings"
 
 	val USED_OBD_DEVICES =
@@ -361,6 +364,9 @@ class VehicleMetricsPlugin(app: OsmandApplication) : OsmandPlugin(app), OBDReadS
 		LOG.info("VMPlugin disconnect {$forgetCurrentDeviceConnected}")
 		obdDispatcher?.stopReading()
 		val lastConnectedDeviceInfo = connectedDeviceInfo
+		if (lastConnectedDeviceInfo?.isBLE == true) {
+			explicitBleDisconnectDeviceId = lastConnectedDeviceInfo.address
+		}
 		connectedDeviceInfo = null
 		if (forgetCurrentDeviceConnected) {
 			setLastConnectedDevice(null)
@@ -414,11 +420,16 @@ class VehicleMetricsPlugin(app: OsmandApplication) : OsmandPlugin(app), OBDReadS
 		saveDeviceToUsedOBDDevicesList(deviceInfo)
 		LOG.debug("connectToObd $deviceInfo reconnectCount left $currentReconnectAttempt")
 		if (deviceInfo.isBLE) {
+			if (bleConnectingAddress == deviceInfo.address) {
+				LOG.debug("connectToObd $deviceInfo already connecting, skip duplicate attempt")
+				return
+			}
 			val bleDevice = getBLEOBDDeviceById(deviceInfo.address)
 			if (bleDevice != null) {
 				if (!devicesHelper.isDevicePaired(bleDevice)) {
 					devicesHelper.setDevicePaired(bleDevice, true)
 				}
+				bleConnectingAddress = deviceInfo.address
 				connectDevice(activity, bleDevice, deviceInfo)
 			}
 			return
@@ -1256,12 +1267,28 @@ class VehicleMetricsPlugin(app: OsmandApplication) : OsmandPlugin(app), OBDReadS
 				device: AbstractDevice<*>,
 				result: DeviceConnectionResult,
 				error: String?) {
+				if (bleConnectingAddress == deviceInfo.address) {
+					bleConnectingAddress = null
+				}
 				onDeviceConnected(deviceInfo)
 			}
 
 			override fun onDeviceDisconnect(device: AbstractDevice<*>) {
+				val wasExplicitDisconnect = explicitBleDisconnectDeviceId == device.deviceId
+				if (wasExplicitDisconnect) {
+					explicitBleDisconnectDeviceId = null
+				}
+				if (bleConnectingAddress == deviceInfo.address) {
+					bleConnectingAddress = null
+				}
 				onDisconnected(deviceInfo)
 				device.removeListener(this)
+				if (!wasExplicitDisconnect) {
+					LOG.debug("Unexpected OBD BLE disconnect from ${deviceInfo.name}, scheduling reconnect")
+					handler.postDelayed({
+						connectToLastConnectedDevice(RECONNECT_ATTEMPTS_COUNT)
+					}, RECONNECT_DELAY)
+				}
 			}
 
 			override fun onSensorData(sensor: AbstractSensor, data: SensorData) {
@@ -1270,6 +1297,9 @@ class VehicleMetricsPlugin(app: OsmandApplication) : OsmandPlugin(app), OBDReadS
 			override fun onDeviceConnectionFailed(device: AbstractDevice<*>) {
 				super.onDeviceConnectionFailed(device)
 				LOG.debug("Device ${deviceInfo.name} connection failed. Reconnection attempts left $currentReconnectAttempt")
+				if (bleConnectingAddress == deviceInfo.address) {
+					bleConnectingAddress = null
+				}
 				device.removeListener(this)
 				activity?.let {
 					connectToLastConnectedDevice(it, currentReconnectAttempt)


### PR DESCRIPTION
## Summary
- Auto-reconnect on an unexpected BLE disconnect (`VehicleMetricsPlugin`), instead of leaving the OBD widget stuck disconnected until the user manually reconnects.
- Guard against duplicate/racing GATT connection attempts, including duplicate `STATE_CONNECTED`/`STATE_DISCONNECTED` callbacks observed on some OEM Bluetooth stacks, which raced GATT operations against each other and broke the session.
- Negotiate a larger BLE MTU before service discovery (`BLEAbstractDevice`) to reduce notification fragmentation for multi-line responses.
- Fix `BLEOBDDevice.read()` overwriting (instead of appending) queued BLE notifications, which silently dropped CAN frames of multi-frame responses such as VIN.
- Reject VIN responses with an incorrect mode/pid echo or a truncated payload instead of caching garbage (`Obd2Connection`); `OBD_VIN_COMMAND`'s `responseLength` was `1`, effectively disabling that validation.

## Test plan
- [x] Built `gplayFullOpenglArm64Debug` and installed on a physical Samsung Galaxy S23, paired to a Veepeak BLE OBD-II adapter.
- [x] Verified the adapter reconnects automatically after an unexpected BLE drop, without a duplicate/racing connection attempt.
- [x] Verified VIN is read correctly and consistently across multiple read cycles (`WAUENAF49KA055323`), where it previously came back garbled/truncated.

## AI disclaimer

Produced with Claude Code (Sonnet 5).

Prompts used (summarised):
1. Report that the app keeps disconnecting from a BLE OBD-II adapter (Veepeak) after a while and asking for a fix, to be verified on a physical device.
2. Clarification of the physical-device testing setup, then a request to verify the connection stays stable while the sensor is present (without deliberately walking it out of range).
3. Report that VIN reading shows a wrong/garbled value, asking for a fix.
4. Iterative real-device debugging over several rebuild/install/reconnect cycles, including a report that the adapter stopped connecting again (which turned out to be duplicate/racing GATT connection attempts) and a specific find that a "zero frame" was being overwritten in the BLE read buffer.
5. Question about why MTU 247 was requested.
6. Request to commit the changes on the already-created branch and open this PR against master with the AI disclaimer.

Decided by the agent, not requested explicitly:
- The BLE MTU negotiation and the duplicate-GATT-callback guard were added as defensive fixes discovered while debugging the VIN corruption and reconnect issues live on-device, not requested up front.
- Rejecting responses with a bad mode/pid echo in `Obd2Connection.run()` and raising `OBD_VIN_COMMAND`'s `responseLength` from `1` to `18` (root-causing the "garbled VIN" report).
- `OBD_VIN_COMMAND`'s `isStale` was temporarily set to `false` during testing (by the user) and reverted back to `true` once the fix was confirmed working, since the VIN doesn't change and re-querying it every cycle is wasteful.