### PR TITLE
Reuse the map renderer when the map activity is recreated

### DIFF
--- a/OsmAnd/src/net/osmand/plus/activities/MapActivity.java
+++ b/OsmAnd/src/net/osmand/plus/activities/MapActivity.java
@@ -131,6 +131,7 @@ import net.osmand.plus.views.AddGpxPointBottomSheetHelper.NewGpxPoint;
 import net.osmand.plus.views.AnimateDraggingMapThread;
 import net.osmand.plus.views.MapLayers;
 import net.osmand.plus.views.MapViewWithLayers;
+import net.osmand.plus.views.MapViewWithLayers.RetainedRenderer;
 import net.osmand.plus.views.OsmandMapTileView;
 import net.osmand.plus.views.OsmandMapTileView.OnDrawMapListener;
 import net.osmand.plus.views.controls.VerticalWidgetPanel;
@@ -191,6 +192,7 @@ public class MapActivity extends OsmandActionBarActivity implements DownloadEven
 
 	private AppInitializeListener initListener;
 	private MapViewWithLayers mapViewWithLayers;
+	private RetainedRenderer retainedRenderer;
 	private DrawerLayout drawerLayout;
 	private boolean drawerDisabled;
 
@@ -319,6 +321,7 @@ public class MapActivity extends OsmandActionBarActivity implements DownloadEven
 
 		drawerLayout = findViewById(R.id.drawer_layout);
 		mapViewWithLayers = findViewById(R.id.map_view_with_layers);
+		takeRetainedRenderer();
 
 		checkAppInitialization();
 
@@ -1037,6 +1040,28 @@ public class MapActivity extends OsmandActionBarActivity implements DownloadEven
 		super.onStop();
 	}
 
+	/**
+	 * Keeps the map renderer of the map view across an activity recreation, so that the
+	 * replacement view reuses it instead of releasing rendering and initializing it anew.
+	 * Android calls this only when the activity is going to be created again, so no
+	 * configuration change has to be guessed here. The renderer itself is put into the holder
+	 * by {@link MapViewWithLayers#onDestroy(RetainedRenderer)}, which runs after this call
+	 */
+	@SuppressWarnings("deprecation")
+	@Override
+	public Object onRetainCustomNonConfigurationInstance() {
+		retainedRenderer = new RetainedRenderer();
+		return retainedRenderer;
+	}
+
+	@SuppressWarnings("deprecation")
+	private void takeRetainedRenderer() {
+		Object retained = getLastCustomNonConfigurationInstance();
+		if (mapViewWithLayers != null && retained instanceof RetainedRenderer) {
+			mapViewWithLayers.setRetainedRenderer((RetainedRenderer) retained);
+		}
+	}
+
 	@Override
 	protected void onDestroy() {
 		super.onDestroy();
@@ -1057,7 +1082,7 @@ public class MapActivity extends OsmandActionBarActivity implements DownloadEven
 			getMapViewTrackingUtilities().setMapView(null);
 		}
 		if (mapViewWithLayers != null) {
-			mapViewWithLayers.onDestroy();
+			mapViewWithLayers.onDestroy(retainedRenderer);
 		}
 		lockHelper.setLockUIAdapter(null);
 		keyEventHelper.setMapActivity(null);

--- a/OsmAnd/src/net/osmand/plus/auto/SurfaceRenderer.java
+++ b/OsmAnd/src/net/osmand/plus/auto/SurfaceRenderer.java
@@ -393,6 +393,13 @@ public final class SurfaceRenderer implements DefaultLifecycleObserver, MapRende
 				if (offscreenMapRendererView != null) {
 					MapRendererContext mapRendererContext = NativeCoreContext.getMapRendererContext();
 					if (mapRendererContext != null && mapRendererContext.getMapRendererView() != offscreenMapRendererView) {
+						// The context doesn't refer to the view anymore: either the phone took its
+						// renderer over, or recreateAndroidAutoRenderer() dropped it. In the latter
+						// case the renderer is still alive and nothing else is going to stop it
+						if (mapView != null && mapView.getMapRenderer() == offscreenMapRendererView) {
+							mapView.detachMapRenderer();
+						}
+						offscreenMapRendererView.stopRenderer();
 						offscreenMapRendererView = null;
 					}
 				}

