### PR TITLE
Fix false Map Sources local changes caused by cache updates

### DIFF
--- a/OsmAnd/src/net/osmand/plus/resources/SQLiteTileSource.java
+++ b/OsmAnd/src/net/osmand/plus/resources/SQLiteTileSource.java
@@ -52,6 +52,9 @@ public class SQLiteTileSource implements ITileSource {
 	private static final String TILENUMBERING = "tilenumbering";
 	private static final String BIG_PLANET_TILE_NUMBERING = "BigPlanet";
 	private static final String TILESIZE = "tilesize";
+	private static final String TILE_FORMAT = "ext";
+	private static final String BIT_DENSITY = "img_density";
+	private static final String AVG_SIZE = "avg_size";
 	private static final String TITLE = "title";
 
 	private final OsmandApplication app;
@@ -75,7 +78,10 @@ public class SQLiteTileSource implements ITileSource {
 	private String referer;
 	private String userAgent;
 
+	private String tileFormat = ".png";
 	private int tileSize = 256;
+	private int bitDensity = 16;
+	private int avgSize = -1;
 	private boolean tileSizeSpecified;
 	private boolean onlyReadonlyAvailable;
 
@@ -113,6 +119,34 @@ public class SQLiteTileSource implements ITileSource {
 	public SQLiteTileSource(@NonNull OsmandApplication app, String name, int minZoom, int maxZoom, String urlTemplate,
 	                        String randoms, boolean isEllipsoid, boolean invertedY, String referer, String userAgent,
 	                        boolean timeSupported, long expirationTimeMillis, boolean inversiveZoom, String rule) {
+		this(app, name, minZoom, maxZoom, urlTemplate, randoms, isEllipsoid, invertedY, referer, userAgent,
+				timeSupported, expirationTimeMillis, inversiveZoom, rule, ".png", 0, 16, -1);
+	}
+
+	/**
+	 * Creates a source from the Map Sources backup representation. The backup format
+	 * cannot distinguish an explicitly configured tile size from an old runtime
+	 * default, so the value must remain eligible for local auto-detection.
+	 */
+	@NonNull
+	public static SQLiteTileSource fromBackup(@NonNull OsmandApplication app, String name, int minZoom, int maxZoom,
+	                                          String urlTemplate, String randoms, boolean isEllipsoid, boolean invertedY,
+	                                          String referer, String userAgent, boolean timeSupported,
+	                                          long expirationTimeMillis, boolean inversiveZoom, String rule,
+	                                          String tileFormat, int tileSize, int bitDensity, int avgSize) {
+		return new SQLiteTileSource(app, name, minZoom, maxZoom, urlTemplate, randoms, isEllipsoid, invertedY,
+				referer, userAgent, timeSupported, expirationTimeMillis, inversiveZoom, rule, tileFormat,
+				tileSize, bitDensity, avgSize);
+	}
+
+	/**
+	 * A source built in memory never has an explicitly configured tile size, only
+	 * a tile size stored in the database marks it as specified.
+	 */
+	private SQLiteTileSource(@NonNull OsmandApplication app, String name, int minZoom, int maxZoom, String urlTemplate,
+	                         String randoms, boolean isEllipsoid, boolean invertedY, String referer, String userAgent,
+	                         boolean timeSupported, long expirationTimeMillis, boolean inversiveZoom, String rule,
+	                         String tileFormat, int tileSize, int bitDensity, int avgSize) {
 		this.app = app;
 		this.title = name;
 		this.fileName = name;
@@ -128,6 +162,10 @@ public class SQLiteTileSource implements ITileSource {
 		this.invertedY = invertedY;
 		this.timeSupported = timeSupported;
 		this.inversiveZoom = inversiveZoom;
+		this.tileFormat = normalizeTileFormat(tileFormat);
+		this.tileSize = normalizeTileSize(tileSize);
+		this.bitDensity = normalizeBitDensity(bitDensity);
+		this.avgSize = avgSize;
 	}
 
 	public SQLiteTileSource(@NonNull SQLiteTileSource tileSource, @NonNull String name, @NonNull OsmandApplication app) {
@@ -145,6 +183,12 @@ public class SQLiteTileSource implements ITileSource {
 		this.invertedY = tileSource.isInvertedYTile();
 		this.timeSupported = tileSource.isTimeSupported();
 		this.inversiveZoom = tileSource.getInversiveZoom();
+		this.rule = tileSource.getRule();
+		this.tileFormat = normalizeTileFormat(tileSource.getTileFormat());
+		this.tileSize = normalizeTileSize(tileSource.getTileSize());
+		this.bitDensity = normalizeBitDensity(tileSource.getBitDensity());
+		this.avgSize = tileSource.getAvgSize();
+		this.tileSizeSpecified = tileSource.tileSizeSpecified;
 	}
 
 	public void createDataBase() {
@@ -152,10 +196,15 @@ public class SQLiteTileSource implements ITileSource {
 		SQLiteConnection db = app.getSQLiteAPI().getOrCreateDatabase(name, true);
 		if (db != null) {
 			try {
+				// BigPlanet databases store inverted zooms, mirroring how getDatabase() reads
+				// them back. Writing plain zooms here would turn the source into a simple one.
+				int databaseMinZoom = inversiveZoom ? 17 - maxZoom : minZoom;
+				int databaseMaxZoom = inversiveZoom ? 17 - minZoom : maxZoom;
 				db.execSQL("CREATE TABLE IF NOT EXISTS tiles (x int, y int, z int, s int, image blob, time long, PRIMARY KEY (x,y,z,s))");
 				db.execSQL("CREATE INDEX IF NOT EXISTS IND on tiles (x,y,z,s)");
 				db.execSQL("CREATE TABLE IF NOT EXISTS info(tilenumbering,minzoom,maxzoom)");
-				db.execSQL("INSERT INTO info (tilenumbering,minzoom,maxzoom) VALUES ('simple','" + minZoom + "','" + maxZoom + "');");
+				db.execSQL("INSERT INTO info (tilenumbering,minzoom,maxzoom) VALUES (?, ?, ?)",
+						new Object[] {inversiveZoom ? BIG_PLANET_TILE_NUMBERING : "simple", databaseMinZoom, databaseMaxZoom});
 
 				addInfoColumn(db, TITLE, title);
 				addInfoColumn(db, URL, urlTemplate);
@@ -166,6 +215,15 @@ public class SQLiteTileSource implements ITileSource {
 				addInfoColumn(db, USER_AGENT, userAgent);
 				addInfoColumn(db, TIME_COLUMN, timeSupported ? "yes" : "no");
 				addInfoColumn(db, EXPIRE_MINUTES, String.valueOf(getExpirationTimeMinutes()));
+				addInfoColumn(db, RULE, rule);
+				// Unlike the declarative properties below, the tile size is only stored once
+				// it is known, so that an unset one stays open to local auto-detection.
+				if (tileSizeSpecified) {
+					addInfoColumn(db, TILESIZE, String.valueOf(tileSize));
+				}
+				addInfoColumn(db, TILE_FORMAT, tileFormat);
+				addInfoColumn(db, BIT_DENSITY, String.valueOf(bitDensity));
+				addInfoColumn(db, AVG_SIZE, String.valueOf(avgSize));
 			} finally {
 				db.close();
 			}
@@ -174,7 +232,7 @@ public class SQLiteTileSource implements ITileSource {
 
 	@Override
 	public int getBitDensity() {
-		return base != null ? base.getBitDensity() : 16;
+		return base != null ? base.getBitDensity() : bitDensity;
 	}
 
 	@Override
@@ -194,7 +252,7 @@ public class SQLiteTileSource implements ITileSource {
 
 	@Override
 	public String getTileFormat() {
-		return base != null ? base.getTileFormat() : ".png"; //$NON-NLS-1$
+		return base != null ? base.getTileFormat() : tileFormat;
 	}
 
 	@Override
@@ -272,7 +330,22 @@ public class SQLiteTileSource implements ITileSource {
 	}
 
 	public void initDatabaseIfNeeded() {
-		getDatabase();
+		if (file != null) {
+			getDatabase();
+		}
+	}
+
+	@NonNull
+	private static String normalizeTileFormat(@Nullable String tileFormat) {
+		return Algorithms.isEmpty(tileFormat) ? ".png" : tileFormat;
+	}
+
+	private static int normalizeTileSize(int tileSize) {
+		return tileSize > 0 ? tileSize : 256;
+	}
+
+	private static int normalizeBitDensity(int bitDensity) {
+		return bitDensity > 0 ? bitDensity : 16;
 	}
 
 	protected synchronized SQLiteConnection getDatabase() {
@@ -335,9 +408,22 @@ public class SQLiteTileSource implements ITileSource {
 						addInfoColumn(db, EXPIRE_MINUTES, "0");
 					}
 					int tsColumn = list.indexOf(TILESIZE);
-					this.tileSizeSpecified = tsColumn != -1;
-					if(tileSizeSpecified) {
-						this.tileSize = cursor.getInt(tsColumn);
+					if (tsColumn != -1) {
+						int storedTileSize = cursor.getInt(tsColumn);
+						this.tileSize = normalizeTileSize(storedTileSize);
+						this.tileSizeSpecified = storedTileSize > 0;
+					}
+					int tileFormatId = list.indexOf(TILE_FORMAT);
+					if (tileFormatId != -1) {
+						this.tileFormat = normalizeTileFormat(cursor.getString(tileFormatId));
+					}
+					int bitDensityId = list.indexOf(BIT_DENSITY);
+					if (bitDensityId != -1) {
+						this.bitDensity = normalizeBitDensity(cursor.getInt(bitDensityId));
+					}
+					int avgSizeId = list.indexOf(AVG_SIZE);
+					if (avgSizeId != -1) {
+						this.avgSize = cursor.getInt(avgSizeId);
 					}
 					int ellipsoid = list.indexOf(ELLIPSOID);
 					if(ellipsoid != -1) {
@@ -448,7 +534,7 @@ public class SQLiteTileSource implements ITileSource {
 			} catch (SQLException e) {
 				LOG.info("Error adding column " + e);
 			}
-			db.execSQL("update info set " + columnName + " = '" + value + "'");
+			db.execSQL("update info set " + columnName + " = ?", new Object[] {value != null ? value : ""});
 		}
 	}
 
@@ -637,7 +723,7 @@ public class SQLiteTileSource implements ITileSource {
 
 	@Override
 	public int getAvgSize() {
-		return base != null ? base.getAvgSize() : -1;
+		return base != null ? base.getAvgSize() : avgSize;
 	}
 
 	@Override

--- a/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/OsmandSettings.java
@@ -1575,6 +1575,8 @@ public class OsmandSettings {
 
 	public final CommonPreference<Long> LAST_AUTO_BACKUP_TIMESTAMP = registerLongPreference("last_auto_backup_timestamp", 0L).makeGlobal();
 	public final CommonPreference<Long> AUTO_BACKUP_INTERVAL_MS = registerLongPreference("auto_backup_interval_ms", DEFAULT_AUTO_BACKUP_INTERVAL_MS).makeGlobal();
+	public final CommonPreference<String> MAP_SOURCES_BACKUP_STATE_HASH = registerStringPreference("map_sources_backup_state_hash", "").makeGlobal();
+	public final CommonPreference<Long> MAP_SOURCES_LOCAL_MODIFIED_TIME = registerLongPreference("map_sources_local_modified_time", 0L).makeGlobal();
 
 	public final CommonPreference<DayNightMode> DAYNIGHT_MODE = new EnumStringPreference<>(this, "daynight_mode", DayNightMode.DAY, DayNightMode.values());
 

--- a/OsmAnd/src/net/osmand/plus/settings/backend/backup/items/MapSourcesSettingsItem.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/backup/items/MapSourcesSettingsItem.java
@@ -11,19 +11,25 @@ import net.osmand.map.TileSourceManager;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.R;
 import net.osmand.plus.resources.SQLiteTileSource;
+import net.osmand.plus.settings.backend.OsmandSettings;
 import net.osmand.plus.settings.backend.backup.SettingsHelper;
 import net.osmand.plus.settings.backend.backup.SettingsItemReader;
 import net.osmand.plus.settings.backend.backup.SettingsItemType;
 import net.osmand.plus.settings.backend.backup.SettingsItemWriter;
 import net.osmand.util.Algorithms;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 public class MapSourcesSettingsItem extends CollectionSettingsItem<ITileSource> {
 
@@ -57,19 +63,52 @@ public class MapSourcesSettingsItem extends CollectionSettingsItem<ITileSource> 
 
 	@Override
 	public long getLocalModifiedTime() {
+		OsmandSettings settings = app.getSettings();
+		String storedStateHash = settings.MAP_SOURCES_BACKUP_STATE_HASH.get();
+		long storedModifiedTime = settings.MAP_SOURCES_LOCAL_MODIFIED_TIME.get();
+		boolean hasStoredState = !Algorithms.isEmpty(storedStateHash);
+		// Has to be resolved before the state hash is computed: computing the hash opens
+		// the tile databases, which may add missing info columns to them and by that
+		// change the very file timestamps the initial time is derived from.
+		long initialModifiedTime = hasStoredState ? 0 : getInitialModifiedTime(storedModifiedTime);
+
+		String currentStateHash = getStateHash(items);
+		if (currentStateHash.equals(storedStateHash)) {
+			return storedModifiedTime;
+		}
+		long modifiedTime = hasStoredState
+				? Math.max(System.currentTimeMillis(), storedModifiedTime + 1)
+				: initialModifiedTime;
+		persistBackupState(currentStateHash, modifiedTime);
+		return modifiedTime;
+	}
+
+	/**
+	 * There is no semantic baseline on the first run after upgrading, so the legacy file
+	 * time is kept to not silently discard a source edit that was never synced.
+	 *
+	 * @param storedModifiedTime a non zero time without a stored hash is left over from an
+	 * initialization that was interrupted between the two writes, and is reused as it is.
+	 */
+	private long getInitialModifiedTime(long storedModifiedTime) {
+		if (storedModifiedTime != 0) {
+			return storedModifiedTime;
+		}
+		long legacyModifiedTime = getLegacyLocalModifiedTime();
+		return legacyModifiedTime == 0 && !items.isEmpty() ? System.currentTimeMillis() : legacyModifiedTime;
+	}
+
+	private long getLegacyLocalModifiedTime() {
 		long lastModifiedTime = 0;
 		for (ITileSource source : items) {
+			File file = null;
 			if (source instanceof SQLiteTileSource) {
-				long lastModified = app.getAppPath(IndexConstants.TILES_INDEX_DIR + source.getName()
-						+ IndexConstants.SQLITE_EXT).lastModified();
-				if (lastModified > lastModifiedTime) {
-					lastModifiedTime = lastModified;
-				}
+				file = app.getAppPath(IndexConstants.TILES_INDEX_DIR + source.getName() + IndexConstants.SQLITE_EXT);
 			} else if (source instanceof TileSourceManager.TileSourceTemplate) {
-				long lastModified = new File(app.getAppPath(IndexConstants.TILES_INDEX_DIR + source.getName()), ".metainfo").lastModified();
-				if (lastModified > lastModifiedTime) {
-					lastModifiedTime = lastModified;
-				}
+				file = new File(app.getAppPath(IndexConstants.TILES_INDEX_DIR + source.getName()), ".metainfo");
+			}
+			if (file != null) {
+				lastModifiedTime = Math.max(lastModifiedTime, file.lastModified());
 			}
 		}
 		return lastModifiedTime;
@@ -77,19 +116,15 @@ public class MapSourcesSettingsItem extends CollectionSettingsItem<ITileSource> 
 
 	@Override
 	public void setLocalModifiedTime(long lastModifiedTime) {
-		for (ITileSource source : items) {
-			if (source instanceof SQLiteTileSource) {
-				File file = app.getAppPath(IndexConstants.TILES_INDEX_DIR + source.getName() + IndexConstants.SQLITE_EXT);
-				if (file.lastModified() > lastModifiedTime) {
-					file.setLastModified(lastModifiedTime);
-				}
-			} else if (source instanceof TileSourceManager.TileSourceTemplate) {
-				File file = new File(app.getAppPath(IndexConstants.TILES_INDEX_DIR + source.getName()), ".metainfo");
-				if (file.lastModified() > lastModifiedTime) {
-					file.setLastModified(lastModifiedTime);
-				}
-			}
-		}
+		persistBackupState(getStateHash(items), lastModifiedTime);
+	}
+
+	private void persistBackupState(@NonNull String stateHash, long lastModifiedTime) {
+		OsmandSettings settings = app.getSettings();
+		// Write the hash last. An interrupted update may then cause a harmless repeat
+		// detection, but cannot acknowledge a state whose timestamp was not stored.
+		settings.MAP_SOURCES_LOCAL_MODIFIED_TIME.set(lastModifiedTime);
+		settings.MAP_SOURCES_BACKUP_STATE_HASH.set(stateHash);
 	}
 
 	@Override
@@ -226,7 +261,8 @@ public class MapSourcesSettingsItem extends CollectionSettingsItem<ITileSource> 
 
 					template = tileSourceTemplate;
 				} else {
-					template = new SQLiteTileSource(app, name, minZoom, maxZoom, url, randoms, ellipsoid, invertedY, referer, userAgent, timeSupported, expire, inversiveZoom, rule);
+					template = SQLiteTileSource.fromBackup(app, name, minZoom, maxZoom, url, randoms, ellipsoid, invertedY,
+							referer, userAgent, timeSupported, expire, inversiveZoom, rule, ext, tileSize, bitDensity, avgSize);
 				}
 				items.add(template);
 			}
@@ -242,28 +278,8 @@ public class MapSourcesSettingsItem extends CollectionSettingsItem<ITileSource> 
 		JSONArray jsonArray = new JSONArray();
 		if (!items.isEmpty()) {
 			try {
-				for (ITileSource template : items) {
-					JSONObject jsonObject = new JSONObject();
-					boolean sql = template instanceof SQLiteTileSource;
-					jsonObject.put("sql", sql);
-					jsonObject.put("name", template.getName());
-					jsonObject.put("minZoom", template.getMinimumZoomSupported());
-					jsonObject.put("maxZoom", template.getMaximumZoomSupported());
-					jsonObject.put("url", template.getUrlTemplate());
-					jsonObject.put("randoms", template.getRandoms());
-					jsonObject.put("ellipsoid", template.isEllipticYTile());
-					jsonObject.put("inverted_y", template.isInvertedYTile());
-					jsonObject.put("referer", template.getReferer());
-					jsonObject.put("userAgent", template.getUserAgent());
-					jsonObject.put("timesupported", template.isTimeSupported());
-					jsonObject.put("expire", template.getExpirationTimeMinutes());
-					jsonObject.put("inversiveZoom", template.getInversiveZoom());
-					jsonObject.put("ext", template.getTileFormat());
-					jsonObject.put("tileSize", template.getTileSize());
-					jsonObject.put("bitDensity", template.getBitDensity());
-					jsonObject.put("avgSize", template.getAvgSize());
-					jsonObject.put("rule", template.getRule());
-					jsonArray.put(jsonObject);
+				for (MapSourceBackupState state : snapshotSources(items)) {
+					jsonArray.put(state.toJson());
 				}
 				json.put("items", jsonArray);
 
@@ -273,6 +289,117 @@ public class MapSourcesSettingsItem extends CollectionSettingsItem<ITileSource> 
 			}
 		}
 		return json;
+	}
+
+	@NonNull
+	static String getStateHash(@NonNull List<? extends ITileSource> sources) {
+		StringBuilder state = new StringBuilder();
+		List<MapSourceBackupState> sourceStates = snapshotSources(sources);
+		sourceStates.sort(Comparator.comparing(sourceState -> sourceState.canonicalState));
+		for (MapSourceBackupState sourceState : sourceStates) {
+			appendField(state, sourceState.canonicalState);
+		}
+		return DigestUtils.sha256Hex(state.toString());
+	}
+
+	@NonNull
+	private static List<MapSourceBackupState> snapshotSources(@NonNull List<? extends ITileSource> sources) {
+		List<MapSourceBackupState> states = new ArrayList<>(sources.size());
+		for (ITileSource source : sources) {
+			states.add(new MapSourceBackupState(source));
+		}
+		return states;
+	}
+
+	private static void appendField(@NonNull StringBuilder state, @Nullable Object value) {
+		String stringValue = value != null ? String.valueOf(value) : "";
+		state.append(stringValue.length()).append(':').append(stringValue).append('|');
+	}
+
+	private static final class MapSourceBackupState {
+
+		private final SortedMap<String, BackupProperty> properties = new TreeMap<>();
+		private final String canonicalState;
+
+		private MapSourceBackupState(@NonNull ITileSource source) {
+			boolean sqlite = source instanceof SQLiteTileSource;
+			if (sqlite) {
+				// Load the SQLite metadata before reading any getters. Otherwise lazily
+				// initialized fields such as zoom limits could be captured as defaults.
+				((SQLiteTileSource) source).initDatabaseIfNeeded();
+			}
+			put("sql", sqlite);
+			put("name", normalizeString(source.getName()));
+			put("minZoom", source.getMinimumZoomSupported());
+			put("maxZoom", source.getMaximumZoomSupported());
+			put("url", normalizeString(source.getUrlTemplate()));
+			put("randoms", normalizeString(source.getRandoms()));
+			put("ellipsoid", source.isEllipticYTile());
+			put("inverted_y", source.isInvertedYTile());
+			put("referer", normalizeString(source.getReferer()));
+			put("userAgent", normalizeString(source.getUserAgent()));
+			put("timesupported", source.isTimeSupported());
+			put("expire", source.getExpirationTimeMinutes());
+			put("inversiveZoom", source.getInversiveZoom());
+			put("ext", normalizeString(source.getTileFormat()));
+			// Legacy SQLite sources can discover and persist this value when a tile is
+			// decoded. Keep it in backup, but do not treat derived runtime metadata as
+			// a semantic source change. Directory-source tile size remains semantic.
+			put("tileSize", source.getTileSize(), !sqlite);
+			put("bitDensity", source.getBitDensity());
+			put("avgSize", source.getAvgSize());
+			put("rule", normalizeString(source.getRule()));
+			canonicalState = createCanonicalState();
+		}
+
+		private void put(@NonNull String name, @NonNull Object value) {
+			put(name, value, true);
+		}
+
+		private void put(@NonNull String name, @NonNull Object value, boolean hashRelevant) {
+			properties.put(name, new BackupProperty(value, hashRelevant));
+		}
+
+		@NonNull
+		private JSONObject toJson() throws JSONException {
+			JSONObject json = new JSONObject();
+			for (Map.Entry<String, BackupProperty> property : properties.entrySet()) {
+				json.put(property.getKey(), property.getValue().value);
+			}
+			return json;
+		}
+
+		@NonNull
+		private String createCanonicalState() {
+			StringBuilder state = new StringBuilder();
+			for (Map.Entry<String, BackupProperty> entry : properties.entrySet()) {
+				BackupProperty property = entry.getValue();
+				if (!property.hashRelevant) {
+					continue;
+				}
+				appendField(state, entry.getKey());
+				Object value = property.value;
+				appendField(state, value instanceof Boolean ? "boolean" : value instanceof Number ? "number" : "string");
+				appendField(state, value);
+			}
+			return state.toString();
+		}
+
+		@NonNull
+		private static String normalizeString(@Nullable String value) {
+			return value != null ? value : "";
+		}
+
+		private static final class BackupProperty {
+
+			private final Object value;
+			private final boolean hashRelevant;
+
+			private BackupProperty(@NonNull Object value, boolean hashRelevant) {
+				this.value = value;
+				this.hashRelevant = hashRelevant;
+			}
+		}
 	}
 
 	@Nullable

--- a/OsmAnd/test/java/net/osmand/plus/settings/backend/backup/items/MapSourcesSettingsItemTest.java
+++ b/OsmAnd/test/java/net/osmand/plus/settings/backend/backup/items/MapSourcesSettingsItemTest.java
@@ -1,0 +1,366 @@
+package net.osmand.plus.settings.backend.backup.items;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import net.osmand.IndexConstants;
+import net.osmand.map.ITileSource;
+import net.osmand.map.TileSourceManager.TileSourceTemplate;
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.api.SQLiteAPI.SQLiteConnection;
+import net.osmand.plus.resources.SQLiteTileSource;
+import net.osmand.plus.settings.backend.OsmandSettings;
+import net.osmand.util.Algorithms;
+
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@RunWith(AndroidJUnit4.class)
+public class MapSourcesSettingsItemTest {
+
+	private static final String TEST_SOURCE_PREFIX = "map_sources_backup_test_";
+
+	private final List<File> filesToDelete = new ArrayList<>();
+
+	private OsmandApplication app;
+	private OsmandSettings settings;
+	private boolean stateHashWasSet;
+	private boolean modifiedTimeWasSet;
+	private String previousStateHash;
+	private long previousModifiedTime;
+
+	@Before
+	public void setup() {
+		Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+		app = (OsmandApplication) targetContext.getApplicationContext();
+		settings = app.getSettings();
+		stateHashWasSet = settings.MAP_SOURCES_BACKUP_STATE_HASH.isSet();
+		modifiedTimeWasSet = settings.MAP_SOURCES_LOCAL_MODIFIED_TIME.isSet();
+		previousStateHash = settings.MAP_SOURCES_BACKUP_STATE_HASH.get();
+		previousModifiedTime = settings.MAP_SOURCES_LOCAL_MODIFIED_TIME.get();
+		settings.MAP_SOURCES_BACKUP_STATE_HASH.resetToDefault();
+		settings.MAP_SOURCES_LOCAL_MODIFIED_TIME.resetToDefault();
+	}
+
+	@After
+	public void cleanup() {
+		if (stateHashWasSet) {
+			settings.MAP_SOURCES_BACKUP_STATE_HASH.set(previousStateHash);
+		} else {
+			settings.MAP_SOURCES_BACKUP_STATE_HASH.resetToDefault();
+		}
+		if (modifiedTimeWasSet) {
+			settings.MAP_SOURCES_LOCAL_MODIFIED_TIME.set(previousModifiedTime);
+		} else {
+			settings.MAP_SOURCES_LOCAL_MODIFIED_TIME.resetToDefault();
+		}
+		for (File file : filesToDelete) {
+			Algorithms.removeAllFiles(file);
+		}
+	}
+
+	@Test
+	public void stateHashDoesNotDependOnSourceOrder() {
+		ITileSource first = createSource("First", "https://first.example/{0}/{1}/{2}");
+		ITileSource second = createSource("Second", "https://second.example/{0}/{1}/{2}");
+
+		String forwardHash = MapSourcesSettingsItem.getStateHash(Arrays.asList(first, second));
+		String reverseHash = MapSourcesSettingsItem.getStateHash(Arrays.asList(second, first));
+
+		assertEquals(forwardHash, reverseHash);
+	}
+
+	@Test
+	public void jsonWriterPreservesSourceOrder() throws Exception {
+		ITileSource first = createSource("First", "https://first.example/{0}/{1}/{2}");
+		ITileSource second = createSource("Second", "https://second.example/{0}/{1}/{2}");
+		MapSourcesSettingsItem item = new MapSourcesSettingsItem(app, Arrays.asList(second, first));
+
+		JSONObject json = item.writeItemsToJson(new JSONObject());
+
+		assertEquals("Second", json.getJSONArray("items").getJSONObject(0).getString("name"));
+		assertEquals("First", json.getJSONArray("items").getJSONObject(1).getString("name"));
+	}
+
+	@Test
+	public void stateHashChangesWithExportedSourceConfiguration() {
+		TileSourceTemplate source = createSource("Source", "https://example.com/{0}/{1}/{2}");
+		String initialHash = MapSourcesSettingsItem.getStateHash(Collections.singletonList(source));
+
+		source.setReferer("https://osmand.net");
+
+		assertNotEquals(initialHash, MapSourcesSettingsItem.getStateHash(Collections.singletonList(source)));
+	}
+
+	@Test
+	public void stateHashNormalizesMissingAndEmptyJsonStrings() {
+		TileSourceTemplate missingReferer = createSource("Source", "https://example.com/{0}/{1}/{2}");
+		TileSourceTemplate emptyReferer = createSource("Source", "https://example.com/{0}/{1}/{2}");
+		emptyReferer.setReferer("");
+
+		assertEquals(MapSourcesSettingsItem.getStateHash(Collections.singletonList(missingReferer)),
+				MapSourcesSettingsItem.getStateHash(Collections.singletonList(emptyReferer)));
+	}
+
+	@Test
+	public void jsonRoundTripPreservesDirectorySourceState() throws Exception {
+		TileSourceTemplate source = createSource("Directory", "https://example.com/{0}/{1}/{2}.jpg");
+		source.setEllipticYTile(true);
+		source.setInvertedYTile(true);
+		source.setReferer("https://osmand.net");
+		source.setUserAgent("OsmAnd test");
+		source.setRule("template:1");
+
+		MapSourcesSettingsItem original = new MapSourcesSettingsItem(app, Collections.singletonList(source));
+		JSONObject json = original.writeItemsToJson(new JSONObject());
+		MapSourcesSettingsItem restored = new MapSourcesSettingsItem(app, json);
+
+		assertEquals(MapSourcesSettingsItem.getStateHash(original.getItems()),
+				MapSourcesSettingsItem.getStateHash(restored.getItems()));
+	}
+
+	@Test
+	public void sqliteDatabaseRoundTripPreservesBackupState() {
+		String name = TEST_SOURCE_PREFIX + System.nanoTime();
+		File file = app.getAppPath(IndexConstants.TILES_INDEX_DIR + name + IndexConstants.SQLITE_EXT);
+		filesToDelete.add(file);
+		SQLiteTileSource original = SQLiteTileSource.fromBackup(app, name, 3, 16,
+				"https://tiles.example/{0}/{1}/{2}.jpg", "1-4", true, true,
+				"https://example.com/a'b", "OsmAnd test", true, 3_600_000L,
+				true, "template:1", ".jpg", 512, 32, 24_000);
+		String originalHash = MapSourcesSettingsItem.getStateHash(Collections.singletonList(original));
+
+		original.createDataBase();
+		SQLiteTileSource restored = new SQLiteTileSource(app, file, Collections.emptyList());
+		try {
+			assertEquals(originalHash,
+					MapSourcesSettingsItem.getStateHash(Collections.singletonList(restored)));
+		} finally {
+			restored.closeDB();
+		}
+	}
+
+	@Test
+	public void restoredSqliteTileSizeRemainsAutoDetectable() throws Exception {
+		String name = TEST_SOURCE_PREFIX + System.nanoTime();
+		File file = app.getAppPath(IndexConstants.TILES_INDEX_DIR + name + IndexConstants.SQLITE_EXT);
+		filesToDelete.add(file);
+		SQLiteTileSource.fromBackup(app, name, 1, 20, "https://example.com/{0}/{1}/{2}", "",
+				false, false, "", "", false, -1, false, "", ".png", 256, 16, -1).createDataBase();
+		SQLiteTileSource restored = new SQLiteTileSource(app, file, Collections.emptyList());
+		try {
+			String initialHash = MapSourcesSettingsItem.getStateHash(Collections.singletonList(restored));
+			assertEquals(256, restored.getTileSize());
+
+			decodeTile(restored, 512);
+
+			assertEquals(512, restored.getTileSize());
+			assertEquals(initialHash, MapSourcesSettingsItem.getStateHash(Collections.singletonList(restored)));
+		} finally {
+			restored.closeDB();
+		}
+	}
+
+	@Test
+	public void legacySqliteConstructorLeavesTileSizeAutoDetectable() throws Exception {
+		String name = TEST_SOURCE_PREFIX + System.nanoTime();
+		File file = app.getAppPath(IndexConstants.TILES_INDEX_DIR + name + IndexConstants.SQLITE_EXT);
+		filesToDelete.add(file);
+		new SQLiteTileSource(app, name, 1, 20, "https://example.com/{0}/{1}/{2}", "", false,
+				false, "", "", false, -1, false, "").createDataBase();
+		SQLiteTileSource restored = new SQLiteTileSource(app, file, Collections.emptyList());
+		try {
+			restored.initDatabaseIfNeeded();
+			assertEquals(256, restored.getTileSize());
+
+			decodeTile(restored, 512);
+
+			assertEquals(512, restored.getTileSize());
+		} finally {
+			restored.closeDB();
+		}
+	}
+
+	@Test
+	public void autoDetectedSqliteTileSizeDoesNotChangeStateHash() throws Exception {
+		SQLiteTileSource source = createLegacySqliteSource(null, 16);
+		try {
+			String initialHash = MapSourcesSettingsItem.getStateHash(Collections.singletonList(source));
+			assertEquals(256, source.getTileSize());
+
+			decodeTile(source, 512);
+
+			assertEquals(512, source.getTileSize());
+			assertEquals(initialHash, MapSourcesSettingsItem.getStateHash(Collections.singletonList(source)));
+			JSONObject json = new MapSourcesSettingsItem(app, Collections.singletonList(source))
+					.writeItemsToJson(new JSONObject());
+			assertEquals(512, json.getJSONArray("items").getJSONObject(0).getInt("tileSize"));
+		} finally {
+			source.closeDB();
+		}
+	}
+
+	@Test
+	public void sqliteMetadataDefaultsAreNormalizedBeforeBackup() throws Exception {
+		SQLiteTileSource source = createLegacySqliteSource(null, 0);
+		try {
+			MapSourcesSettingsItem original = new MapSourcesSettingsItem(app, Collections.singletonList(source));
+			JSONObject json = original.writeItemsToJson(new JSONObject());
+			MapSourcesSettingsItem restored = new MapSourcesSettingsItem(app, json);
+
+			assertEquals(".png", source.getTileFormat());
+			assertEquals(16, source.getBitDensity());
+			assertEquals(MapSourcesSettingsItem.getStateHash(original.getItems()),
+					MapSourcesSettingsItem.getStateHash(restored.getItems()));
+		} finally {
+			source.closeDB();
+		}
+	}
+
+	@Test
+	public void fileTimestampChangeDoesNotChangeInitializedLogicalTime() throws IOException {
+		TileSourceTemplate source = createSource(TEST_SOURCE_PREFIX + System.nanoTime(), "https://example.com/{0}/{1}/{2}");
+		File metainfo = createMetainfoFile(source.getName());
+		MapSourcesSettingsItem item = new MapSourcesSettingsItem(app, Collections.singletonList(source));
+		long baseline = System.currentTimeMillis() - 60_000L;
+		item.setLocalModifiedTime(baseline);
+
+		assertTrue(metainfo.setLastModified(System.currentTimeMillis()));
+
+		assertEquals(baseline, item.getLocalModifiedTime());
+	}
+
+	@Test
+	public void sqliteFileTimestampChangeDoesNotChangeInitializedLogicalTime() {
+		SQLiteTileSource source = createLegacySqliteSource(null, 16);
+		try {
+			File file = app.getAppPath(IndexConstants.TILES_INDEX_DIR + source.getName() + IndexConstants.SQLITE_EXT);
+			MapSourcesSettingsItem item = new MapSourcesSettingsItem(app, Collections.singletonList(source));
+			long baseline = System.currentTimeMillis() - 60_000L;
+			item.setLocalModifiedTime(baseline);
+
+			assertTrue(file.setLastModified(System.currentTimeMillis()));
+
+			assertEquals(baseline, item.getLocalModifiedTime());
+		} finally {
+			source.closeDB();
+		}
+	}
+
+	@Test
+	public void sourceConfigurationChangeAdvancesLogicalTime() {
+		TileSourceTemplate source = createSource("Source", "https://example.com/{0}/{1}/{2}");
+		MapSourcesSettingsItem item = new MapSourcesSettingsItem(app, Collections.singletonList(source));
+		long baseline = System.currentTimeMillis() - 60_000L;
+		item.setLocalModifiedTime(baseline);
+
+		source.setReferer("https://osmand.net");
+
+		assertTrue(item.getLocalModifiedTime() > baseline);
+	}
+
+	@Test
+	public void cloudModifiedTimeRemainsStableWhenStateDoesNotChange() {
+		TileSourceTemplate source = createSource("Source", "https://example.com/{0}/{1}/{2}");
+		MapSourcesSettingsItem item = new MapSourcesSettingsItem(app, Collections.singletonList(source));
+		long remoteTime = System.currentTimeMillis() - 60_000L;
+
+		item.setLocalModifiedTime(remoteTime);
+
+		assertEquals(remoteTime, item.getLocalModifiedTime());
+	}
+
+	@Test
+	public void firstInitializationPreservesLegacyModifiedTime() throws IOException {
+		TileSourceTemplate source = createSource(TEST_SOURCE_PREFIX + System.nanoTime(), "https://example.com/{0}/{1}/{2}");
+		File metainfo = createMetainfoFile(source.getName());
+		assertTrue(metainfo.setLastModified(System.currentTimeMillis() - 60_000L));
+		long legacyTime = metainfo.lastModified();
+		MapSourcesSettingsItem item = new MapSourcesSettingsItem(app, Collections.singletonList(source));
+
+		assertEquals(legacyTime, item.getLocalModifiedTime());
+		assertNotEquals("", settings.MAP_SOURCES_BACKUP_STATE_HASH.get());
+		assertEquals(legacyTime, settings.MAP_SOURCES_LOCAL_MODIFIED_TIME.get().longValue());
+	}
+
+	@Test
+	public void interruptedFirstInitializationReusesStoredModifiedTime() throws IOException {
+		TileSourceTemplate source = createSource(TEST_SOURCE_PREFIX + System.nanoTime(), "https://example.com/{0}/{1}/{2}");
+		File metainfo = createMetainfoFile(source.getName());
+		assertTrue(metainfo.setLastModified(System.currentTimeMillis()));
+		// The time was stored, the hash was not: the previous initialization was interrupted.
+		long interruptedTime = System.currentTimeMillis() - 120_000L;
+		settings.MAP_SOURCES_LOCAL_MODIFIED_TIME.set(interruptedTime);
+		MapSourcesSettingsItem item = new MapSourcesSettingsItem(app, Collections.singletonList(source));
+
+		assertEquals(interruptedTime, item.getLocalModifiedTime());
+		assertNotEquals("", settings.MAP_SOURCES_BACKUP_STATE_HASH.get());
+	}
+
+	private File createMetainfoFile(String sourceName) throws IOException {
+		File sourceDirectory = app.getAppPath(IndexConstants.TILES_INDEX_DIR + sourceName);
+		filesToDelete.add(sourceDirectory);
+		assertTrue(sourceDirectory.exists() || sourceDirectory.mkdirs());
+		File metainfo = new File(sourceDirectory, ".metainfo");
+		assertTrue(metainfo.exists() || metainfo.createNewFile());
+		return metainfo;
+	}
+
+	private SQLiteTileSource createLegacySqliteSource(String tileFormat, int bitDensity) {
+		String name = TEST_SOURCE_PREFIX + System.nanoTime();
+		File file = app.getAppPath(IndexConstants.TILES_INDEX_DIR + name + IndexConstants.SQLITE_EXT);
+		filesToDelete.add(file);
+		SQLiteConnection db = app.getSQLiteAPI().getOrCreateDatabase(file.getAbsolutePath(), true);
+		assertNotNull(db);
+		try {
+			db.execSQL("CREATE TABLE tiles (x int, y int, z int, s int, image blob, PRIMARY KEY (x,y,z,s))");
+			db.execSQL("CREATE TABLE info(tilenumbering, minzoom, maxzoom, url, ext, img_density)");
+			db.execSQL("INSERT INTO info (tilenumbering, minzoom, maxzoom, url, ext, img_density) "
+					+ "VALUES (?, ?, ?, ?, ?, ?)", new Object[] {"simple", 1, 20,
+					"https://example.com/{0}/{1}/{2}", tileFormat, bitDensity});
+		} finally {
+			db.close();
+		}
+		return new SQLiteTileSource(app, file, Collections.emptyList());
+	}
+
+	private static void decodeTile(SQLiteTileSource source, int tileSize) throws IOException {
+		Bitmap bitmap = Bitmap.createBitmap(tileSize, tileSize, Bitmap.Config.ARGB_8888);
+		ByteArrayOutputStream output = new ByteArrayOutputStream();
+		try {
+			assertTrue(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output));
+			Bitmap decoded = source.getImage(output.toByteArray(), new String[] {"0", "0", "1"});
+			assertNotNull(decoded);
+			decoded.recycle();
+		} finally {
+			bitmap.recycle();
+			output.close();
+		}
+	}
+
+	private static TileSourceTemplate createSource(String name, String url) {
+		TileSourceTemplate source = new TileSourceTemplate(name, url, ".png", 20, 1, 256, 16, 12_000);
+		source.setRandoms("1-4");
+		source.setExpirationTimeMinutes(60);
+		return source;
+	}
+}


### PR DESCRIPTION
## Problem

Map Sources currently uses filesystem modification times as the local modification time for Backup / Cloud Sync.

This is unreliable for SQLite Map Sources because the same `.sqlitedb` file is also used as a tile cache. Normal map usage can therefore modify the file timestamp even when the Map Source configuration itself has not changed.

As a result, Map Sources may repeatedly appear as a **Local Change** and can produce a false conflict when a newer Cloud version is also available.

Directory-based sources have a similar problem because `.metainfo` modification time also represents filesystem activity rather than a semantic change to the Map Source configuration.

## Solution

This PR separates the semantic state of Map Sources from filesystem modification times.

The new model is:

```text
Map Source configuration
        ↓
canonical backup state
        ├── JSON backup representation
        └── deterministic semantic hash
                         ↓
              logical modification time
````

Two local metadata preferences are used:

* `MAP_SOURCES_BACKUP_STATE_HASH`
* `MAP_SOURCES_LOCAL_MODIFIED_TIME`

Both are `global`, but not `shared`, so they are persisted on the current device without becoming part of `general_settings.json` or creating Global Settings changes themselves.

After initialization, filesystem timestamps are no longer used to determine whether Map Sources have changed.

This means that:

* SQLite tile-cache writes do not create Map Sources Local Changes;
* `.sqlitedb` filesystem mtime changes alone do not affect Sync state;
* `.metainfo` filesystem mtime changes alone do not affect Sync state;
* actual Map Source configuration changes still update the logical modification time.

## Canonical Map Source state

`MapSourceBackupState` is used as the common representation for both:

* Map Sources JSON backup;
* semantic state calculation.

Each `ITileSource` is read once into a snapshot containing the fields that are actually exported.

This avoids maintaining two separate lists of Map Source properties where a new field could be added to backup serialization but accidentally omitted from change detection.

Equivalent `null` / empty values are normalized before the canonical state is generated.

The source states are sorted before calculating the hash.

This is required because `getTileSourceEntries()` orders Map Source files by filesystem `lastModified()`. A normal SQLite cache write can therefore change the order of sources even when no configuration changed.

Without canonical sorting, the semantic hash could still change because of tile-cache activity through source ordering.

JSON export remains based on the same backup snapshots, while hash ordering is treated independently from the physical file ordering.

## Logical modification time

The stored semantic hash represents the last known Map Sources configuration.

When the current state differs from the stored state, the logical local modification time is updated and the new hash is persisted.

The persistence order is intentional:

```text
logical modification time
→ state hash
```

The hash is written last so that an interrupted write cannot mark a new state as already processed before its logical timestamp has been stored.

### Interrupted initialization

The first initialization is also crash-safe.

If the logical timestamp has already been stored but the state hash is still missing, the existing timestamp is reused instead of reading the filesystem modification time again.

This handles a process interruption between the two metadata writes and avoids depending again on a potentially changed SQLite mtime.

## Migration from filesystem timestamps

On the first run after updating, the previous filesystem-based modification time is used once as the initial logical modification time.

This is intentional.

Ignoring the legacy timestamp completely could hide a real unsynced Map Source change that was made before the application update.

The initialization order is also important:

```text
1. read legacy filesystem modification time
2. build current semantic Map Source state
3. persist logical modification time
4. persist semantic hash
```

The legacy mtime must be read before building the semantic state because reading an older SQLite source can initialize its database metadata and modify the `.sqlitedb` file itself.

After this one-time initialization, filesystem timestamps no longer participate in normal change detection.

## SQLite backup / restore

While implementing semantic state tracking, an existing SQLite backup/restore inconsistency was found.

Some Map Source properties exported to backup were not fully restored into the SQLite `info` table.

This could cause:

```text
backup state
→ restore
→ read restored SQLite source
→ different semantic state
```

and consequently produce another Local Change immediately after restore.

The SQLite restore path now preserves the relevant source metadata, including BigPlanet / inversive zoom configuration and the exported SQLite source properties required for a stable round trip.

The intended invariant is:

```text
Map Source state A
→ backup
→ restore
→ read from disk
→ Map Source state A
```

### SQLite tile size

`tileSize` requires special handling.

For directory/template sources it is stable Map Source configuration and participates in semantic change detection.

For SQLite sources it can also be detected automatically at runtime from decoded tiles and written back into the database.

Therefore:

* SQLite `tileSize` is not treated as a semantic change trigger;
* runtime tile-size detection does not create a Sync Local Change;
* a value read from backup is not automatically materialized as an explicitly specified SQLite tile size;
* the existing runtime auto-detection behavior remains available.

`bitDensity` and average image size remain part of the semantic state because the reviewed code does not mutate them as a result of normal runtime tile-cache activity.

## SQLite metadata compatibility

The SQLite `info` metadata written by this change is additive.

The existing metadata format is preserved where possible.

Because `.sqlitedb` Map Sources may also be consumed by iOS and other OsmAnd components, metadata column names should be treated as part of a cross-platform file-format contract rather than as Android-only implementation details.

No cosmetic schema renaming should be made without checking compatibility with the iOS implementation and other readers.

## Validation

Regression coverage was added for:

* deterministic semantic hashing;
* source ordering not affecting the hash;
* semantic configuration changes affecting the hash;
* equivalent `null` / empty values producing equivalent state;
* directory Map Source backup / restore round trip;
* SQLite Map Source backup / restore round trip;
* BigPlanet / inversive zoom persistence;
* SQLite metadata persistence;
* legacy SQLite metadata normalization;
* preservation of SQLite tile-size auto-detection;
* runtime-detected SQLite tile size not changing semantic state;
* `.metainfo` filesystem timestamp changes not changing logical modification time;
* `.sqlitedb` filesystem timestamp changes not changing logical modification time;
* remote modification-time restoration;
* first initialization using the legacy modification time;
* interrupted first initialization reusing the already stored logical timestamp.

Android `main` and `androidTest` compilation passes successfully.

The instrumentation tests compile successfully but still require a real emulator/device run before merge.

## Scope

This PR fixes the **Map Sources** false Local Change mechanism caused by filesystem modification times and SQLite cache activity.

It does not change the general Cloud Sync conflict algorithm.

It also does **not** fix Online Routing.

Online Routing uses a separate preference-based modification-time mechanism and should be investigated independently from this Map Sources fix.
