### PR TITLE
Fix Clear all tiles not freeing disk space for SQLite map sources

### DIFF
--- a/OsmAnd/src/net/osmand/plus/resources/SQLiteTileSource.java
+++ b/OsmAnd/src/net/osmand/plus/resources/SQLiteTileSource.java
@@ -448,10 +448,8 @@ public class SQLiteTileSource implements ITileSource {
 			} catch (SQLException e) {
 				LOG.info("Error adding column " + e);
 			}
-			// A null value must not be written as the literal text "null".
-			if (value != null) {
-				db.execSQL("update info set " + columnName + " = '" + value + "'");
-			}
+			// A null value must become SQL NULL, not the text "null".
+			db.execSQL("update info set " + columnName + " = ?", new Object[] {value});
 		}
 	}
 
@@ -634,28 +632,29 @@ public class SQLiteTileSource implements ITileSource {
 		if (db == null || db.isReadOnly() || onlyReadonlyAvailable) {
 			return;
 		}
-		// Recreate the database file from scratch instead of "DELETE FROM tiles" + "VACUUM".
-		// VACUUM does not reliably shrink a WAL-mode database (the mode used by
-		// openByAbsolutePath()) on disk: per SQLite semantics it cannot truncate the file
-		// while any other connection to it is open (e.g. another SQLiteTileSource instance
-		// that briefly opened this same file just to read its title/URL for a list screen),
-		// so it can silently complete without freeing any space at all. Deleting the file
-		// outright and recreating an empty database with the same metadata guarantees the
-		// disk space is actually reclaimed, matching how directory-based tile sources behave.
-		// Resolve the display title before recreating: some older/manually-added databases
-		// never had a "title" column, so the "title" field can still be null here even
-		// though getTitle() correctly falls back to the file name.
-		title = getTitle();
-		db.close();
-		this.db = null;
-		if (file != null) {
-			Algorithms.removeAllFiles(file);
-			File walFile = new File(file.getParentFile(), file.getName() + "-wal");
-			File shmFile = new File(file.getParentFile(), file.getName() + "-shm");
-			Algorithms.removeAllFiles(walFile);
-			Algorithms.removeAllFiles(shmFile);
+		db.execSQL("DELETE FROM tiles");
+		db.execSQL("VACUUM");
+		// In WAL mode VACUUM only rewrites the database into the -wal file, the .sqlitedb
+		// keeps its size until a checkpoint truncates it.
+		checkpointWal(db);
+	}
+
+	private void checkpointWal(@NonNull SQLiteConnection db) {
+		SQLiteCursor cursor = null;
+		try {
+			// TRUNCATE waits for the other readers, the default PASSIVE gives up on them.
+			cursor = db.rawQuery("PRAGMA wal_checkpoint(TRUNCATE)", null);
+			// rawQuery() is lazy: the checkpoint runs only when the cursor is stepped.
+			if (cursor != null && cursor.moveToFirst() && cursor.getInt(0) != 0) {
+				LOG.warn("Checkpoint is busy, tiles database was not truncated: " + file);
+			}
+		} catch (RuntimeException e) {
+			LOG.error("Failed to checkpoint tiles database " + file, e);
+		} finally {
+			if (cursor != null) {
+				cursor.close();
+			}
 		}
-		createDataBase();
 	}
 
 	@Override

--- a/OsmAnd/src/net/osmand/plus/resources/SQLiteTileSource.java
+++ b/OsmAnd/src/net/osmand/plus/resources/SQLiteTileSource.java
@@ -448,7 +448,10 @@ public class SQLiteTileSource implements ITileSource {
 			} catch (SQLException e) {
 				LOG.info("Error adding column " + e);
 			}
-			db.execSQL("update info set " + columnName + " = '" + value + "'");
+			// A null value must not be written as the literal text "null".
+			if (value != null) {
+				db.execSQL("update info set " + columnName + " = '" + value + "'");
+			}
 		}
 	}
 
