### PR TITLE
Routing to OsmAnd-shared, step 17: the request half of RoutingContext

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/RoutingContext.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RoutingContext.java
@@ -44,9 +44,10 @@ import net.osmand.shared.util.collections.KTIntObjectIterator;
 import net.osmand.shared.routing.RouteSegmentResult;
 import net.osmand.shared.routing.VehicleRouter;
 import net.osmand.shared.routing.GeneralRouter;
+import net.osmand.shared.routing.RoutingRequest;
 
 
-public class RoutingContext {
+public class RoutingContext extends RoutingRequest {
 
 	public static boolean SHOW_GC_SIZE = false;
 	public static boolean PRINT_ROUTING_ALERTS = false;
@@ -55,43 +56,21 @@ public class RoutingContext {
 	private final static Log log = PlatformUtil.getLog(RoutingContext.class);
 	
 	// Final context variables
-	public final RoutingConfiguration config;
-	public final RouteCalculationMode calculationMode;
 	public final Map<BinaryMapIndexReader, List<RouteSubregion>> map = new LinkedHashMap<BinaryMapIndexReader, List<RouteSubregion>>();
 	public final Map<RouteRegion, BinaryMapIndexReader> reverseMap = new LinkedHashMap<RouteRegion, BinaryMapIndexReader>();
 	private RouteConditionalHelper conditionalHelper = new RouteConditionalHelper();
 	public NativeLibrary nativeLib;
 	
-	// 0. Reference to native routingcontext for multiple routes
-	public long nativeRoutingContext;
-	public boolean keepNativeRoutingContext;
-	public boolean requestNativePrepareResult; // OK for tests/tools. Do not use in Android UI.
-	
-	// 1. Initial variables
-	public int startX;
-	public int startY;
-	public long startRoadId;
-	public int startSegmentInd;
-	public boolean startTransportStop;
-	public int targetX;
-	public int targetY;
-	public int[] intermediatesX;
-	public int[] intermediatesY;
-	public long targetRoadId;
-	public int targetSegmentInd;
-	public boolean targetTransportStop;
+	// 1. What is left of the request here: the pieces the java planner owns.
+	// The rest is on RoutingRequest, which the C++ router reads.
 	public int dijkstraMode;
-	public boolean publicTransport;
 	public HashSet<BinaryMapIndexReader> mapIndexReaderFilter = new HashSet<>();
-	public String[] regionsCoveringStartAndTargets = new String[0];
 	public boolean hhHasUnsupportedParameters = false;
 
-	public RouteCalculationProgress calculationProgress;
 	public RouteCalculationProgress calculationProgressFirstPhase;
 	public boolean leftSideNavigation;
 	public List<RouteSegmentResult> previouslyCalculatedRoute;
-	public PrecalculatedRouteDirection precalculatedRouteDirection;
-	
+
 	
 	// 2. Routing memory cache (big objects)
 	TLongObjectHashMap<List<RoutingSubregionTile>> indexedSubregions = new TLongObjectHashMap<List<RoutingSubregionTile>>();
@@ -114,17 +93,13 @@ public class RoutingContext {
 	// callback of processing segments
 	RouteSegmentVisitor visitor = null;
 
-	public int alertFasterRoadToVisitedSegments;
-	public int alertSlowerSegmentedWasVisitedEarlier;
-	
 	// old planner
 	public FinalRouteSegment finalRouteSegment;
 	
 	
 	RoutingContext(RoutingContext cp) {
-		this.config = cp.config;
+		super(cp.config, cp.calculationMode);
 		this.map.putAll(cp.map);
-		this.calculationMode = cp.calculationMode;
 		this.leftSideNavigation = cp.leftSideNavigation;
 		this.reverseMap.putAll(cp.reverseMap);
 		this.nativeLib = cp.nativeLib;
@@ -133,7 +108,7 @@ public class RoutingContext {
 	}
 	
 	RoutingContext(RoutingConfiguration config, NativeLibrary nativeLibrary, BinaryMapIndexReader[] list, RouteCalculationMode calcMode) {
-		this.calculationMode = calcMode;
+		super(config, calcMode);
 		for (BinaryMapIndexReader mr : list) {
 			List<RouteRegion> rr = mr.getRoutingIndexes();
 			List<RouteSubregion> subregions = new ArrayList<RouteSubregion>();
@@ -147,7 +122,6 @@ public class RoutingContext {
 			}
 			this.map.put(mr, subregions);
 		}
-		this.config = config;
 		this.nativeLib = nativeLibrary;
 		this.intermediatesX = new int[0];
 		this.intermediatesY = new int[0];
@@ -175,26 +149,6 @@ public class RoutingContext {
 	
 	public void setVisitor(RouteSegmentVisitor visitor) {
 		this.visitor = visitor;
-	}
-
-	public void setRouter(GeneralRouter router) {
-		config.router = router;
-	}
-	
-	public void setHeuristicCoefficient(float heuristicCoefficient) {
-		config.heuristicCoefficient = heuristicCoefficient;
-	}
-
-	public VehicleRouter getRouter() {
-		return config.router;
-	}
-
-	public boolean planRouteIn2Directions() {
-		return config.planRoadDirection == 0;
-	}
-
-	public int getPlanRoadDirection() {
-		return config.planRoadDirection;
 	}
 
 	public void initStartAndTargetPoints(RouteSegmentPoint start, RouteSegmentPoint end) {
@@ -971,20 +925,6 @@ public class RoutingContext {
 	
 	public BinaryMapIndexReader[] getMaps() {
 		return map.keySet().toArray(new BinaryMapIndexReader[0]);
-	}
-
-	public int getVisitedSegments() {
-		if (calculationProgress != null) {
-			return calculationProgress.visitedSegments;
-		}
-		return 0;
-	}
-
-	public int getLoadedTiles() {
-		if (calculationProgress != null) {
-			return calculationProgress.loadedTiles;
-		}
-		return 0;
 	}
 
 	public synchronized void deleteNativeRoutingContext() {

--- a/OsmAnd-java/src/test/java/net/osmand/router/RoutingConfigurationDefaultTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/router/RoutingConfigurationDefaultTest.java
@@ -12,18 +12,13 @@ import net.osmand.shared.routing.RoutingConfiguration;
 
 import org.junit.Test;
 
-import java.lang.reflect.Field;
-
 /**
- * The two things about {@link RoutingConfiguration} that only this module can check.
+ * The one thing about {@link RoutingConfiguration} that only this module can check.
  *
  * The class lives in OsmAnd-shared now, but the `routing.xml` it parses by default does not: this
  * module's `collectRoutingResources` task copies it out of the `resources` repository into
  * `net/osmand/router/`, and the shared class looks it up at that path. Nothing fails to compile if
  * the two drift apart - routing just stops having a profile.
- *
- * {@link RoutingContext#config} is also the field the C++ core resolves by the descriptor
- * {@code Lnet/osmand/shared/routing/RoutingConfiguration;}, and that field is declared here.
  */
 public class RoutingConfigurationDefaultTest {
 
@@ -43,12 +38,5 @@ public class RoutingConfigurationDefaultTest {
 	@Test
 	public void testDefaultConfigurationIsParsedOnce() {
 		assertSame(RoutingConfiguration.getDefault(), RoutingConfiguration.getDefault());
-	}
-
-	@Test
-	public void testRoutingContextHoldsTheConfigurationInTheFieldTheCoreResolves() throws Exception {
-		Field field = RoutingContext.class.getDeclaredField("config");
-		assertEquals(RoutingConfiguration.class, field.getType());
-		assertEquals("net.osmand.shared.routing.RoutingConfiguration", field.getType().getName());
 	}
 }

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RoutingRequest.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RoutingRequest.kt
@@ -1,0 +1,94 @@
+package net.osmand.shared.routing
+
+import kotlin.jvm.JvmField
+
+/**
+ * What a route calculation is asked for: where it starts, where it has to reach, on what profile,
+ * and where to report progress. Not how it is worked out - the search itself, its tile cache and its
+ * graph nodes belong to whichever planner runs, and stay there.
+ *
+ * This is the half of the routing context that crosses the boundary to the C++ router. Every one of
+ * the twenty two fields `native/src/java_wrap.cpp` resolves on
+ * `net/osmand/router/RoutingContext` is declared here, and that still works because Java's
+ * `RoutingContext` extends this class: `GetFieldID` on a subclass resolves fields declared in a
+ * superclass, whatever their visibility. So the core keeps looking the subclass up by name and
+ * needs no change.
+ *
+ * The fields are `@JvmField` for a different reason: the java planner reads and assigns them as
+ * fields (`ctx.startX`), which Kotlin accessors would break, and javac catches that.
+ *
+ * Renaming one of them, or changing its type, still means changing `java_wrap.cpp` in the same
+ * breath. No build says so - the app consumes OsmAndCore as a prebuilt snapshot, so a mismatch
+ * first shows up as a failed route calculation on a device.
+ */
+open class RoutingRequest(
+	/** The profile and the limits this calculation runs under. Read by the core. */
+	@JvmField val config: RoutingConfiguration,
+	/** How much of the network the calculation may see. The core reads its `ordinal()`. */
+	@JvmField val calculationMode: RouteCalculationMode
+) {
+
+	// 0. The native session, so several routes can reuse one C++ context
+
+	@JvmField var nativeRoutingContext: Long = 0
+
+	@JvmField var keepNativeRoutingContext: Boolean = false
+
+	/** Let the core prepare the turns as well. OK for tests and tools, not for the Android UI. */
+	@JvmField var requestNativePrepareResult: Boolean = false
+
+	// 1. Where the route runs
+
+	@JvmField var startX: Int = 0
+	@JvmField var startY: Int = 0
+	@JvmField var startRoadId: Long = 0
+	@JvmField var startSegmentInd: Int = 0
+	@JvmField var startTransportStop: Boolean = false
+
+	@JvmField var targetX: Int = 0
+	@JvmField var targetY: Int = 0
+	@JvmField var targetRoadId: Long = 0
+	@JvmField var targetSegmentInd: Int = 0
+	@JvmField var targetTransportStop: Boolean = false
+
+	@JvmField var intermediatesX: IntArray? = null
+	@JvmField var intermediatesY: IntArray? = null
+
+	@JvmField var publicTransport: Boolean = false
+
+	/** Names of the regions the ends fall into, so a route across a missing map can be reported. */
+	@JvmField var regionsCoveringStartAndTargets: Array<String> = emptyArray()
+
+	// 2. Progress, and a route to lean on
+
+	@JvmField var calculationProgress: RouteCalculationProgress? = null
+
+	@JvmField var precalculatedRouteDirection: PrecalculatedRouteDirection? = null
+
+	// 3. Counters the core writes back into
+
+	@JvmField var alertFasterRoadToVisitedSegments: Int = 0
+	@JvmField var alertSlowerSegmentedWasVisitedEarlier: Int = 0
+
+	// What the request says about the profile, which lives on the configuration
+
+	fun setRouter(router: GeneralRouter) {
+		config.router = router
+	}
+
+	fun getRouter(): VehicleRouter = config.router
+
+	fun setHeuristicCoefficient(heuristicCoefficient: Float) {
+		config.heuristicCoefficient = heuristicCoefficient
+	}
+
+	fun planRouteIn2Directions(): Boolean = config.planRoadDirection == 0
+
+	fun getPlanRoadDirection(): Int = config.planRoadDirection
+
+	// What the request says about how far it has got
+
+	fun getVisitedSegments(): Int = calculationProgress?.visitedSegments ?: 0
+
+	fun getLoadedTiles(): Int = calculationProgress?.loadedTiles ?: 0
+}


### PR DESCRIPTION
Stacked on #25950, so the diff to read is the last commit.

`RoutingContext` is two objects in one file:

- **the request** — where the route starts, where it has to reach, on what profile, where to report progress;
- **the java planner's machinery** — the tile cache, the reader map, and the `BinaryRoutePlanner.RouteSegment` graph nodes it builds as it loads each tile.

Only the first crosses the boundary to the C++ router, and only the first is expressible in shared types now that the last of them, `RouteCalculationMode`, moved in #25949.

So the request becomes `RoutingRequest` in `OsmAnd-shared`, and java's `RoutingContext extends RoutingRequest`. The planner is untouched — it still writes `ctx.startX` and reads `ctx.config` exactly as before.

### core-legacy needs no change at all

This is the first step of the series with no paired PR, and it is worth saying why.

`java_wrap.cpp` resolves **twenty two fields** on `net/osmand/router/RoutingContext` by name, and after this they are every one of them declared in the Kotlin superclass. That still works: `GetFieldID` on a subclass resolves fields declared in a superclass, whatever their visibility.

That was not taken on faith. A throwaway JNI library did `FindClass` on a Java subclass of a Kotlin parent and then read and wrote the parent's fields through it:

```
FindClass(probe/Child) ok
  plainProp      I    kotlin parent, private backing field   read 1100
  jvmFieldProp   I    kotlin parent, @JvmField               read 2200
  objectProp     L…   kotlin parent, @JvmField object        read non-null
  reallyPrivate  I    kotlin parent, private property        read 44
  absent         I    nowhere - control                      NOT FOUND
  wrote plainProp = 9911 / reallyPrivate = 9944
```

The control field coming back NOT FOUND is what says the probe was not passing vacuously. All twenty two names and descriptors were then compared against `java_wrap.cpp` on the compiled class — 22 of 22 match.

`@JvmField` is on them for the other reason: the java planner reads and assigns them as fields, which Kotlin accessors would break, and javac catches that.

### What stayed behind

| | why |
|---|---|
| `map`, `reverseMap`, `mapIndexReaderFilter` | hold `BinaryMapIndexReader`s |
| `nativeLib` | `NativeLibrary`, which step 18 puts behind an interface |
| `dijkstraMode`, `hhHasUnsupportedParameters`, `leftSideNavigation`, `calculationProgressFirstPhase`, `previouslyCalculatedRoute` | the java planner's own knobs; they can follow when something outside java needs them |
| `initStartAndTargetPoints` | takes a `BinaryRoutePlanner.RouteSegmentPoint` |
| `throwNotEnoughMemory` | formats with `%.5f`, and a hand written float formatter is not worth it for an exception message |

The seven accessors that only touch `config` or `calculationProgress` came along.

### One deletion you did not ask for

The first commit removes `RoutingContext.config`'s field type assertion, cherry picked from #25920 where it was already removed. This refactor is exactly the change it mis-reports: it reads `getDeclaredField("config")`, the field is declared one level up now, and the contract it claimed to protect is intact — as the probe above shows. Without it this branch would be red for a reason that is not a defect.

### Checks

459 routing tests in `OsmAnd-java` pass, the app compiles, `java-tools` compiles across all five modules, `OsmAnd-shared` passes on the jvm. On iOS the only failures are the six already failing on this branch's base (`GpxUtilitiesLoad`, `KGeoPointParserUtil`, `NetworkAPI`).