### PR TITLE
Fix for map markers ( the dot ) remaining on screen stuck 

### DIFF
--- a/OsmAnd/src/net/osmand/plus/views/mapwidgets/widgets/ElevationProfileWidget.java
+++ b/OsmAnd/src/net/osmand/plus/views/mapwidgets/widgets/ElevationProfileWidget.java
@@ -190,6 +190,8 @@ public class ElevationProfileWidget extends MapWidget {
 		updateVisibility(visible);
 		if (visible) {
 			updateInfoImpl();
+		} else {
+			clearTrackChartPoints();
 		}
 	}
 
@@ -253,7 +255,16 @@ public class ElevationProfileWidget extends MapWidget {
 		return routeChanged || slopesChanged;
 	}
 
+	private void clearTrackChartPoints() {
+		if (trackChartPoints != null) {
+			mapActivity.getMapLayers().getRouteLayer().setTrackChartPoints(null);
+			trackChartPoints = null;
+			mapActivity.refreshMap();
+		}
+	}
+
 	private void setupChart() {
+		clearTrackChartPoints();
 		gpx = GpxUiHelper.makeGpxFromLocations(route.getImmutableAllLocations(), app);
 		GpxTrackAnalysis analysis = gpx.getAnalysis(0);
 		allPoints = gpx.getAllSegmentsPoints();


### PR DESCRIPTION
This change address the case, when user create a Map markers ( the dot ) by clicking on the graph in Eleavation Profile Widget and route has been recalculated or finished. It that case marker will remain  stuck.
