### PR TITLE
Search POI by name without building an object per candidate

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/binary/BinaryMapIndexReaderStats.java
+++ b/OsmAnd-java/src/main/java/net/osmand/binary/BinaryMapIndexReaderStats.java
@@ -37,7 +37,10 @@ public class BinaryMapIndexReaderStats {
 		long decodeTimeNs;
 		long matcherTimeNs;
 		long blocksLoaded;
+		/** Atoms examined, whether or not an Amenity was built for them. */
 		long objectsLoaded;
+		/** Atoms decoded into an Amenity. Equal to objectsLoaded until the name probe skips one. */
+		long objectsBuilt;
 		long matchedObjectsLoaded;
 		long maxObjectsPerBlock;
 		private long objectsLoadedBefore, payloadBytesParsedBefore;
@@ -62,7 +65,7 @@ public class BinaryMapIndexReaderStats {
 		public final String mapName;
 		private long time = 0, count = 0, calls = 0, bytes = 0;
 		private long payloadBytesParsed = 0, decodeTime = 0, matcherTime = 0;
-		private long blocksLoaded = 0, objectsLoaded = 0, matchedObjects = 0, maxObjectsPerBlock = 0;
+		private long blocksLoaded = 0, objectsLoaded = 0, objectsBuilt = 0, matchedObjects = 0, maxObjectsPerBlock = 0;
 
 		SubStatByAPI(BinaryMapIndexReaderApiName api, BinaryMapIndexReaderSubApiName subApi, String mapName) {
 			this.api = api;
@@ -86,6 +89,7 @@ public class BinaryMapIndexReaderStats {
 			this.matcherTime +=  metrics.matcherTimeNs;
 			this.blocksLoaded += metrics.blocksLoaded;
 			this.objectsLoaded += metrics.objectsLoaded;
+			this.objectsBuilt += metrics.objectsBuilt;
 			this.matchedObjects += metrics.matchedObjectsLoaded;
 			this.maxObjectsPerBlock = Math.max(this.maxObjectsPerBlock,  metrics.maxObjectsPerBlock);
 			calls++;
@@ -125,6 +129,11 @@ public class BinaryMapIndexReaderStats {
 
 		public long getObjectsLoaded() {
 			return objectsLoaded;
+		}
+
+		/** Of {@link #getObjectsLoaded()}, the ones that were decoded into an object. */
+		public long getObjectsBuilt() {
+			return objectsBuilt;
 		}
 
 		public long getMatchedObjects() {
@@ -214,6 +223,7 @@ public class BinaryMapIndexReaderStats {
 					agg.matcherTime += st.matcherTime;
 					agg.blocksLoaded += st.blocksLoaded;
 					agg.objectsLoaded += st.objectsLoaded;
+					agg.objectsBuilt += st.objectsBuilt;
 					agg.matchedObjects += st.matchedObjects;
 					agg.maxObjectsPerBlock = Math.max(agg.maxObjectsPerBlock, st.maxObjectsPerBlock);
 					agg.calls += st.calls;
@@ -335,6 +345,11 @@ public class BinaryMapIndexReaderStats {
 		                                  Map<String, SubStatByAPI> totalsByApiObf,
 		                                  int subApiCount) {
 
+			/** Objects built against objects examined; the two differ once the name probe skips atoms. */
+			private static String builtOf(SubStatByAPI stat) {
+				return String.format(Locale.US, "%d/%d", stat.objectsBuilt, stat.objectsLoaded);
+			}
+
 			private String renderDetailedString(Map<String, WordSearchStat>  wordStats, long totalTime, long totalBytes, int topKObf) {
 				int w1 = c1.length(), w2 = c2.length(), w3 = c3.length(), w4 = c4.length(), w5 = c5.length(), w6 = c6.length(),
 						w9 = c9.length(), w10 = c10.length(), w11 = c11.length(),
@@ -407,7 +422,7 @@ public class BinaryMapIndexReaderStats {
 							.append(padLeft(String.format(Locale.US, "%.2f", apiTotal.decodeTime / 1e6), w10)).append(", ")
 							.append(padLeft(String.format(Locale.US, "%.2f", apiTotal.matcherTime / 1e6), w11)).append(", ")
 							.append(padLeft(String.format(Locale.US, "% d", apiTotal.blocksLoaded), w12)).append(", ")
-							.append(padLeft(String.format(Locale.US, "% d", apiTotal.objectsLoaded), w13)).append(", ")
+							.append(padLeft(builtOf(apiTotal), w13)).append(", ")
 							.append(padLeft(String.format(Locale.US, "% d", apiTotal.matchedObjects), w14)).append(", ")
 							.append(padLeft(String.format(Locale.US, "% d", apiTotal.maxObjectsPerBlock), w15));
 
@@ -436,7 +451,7 @@ public class BinaryMapIndexReaderStats {
 								.append(padLeft(String.format(Locale.US, "%.2f", subTotal.decodeTime / 1e6), w10)).append(", ")
 								.append(padLeft(String.format(Locale.US, "%.2f", subTotal.matcherTime / 1e6), w11)).append(", ")
 								.append(padLeft(String.format(Locale.US, "% d", subTotal.blocksLoaded), w12)).append(", ")
-								.append(padLeft(String.format(Locale.US, "% d", subTotal.objectsLoaded), w13)).append(", ")
+								.append(padLeft(builtOf(subTotal), w13)).append(", ")
 								.append(padLeft(String.format(Locale.US, "% d", subTotal.matchedObjects), w14)).append(", ")
 								.append(padLeft(String.format(Locale.US, "% d", subTotal.maxObjectsPerBlock), w15));
 
@@ -458,7 +473,7 @@ public class BinaryMapIndexReaderStats {
 									.append(padLeft(String.format(Locale.US, "%.2f", st.decodeTime / 1e6), w10)).append(", ")
 									.append(padLeft(String.format(Locale.US, "%.2f", st.matcherTime / 1e6), w11)).append(", ")
 									.append(padLeft(String.format(Locale.US, "% d", st.blocksLoaded), w12)).append(", ")
-									.append(padLeft(String.format(Locale.US, "% d", st.objectsLoaded), w13)).append(", ")
+									.append(padLeft(builtOf(st), w13)).append(", ")
 									.append(padLeft(String.format(Locale.US, "% d", st.matchedObjects), w14)).append(", ")
 									.append(padLeft(String.format(Locale.US, "% d", st.maxObjectsPerBlock), w15));
 						}
@@ -486,7 +501,7 @@ public class BinaryMapIndexReaderStats {
 							.append(", ").append(String.format(Locale.US, "%.2f", obfTotal.time / 1e9))
 							.append(",").append(String.format(Locale.US, "% d", obfTotal.payloadBytesParsed / 1024))
 							.append(", ").append(String.format(Locale.US, "%d", obfTotal.blocksLoaded))
-							.append(", ").append(String.format(Locale.US, "%d", obfTotal.objectsLoaded))
+							.append(", ").append(builtOf(obfTotal))
 							.append(", ").append(String.format(Locale.US, "%d", obfTotal.matchedObjects));
 				}
 				return sb.toString();
@@ -511,7 +526,7 @@ public class BinaryMapIndexReaderStats {
 			String c1 = "API       ", c2 = String.format(Locale.US, "Sub-API / Top-%d OBF                             ", topKObf), c3 = "Time (s)",
 					c4 = "Count (O)", c5 = "Volume (KB)", c6 = "Calls",
 					c9 = "Payload (KB)", c10 = "Decode (ms)", c11 = "Matcher (ms)",
-					c12 = "Blocks", c13 = "Objects", c14 = "Matched", c15 = "Max Obj/Block";
+					c12 = "Blocks", c13 = "Built/Objects", c14 = "Matched", c15 = "Max Obj/Block";
 
 			Map<BinaryMapIndexReaderApiName, Map<BinaryMapIndexReaderSubApiName, List<SubStatByAPI>>> rows = new HashMap<>();
 			Map<BinaryMapIndexReaderApiName, Map<BinaryMapIndexReaderSubApiName, SubStatByAPI>> totalsByApiSubApi = new HashMap<>();
@@ -550,6 +565,7 @@ public class BinaryMapIndexReaderStats {
 							obfTotal.matcherTime += st.matcherTime;
 							obfTotal.blocksLoaded += st.blocksLoaded;
 							obfTotal.objectsLoaded += st.objectsLoaded;
+							obfTotal.objectsBuilt += st.objectsBuilt;
 							obfTotal.matchedObjects += st.matchedObjects;
 							obfTotal.maxObjectsPerBlock = Math.max(obfTotal.maxObjectsPerBlock, st.maxObjectsPerBlock);
 							obfTotal.calls += st.calls;
@@ -569,6 +585,7 @@ public class BinaryMapIndexReaderStats {
 						subTotal.matcherTime += st.matcherTime;
 						subTotal.blocksLoaded += st.blocksLoaded;
 						subTotal.objectsLoaded += st.objectsLoaded;
+						subTotal.objectsBuilt += st.objectsBuilt;
 						subTotal.matchedObjects += st.matchedObjects;
 						subTotal.maxObjectsPerBlock = Math.max(subTotal.maxObjectsPerBlock, st.maxObjectsPerBlock);
 						subTotal.calls += st.calls;
@@ -583,6 +600,7 @@ public class BinaryMapIndexReaderStats {
 						apiTotal.matcherTime += st.matcherTime;
 						apiTotal.blocksLoaded += st.blocksLoaded;
 						apiTotal.objectsLoaded += st.objectsLoaded;
+						apiTotal.objectsBuilt += st.objectsBuilt;
 						apiTotal.matchedObjects += st.matchedObjects;
 						apiTotal.maxObjectsPerBlock = Math.max(apiTotal.maxObjectsPerBlock, st.maxObjectsPerBlock);
 						apiTotal.calls += st.calls;

--- a/OsmAnd-java/src/main/java/net/osmand/binary/BinaryMapPoiReaderAdapter.java
+++ b/OsmAnd-java/src/main/java/net/osmand/binary/BinaryMapPoiReaderAdapter.java
@@ -39,6 +39,9 @@ import net.osmand.binary.OsmandOdb.CommonIndexedStats;
 import net.osmand.binary.OsmandOdb.OsmAndPoiNameIndex.OsmAndPoiNameIndexData;
 import net.osmand.data.Amenity;
 import net.osmand.data.Amenity.AmenityRoutePoint;
+import net.osmand.data.MapObject;
+import net.osmand.util.Algorithms;
+import net.osmand.util.TransliterationHelper;
 import net.osmand.data.LatLon;
 import net.osmand.data.QuadRect;
 import net.osmand.osm.MapPoiTypes;
@@ -892,15 +895,38 @@ public class BinaryMapPoiReaderAdapter {
 			case OsmandOdb.OsmAndPoiBoxData.POIDATA_FIELD_NUMBER:
 				long decodeStartNs = 0, matcherStartNs = 0;
 				if (metrics != null) {
+					// every atom is examined; objectsBuilt below counts the ones decoded into an object
 					metrics.objectsLoaded++;
 					decodeStartNs = System.nanoTime();
 				}
 				int len = codedIS.readRawVarint32();
+				long start = codedIS.getTotalBytesRead();
 				long oldLim = codedIS.pushLimitLong((long) len);
 
+				if (USE_NAME_PROBE) {
+					// Test every name as it is decoded and build nothing for the rest. Only a few
+					// candidates in a thousand match, and those are read a second time below.
+					boolean probeMatches = probePoiName(matcher, region);
+					codedIS.skipRawBytes(codedIS.getBytesUntilLimit());
+					if (metrics != null) {
+						metrics.decodeTimeNs += System.nanoTime() - decodeStartNs;
+					}
+					codedIS.popLimit(oldLim);
+					if (!probeMatches) {
+						break;
+					}
+					codedIS.seek(start);
+					oldLim = codedIS.pushLimitLong((long) len);
+				}
+
+				if (metrics != null) {
+					metrics.objectsBuilt++;
+				}
 				Amenity am = readPoiPoint(0, Integer.MAX_VALUE, 0, Integer.MAX_VALUE, x, y, zoom, req, region, false);
 				if (metrics != null)  {
-					metrics.decodeTimeNs += System.nanoTime() - decodeStartNs;
+					if (!USE_NAME_PROBE) {
+						metrics.decodeTimeNs += System.nanoTime() - decodeStartNs;
+					}
 					matcherStartNs = System.nanoTime();
 				}
 				codedIS.popLimit(oldLim);
@@ -1030,6 +1056,170 @@ public class BinaryMapPoiReaderAdapter {
 					arp.pointB.getLatitude(), arp.pointB.getLongitude());
 		}
 		return arp;
+	}
+
+	/**
+	 * When set, {@link #readPoiData(CollatorStringMatcher, SearchRequest, PoiRegion, BinaryMapIndexReaderStats.PoiReadMetricSet)}
+	 * matches names as they are decoded instead of building an {@link Amenity} for every candidate.
+	 * Kept as a switch so the two paths can be compared on real maps; they must publish the same objects.
+	 */
+	static boolean USE_NAME_PROBE = true;
+
+	/**
+	 * Reads one {@code OsmAndPoiBoxDataAtom} and answers only whether the name search accepts it,
+	 * without allocating an {@link Amenity}, its additional info map or its name list. The strings
+	 * tested are the ones {@code readPoiData} would have tested on the built object, in the order
+	 * they appear in the block instead of the order the getters return them; the answer is their OR,
+	 * so it does not depend on that order.
+	 *
+	 * The caller is left anywhere inside the atom and has to skip to its end.
+	 */
+	private boolean probePoiName(CollatorStringMatcher matcher, PoiRegion region) throws IOException {
+		boolean matched = false;
+		boolean hasType = false;
+		String name = null;
+		boolean hasEnName = false;
+		StringBuilder retValue = new StringBuilder();
+		LinkedList<String> textTags = null;
+		while (true) {
+			int t = codedIS.readTag();
+			int tag = WireFormat.getTagFieldNumber(t);
+			if (!hasType && (tag > OsmandOdb.OsmAndPoiBoxDataAtom.CATEGORIES_FIELD_NUMBER || tag == 0)) {
+				// readPoiPoint gives up on an atom with no category, so nothing can match
+				return false;
+			}
+			// a tag and a value that setAdditionalInfo would have routed, filled in by the two cases
+			// that carry them; the routing is shared below because both feed the same fields
+			String pendingKey = null;
+			String pendingValue = null;
+			switch (tag) {
+			case 0:
+				if (!matched && !hasEnName && !Algorithms.isEmpty(name)) {
+					// Amenity.getEnName(true) transliterates the name, and whether it is needed is
+					// only known once the atom has ended without an english name
+					matched = matcher.matches(TransliterationHelper.transliterate(name).toLowerCase(Locale.ROOT));
+				}
+				return matched;
+			case OsmandOdb.OsmAndPoiBoxDataAtom.CATEGORIES_FIELD_NUMBER:
+				codedIS.readUInt32();
+				hasType = true;
+				break;
+			case OsmandOdb.OsmAndPoiBoxDataAtom.NAME_FIELD_NUMBER:
+				pendingKey = "name";
+				pendingValue = codedIS.readString();
+				break;
+			case OsmandOdb.OsmAndPoiBoxDataAtom.NAMEEN_FIELD_NUMBER:
+				pendingKey = "name:en";
+				pendingValue = codedIS.readString();
+				break;
+			case OsmandOdb.OsmAndPoiBoxDataAtom.SUBCATEGORIES_FIELD_NUMBER: {
+				int subtypev = codedIS.readUInt32();
+				retValue.setLength(0);
+				PoiSubType st = region.getSubtypeFromId(subtypev, retValue);
+				if (st != null) {
+					pendingKey = st.name;
+					pendingValue = retValue.toString();
+				}
+				break;
+			}
+			case OsmandOdb.OsmAndPoiBoxDataAtom.TEXTCATEGORIES_FIELD_NUMBER: {
+				int texttypev = codedIS.readUInt32();
+				retValue.setLength(0);
+				PoiSubType textt = region.getSubtypeFromId(texttypev, retValue);
+				if (textt != null && textt.text) {
+					if (textTags == null) {
+						textTags = new LinkedList<String>();
+					}
+					textTags.add(textt.name);
+				}
+				break;
+			}
+			case OsmandOdb.OsmAndPoiBoxDataAtom.TEXTVALUES_FIELD_NUMBER: {
+				String str = codedIS.readString();
+				if (textTags != null && !textTags.isEmpty()) {
+					pendingKey = textTags.poll();
+					pendingValue = str;
+				}
+				break;
+			}
+			default:
+				skipUnknownField(t);
+				break;
+			}
+			if (pendingKey == null) {
+				continue;
+			}
+			switch (nameRole(pendingKey)) {
+			case NAME:
+				// the name can arrive as field 6 or as a "name" text value; either way it is the
+				// string getName() would return, and the one transliterated at the end
+				name = MapObject.unzipContent(pendingValue);
+				if (!matched) {
+					matched = matcher.matches(name.toLowerCase(Locale.ROOT));
+				}
+				break;
+			case EN_NAME: {
+				String enName = MapObject.unzipContent(pendingValue);
+				hasEnName = !Algorithms.isEmpty(enName);
+				if (!matched) {
+					matched = matcher.matches(enName.toLowerCase(Locale.ROOT));
+				}
+				break;
+			}
+			case LOCALIZED_NAME:
+				if (!matched) {
+					matched = matcher.matches(MapObject.unzipContent(pendingValue).toLowerCase(Locale.ROOT));
+				}
+				break;
+			case ADDITIONAL_INFO:
+				// note the asymmetry kept from readPoiData: additional info is not lowercased
+				if (!matched) {
+					matched = matcher.matches(MapObject.unzipContent(pendingValue));
+				}
+				break;
+			default:
+				break;
+			}
+		}
+	}
+
+	/**
+	 * Where {@code Amenity.setAdditionalInfo} would have put a tag, which is what decides whether
+	 * the name search ever compares its value.
+	 */
+	private enum NameRole {
+		/** Stored, but never compared: an unindexed tag, or a bookkeeping language. */
+		IGNORED,
+		/** The name itself, and the string {@code getEnName(true)} transliterates. */
+		NAME,
+		/** The english name, which suppresses that transliteration. */
+		EN_NAME,
+		/** A localized name, compared through {@code getOtherNames()}. */
+		LOCALIZED_NAME,
+		/** Additional info that one of the four indexed-for-search predicates accepts. */
+		ADDITIONAL_INFO,
+	}
+
+	private static NameRole nameRole(String tag) {
+		if ("name".equals(tag)) {
+			return NameRole.NAME;
+		}
+		if (MapObject.isNameLangTag(tag)) {
+			String lang = tag.substring("name:".length());
+			if (lang.equals("en")) {
+				return NameRole.EN_NAME;
+			}
+			if (lang.equals(MapObject.NAME_ADMIN_LEVEL_ATTR) || lang.equals(MapObject.NAME_PLACE_ATTR)
+					|| lang.contains(MapObject.NAME_ETYMOLOGY_ATTR) || lang.equals(MapObject.NAME_WIKIDATA_ATTR)) {
+				return NameRole.IGNORED;
+			}
+			return NameRole.LOCALIZED_NAME;
+		}
+		if (isTagIndexedForSearchAsName(tag) || isTagNonIndexedForSearchAsName(tag)
+				|| isTagIndexedForSearchAsId(tag) || isTagIndexedAsSearchRelated(tag)) {
+			return NameRole.ADDITIONAL_INFO;
+		}
+		return NameRole.IGNORED;
 	}
 
 	private Amenity readPoiPoint(int left31, int right31, int top31, int bottom31,


### PR DESCRIPTION
`searchPoiByName` decoded every candidate into an `Amenity` — a `LinkedHashMap` of additional info, the localized names, and `getOtherNames()` allocating a list on top — and then threw all of it away for everything that did not match. A 10 km search for «аптека» over `Russia_moscow_asia` builds **65 169 objects and publishes 323**.

`readPoiData` now tests each name as it comes off the stream and builds nothing for the rest. An atom that matches is read a second time by the existing `readPoiPoint`, which is left untouched, so the search by area is not affected; re-reading costs nothing at 0.5 % of candidates.

`readPoiPoint` is deliberately not restructured — it is shared with the area search and carries the bbox, `precisionXY`, tag groups and `poiTypeFilter` logic.

### What the probe has to reproduce

Where `Amenity.setAdditionalInfo` would have routed a tag, because that decides whether the search ever compares its value:

- `name` → the name;
- `name:xx` → a localized name, which reaches the comparison through `getOtherNames()`, and that drops `admin_level`, `place`, `etymology` and `wikidata`;
- anything else → additional info, compared only when one of the four indexed-for-search predicates holds.

Two details are easy to lose, and the test covers both:

1. **The name can arrive as a text value rather than as field 6**, and it has to be remembered either way, because `getEnName(true)` transliterates it at the end of the atom. Getting this wrong silently loses every result that is found only through transliteration — «Апостроф» for the query `apo` — while everything with a latin string still matches, so counts look plausible.
2. **Additional info is matched without the `toLowerCase`** that the names get. The asymmetry is in the current code and is kept.

### Counters

`PoiReadMetricSet` counted one thing that has now become two: `objectsLoaded` keeps its meaning of atoms examined, `objectsBuilt` is added for the ones decoded into an object. The detailed stats column prints them as `built/objects` rather than growing a fifteen-column table by one more.

### Verification

Three regional maps — Kyiv 73 MB, Moscow 317 MB, Upper Bavaria 549 MB — 27 queries each with and without a bbox, so 162 searches and **182 651 published objects. Both paths publish exactly the same ones**, compared by id, name, type, subtype, location and other names, not by count.

```
аптека:  probe     examined 65169  built   323  matched 323
         no probe  examined 65169  built 65169  matched 323
```

`SearchUICoreTest` (60 cases), `SearchUICoreGenericTest`, `LocationSearchTest`, `SpatialSearchContextTest` and the rest of `OsmAnd-java` pass.

The comparison harness is not part of this change: the maps are not in the repository, so a test over them could only ever skip. It can be added if a place for tests that need real maps exists.

### Numbers

Time for a poi-name search over those maps, best of five after three warmups:

| map | query | candidates | builds objects | probes | |
|---|---|---:|---:|---:|---:|
| Upper Bavaria | apotheke | 61 667 | 92.5 | 79.1 | 1.17× |
| Upper Bavaria | bäckerei | 56 783 | 82.6 | 71.9 | 1.15× |
| Upper Bavaria | aldi | 35 407 | 68.0 | 61.7 | 1.10× |
| Moscow | аптека | 37 387 | 67.5 | 57.9 | 1.17× |
| Moscow | пятёрочка | 31 749 | 46.9 | 41.7 | 1.12× |
| Moscow | шоколадница | 7 793 | 13.2 | 12.0 | 1.10× |
| Kyiv | аптека | 25 524 | 50.3 | 45.4 | 1.11× |
| Kyiv | макдональдс | 21 601 | 38.2 | 32.1 | 1.19× |
| Kyiv | сільпо | 12 270 | 27.0 | 25.9 | 1.04× |

Median 1.12×.

### Open question for review

`USE_NAME_PROBE` exists so the test can run both paths against each other. Worth deciding whether to keep it.
