### PR TITLE
Remove duplicate map region status colors

### DIFF
--- a/OsmAnd/res/values/colors.xml
+++ b/OsmAnd/res/values/colors.xml
@@ -420,9 +420,9 @@
 	<color name="inactive_item_orange">#ffc87f</color>
 
 	<!-- DownloadedRegionsLayer -->
-	<color name="map_region_downloaded_fill">#5532C832</color>
-	<color name="map_region_outdated_fill">#55FD9822</color>
-	<color name="map_region_deactivated_fill">#55727272</color>
+	<color name="map_region_downloaded_fill">#66339944</color>
+	<color name="map_region_outdated_fill">#66FF8800</color>
+	<color name="map_region_deactivated_fill">#66858594</color>
 	<color name="map_region_selected_fill">#55FFFF00</color>
 	<color name="region_downloading">#44FF61FF</color>
 
@@ -789,13 +789,5 @@
 
     <color name="scrim_light">#52000000</color>
     <color name="scrim_dark">#52000000</color>
-
-	<color name="map_region_downloaded_fill">#66339944</color>
-	<color name="map_region_outdated_fill">#66FF8800</color>
-	<color name="map_region_deactivated_fill">#66858594</color>
-
-	
-
-
 
 </resources>


### PR DESCRIPTION
Remove duplicate resource definitions for `map_region_downloaded_fill`, `map_region_outdated_fill`, and `map_region_deactivated_fill` in `OsmAnd/res/values/colors.xml`.