--- a/OsmAnd/src/net/osmand/plus/views/MapViewWithLayers.java
+++ b/OsmAnd/src/net/osmand/plus/views/MapViewWithLayers.java
@@ -39,6 +39,18 @@ public class MapViewWithLayers extends FrameLayout {
 
 	private RenderingViewSetupListener renderingViewSetupListener;
 	private AtlasMapRendererView atlasMapRendererView;
+	@Nullable
+	private MapRendererView retainedMapRendererView;
+
+	/**
+	 * Holds the initialized map renderer of a map view whose activity is being recreated.
+	 * Android hands it over to the replacement activity only when that activity is really
+	 * created again, so no configuration change has to be guessed
+	 */
+	public static class RetainedRenderer {
+		@Nullable
+		private MapRendererView mapRendererView;
+	}
 
 	public MapViewWithLayers(@NonNull Context context) {
 		this(context, null);
@@ -89,10 +101,29 @@ public class MapViewWithLayers extends FrameLayout {
 			mapView.setMapRenderer(null, false);
 			resetMapRendererView();
 		}
+		// Nothing took the renderer of the previous activity's view over, so it has to be released
+		releaseRetainedRenderer();
+
 		AndroidUiHelper.updateVisibility(surfaceView, !useAndroidAuto && !useOpenglRender);
 		AndroidUiHelper.updateVisibility(mapLayersView, !useAndroidAuto && useOpenglRender);
 		AndroidUiHelper.updateVisibility(atlasMapRendererView, !useAndroidAuto && useOpenglRender);
 		AndroidUiHelper.updateVisibility(androidAutoPlaceholder, useAndroidAuto);
+	}
+
+	/**
+	 * Takes the map renderer that the previous activity's map view kept for this one
+	 */
+	public void setRetainedRenderer(@NonNull RetainedRenderer retained) {
+		retainedMapRendererView = retained.mapRendererView;
+		retained.mapRendererView = null;
+	}
+
+	private void releaseRetainedRenderer() {
+		MapRendererView mapRendererView = retainedMapRendererView;
+		if (mapRendererView != null) {
+			retainedMapRendererView = null;
+			mapRendererView.stopRenderer();
+		}
 	}
 
 	private void resetMapRendererView() {
@@ -124,6 +155,13 @@ public class MapViewWithLayers extends FrameLayout {
 				atlasMapRendererView = (AtlasMapRendererView) stub.inflate();
 			} else {
 				atlasMapRendererView.handleOnCreate(null);
+			}
+			if (mapRendererView == null) {
+				// Renderer of the previous activity's map view, suspended by its onDestroy().
+				// It's taken right before the handover, so that it's released by
+				// setupRenderingView() when there's no renderer context to hand it to
+				mapRendererView = retainedMapRendererView;
+				retainedMapRendererView = null;
 			}
 			// Get MSAA setting from development plugin
 			boolean enableMSAA = settings.ENABLE_MSAA.get();
@@ -163,15 +201,27 @@ public class MapViewWithLayers extends FrameLayout {
 		}
 	}
 
-	public void onDestroy() {
+	public void onDestroy(@Nullable RetainedRenderer retained) {
 		if (atlasMapRendererView != null) {
 			NavigationSession carNavigationSession = app.getCarNavigationSession();
 			if (carNavigationSession == null || !carNavigationSession.hasStarted()) {
 				mapView.setMapRenderer(null, true);
-				resetMapRendererView();
-				atlasMapRendererView.handleOnDestroy();
+				MapRendererContext mapRendererContext = NativeCoreContext.getMapRendererContext();
+				boolean retainRenderer = retained != null && mapRendererContext != null
+						&& mapRendererContext.getMapRendererView() == atlasMapRendererView
+						&& atlasMapRendererView.suspendRenderer();
+				if (retainRenderer) {
+					// The renderer and its EGL contexts stay alive until the map view of the
+					// recreated activity takes them over in setupAtlasMapRendererView()
+					retained.mapRendererView = atlasMapRendererView;
+					mapRendererContext.setMapRendererView(null);
+				} else {
+					resetMapRendererView();
+					atlasMapRendererView.handleOnDestroy();
+				}
 			}
 		}
+		releaseRetainedRenderer();
 		mapView.clearTouchDetectors();
 		app.getOsmandMap().removeRenderingViewSetupListener(getRenderingViewSetupListener());
 	}


### PR DESCRIPTION
App side of the renderer handover. Requires [osmandapp/OsmAnd-core#1113](https://github.com/osmandapp/OsmAnd-core/pull/1113): merge it first, rebuild and publish
the wrapper artifacts, and only then merge this. The new `suspendRenderer()` returns whether a
renderer is kept, and the handover moved to `exportRenderer()`, so both the OpenGL AAR and the
wrapper JAR used by the legacy flavor need those signatures.

Separate proposal from #25866 and #25921. Neither is modified or closed.

## Why a recreation rebuilds rendering

`MapActivity.onDestroy()` calls `MapViewWithLayers.onDestroy()`, which releases the renderer
through `MapRendererContext.releaseMapRendererView()` / `stopRenderer()`. That tears down the EGL
thread and its contexts on the main thread, and the replacement view then runs a full
`INITIALIZE_RENDERING`. On a recreation the new activity comes immediately, so there is nothing to
release - and `setupAtlasMapRendererView()` already knows how to take a suspended renderer over
from a previous view, which is what an Android Auto transition does.

## Retention is not guessed

`onRetainCustomNonConfigurationInstance()` is called by Android only when the activity is going to
be created again. It *is* the retention decision, so nothing has to be inferred from
`isChangingConfigurations()` or from a `getChangingConfigurations()` mask, and an unexpected
configuration flag can't silently switch the whole thing off.

- `MapActivity.onRetainCustomNonConfigurationInstance()` returns a holder.
- `MapViewWithLayers.onDestroy(holder)` suspends the renderer and puts the view into it, instead
  of releasing rendering.
- The recreated `MapActivity` reads the holder right after `findViewById()` and hands it to its
  own `MapViewWithLayers`, before `checkAppInitialization()` sets the rendering view up.
- `setupAtlasMapRendererView()` uses it as the previous view when the context has none. It is
  taken right before `setupRenderer()`, so an early return or a missing renderer context leaves
  it to the release at the end of `setupRenderingView()`.

The renderer is retained only while it is still owned by `MapRendererContext` and the core
suspends it successfully. A missing or uninitialized renderer, an ownership mismatch and an active
Android Auto session all keep the existing release path. The context reference is cleared with
`setMapRendererView(null)` rather than released, so it never points at a view that is gone -
during the swap `getMapRendererView()` returns null instead of a dead view.

A retained renderer that nothing takes over is released rather than leaked. That covers the
recreated activity not using the OpenGL rendering view, Android Auto owning rendering by then, and
the activity being destroyed again before it sets a rendering view up.

| Event | Renderer retained |
|---|---|
| Configuration-driven recreation (rotation, and `recreate()` for theme, language, settings) | Yes, if the core suspends it |
| Home/background, screen lock, resume | No, existing pause behavior |
| Finish or ordinary destruction | No, existing release behavior |
| Recreation while Android Auto owns rendering | No, existing Android Auto behavior |
| Recreated activity that doesn't set an OpenGL rendering view up | Released, not leaked |

`handleOnPause()` still waits for the frame in flight, so this doesn't claim to fix a GPU driver
stall inside one frame. The deadline for that is in the core PR.

`onRetainCustomNonConfigurationInstance()` and `getLastCustomNonConfigurationInstance()` are
deprecated in favour of `ViewModel`. A `ViewModel` would also give an `onCleared()` release hook,
but there is no `ViewModel` anywhere in the app yet and no `androidx.lifecycle` dependency is
declared, so the deprecated pair is the smaller change here; the cases `onCleared()` would cover
are handled explicitly above.

## Offscreen renderer dropped by `recreateAndroidAutoRenderer()`

Second commit, found while checking the Android Auto paths against the handover. 
`setupOffscreenRenderer()` forgets its offscreen view as soon as the renderer context no longer
refers to it. That is right when the phone took the renderer over, but
`recreateAndroidAutoRenderer()` gets there by clearing the context reference on purpose, and then
the view is still alive: its renderer, EGL thread and GPU resources were leaked and a fresh set was
created next to them. The view is now stopped instead of dropped; on a view whose renderer was
handed over `stopRenderer()` is a no-op with the core change, so the phone path is unaffected.

## Validation

Nothing here was compiled or run - it can't be until the core change is published, since the app
compiles against the wrapper artifacts and this uses the new `suspendRenderer()` signature. What
was done is static: `git diff --check`, a brace-balance check of both files, and a check of
`androidx.activity:activity:1.10.1` sources confirming that
`onRetainCustomNonConfigurationInstance()` is still `open` (only `onRetainNonConfigurationInstance()`
is final) and that `lastCustomNonConfigurationInstance` maps to the getter used here.

Do not merge before a build and a device run with matching artifacts. What needs checking: repeated
rotations with a visible map, `recreate()` through a theme/language/settings change, background and
resume, lock and unlock, final destruction, Android Auto connect and disconnect in both directions
across a rotation, and the OpenGL rendering engine switched off. Confirm the same renderer and EGL
thread are reused, frames continue on the new view, ordinary destruction still releases, and no old
activity is retained after a handover.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Review #25866 and #25921 and say whether either is right or it should be done differently.
2. No manifest flags. Propose a new correct solution against the `r5.4` branches.
3. Three commits, one pull request (that is the core PR).
4. Go ahead with the app side.
5. Target `master` instead of `r5.4`.
6. Does this break Android Auto? Then: fix the leak found while checking that.

Decided by the agent, not requested explicitly: using the non-configuration instance as the
retention decision instead of a configuration heuristic; passing the renderer explicitly instead of
parking it in `MapRendererContext`; clearing the context reference rather than releasing it;
releasing a retained renderer that nothing takes over, in all three cases where that can happen;
choosing the deprecated retain API over introducing the first `ViewModel` in the app; and opening
this as a draft because nothing was built or run.