@@ -631,8 +634,28 @@ public class SQLiteTileSource implements ITileSource {
 		if (db == null || db.isReadOnly() || onlyReadonlyAvailable) {
 			return;
 		}
-		db.execSQL("DELETE FROM tiles");
-		db.execSQL("VACUUM");
+		// Recreate the database file from scratch instead of "DELETE FROM tiles" + "VACUUM".
+		// VACUUM does not reliably shrink a WAL-mode database (the mode used by
+		// openByAbsolutePath()) on disk: per SQLite semantics it cannot truncate the file
+		// while any other connection to it is open (e.g. another SQLiteTileSource instance
+		// that briefly opened this same file just to read its title/URL for a list screen),
+		// so it can silently complete without freeing any space at all. Deleting the file
+		// outright and recreating an empty database with the same metadata guarantees the
+		// disk space is actually reclaimed, matching how directory-based tile sources behave.
+		// Resolve the display title before recreating: some older/manually-added databases
+		// never had a "title" column, so the "title" field can still be null here even
+		// though getTitle() correctly falls back to the file name.
+		title = getTitle();
+		db.close();
+		this.db = null;
+		if (file != null) {
+			Algorithms.removeAllFiles(file);
+			File walFile = new File(file.getParentFile(), file.getName() + "-wal");
+			File shmFile = new File(file.getParentFile(), file.getName() + "-shm");
+			Algorithms.removeAllFiles(walFile);
+			Algorithms.removeAllFiles(shmFile);
+		}
+		createDataBase();
 	}
 
 	@Override


### PR DESCRIPTION
Fixes osmandapp/OsmAnd-Issues#3327

### Summary

"Clear all tiles" (Maps & Resources → Local → Map sources → ⋮ → Clear all tiles) did not free disk space for online map sources stored as SQLiteDB (.sqlitedb) — neither built-in-list sources nor manually-added ones. Tile-directory-based sources were not affected.

Root cause: `SQLiteTileSource.deleteTiles()` ran `DELETE FROM tiles` followed by `VACUUM`, and that is not enough on its own. `openByAbsolutePath()` opens these databases in WAL mode, where VACUUM writes the rebuilt (smaller) content into the `-wal` file — the `.sqlitedb` itself is only truncated once a checkpoint copies those pages back. Nothing triggers such a checkpoint while the source stays open, so VACUUM completed without throwing and the file on disk never shrank, not even after a full app restart or "Calculate size".

### Changes

`deleteTiles()` now runs `PRAGMA wal_checkpoint(TRUNCATE)` after the VACUUM. TRUNCATE rather than the default PASSIVE, so it waits for the other readers of the same file instead of giving up on them — e.g. another `SQLiteTileSource` instance that briefly opened it just to read its title/URL for a list screen. The pragma goes through `rawQuery()` + `moveToFirst()` because it returns a row and Android cursors are lazy; a busy result is logged rather than swallowed.

`addInfoColumn()` binds its value instead of inlining it into the SQL. A null was stored as the four-character text `"null"`, which is more than cosmetic: `MapTileDownloader` skips the `Referer` header only when it is null and falls back to the default user agent only when it is empty, so a source created without a referer or a user agent requested its tiles with `Referer: null` and `User-Agent: null`. Binding also keeps a title or an url containing an apostrophe from breaking the statement.

One file, +24/−25. Directory-based tile sources go through a different code path and are untouched.

### Testing

Reproduction (against master) is the one written up in osmandapp/OsmAnd-Issues#3327, with root-cause logcat output and the full before/after tables: an emulator (Pixel 3a, API 33) and a real device (Samsung Galaxy S22) with 67 MB / 361 accumulated tiles, where the `.sqlitedb` size never changed after "Clear all tiles". Temporary logging confirmed VACUUM completing without throwing while `file.length()` stayed byte-for-byte identical.

The checkpoint-based fix in its current form has **not been re-verified on a device yet**. The before/after tables in the issue were produced with an earlier implementation that deleted and recreated the `.sqlitedb`; that approach was dropped because removing the file while other connections to it are still open is undefined behaviour for SQLite, does not release the blocks until the last descriptor is closed, and lost `tilenumbering`/`rule`/`tilesize` metadata on recreate.

Still to check before merging:

- the `.sqlitedb` shrinks right after "Clear all tiles", with no restart, for both a freshly created source and a legacy-schema one (no `title` column);
- `COUNT(*)` on `tiles` is 0 and title/url/zoom/referer/expiry survive;
- a directory-based source (e.g. Microsoft Earth) still clears as before, as a regression control;
- no "Checkpoint is busy" warning in logcat during the above.

---

This fix was investigated, implemented, and tested by Claude AI in collaboration with @EugeneZmeuk.
