### PR TITLE
Fix the three causes of the red OsmAnd-ui-tests build

### DIFF
--- a/OsmAnd/res/values/colors.xml
+++ b/OsmAnd/res/values/colors.xml
@@ -790,10 +790,6 @@
     <color name="scrim_light">#52000000</color>
     <color name="scrim_dark">#52000000</color>
 
-	<color name="map_region_downloaded_fill">#66339944</color>
-	<color name="map_region_outdated_fill">#66FF8800</color>
-	<color name="map_region_deactivated_fill">#66858594</color>
-
 	
 
 

--- a/OsmAnd/test/assets/download/search_examples.json
+++ b/OsmAnd/test/assets/download/search_examples.json
@@ -6,7 +6,7 @@
     "The first examples are the rules of the screen, the ones after them are the corner cases that broke it.",
     "Every 'screen' entry is one row of the list: '[Header]' for a section header,",
     "'Title' for a row without a second line and 'Title | Subtitle' for a row with the region shown in the second line.",
-    "Update the file when the shipped region data changes - the report the test writes shows the new screens side by side."
+    "Update the file when the shipped data changes: the cities come from World_basemap_mini.obf, which is downloaded at build time and rebuilt on the builder every so often, so a rebuild moves the rows of a broad query with no commit behind it. The test then fails on every screen that moved at once and writes search_examples.actual.json next to its HTML report, in this format - paste the screens from there, and read the diff first: a row appearing is what a bigger basemap does, a row disappearing is not."
   ],
   "examples": [
     {
@@ -107,7 +107,10 @@
         "Nouvelle-Aquitaine | France",
         "Papua New Guinea",
         "[Maps]",
+        "New Castle | Pennsylvania",
         "New Delhi | Delhi",
+        "New Haven | Connecticut",
+        "New Town | West Bengal",
         "Newark | Ohio",
         "Newark | Delaware",
         "Newburgh | Albany and surroundings",
@@ -120,6 +123,7 @@
         "Newport News | Virginia",
         "Newry | Northern Ireland",
         "Невинномысск | Stavropol Krai",
+        "兰州新区 | Gansu Province",
         "新北市 | Taiwan",
         "Geneva | Switzerland",
         "New Brunswick | Canada",
@@ -142,6 +146,7 @@
         "San Francisco | United States",
         "[Maps]",
         "San Francisco | Venezuela",
+        "San Francisco de Macorís | Dominican Republic",
         "Central African Republic",
         "San Francisco | United States"
       ]
@@ -194,7 +199,8 @@
       "query": "santo domingo",
       "screen": [
         "[Maps]",
-        "Santo Domingo | Dominican Republic"
+        "Santo Domingo de los Tsáchilas | Ecuador",
+        "Santo Domingo Oeste | Dominican Republic"
       ]
     },
     {

--- a/OsmAnd/test/java/net/osmand/plus/download/DownloadSearchUIModelTest.java
+++ b/OsmAnd/test/java/net/osmand/plus/download/DownloadSearchUIModelTest.java
@@ -4,9 +4,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 import android.content.Context;
+import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -71,12 +73,22 @@ import java.util.Set;
  * directory, so the screens can be reviewed without taking screenshots. Run the tests with
  * {@code adb shell am instrument} to keep the file - {@code connectedAndroidTest} uninstalls the
  * app, and the report goes away with it.
+ * <p>
+ * <b>Updating the examples after the world basemap is rebuilt.</b> The cities are the one part of
+ * a screen that is not checked into this repository: {@code World_basemap_mini.obf} is downloaded
+ * from builder.osmand.net by the {@code downloadWorldMiniBasemap} Gradle task, and every rebuild
+ * of it changes the long tail of a broad query - {@link #searchResultsMatchExamples()} then fails
+ * on data rather than on code, with no commit behind it. The failure lists every screen that
+ * moved and writes {@code search_examples.actual.json} next to the HTML report, ready to be
+ * pasted into {@code test/assets/download/search_examples.json}. Read the diff before pasting:
+ * a city appearing is what a bigger basemap does, a city disappearing is not.
  */
 @RunWith(AndroidJUnit4.class)
 public class DownloadSearchUIModelTest extends AndroidTest {
 
 	private static final String EXAMPLES_ASSET = "download/search_examples.json";
 	private static final String REPORT_FILE = "download_search_report.html";
+	private static final String ACTUAL_EXAMPLES_FILE = "search_examples.actual.json";
 	private static final String BASEMAP_FILE =
 			WorldRegion.WORLD_BASEMAP_MINI + IndexConstants.BINARY_MAP_INDEX_EXT;
 
@@ -112,6 +124,8 @@ public class DownloadSearchUIModelTest extends AndroidTest {
 		DownloadResources indexes = fullCatalog();
 		JSONArray examples = new JSONObject(readAsset(EXAMPLES_ASSET)).getJSONArray("examples");
 		assertTrue("No examples to check", examples.length() > 0);
+		JSONArray produced = new JSONArray();
+		List<String> mismatches = new ArrayList<>();
 		for (int i = 0; i < examples.length(); i++) {
 			JSONObject example = examples.getJSONObject(i);
 			String name = example.getString("name");
@@ -121,10 +135,55 @@ public class DownloadSearchUIModelTest extends AndroidTest {
 			List<Object> rows = model.search(indexes, query, searchCities(model, query));
 			REPORT.add(new ReportScreen("Examples", query, name, toReportRows(model, rows)));
 
-			assertEquals(name + " (query: \"" + query + "\")",
-					toStringList(example.getJSONArray("screen")), renderAll(model, rows));
+			List<String> expected = toStringList(example.getJSONArray("screen"));
+			List<String> actual = renderAll(model, rows);
+			produced.put(withScreen(example, actual));
+			if (!expected.equals(actual)) {
+				// every screen is checked, so one run is enough to update the examples
+				mismatches.add(name + " (query: \"" + query + "\")"
+						+ "\n  expected: " + expected
+						+ "\n  but was:  " + actual);
+			}
 			assertScreenIsWellFormed(query, rows);
 		}
+		if (!mismatches.isEmpty()) {
+			fail(mismatches.size() + " of " + examples.length() + " screens differ from "
+					+ EXAMPLES_ASSET + ":\n" + TextUtils.join("\n", mismatches)
+					+ "\nWhat this run produced: " + writeActualExamples(produced));
+		}
+	}
+
+	/** The example as it would have to be written down for this run to pass. */
+	@NonNull
+	private JSONObject withScreen(@NonNull JSONObject example, @NonNull List<String> screen)
+			throws JSONException {
+		JSONObject copy = new JSONObject();
+		copy.put("name", example.getString("name"));
+		copy.put("query", example.getString("query"));
+		if (example.has("showGroup")) {
+			copy.put("showGroup", example.getBoolean("showGroup"));
+		}
+		copy.put("screen", new JSONArray(screen));
+		return copy;
+	}
+
+	/**
+	 * Writes the screens this run produced next to the HTML report, in the format of
+	 * {@code search_examples.json}, so that a legitimate change of the shipped data can be
+	 * pasted back instead of being typed out of an assertion message.
+	 */
+	@NonNull
+	private String writeActualExamples(@NonNull JSONArray produced) throws Exception {
+		File dir = app.getExternalFilesDir(null);
+		if (dir == null) {
+			return "nowhere, the app has no external files directory";
+		}
+		File file = new File(dir, ACTUAL_EXAMPLES_FILE);
+		try (FileOutputStream out = new FileOutputStream(file)) {
+			String json = new JSONObject().put("examples", produced).toString(1);
+			out.write(json.getBytes(StandardCharsets.UTF_8));
+		}
+		return file.getAbsolutePath();
 	}
 
 	@Test

--- a/OsmAnd/test/java/net/osmand/test/junit/NavigationServiceBackgroundStartTest.java
+++ b/OsmAnd/test/java/net/osmand/test/junit/NavigationServiceBackgroundStartTest.java
@@ -4,6 +4,7 @@ import static net.osmand.plus.NavigationService.USED_BY_GPX;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import android.Manifest;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.ContextWrapper;
@@ -12,11 +13,13 @@ import android.content.Intent;
 import androidx.annotation.NonNull;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.rule.GrantPermissionRule;
 
 import net.osmand.plus.OsmAndLocationProvider;
 import net.osmand.plus.OsmandApplication;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -49,6 +52,16 @@ import java.util.List;
  */
 @RunWith(AndroidJUnit4.class)
 public class NavigationServiceBackgroundStartTest {
+
+	/**
+	 * {@code startNavigationService()} returns before the check under test when the location
+	 * permission is missing, so a fresh install - which is what CI runs on - would pass the
+	 * test without exercising anything. This test does not extend {@code AndroidTest}, whose
+	 * {@code setup()} grants permissions, because it must run without an activity.
+	 */
+	@Rule
+	public final GrantPermissionRule grantPermissionRule =
+			GrantPermissionRule.grant(Manifest.permission.ACCESS_FINE_LOCATION);
 
 	private OsmandApplication app;
 


### PR DESCRIPTION
Makes `OsmAnd-ui-tests` green again. Three separate causes, none of them a regression in the code the tests cover.

### 1. `colors.xml` — master does not build right now

PR #25760 (`25300-map-status-color`, merged today) renamed `region_uptodate` / `region_backuped` / `region_selected` to `map_region_*_fill` under the `<!-- DownloadedRegionsLayer -->` comment. Its branch was cut before 20e50e57b1 ("Added colors for region status on the map", 28 Aug) added three of those same names at the end of the file, so the merge went through cleanly and left them declared twice:

```
ERROR: OsmAnd/res/values/colors.xml: Resource and asset merger:
       Found item Color/map_region_downloaded_fill more than one time
```

`mergeResources` fails on that, so the next run of this job would not have reached the tests at all. The set from #25760 is kept — it is the complete one (it carries `map_region_selected_fill`, which the layer also reads) and it sits with the layer's other colours. `DownloadedRegionsLayer` is the only consumer of all four. If design wants the more saturated `#66…` values, change the values in the kept block rather than re-adding the second declaration.

### 2. `NavigationServiceBackgroundStartTest` — the location permission was never granted

```
java.lang.AssertionError: the test needs the location permission granted
```

The assertion is deliberate: `startNavigationService()` returns before the check under test when the permission is missing, so without it the test would pass without exercising anything. But nothing granted it on CI. The test does not extend `AndroidTest` (it must run without an activity), and `EspressoUtils.grantPermissions()` only grants `POST_NOTIFICATIONS` anyway; `ACCESS_FINE_LOCATION` is granted in exactly one other place in the test tree, through `GrantPermissionRule`. It passed locally only because the development emulator already had the permission.

Added the rule.

### 3. `DownloadSearchUIModelTest` — the world basemap was rebuilt

The cities on the screen come from `World_basemap_mini.obf`, which `downloadWorldMiniBasemap` fetches from builder.osmand.net at build time. The server's copy was rebuilt on **2026-09-07 14:49 UTC**, between #1657 (`Not modified. Skipping`) and #1658 (downloaded it), and the test has failed ever since — with no commit behind it. The `[Regions]` part of the failing screen is identical, because `regions.ocbf` was not rebuilt.

The examples are updated to what the new basemap produces. Eight rows appear:

```
+ New Castle | Pennsylvania          + San Francisco de Macorís | Dominican Republic
+ New Haven | Connecticut            + Santo Domingo de los Tsáchilas | Ecuador
+ New Town | West Bengal             + Santo Domingo Oeste | Dominican Republic
+ 兰州新区 | Gansu Province
```

and one disappears:

```
- Santo Domingo | Dominican Republic
```

**That last one is worth knowing about.** It is not a data loss — Santo Domingo is still a `city` in the new basemap. `filterDuplicateCities()` keeps the first city that resolves to a given map, and the POI name index now returns `Santo Domingo Oeste` before the capital, so the row for the Dominican Republic map is now the suburb. Which of several same-map cities is shown is decided by index order, i.e. by chance. That deserves a fix of its own; this PR only records the current behaviour.

Two smaller changes so the next basemap rebuild costs less:

- every screen that moved is reported in one failure. The CI failure named only the `New` screen while three of the eighteen had moved, and each round of "fix one, run again" is a full instrumentation run.
- the run writes `search_examples.actual.json` next to the HTML report, in the format of the asset, so a legitimate change of the shipped data can be pasted back instead of being typed out of a truncated assertion message (Jenkins cuts the stack trace at ~2.4 kB, which is well inside the `New` screen).

### Verified

`Claude_Phone_API_35` emulator (API 35), `nightlyFreeOpenglArm64Debug`, with the same basemap the CI has (70 555 576 bytes, 2026-09-07 14:49 UTC):

- before the colour fix: `mergeResources` FAILED, exactly as above; after it: `BUILD SUCCESSFUL`
- `DownloadSearchUIModelTest` + `NavigationServiceBackgroundStartTest`: `OK (8 tests)`
- the permission rule does grant it: `pm revoke ACCESS_FINE_LOCATION`, re-run, still passes

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Analyse why the tests failed at https://builder.osmand.net:8080/job/OsmAnd-ui-tests/lastCompletedBuild/ — what was committed, or not committed.
2. Make an example PR with the fix.
3. On how to handle the stale search examples: prefer accepting the new output over weakening the assertion, since the basemap is not changed often, and describe the process for doing it next time.

Decided by the agent, not requested explicitly:
- The `colors.xml` duplicate was found while building the branch, not asked for. It is included because the branch — and master — does not build without it, so neither fix could be verified otherwise. Choosing which of the two colour blocks to keep is a judgement call and is called out above.
- Reporting all mismatching screens in one failure, and writing `search_examples.actual.json`, are the agent's reading of "describe the process for next time" — they make the update mechanical rather than documented.
- The `Santo Domingo` → `Santo Domingo Oeste` substitution is recorded, not fixed; changing how `filterDuplicateCities()` picks among cities sharing a map is a product decision outside this PR.
- Verification on a local API 35 arm64 emulator rather than the CI x86 image.
