### PR TITLE
[5.4] Preserve the map renderer only across display rotation

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/MapActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/MapActivity.java
@@ -15,10 +15,13 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
+import android.hardware.display.DisplayManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.view.Display;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
@@ -191,6 +194,8 @@ public class MapActivity extends OsmandActionBarActivity implements DownloadEven
 
 	private AppInitializeListener initListener;
 	private MapViewWithLayers mapViewWithLayers;
+	private int initialDisplayId;
+	private int initialDisplayRotation;
 	private DrawerLayout drawerLayout;
 	private boolean drawerDisabled;
 
@@ -236,6 +241,9 @@ public class MapActivity extends OsmandActionBarActivity implements DownloadEven
 		supportRequestWindowFeature(Window.FEATURE_NO_TITLE);
 		setRequestedOrientation(AndroidUiHelper.getScreenOrientation(this));
 		super.onCreate(savedInstanceState);
+		Display display = getDeviceDisplay();
+		initialDisplayId = display != null ? display.getDisplayId() : -1;
+		initialDisplayRotation = display != null ? display.getRotation() : -1;
 
 		lockHelper = app.getLockHelper();
 		mapScrollHelper = new MapScrollHelper(app);
@@ -1057,7 +1065,7 @@ public class MapActivity extends OsmandActionBarActivity implements DownloadEven
 			getMapViewTrackingUtilities().setMapView(null);
 		}
 		if (mapViewWithLayers != null) {
-			mapViewWithLayers.onDestroy();
+			mapViewWithLayers.onDestroy(isChangingScreenOrientation());
 		}
 		lockHelper.setLockUIAdapter(null);
 		keyEventHelper.setMapActivity(null);
@@ -1066,6 +1074,34 @@ public class MapActivity extends OsmandActionBarActivity implements DownloadEven
 		mIsDestroyed = true;
 
 		removeActivityResultListener(importHelper.getSaveFileResultListener());
+	}
+
+	private boolean isChangingScreenOrientation() {
+		// Rotation also changes the screen dimensions/layout. Other configuration changes,
+		// explicit recreate(), and normal destruction must keep the usual release path.
+		int changes = getChangingConfigurations();
+		int rotationChanges = ActivityInfo.CONFIG_ORIENTATION | ActivityInfo.CONFIG_SCREEN_SIZE
+				| ActivityInfo.CONFIG_SCREEN_LAYOUT;
+		if (!isChangingConfigurations() || isFinishing()
+				|| (changes & ActivityInfo.CONFIG_ORIENTATION) == 0
+				|| (changes & ~rotationChanges) != 0) {
+			return false;
+		}
+		// Resizing a multi-window activity can change its orientation without rotating
+		// the display. Moving to another display must not retain the phone renderer either.
+		Display display = getDeviceDisplay();
+		return display != null && initialDisplayRotation != -1
+				&& display.getDisplayId() == initialDisplayId
+				&& display.getRotation() != initialDisplayRotation;
+	}
+
+	@Nullable
+	private Display getDeviceDisplay() {
+		// An Activity-scoped Display can still report the old configuration's rotation
+		// during relaunch. Use the application's DisplayManager for the current rotation.
+		DisplayManager displayManager = app.getSystemService(DisplayManager.class);
+		return displayManager != null
+				? displayManager.getDisplay(getWindowManager().getDefaultDisplay().getDisplayId()) : null;
 	}
 
 	public LatLon getMapLocation() {

--- a/OsmAnd/src/net/osmand/plus/views/MapViewWithLayers.java
+++ b/OsmAnd/src/net/osmand/plus/views/MapViewWithLayers.java
@@ -163,13 +163,21 @@ public class MapViewWithLayers extends FrameLayout {
 		}
 	}
 
