### PR TITLE
Stop the offscreen renderer that setupOffscreenRenderer() drops

### DIFF
--- a/OsmAnd/src/net/osmand/plus/auto/SurfaceRenderer.java
+++ b/OsmAnd/src/net/osmand/plus/auto/SurfaceRenderer.java
@@ -393,6 +393,13 @@ public final class SurfaceRenderer implements DefaultLifecycleObserver, MapRende
 				if (offscreenMapRendererView != null) {
 					MapRendererContext mapRendererContext = NativeCoreContext.getMapRendererContext();
 					if (mapRendererContext != null && mapRendererContext.getMapRendererView() != offscreenMapRendererView) {
+						// The context doesn't refer to the view anymore: either the phone took its
+						// renderer over, or recreateAndroidAutoRenderer() dropped it. In the latter
+						// case the renderer is still alive and nothing else is going to stop it
+						if (mapView != null && mapView.getMapRenderer() == offscreenMapRendererView) {
+							mapView.detachMapRenderer();
+						}
+						offscreenMapRendererView.stopRenderer();
 						offscreenMapRendererView = null;
 					}
 				}


### PR DESCRIPTION
Reduced replacement for #25926: seven lines, one file, **no renderer hand-over across activity
recreation**. It is the second commit of #25926, which is an independent leak fix that happens to
have been found while checking that PR's Android Auto paths.

#25926 is not closed. Requires [osmandapp/OsmAnd-core#1114](https://github.com/osmandapp/OsmAnd-core/pull/1114)
(merge and publish the wrapper artifacts first), but only for safety, not for compilation - see below.

## The defect

`SurfaceRenderer.setupOffscreenRenderer()` forgets its offscreen view as soon as the renderer context
no longer refers to it:

```java
if (mapRendererContext != null && mapRendererContext.getMapRendererView() != offscreenMapRendererView) {
    offscreenMapRendererView = null;
}
```

Two different situations reach that branch. When the phone took the renderer over, dropping the view
is right. But `OsmandDevelopmentPlugin.recreateAndroidAutoRenderer()` gets there by calling
`mapRendererContext.setMapRendererView(null)` on purpose, and then the view is still alive and still
owns its renderer, its EGL thread and its GPU resources - all of which were leaked, while a fresh set
was created next to them. The MSAA switch in the development plugin calls it on every toggle while a
car session is running.

## Why the core PR

`stopRenderer()` on a view that already handed its renderer over would release a renderer that
belongs to the phone view now. osmandapp/OsmAnd-core#1114 marks such a view as handed over and makes
`stopRenderer()` a no-op on it. Without that commit this change is only as safe as the identity guard
in `MapRendererContext.releaseMapRendererView()`, which is why the core PR should go in first.

## Validation

Built and run on a Pixel 9 Pro XL (Android 17) against a wrapper built from
osmandapp/OsmAnd-core#1114, with Android Auto driven by the Desktop Head Unit. Four MSAA toggles with
a car session running:

- 8 fresh renderers (phone + car per toggle) and **4 `Stopping active renderer`** - the dropped
  offscreen view is now stopped rather than leaked;
- live `OpenGLThread` threads: **1 before, 1 after**;
- no crash, no `Swig::DirectorException`.

Also exercised around it, unchanged: connect, disconnect, a phone rotation during projection, and a
rotate/disconnect race, over three full cycles.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Analyse #25926 and osmandapp/OsmAnd-core#1113, build them and run them; the proposal to keep the
   old renderer in other cases too looks wrong and likely to cause problems.
2. Add sleeps in rendering if useful - the suspicion is a slow frame, and test devices may not have
   the slow tiles that cause it.
3. Isn't the refactoring too large - can it be made smaller?
4. Run the Android Auto checks over the Desktop Head Unit.
5. Create shortened pull requests with what the findings support as a minimal fix, and link them
   from the two old pull requests.

Decided by the agent, not requested explicitly: that the second commit of #25926 is worth keeping on
its own while the activity-recreation hand-over is not (measured at ~50 ms per recreation on real
hardware, against a change that rewires activity lifetime and renderer ownership); and enabling the
development plugin through `shared_prefs` to reach the MSAA switch during the test.
