### PR TITLE
Stop the offscreen renderer that setupOffscreenRenderer() drops (backport of #25936)

### DIFF
--- a/OsmAnd/src/net/osmand/plus/auto/SurfaceRenderer.java
+++ b/OsmAnd/src/net/osmand/plus/auto/SurfaceRenderer.java
@@ -393,6 +393,13 @@ public final class SurfaceRenderer implements DefaultLifecycleObserver, MapRende
 				if (offscreenMapRendererView != null) {
 					MapRendererContext mapRendererContext = NativeCoreContext.getMapRendererContext();
 					if (mapRendererContext != null && mapRendererContext.getMapRendererView() != offscreenMapRendererView) {
+						// The context doesn't refer to the view anymore: either the phone took its
+						// renderer over, or recreateAndroidAutoRenderer() dropped it. In the latter
+						// case the renderer is still alive and nothing else is going to stop it
+						if (mapView != null && mapView.getMapRenderer() == offscreenMapRendererView) {
+							mapView.detachMapRenderer();
+						}
+						offscreenMapRendererView.stopRenderer();
 						offscreenMapRendererView = null;
 					}
 				}


### PR DESCRIPTION
Backport of #25936 to `r5.4`. Cherry-picked unchanged — `SurfaceRenderer.java` on this branch is byte-identical to the file on `master`. Seven lines, one file.

`setupOffscreenRenderer()` forgets its offscreen view as soon as the renderer context no longer refers to it. That is right when the phone took the renderer over, but `recreateAndroidAutoRenderer()` gets there by clearing the context reference on purpose, and the view is still alive: its renderer, EGL thread and GPU resources were leaked and a fresh set created next to them. The dev plugin's MSAA switch calls it on every toggle while a car session runs.

The view is stopped instead of dropped.

**Requires** the core backport osmandapp/OsmAnd-core#1115 — on a view whose renderer was handed over, `stopRenderer()` is a no-op only with the ownership guard from that change.

**Verified** on a Pixel 9 Pro XL with Android Auto over the Desktop Head Unit: four MSAA toggles with a car session running produce four `Stopping active renderer` and eight fresh renderers, and the number of live `OpenGLThread` threads stays at one.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Explain why the two renderer PRs do not fix the rotation ANR, and why the wait cannot be bounded where it is.
2. Check the Play ANR cluster for 5.4 and for the last 28 days.
3. Advise what to move into 5.4.
4. Compose the 5.4 pull requests from the small, already-verified extracts.

Decided by the agent, not requested explicitly: verifying the cherry-pick is byte-identical to `master` before opening this.