-	public void onDestroy() {
+	public void onDestroy(boolean changingScreenOrientation) {
 		if (atlasMapRendererView != null) {
 			NavigationSession carNavigationSession = app.getCarNavigationSession();
 			if (carNavigationSession == null || !carNavigationSession.hasStarted()) {
 				mapView.setMapRenderer(null, true);
-				resetMapRendererView();
-				atlasMapRendererView.handleOnDestroy();
+				MapRendererContext rendererContext = NativeCoreContext.getMapRendererContext();
+				boolean retainRenderer = changingScreenOrientation && rendererContext != null
+						&& rendererContext.getMapRendererView() == atlasMapRendererView
+						&& atlasMapRendererView.prepareRendererForReuse();
+				if (!retainRenderer) {
+					resetMapRendererView();
+					atlasMapRendererView.handleOnDestroy();
+				}
+				// On rotation the context keeps the prepared view until the replacement
+				// picks it up through setupAtlasMapRendererView(), as in Android Auto.
 			}
 		}
 		mapView.clearTouchDetectors();

--- a/OsmAnd/test/isolated/test_renderer_rotation.py
+++ b/OsmAnd/test/isolated/test_renderer_rotation.py
@@ -1,0 +1,189 @@
+"""Test the actual renderer rotation gate and destruction methods in isolation.
+
+Run with Python 3 and JDK 17+ on PATH, or set JAVA_HOME. An optional first
+argument selects a different repository checkout (for regression controls).
+Platform/native dependencies use minimal doubles; this does not compile the app
+or validate Android lifecycle ordering, real EGL drivers, or rendering output.
+"""
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+ROOT = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(__file__).resolve().parents[3]
+
+
+def block(source, signature):
+    start = source.index(signature)
+    opening = source.index('{', start)
+    depth = 1
+    end = opening + 1
+    while depth:
+        depth += (source[end] == '{') - (source[end] == '}')
+        end += 1
+    return source[start:end]
+
+
+
+activity = (ROOT / 'OsmAnd/src/net/osmand/plus/activities/MapActivity.java').read_text()
+view = (ROOT / 'OsmAnd/src/net/osmand/plus/views/MapViewWithLayers.java').read_text()
+
+android_test = r'''
+class RotationPolicyTest {
+    static class ActivityInfo {
+        static final int CONFIG_ORIENTATION=128, CONFIG_SCREEN_SIZE=1024, CONFIG_SCREEN_LAYOUT=256;
+    }
+    static class Display {
+        int id, rotation;
+        int getDisplayId() { return id; }
+        int getRotation() { return rotation; }
+    }
+    static class WindowManager {
+        Display display = new Display();
+        Display getDefaultDisplay() { return display; }
+    }
+    static class DisplayManager {
+        Display display = new Display();
+        Display getDisplay(int id) { return display; }
+    }
+    WindowManager manager = new WindowManager();
+    App app = new App();
+    int changes, initialDisplayId, initialDisplayRotation;
+    boolean changing, finishing;
+    WindowManager getWindowManager() { return manager; }
+    int getChangingConfigurations() { return changes; }
+    boolean isChangingConfigurations() { return changing; }
+    boolean isFinishing() { return finishing; }
+    __POLICY__
+    __DISPLAY__
+
+    static class Renderer {
+        boolean available = true;
+        int preparations, destroys;
+        boolean prepareRendererForReuse() { preparations++; return available; }
+        void handleOnDestroy() { destroys++; }
+    }
+    static class MapRendererContext {
+        Renderer renderer;
+        Renderer getMapRendererView() { return renderer; }
+    }
+    static class NativeCoreContext {
+        static MapRendererContext context;
+        static MapRendererContext getMapRendererContext() { return context; }
+    }
+    static class NavigationSession {
+        boolean started;
+        boolean hasStarted() { return started; }
+    }
+    static class App {
+        DisplayManager displayManager = new DisplayManager();
+        <T> T getSystemService(Class<T> type) { return type.cast(displayManager); }
+        NavigationSession car;
+        int removals;
+        NavigationSession getCarNavigationSession() { return car; }
+        App getOsmandMap() { return this; }
+        void removeRenderingViewSetupListener(Object listener) { removals++; }
+    }
+    static class MapView {
+        int detaches, cleared;
+        void setMapRenderer(Object renderer, boolean disable) { detaches++; }
+        void clearTouchDetectors() { cleared++; }
+    }
+    static class Layers {
+        Renderer atlasMapRendererView = new Renderer();
+        App app = new App();
+        MapView mapView = new MapView();
+        int resets;
+        void resetMapRendererView() { resets++; }
+        Object getRenderingViewSetupListener() { return this; }
+        __DESTROY__
+    }
+    static int checks;
+    static void check(boolean condition, String name) {
+        checks++;
+        if (!condition) throw new AssertionError(name);
+    }
+    public static void main(String[] args) {
+        RotationPolicyTest policy = new RotationPolicyTest();
+        policy.changing = true;
+        policy.app.displayManager.display.rotation = 1;
+        // Every combination of the documented rotation companion flags is allowed.
+        for (int companions : new int[] {0, 256, 1024, 1280}) {
+            policy.changes = 128 | companions;
+            check(policy.isChangingScreenOrientation(), "rotation " + companions);
+        }
+        // Every other bit, including unknown future flags, prevents retention.
+        for (int bit = 0; bit < 32; bit++) {
+            int flag = 1 << bit;
+            if ((flag & (128 | 256 | 1024)) != 0) continue;
+            policy.changes = 128 | 1024 | flag;
+            check(!policy.isChangingScreenOrientation(), "unrelated configuration bit " + bit);
+        }
+        policy.changes = 128 | 1024;
+        policy.changing = false;
+        check(!policy.isChangingScreenOrientation(), "background/normal destruction");
+        policy.changing = true;
+        policy.finishing = true;
+        check(!policy.isChangingScreenOrientation(), "finishing");
+        policy.finishing = false;
+        policy.changes = 0;
+        check(!policy.isChangingScreenOrientation(), "explicit recreate");
+        policy.changes = 1024;
+        check(!policy.isChangingScreenOrientation(), "size only");
+        policy.changes = 128 | 1024;
+        policy.app.displayManager.display.rotation = 0;
+        check(!policy.isChangingScreenOrientation(), "window resize without display rotation");
+        policy.app.displayManager.display.rotation = 1;
+        policy.app.displayManager.display.id = 1;
+        check(!policy.isChangingScreenOrientation(), "different display");
+        policy.app.displayManager.display.id = 0;
+        policy.initialDisplayRotation = 3;
+        policy.app.displayManager.display.rotation = 0;
+        check(policy.isChangingScreenOrientation(), "reverse rotation");
+
+        policy.app.displayManager.display = null;
+        check(!policy.isChangingScreenOrientation(), "display removed");
+        policy.app.displayManager.display = new Display();
+        policy.initialDisplayRotation = -1;
+        check(!policy.isChangingScreenOrientation(), "initial display unavailable");
+        policy.app.displayManager = null;
+        check(!policy.isChangingScreenOrientation(), "display service unavailable");
+
+        for (int mode = 0; mode < 8; mode++) {
+            Layers layers = new Layers();
+            MapRendererContext context = new MapRendererContext();
+            NativeCoreContext.context = context;
+            context.renderer = layers.atlasMapRendererView;
+            if (mode == 2) layers.atlasMapRendererView.available = false;
+            if (mode == 3) NativeCoreContext.context = null;
+            if (mode == 4) context.renderer = new Renderer();
+            if (mode == 5 || mode == 6) {
+                layers.app.car = new NavigationSession();
+                layers.app.car.started = mode == 5;
+            }
+            if (mode == 7) layers.atlasMapRendererView = null;
+            layers.onDestroy(mode != 1);
+            boolean retained = mode == 0 || mode == 6;
+            boolean carOrAbsent = mode == 5 || mode == 7;
+            check(layers.resets == (retained || carOrAbsent ? 0 : 1), "release fallback " + mode);
+            if (layers.atlasMapRendererView != null) {
+                check(layers.atlasMapRendererView.destroys == (retained || carOrAbsent ? 0 : 1), "destroy " + mode);
+                check(layers.atlasMapRendererView.preparations == (mode == 0 || mode == 2 || mode == 6 ? 1 : 0), "prepare " + mode);
+            }
+            check(layers.mapView.cleared == 1 && layers.app.removals == 1, "UI cleanup " + mode);
+        }
+        System.out.println("Android rotation policy and cleanup: " + checks + " assertions passed");
+    }
+}
+'''.replace('__POLICY__', block(activity, 'private boolean isChangingScreenOrientation()')) \
+   .replace('__DESTROY__', block(view, 'public void onDestroy(boolean changingScreenOrientation)')) \
+   .replace('__DISPLAY__', block(activity, 'private Display getDeviceDisplay()'))
+
+with tempfile.TemporaryDirectory(prefix='renderer-isolated-tests-') as temp:
+    work = Path(temp)
+    source_file = work / 'RotationPolicyTest.java'
+    source_file.write_text(android_test)
+    java_bin = Path(os.environ['JAVA_HOME']) / 'bin' if 'JAVA_HOME' in os.environ else Path('')
+    subprocess.run([str(java_bin / 'javac'), '-d', temp, str(source_file)], check=True)
+    subprocess.run([str(java_bin / 'java'), '-cp', temp, 'RotationPolicyTest'], check=True, timeout=15)


### PR DESCRIPTION
Preserve the initialized phone map renderer across a display-rotation Activity recreation, using the same renderer/EGL-thread handoff as Android Auto. Backgrounding, screen locking, ordinary destruction, explicit recreation, and unrelated configuration changes retain their existing lifecycle behavior.

Requires the [companion core PR](https://github.com/osmandapp/OsmAnd-core/pull/1110). Merge core and rebuild/publish the 5.4 wrapper artifacts first; merge this PR only with those updated artifacts. `MapViewWithLayers` calls the new `prepareRendererForReuse()` method, which must exist in both the OpenGL AAR and the wrapper JAR used by the legacy flavor.

This is a separate, narrower proposal from #25866 and osmandapp/OsmAnd-core#1104, as explicitly requested. Those PRs are not modified or closed.

## Why rotation currently rebuilds rendering

`MapActivity.onDestroy()` calls `MapViewWithLayers.onDestroy()`, which releases the renderer through `MapRendererContext.releaseMapRendererView()` / `stopRenderer()`. That also stops the EGL thread. The new Activity then creates a fresh renderer.

For rotation, the old view must be prepared before it is detached so that detach/context callbacks do not release native rendering. The replacement's existing `setupAtlasMapRendererView()` already takes the context's previous view and passes it to `setupRenderer(..., oldView)`. The companion core change supports this deferred transfer without allowing the old view to export the same renderer twice.

## Exact retention policy

`MapActivity` records its display ID and rotation at creation. At destruction it requests retention only when all these checks pass:

1. Android reports configuration-driven recreation, and the Activity is not finishing.
2. `getChangingConfigurations()` includes `CONFIG_ORIENTATION`.
3. The mask contains only orientation and its screen-size/screen-layout companion flags. Locale, density, font scale, UI mode, smallest-screen-size changes, and unknown flags use normal cleanup, even when combined with orientation.
4. The display still exists, has the same ID, and its rotation differs from the recorded value.

The current rotation is read through the application's `DisplayManager`: an Activity-scoped `Display` can still report the old Activity configuration during relaunch. Comparing display rotation also excludes a multi-window resize that merely changes the Activity's portrait/landscape shape. Missing display information falls back to normal cleanup.

`MapViewWithLayers.onDestroy(boolean)` retains only a phone renderer that is still owned by `MapRendererContext` and that the core successfully prepares. Missing/uninitialized renderers, ownership mismatches, and failed preparation all use the existing release/destroy path. An active Android Auto session keeps its existing ownership behavior. Touch detectors and the rendering-setup listener are cleaned up on every path.

| Event | New rotation-retention path |
|---|---|
| Portrait/landscape recreation on the same rotating display | Yes, if preparation succeeds |
| Home/background or screen lock | No; existing pause behavior |
| Resume | Existing resume behavior |
| Finish/Back followed by destruction | No; existing release behavior |
| Explicit `recreate()` without orientation change | No |
| Locale, font scale, density, theme, or other configuration changes | No |
| Window resize without display rotation / move to another display | No |
| Phone Activity destruction while Android Auto owns rendering | Existing Android Auto behavior |

A rotation that does not recreate the Activity needs no new handoff. Android's configuration flags are optimization hints; a missing or unexpected flag conservatively falls back to release. The manifest and the general pause/resume callbacks are unchanged. `handleOnPause()` still waits for an in-flight frame, so this does not claim to fix a GPU-driver stall during one frame.

## Validation

Run from the Android repository with Python 3 and JDK 17+ (`JAVA_HOME` can select the JDK):

```sh
python3 OsmAnd/test/isolated/test_renderer_rotation.py
git diff --check
```

Both passed: **73 assertions** exercise the actual Java rotation predicate, display lookup, and destruction method with minimal platform doubles. Cases include all allowed companion-flag combinations, every other bit in the configuration mask, finish/background/manual recreation, resize without display rotation, reverse rotation, another/missing display, an unavailable display service, failed preparation, ownership mismatch, active/inactive Android Auto, and unconditional UI cleanup.

A negative control that removes the unrelated-configuration exclusion fails the test. The companion core's isolated handoff/thread tests also passed (**44 assertions**), with negative controls for duplicate export and stale thread ownership.

The tests intentionally do not compile the full app or emulate Android lifecycle ordering/native EGL behavior. The `r5.4` checkout's `AGENTS.md` forbids Gradle build tasks and reconstructed Android compilation, so no full APK build or device test was run. The PR remains a draft pending integration verification. Existing PR benchmark results are not presented as measurements of this change.

After the updated core artifacts are available, verify repeated rotations with a visible map, background/resume, lock/unlock, theme/locale/font/density changes, resizing, final destruction, and Android Auto connect/disconnect. Check renderer/thread identity and new-view frame delivery across rotations, ordinary cleanup on other destructions, and absence of retained old Activity references after transfer.

## AI disclaimer

Produced with Codex (GPT-6).

Prompts used (summarised):
1. Assess reusing the Android Auto renderer-suspension mechanism for Android device screen orientation changes, excluding other events such as backgrounding.
2. Create the needed branches and pull requests against the core and Android 5.4 branches, with a complete explanation.
3. After the existing PRs were identified, explicitly choose a separate rotation-only pair and continue the work.

Decided by the agent, not requested explicitly: combine the orientation flag with a strict companion-flag mask and a same-display rotation check; read rotation from the application's DisplayManager; retain only the renderer currently owned by the context with normal cleanup on failure; add isolated Python/JDK tests and negative controls; use clean temporary checkouts; and open drafts pending real Android/EGL integration verification under the r5.4 validation restrictions.
