### PR TITLE
Fix Tracks screen crash when sorting while tracks are deleted

### DIFF
--- a/OsmAnd/src/net/osmand/plus/configmap/tracks/TracksComparator.java
+++ b/OsmAnd/src/net/osmand/plus/configmap/tracks/TracksComparator.java
@@ -24,11 +24,14 @@ import net.osmand.shared.data.KLatLon;
 import net.osmand.shared.gpx.GpxDataItem;
 import net.osmand.shared.gpx.GpxTrackAnalysis;
 import net.osmand.shared.gpx.TrackItem;
+import net.osmand.shared.gpx.filters.TrackFolderAnalysis;
 import net.osmand.shared.io.KFile;
 import net.osmand.shared.util.KMapUtils;
 import net.osmand.util.CollectionUtils;
 
 import java.util.Comparator;
+import java.util.IdentityHashMap;
+import java.util.Map;
 
 public class TracksComparator implements Comparator<Object> {
 
@@ -37,6 +40,12 @@ public class TracksComparator implements Comparator<Object> {
 	public final TracksSortMode sortMode;
 	public final Collator collator = OsmAndCollator.primaryCollator();
 	private boolean useSubdirs = false;
+
+	// Sorting keys have to stay constant for the whole sort, otherwise TimSort throws
+	// "Comparison method violates its general contract!". Track folders read them from the
+	// file system and recalculate them lazily, so they are cached per comparator instance.
+	private final Map<ComparableTracksGroup, Long> lastModifiedCache = new IdentityHashMap<>();
+	private final Map<ComparableTracksGroup, TrackFolderAnalysis> analysisCache = new IdentityHashMap<>();
 
 	public TracksComparator(@NonNull TrackTab trackTab, @NonNull OsmandApplication app) {
 		this.trackTab = trackTab;
@@ -64,17 +73,15 @@ public class TracksComparator implements Comparator<Object> {
 		if (o2 instanceof Integer) {
 			return 1;
 		}
-		if (o1 instanceof TrackItem && ((TrackItem) o1).isShowCurrentTrack()) {
-			return -1;
+		boolean currentTrack1 = o1 instanceof TrackItem && ((TrackItem) o1).isShowCurrentTrack();
+		boolean currentTrack2 = o2 instanceof TrackItem && ((TrackItem) o2).isShowCurrentTrack();
+		if (currentTrack1 || currentTrack2) {
+			return currentTrack1 && currentTrack2 ? 0 : (currentTrack1 ? -1 : 1);
 		}
-		if (o2 instanceof TrackItem && ((TrackItem) o2).isShowCurrentTrack()) {
-			return 1;
-		}
-		if (o1 instanceof VisibleTracksGroup) {
-			return -1;
-		}
-		if (o2 instanceof VisibleTracksGroup) {
-			return 1;
+		boolean visibleGroup1 = o1 instanceof VisibleTracksGroup;
+		boolean visibleGroup2 = o2 instanceof VisibleTracksGroup;
+		if (visibleGroup1 || visibleGroup2) {
+			return visibleGroup1 && visibleGroup2 ? 0 : (visibleGroup1 ? -1 : 1);
 		}
 		if (o1 instanceof ComparableTracksGroup folder1) {
 			if (o2 instanceof ComparableTracksGroup folder2) {
@@ -90,8 +97,15 @@ public class TracksComparator implements Comparator<Object> {
 		if (o2 instanceof ComparableTracksGroup) {
 			return 1;
 		}
-		if (o1 instanceof TrackItem && o2 instanceof TrackItem) {
+		boolean trackItem1 = o1 instanceof TrackItem;
+		boolean trackItem2 = o2 instanceof TrackItem;
+		if (trackItem1 && trackItem2) {
 			return compareTrackItems((TrackItem) o1, (TrackItem) o2);
+		}
+		// Any other row (folder statistics for example) is kept after the tracks. Reporting it
+		// as equal to every track would make the comparator intransitive.
+		if (trackItem1 || trackItem2) {
+			return trackItem1 ? -1 : 1;
 		}
 		return 0;
 	}
@@ -120,8 +134,8 @@ public class TracksComparator implements Comparator<Object> {
 			}
 
 			case DISTANCE_ASCENDING, DISTANCE_DESCENDING: {
-				float dist1 = group1.getFolderAnalysis().getTotalDistance();
-				float dist2 = group2.getFolderAnalysis().getTotalDistance();
+				float dist1 = getFolderAnalysis(group1).getTotalDistance();
+				float dist2 = getFolderAnalysis(group2).getTotalDistance();
 				if (Math.abs(dist1 - dist2) >= EQUIVALENT_TOLERANCE) {
 					multiplier = sortMode == DISTANCE_ASCENDING ? 1 : -1;
 					return multiplier * Float.compare(dist1, dist2);
@@ -129,8 +143,8 @@ public class TracksComparator implements Comparator<Object> {
 			}
 
 			case DURATION_ASCENDING, DURATION_DESCENDING: {
-				int timeSpan1 = group1.getFolderAnalysis().getTimeSpan();
-				int timeSpan2 = group2.getFolderAnalysis().getTimeSpan();
+				int timeSpan1 = getFolderAnalysis(group1).getTimeSpan();
+				int timeSpan2 = getFolderAnalysis(group2).getTimeSpan();
 				if (timeSpan1 != timeSpan2) {
 					multiplier = sortMode == DURATION_ASCENDING ? 1 : -1;
 					return multiplier * Long.compare(timeSpan1, timeSpan2);
@@ -288,15 +302,19 @@ public class TracksComparator implements Comparator<Object> {
 		if (file2 == null) {
 			return -1;
 		}
-		if (file1.lastModified() == file2.lastModified()) {
+		// Deliberately not file.lastModified(): reading the file system during the sort makes the
+		// comparison result change when tracks are deleted in background (a missing file reports 0).
+		long lastModified1 = item1.getLastModified();
+		long lastModified2 = item2.getLastModified();
+		if (lastModified1 == lastModified2) {
 			return compareTrackItemNames(item1, item2);
 		}
-		return compareFilesByLastModified(file1.lastModified(), file2.lastModified());
+		return compareFilesByLastModified(lastModified1, lastModified2);
 	}
 
 	private int compareFolderFilesByLastModified(@NonNull ComparableTracksGroup folder1, @NonNull ComparableTracksGroup folder2) {
-		long lastModified1 = folder1.lastModified();
-		long lastModified2 = folder2.lastModified();
+		long lastModified1 = getLastModified(folder1);
+		long lastModified2 = getLastModified(folder2);
 
 		if (lastModified1 == lastModified2) {
 			return compareTrackFolderNames(folder1, folder2);
@@ -306,6 +324,25 @@ public class TracksComparator implements Comparator<Object> {
 
 	private int compareFilesByLastModified(long lastModified1, long lastModified2) {
 		return -Long.compare(lastModified1, lastModified2);
+	}
+
+	private long getLastModified(@NonNull ComparableTracksGroup group) {
+		Long lastModified = lastModifiedCache.get(group);
+		if (lastModified == null) {
+			lastModified = group.lastModified();
+			lastModifiedCache.put(group, lastModified);
+		}
+		return lastModified;
+	}
+
+	@NonNull
+	private TrackFolderAnalysis getFolderAnalysis(@NonNull ComparableTracksGroup group) {
+		TrackFolderAnalysis analysis = analysisCache.get(group);
+		if (analysis == null) {
+			analysis = group.getFolderAnalysis();
+			analysisCache.put(group, analysis);
+		}
+		return analysis;
 	}
 
 	private int compareTrackItemNames(@NonNull TrackItem item1, @NonNull TrackItem item2) {

--- a/OsmAnd/test/java/net/osmand/plus/configmap/tracks/TracksComparatorTest.java
+++ b/OsmAnd/test/java/net/osmand/plus/configmap/tracks/TracksComparatorTest.java
@@ -1,0 +1,234 @@
+package net.osmand.plus.configmap.tracks;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.shared.SharedUtil;
+import net.osmand.plus.settings.enums.TracksSortMode;
+import net.osmand.shared.gpx.TrackItem;
+import net.osmand.shared.gpx.data.TrackFolder;
+import net.osmand.shared.gpx.filters.TrackFolderAnalysis;
+import net.osmand.shared.io.KFile;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Regression test for the "Comparison method violates its general contract!" crash on the
+ * Tracks screen (BaseTrackFolderFragment.sortItems), reproduced while a bulk track deletion
+ * is still running in background.
+ */
+@RunWith(AndroidJUnit4.class)
+public class TracksComparatorTest {
+
+	private static final int TRACKS_COUNT = 400;
+	private static final int PAIRWISE_TRACKS_COUNT = 50;
+
+	private OsmandApplication app;
+	private File dir;
+
+	@Before
+	public void setUp() {
+		Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+		app = (OsmandApplication) targetContext.getApplicationContext();
+		dir = new File(targetContext.getCacheDir(), "tracks_comparator_test");
+		removeDir(dir);
+		//noinspection ResultOfMethodCallIgnored
+		dir.mkdirs();
+	}
+
+	@After
+	public void tearDown() {
+		removeDir(dir);
+	}
+
+	/**
+	 * The comparator must not read mutable filesystem state: two runs over the very same items
+	 * have to produce the very same answers even if the files are gone in between. That is exactly
+	 * the guarantee TimSort relies on while a sort is in progress.
+	 */
+	@Test
+	public void comparisonDoesNotDependOnFilesPresence() throws IOException {
+		List<TrackItem> items = createTrackItems(PAIRWISE_TRACKS_COUNT);
+		TracksComparator comparator = new TracksComparator(TracksSortMode.LAST_MODIFIED, app);
+
+		List<Integer> before = compareAllPairs(comparator, items);
+		deleteFiles(items);
+		List<Integer> after = compareAllPairs(comparator, items);
+
+		assertEquals("Comparator result changed after the track files were deleted", before, after);
+	}
+
+	/**
+	 * Reproduces the reported crash: the Tracks list is re-sorted (loadTracksProgress ->
+	 * updateContent -> sortItems) while DeleteTracksTask keeps removing files in background.
+	 */
+	@Test
+	public void sortIsStableWhileTracksAreBeingDeleted() throws Exception {
+		List<TrackItem> items = createTrackItems(TRACKS_COUNT);
+		TracksComparator comparator = new TracksComparator(TracksSortMode.LAST_MODIFIED, app);
+
+		List<TrackItem> toDelete = new ArrayList<>(items);
+		Collections.shuffle(toDelete);
+
+		AtomicBoolean deletionFinished = new AtomicBoolean(false);
+		Thread deleter = new Thread(() -> {
+			for (TrackItem item : toDelete) {
+				KFile file = item.getFile();
+				if (file != null) {
+					//noinspection ResultOfMethodCallIgnored
+					SharedUtil.jFile(file).delete();
+				}
+				try {
+					Thread.sleep(1);
+				} catch (InterruptedException e) {
+					break;
+				}
+			}
+			deletionFinished.set(true);
+		}, "delete-tracks-test");
+		deleter.start();
+
+		int sorts = 0;
+		try {
+			while (!deletionFinished.get()) {
+				Collections.sort(new ArrayList<>(items), comparator);
+				sorts++;
+			}
+		} catch (IllegalArgumentException e) {
+			fail("Comparison method violates its general contract after " + sorts
+					+ " sorts: " + e.getMessage());
+		} finally {
+			deleter.interrupt();
+			deleter.join();
+		}
+		assertTrue("The test did not manage to sort while deleting", sorts > 0);
+	}
+
+	/**
+	 * Same guarantee for track folders: {@link TrackFolder#lastModified()} is a live
+	 * {@code stat} of the directory, so deleting a folder must not change an already started sort.
+	 */
+	@Test
+	public void folderComparisonDoesNotDependOnDirPresence() throws IOException {
+		File dir1 = new File(dir, "folder_a");
+		File dir2 = new File(dir, "folder_b");
+		// folder_a is older than folder_b, so "last modified" order is the opposite of the name order
+		createFolderWithTrack(dir1, 10);
+		createFolderWithTrack(dir2, 0);
+
+		TrackFolder folder1 = new TrackFolder(SharedUtil.kFile(dir1), null);
+		TrackFolder folder2 = new TrackFolder(SharedUtil.kFile(dir2), null);
+		TracksComparator comparator = new TracksComparator(TracksSortMode.LAST_MODIFIED, app);
+
+		int before = Integer.signum(comparator.compare(folder1, folder2));
+		removeDir(dir1);
+		removeDir(dir2);
+		int after = Integer.signum(comparator.compare(folder1, folder2));
+
+		assertEquals("Folder comparison changed after the folders were deleted", before, after);
+	}
+
+	/**
+	 * The folder statistics row is not a track and not a folder, so it used to compare as "equal"
+	 * to every track while the tracks themselves are ordered - an intransitive comparator.
+	 */
+	@Test
+	public void folderStatsRowKeepsComparatorTransitive() throws IOException {
+		List<TrackItem> items = createTrackItems(2);
+		TrackItem item1 = items.get(0);
+		TrackItem item2 = items.get(1);
+		TrackFolder folder = new TrackFolder(SharedUtil.kFile(dir), null);
+		TrackFolderAnalysis statsRow = new TrackFolderAnalysis(folder);
+
+		TracksComparator comparator = new TracksComparator(TracksSortMode.LAST_MODIFIED, app);
+
+		assertTrue("Tracks are expected to be ordered", comparator.compare(item1, item2) != 0);
+		assertTrue("Stats row must not be equal to a track",
+				comparator.compare(statsRow, item1) != 0 && comparator.compare(statsRow, item2) != 0);
+	}
+
+	private void createFolderWithTrack(@NonNull File folder, int index) throws IOException {
+		//noinspection ResultOfMethodCallIgnored
+		folder.mkdirs();
+		File file = new File(folder, "track.gpx");
+		try (FileOutputStream out = new FileOutputStream(file)) {
+			out.write("<gpx></gpx>".getBytes());
+		}
+		//noinspection ResultOfMethodCallIgnored
+		folder.setLastModified(System.currentTimeMillis() - index * 60_000L);
+	}
+
+	@NonNull
+	private List<TrackItem> createTrackItems(int count) throws IOException {
+		List<TrackItem> items = new ArrayList<>();
+		long now = System.currentTimeMillis();
+		for (int i = 0; i < count; i++) {
+			File file = new File(dir, "track_" + i + ".gpx");
+			try (FileOutputStream out = new FileOutputStream(file)) {
+				out.write(("<gpx><name>track_" + i + "</name></gpx>").getBytes());
+			}
+			// distinct modification times, so that the order is defined by them
+			//noinspection ResultOfMethodCallIgnored
+			file.setLastModified(now - i * 1000L);
+			items.add(new TrackItem(SharedUtil.kFile(file)));
+		}
+		return items;
+	}
+
+	private void deleteFiles(@NonNull List<TrackItem> items) {
+		for (TrackItem item : items) {
+			KFile file = item.getFile();
+			if (file != null) {
+				//noinspection ResultOfMethodCallIgnored
+				SharedUtil.jFile(file).delete();
+			}
+		}
+	}
+
+	@NonNull
+	private List<Integer> compareAllPairs(@NonNull TracksComparator comparator,
+	                                      @NonNull List<TrackItem> items) {
+		List<Integer> result = new ArrayList<>();
+		for (TrackItem item1 : items) {
+			for (TrackItem item2 : items) {
+				result.add(Integer.signum(comparator.compare(item1, item2)));
+			}
+		}
+		return result;
+	}
+
+	private static void removeDir(@NonNull File dir) {
+		File[] files = dir.listFiles();
+		if (files != null) {
+			for (File file : files) {
+				if (file.isDirectory()) {
+					removeDir(file);
+				} else {
+					//noinspection ResultOfMethodCallIgnored
+					file.delete();
+				}
+			}
+		}
+		//noinspection ResultOfMethodCallIgnored
+		dir.delete();
+	}
+}


### PR DESCRIPTION
Fixes the crash reported as "crash while the Tracks page refreshes after deleting a large number of tracks, not reproducible every time" (internal issue OsmAnd-Issues#3326).

```
java.lang.IllegalArgumentException: Comparison method violates its general contract!
	at java.util.TimSort.mergeLo(TimSort.java:781)
	at java.util.Collections.sort(Collections.java:207)
	at net.osmand.plus.myplaces.tracks.dialogs.BaseTrackFolderFragment.sortItems(BaseTrackFolderFragment.java:316)
	at net.osmand.plus.myplaces.tracks.dialogs.AvailableTracksFragment$2.loadTracksProgress(AvailableTracksFragment.java:503)
	at net.osmand.shared.gpx.TrackFolderLoaderTask.onProgressUpdate(TrackFolderLoaderTask.kt:47)
```

## Cause

`TracksComparator` reads live, concurrently changing state on every comparison, so a single
`Collections.sort()` call can compare the same pair of tracks differently at two points in time -
which is exactly what `TimSort` detects and reports.

* `compareItemFilesByLastModified()` called `KFile.lastModified()` per comparison instead of using
  the `TrackItem.lastModified` value captured when the item was created. A deleted file reports `0`,
  so a track that compared as the newest early in the sort compared as the oldest a few comparisons
  later.
* `compareFolderFilesByLastModified()` had the same problem: `TrackFolder.lastModified()` is
  `getDirFile().lastModified()`, a live `stat`.
* `ComparableTracksGroup.getFolderAnalysis()` is computed lazily and its cache is dropped by
  `TrackFolderLoaderTask.resetCachedData()` from an IO thread, so the distance/duration keys can also
  change in the middle of a sort.
* Independently of the threading: the folder statistics row (`TrackFolderAnalysis`) matches none of
  the `instanceof` branches in `compare()`, so it was reported equal to every `TrackItem` while the
  tracks themselves are ordered - an intransitive comparator.

`LAST_MODIFIED` is the default sort mode of the root Tracks folder
(`TracksSortMode.getDefaultSortMode()`), so the plain Tracks screen is the one affected.

Why it needs a bulk deletion: `DeleteTracksTask.doInBackground()` removes files on a background
thread while the main thread re-sorts the list (`loadTracksProgress` -> `updateContent` ->
`sortItems`). Only a sort that overlaps a deletion sees the keys change, hence "not every time".
`TimSort` also performs the check only for 32+ elements, hence "a large number of tracks".

## Fix

* Use the `TrackItem.lastModified` snapshot instead of a live `stat`. As a side effect this removes
  two file system calls per comparison (O(n log n) `stat` calls) from the UI thread.
* Cache the folder last modified time and the folder analysis per comparator instance. A comparator
  is created per sort at every call site, so the keys are now constant for the duration of one sort.
* Make `compare()` a total order: the statistics row is ordered after the tracks instead of being
  equal to all of them, and the current track / visible group checks are symmetric.

## Testing

New instrumented test `TracksComparatorTest` (4 cases), run on an API 35 emulator with
`nightlyFreeLegacyArm64Debug`:

| | before | after |
|---|---|---|
| `sortIsStableWhileTracksAreBeingDeleted` - sorts 400 real `TrackItem`s while a thread deletes the files | fails with the reported `IllegalArgumentException` after 3-6 sorts | passes |
| `comparisonDoesNotDependOnFilesPresence` | fails | passes |
| `folderComparisonDoesNotDependOnDirPresence` | fails | passes |
| `folderStatsRowKeepsComparatorTransitive` | fails | passes |

`Tests run: 4, Failures: 4` on `master` -> `OK (4 tests)` with this change.

Not covered by a test: the folder-analysis cache. Its instability comes from the loader task
resetting the folder cache from an IO thread, which I could not trigger deterministically in a test;
that part of the change is defensive and follows the same reasoning as the other two keys.

Also noticed while investigating, not addressed here: `BaseTrackFolderFragment.getAdapterItems()`
reads `TrackFolder.getTrackItems()`/`getSubFolders()` on the main thread while
`TrackFolderLoaderTask` mutates them under its own lock from IO threads.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Look at the exception logs in the `issues` folder, reproduce the bug "crash while the Track page
   refreshes after an attempt to delete a large number of tracks - not reproducible every time",
   create an issue for 5.4 and possibly a pull request.

Decided by the agent, not requested explicitly:
- Choice of which stack trace in `exception (14).log` matches the report (the file also contains
  unrelated `MapColorPaletteFragment` and `RemoteServiceException` crashes).
- The reproduction approach: an instrumented test driving the real `TracksComparator` rather than a
  UI test, plus a standalone TimSort simulation used to rule out an initially suspected cause (the
  statistics row alone never trips TimSort because it is always the last element).
- The fix design: snapshot/cache the sorting keys inside the comparator instead of, for example,
  synchronising the loader with the deletion task or catching the exception in `sortItems()`.
- Including the intransitive statistics row and the asymmetric current-track checks in the same
  change, since they are contract violations in the same comparator.
- Branch name, commit message, issue milestone (`5.4-android`), label (`and-bugs`) and the Release
  Backlog / Ready To Do placement.
