### PR TITLE
Fix map update check comparing milliseconds against a seconds constant

### DIFF
--- a/OsmAnd/src/net/osmand/plus/AppInitializer.java
+++ b/OsmAnd/src/net/osmand/plus/AppInitializer.java
@@ -113,7 +113,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
@@ -125,6 +124,7 @@ public class AppInitializer implements IProgress {
 	private static final Log LOG = PlatformUtil.getLog(AppInitializer.class);
 	private static final int MAX_OPENGL_FAILURES = 3;
 	private static final int MAX_OPENGL_DISABLE = 6;
+	private static final long MAP_UPDATES_CHECK_INTERVAL_MS = 2 * 24 * 60 * 60 * 1000L; // 2 days
 
 	private final OsmandApplication app;
 	private final AppVersionUpgradeOnInit appVersionUpgrade;
@@ -225,12 +225,10 @@ public class AppInitializer implements IProgress {
 	}
 
 	private void checkMapUpdates() {
-		long diff = System.currentTimeMillis() - app.getSettings().LAST_CHECKED_UPDATES.get();
-		if (diff >= 2 * 24 * 60 * 60L && new Random().nextInt(5) == 0 &&
-				app.getSettings().isInternetConnectionAvailable()) {
-			app.getDownloadThread().runReloadIndexFiles();
-		} else if (Version.isDeveloperVersion(app)) {
-//			app.getDownloadThread().runReloadIndexFiles();
+		OsmandSettings settings = app.getSettings();
+		long diff = System.currentTimeMillis() - settings.LAST_CHECKED_UPDATES.get();
+		if (diff >= MAP_UPDATES_CHECK_INTERVAL_MS && settings.isInternetConnectionAvailable()) {
+			app.getDownloadThread().runReloadIndexFilesSilent();
 		}
 	}
 

--- a/OsmAnd/test/java/net/osmand/test/junit/MapUpdatesCheckIntervalTest.kt
+++ b/OsmAnd/test/java/net/osmand/test/junit/MapUpdatesCheckIntervalTest.kt
@@ -1,0 +1,192 @@
+package net.osmand.test.junit
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import net.osmand.plus.OsmandApplication
+import net.osmand.plus.download.DownloadIndexesThread
+import net.osmand.plus.settings.backend.OsmandSettings
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.TimeUnit
+
+/**
+ * Regression test for the background map update check, which was meant to ask the server for the
+ * index list at most once every two days and in practice asked roughly every three minutes.
+ *
+ * `AppInitializer.checkMapUpdates()` took the age of `LAST_CHECKED_UPDATES` - a timestamp written
+ * with `System.currentTimeMillis()` in `DownloadIndexesThread` - and compared it against
+ * `2 * 24 * 60 * 60L`, a constant written in seconds. That literal is 172_800, so the gate read
+ * "at most one `/get_indexes` request every 172.8 seconds", and the only remaining brake was
+ * `new Random().nextInt(5) == 0`. Both the comparison and the lottery were introduced together in
+ * `3609492cc7` ("Update indexes"), so the missing `* 1000` had been there from the start.
+ *
+ * `checkMapUpdates()` is private and its only caller is `MapActivity.onCreate()` by way of
+ * `WhatsNewDialogFragment.shouldShowDialog()`, so the tests drive the public entry point
+ * [net.osmand.plus.AppInitializer.checkAppVersionChanged] and watch
+ * [DownloadIndexesThread.getCurrentRunningTask] for the reload task that a passing gate starts.
+ *
+ * With the lottery gone the gate is deterministic and a single call decides each case. The tests
+ * still sweep [ATTEMPTS] calls, because it costs about a second and it keeps the pair conclusive
+ * if a probabilistic brake is ever put back in front of a broken interval - there a single call
+ * would only catch the regression one time in five.
+ */
+@RunWith(AndroidJUnit4::class)
+class MapUpdatesCheckIntervalTest {
+
+	companion object {
+		/** Calls per test. See the class comment for why one call is not enough. */
+		private const val ATTEMPTS = 200
+
+		/** Returned by [firstAttemptThatStartedReload] when no attempt started a reload. */
+		private const val NO_RELOAD = -1
+
+		/**
+		 * `ReloadIndexesTask` is a private inner class of [DownloadIndexesThread], so it can only
+		 * be recognised by name. Naming it keeps an unrelated download task that happens to be
+		 * running from being mistaken for the reload under test; should the class ever be renamed,
+		 * [reloadFiresWhenDueAndClosesTheIntervalBehindIt] fails and says so.
+		 */
+		private const val RELOAD_TASK = "ReloadIndexesTask"
+
+		/** Comfortably past the broken 172.8s gate and comfortably inside the intended two days. */
+		private val RECENTLY_CHECKED = TimeUnit.MINUTES.toMillis(10)
+
+		/** Past the intended two days, so a check really is due. */
+		private val CHECKED_LONG_AGO = TimeUnit.DAYS.toMillis(3)
+
+		private val TASK_IDLE_TIMEOUT = TimeUnit.MINUTES.toMillis(3)
+		private const val TASK_POLL_MS = 200L
+	}
+
+	private lateinit var app: OsmandApplication
+	private lateinit var settings: OsmandSettings
+	private lateinit var downloadThread: DownloadIndexesThread
+
+	private var savedLastChecked = 0L
+
+	@Before
+	fun setup() {
+		app = InstrumentationRegistry.getInstrumentation()
+			.targetContext.applicationContext as OsmandApplication
+		settings = app.settings
+		downloadThread = app.downloadThread
+		savedLastChecked = settings.LAST_CHECKED_UPDATES.get()
+
+		assertTrue("a download task was already running when the test started",
+			awaitNoRunningTask())
+
+		// The first call after the installed version changed returns early, without reaching
+		// checkMapUpdates(). Spend that call here, with the timestamp fresh so that it cannot
+		// start a reload of its own on either build.
+		settings.LAST_CHECKED_UPDATES.set(System.currentTimeMillis())
+		InstrumentationRegistry.getInstrumentation()
+			.runOnMainSync { app.appInitializer.checkAppVersionChanged() }
+	}
+
+	@After
+	fun restoreSettings() {
+		awaitNoRunningTask()
+		settings.LAST_CHECKED_UPDATES.set(savedLastChecked)
+	}
+
+	/**
+	 * The whole point of the gate: a check made ten minutes ago still counts as recent. Ten minutes
+	 * is three and a half times the effective interval the units bug produced, so on that build the
+	 * reload fires almost at once - within a couple of attempts while the lottery still stood in
+	 * front of it, on the very first attempt without it.
+	 */
+	@Test
+	fun indexListIsNotReloadedTenMinutesAfterTheLastCheck() {
+		requireInternet()
+		settings.LAST_CHECKED_UPDATES.set(System.currentTimeMillis() - RECENTLY_CHECKED)
+
+		val attempt = firstAttemptThatStartedReload()
+
+		assertEquals("checkMapUpdates() started a /get_indexes reload on attempt $attempt of" +
+				" $ATTEMPTS, ${TimeUnit.MILLISECONDS.toMinutes(RECENTLY_CHECKED)} minutes after the" +
+				" previous check - the two day interval is not being honoured",
+			NO_RELOAD, attempt)
+	}
+
+	/**
+	 * The positive control for the test above, in two halves. A check that is genuinely due has to
+	 * start a reload on the very first call, since nothing probabilistic stands between the gate
+	 * and the request any more; and once that reload has finished, the interval has to be closed
+	 * behind it, which is what proves `LAST_CHECKED_UPDATES` was written at all.
+	 *
+	 * Without this, "no reload" in the test above would prove nothing - a build where the check
+	 * never fires under any circumstances would pass it.
+	 */
+	@Test
+	fun reloadFiresWhenDueAndClosesTheIntervalBehindIt() {
+		requireInternet()
+		settings.LAST_CHECKED_UPDATES.set(System.currentTimeMillis() - CHECKED_LONG_AGO)
+
+		val whenDue = firstAttemptThatStartedReload()
+		assertEquals("checkMapUpdates() did not start a /get_indexes reload on the first call," +
+				" although the last check was ${TimeUnit.MILLISECONDS.toDays(CHECKED_LONG_AGO)} days" +
+				" old (started on attempt $whenDue of $ATTEMPTS)",
+			1, whenDue)
+
+		assertTrue("the reload never finished", awaitNoRunningTask())
+
+		val afterwards = firstAttemptThatStartedReload()
+		assertEquals("checkMapUpdates() started a second /get_indexes reload on attempt" +
+				" $afterwards of $ATTEMPTS, right after the previous one finished - the completed" +
+				" reload did not close the interval behind it",
+			NO_RELOAD, afterwards)
+	}
+
+	/**
+	 * Calls the entry point until a reload task appears and returns the 1-based attempt that
+	 * started it, or [NO_RELOAD].
+	 *
+	 * The call and the check share one main-thread block on purpose. `AsyncTask` runs
+	 * `onPreExecute()` - which registers the task - synchronously on the caller, and
+	 * `onPostExecute()` - which unregisters it - on the main thread, so a reload cannot start and
+	 * finish unseen between the two statements.
+	 */
+	private fun firstAttemptThatStartedReload(): Int {
+		val instrumentation = InstrumentationRegistry.getInstrumentation()
+		var startedOn = NO_RELOAD
+		var whatsNewBranchTaken = 0
+		for (attempt in 1..ATTEMPTS) {
+			instrumentation.runOnMainSync {
+				if (app.appInitializer.checkAppVersionChanged()) {
+					whatsNewBranchTaken++
+				} else if (downloadThread.currentRunningTask?.javaClass?.simpleName == RELOAD_TASK) {
+					startedOn = attempt
+				}
+			}
+			if (startedOn != NO_RELOAD) {
+				break
+			}
+		}
+		assertEquals("checkAppVersionChanged() took the What's New branch and never reached" +
+				" checkMapUpdates()", 0, whatsNewBranchTaken)
+		return startedOn
+	}
+
+	/**
+	 * Offline, `checkMapUpdates()` never reaches `runReloadIndexFilesSilent()` at all and both tests
+	 * would pass for the wrong reason, so skip rather than report a green run.
+	 */
+	private fun requireInternet() {
+		assumeTrue("the device is offline, the update check cannot be exercised",
+			settings.isInternetConnectionAvailable(true))
+	}
+
+	/** Waits for any download task to finish, so that one run cannot mask the next. */
+	private fun awaitNoRunningTask(): Boolean {
+		val deadline = System.currentTimeMillis() + TASK_IDLE_TIMEOUT
+		while (downloadThread.currentRunningTask != null && System.currentTimeMillis() < deadline) {
+			Thread.sleep(TASK_POLL_MS)
+		}
+		return downloadThread.currentRunningTask == null
+	}
+}


### PR DESCRIPTION
## Problem

`AppInitializer.checkMapUpdates()` computes the age of `LAST_CHECKED_UPDATES` in milliseconds and compares it against a constant written in seconds:

```java
long diff = System.currentTimeMillis() - app.getSettings().LAST_CHECKED_UPDATES.get();
if (diff >= 2 * 24 * 60 * 60L && new Random().nextInt(5) == 0 &&
        app.getSettings().isInternetConnectionAvailable()) {
    app.getDownloadThread().runReloadIndexFiles();
}
```

`LAST_CHECKED_UPDATES` is written with `System.currentTimeMillis()` in `DownloadIndexesThread`, so `diff` is in milliseconds. The literal `2 * 24 * 60 * 60L` is 172 800 — that is 172.8 seconds, not two days. The `* 1000` is missing.

So the gate meant to read "at most one `/get_indexes` request every two days" reads "at most one every ~2.9 minutes", and the only remaining brake is `new Random().nextInt(5) == 0`.

Three things make that worse than it first looks:

- The check runs from `MapActivity.onCreate()` by way of `WhatsNewDialogFragment.shouldShowDialog()`, and `MapActivity` declares only `android:configChanges="uiMode"`. Rotation, locale, density and font-scale changes all recreate the activity and roll again, so the rate is per activity creation, not per app start.
- `checkMapUpdates()` is the **only** trigger that re-fetches the index list after it has already loaded in the current process. `DownloadActivity`, search, the Explore tab, `MapSuggestionController` and the first-usage wizard are all guarded on `!indexes.isDownloadedFromInternet`, so they fire at most once per process and only on user intent.
- `DownloadOsmandIndexesHelper.getIndexesList()` has no cache — every pass is a real request.

Introduced in 3609492cc7 ("Update indexes", 2015-10-23). The comparison, the lottery and the millisecond timestamp all arrived in that one commit, so this has never worked as intended. Present identically on `master`, `r5.4` and `r5.3`.

A repo-wide search for `N * 24 * 60 * 60` without a `1000` returns only this line, so there is no sibling occurrence.

## Fix

**Correct the units, through a named constant.** `MAP_UPDATES_CHECK_INTERVAL_MS` means a millisecond `diff` is now compared against something that states its unit, which is what the inline literal never did. The name follows the existing convention in the codebase (`MIN_AUTO_BACKUP_INTERVAL_MS`, `LOCATION_TIMEOUT_TO_BE_STALE`).

**Drop `nextInt(5)`.** With the interval working, it spreads no load: `LAST_CHECKED_UPDATES` is per device and set at that device's own last check, so users are already staggered by their own usage — there is no synchronised trigger and therefore no herd. What it does instead is turn "every two days" into "every two days plus, on average, five more `MapActivity` creations". For someone who opens the app once a day that is a median of about six days, ~13 days one time in ten and ~23 days one time in a hundred; for a heavy user it is a few hours. That penalises exactly the light users, and removes the bounded-staleness guarantee the setting exists to provide.

**Use `runReloadIndexFilesSilent()`.** This call site is unattended — the user did nothing. `runReloadIndexFiles()` calls `checkRunning(false)`, which shows *"Please wait until current task is finished"* when another download is running, so a user downloading a map who rotated the screen could get a toast telling them to wait for a task they never started. Every other unattended caller already uses the silent variant; both variants return early without starting a reload, so this changes nothing but the toast.

The dead `else if (Version.isDeveloperVersion(app))` branch, whose body was entirely commented out, goes with it.

## Verification

Instrumented regression test: `OsmAnd/test/java/net/osmand/test/junit/MapUpdatesCheckIntervalTest.kt`.

`checkMapUpdates()` is private and reachable only from `MapActivity.onCreate()`, so the tests drive the one public entry point that gets there, `AppInitializer.checkAppVersionChanged()`, and watch `DownloadIndexesThread.getCurrentRunningTask()` for the reload a passing gate starts. The call and the check share one main-thread block: `onPreExecute()` registers the task synchronously on the caller and `onPostExecute()` unregisters it on the main thread, so a reload cannot start and finish unseen.

- `indexListIsNotReloadedTenMinutesAfterTheLastCheck` — sets `LAST_CHECKED_UPDATES` to 10 minutes ago and asserts no reload starts. Ten minutes is 3.5x the effective interval the bug produced.
- `reloadFiresWhenDueAndClosesTheIntervalBehindIt` — the positive control, in two halves: with the last check 3 days old the reload must start on the **first** call, and once it has finished the interval must be closed behind it. Without this, "no reload" above would also pass on a build where the check never fires at all.

Both tests skip rather than pass when the device is offline, since the gate would never be reached.

Built and run from this branch, on both targets:

| | Pixel 8 Pro — arm64-v8a, Android 17 / API 37 | Emulator — x86_64, Android 16 / API 36 |
|---|---|---|
| `master` without this change | **fails** — reload on attempt 23 of 200, 10 min after the previous check | **fails x2** — reload on attempt 5; due-check on attempt 3, not 1 |
| this branch | **OK (2 tests)** x4 | **OK (2 tests)** x4 |

Variant `nightlyFreeLegacyArm64Debug` / `nightlyFreeLegacyX86Debug` (`net.osmand.dev`); the emulator's ABI list is `x86_64,arm64-v8a`, and the `x86` flavour carries `abiFilters 'x86', 'x86_64'`, so it runs natively there.

```
gradlew :OsmAnd:assembleNightlyFreeLegacyArm64Debug :OsmAnd:assembleNightlyFreeLegacyArm64DebugAndroidTest
adb -s <serial> install -r -d <app.apk> && adb -s <serial> install -r <androidTest.apk>
adb -s <serial> shell am instrument -w -e class \
  net.osmand.test.junit.MapUpdatesCheckIntervalTest \
  net.osmand.dev.test/androidx.test.runner.AndroidJUnitRunner
```

On the unfixed Pixel run only one test failed: the control's "fires on the first call" assertion passes whenever the lottery happens to win immediately, which is 1 time in 5. The regression test is the deterministic half and failed on both targets. A reviewer reproducing the before-state should expect one or two failures, not always two.

The reload path itself was also exercised end to end: opening the Downloads screen on the fixed build populates regions and world maps with sizes and dates, with `GET /get_indexes?gzip&osmandver=...` in logcat and no errors logged from the download package.

## Known gap

- `runReloadIndexFilesSilent()` is not covered by a test — toasts are not observable from instrumentation. Its only difference from `runReloadIndexFiles()` is whether `checkRunning()` shows one; both return early without starting a reload.
- The interval is not exercised over a real two days; the tests move `LAST_CHECKED_UPDATES` rather than waiting, and restore it afterwards.
- The tests call `checkAppVersionChanged()` directly rather than going through a real `MapActivity.onCreate()` or a rotation.
- Left for a separate change: in `ReloadIndexesTask.doInBackground()` the request is made before `LAST_CHECKED_UPDATES` is written, and the write sits behind the `while (app.isApplicationInitializing())` wait. If that wait never returns, the request has gone out but the interval never closes. A failed request already closes it today — `getIndexesList()` returns an empty list rather than throwing — so this only affects local failures after the request, and it is a separate root cause that deserves its own review.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Check a bug report claiming `checkMapUpdates()` compares milliseconds against a constant written in seconds.
2. Write a test for it and run it on the connected Pixel.
3. Asked whether `nextInt(5)` is still needed once the interval works, then asked for a proper fix.
4. Questioned the proposed move of the `LAST_CHECKED_UPDATES` write - whether it would record a timestamp for a failed request, and whether it risked regressions - and then asked whether to revert it.
5. Check and test the resulting change on both the Pixel and the emulator, then open a draft pull request.

Decided by the agent, not requested explicitly: extracting the interval into the named `MAP_UPDATES_CHECK_INTERVAL_MS` constant rather than fixing the literal in place; switching this call site to `runReloadIndexFilesSilent()`; the shape of the test, including the two-part positive control and the 200-call sweep that keeps it conclusive if a probabilistic brake is ever reintroduced; and deferring the `ReloadIndexesTask` timestamp ordering to a follow-up.
