### PR TITLE
Routing to OsmAnd-shared, step 18: the native router behind an interface

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/NativeLibrary.java
+++ b/OsmAnd-java/src/main/java/net/osmand/NativeLibrary.java
@@ -36,6 +36,8 @@ import net.osmand.render.RenderingRulesStorage;
 import net.osmand.shared.routing.GeneralRouter;
 import net.osmand.router.GpxRouteApproximation;
 import net.osmand.shared.routing.HHRoutingConfig;
+import net.osmand.shared.routing.NativeRouting;
+import net.osmand.shared.routing.RoutingRequest;
 import net.osmand.router.HHRoutePlanner;
 import net.osmand.router.NativeTransportRoutingResult;
 import net.osmand.shared.routing.RouteCalculationProgress;
@@ -47,7 +49,7 @@ import net.osmand.router.TransportRoutingConfiguration;
 import net.osmand.util.Algorithms;
 import net.osmand.util.MapUtils;
 
-public class NativeLibrary {
+public class NativeLibrary implements NativeRouting {
 
 
 	public NativeLibrary() {
@@ -234,18 +236,35 @@ public class NativeLibrary {
 		return nativeTransportRouting(new int[]{sx31, sy31, ex31, ey31}, cfg, progress);
 	}
 
-	public RouteSegmentResult[] runNativeRouting(RoutingContext c, HHRoutingConfig hhRoutingConfig, RouteRegion[] regions, boolean basemap) {
+	@Override
+	public RouteSegmentResult[] runNativeRouting(RoutingRequest c, HHRoutingConfig hhRoutingConfig, RouteRegion[] regions, boolean basemap) {
+		RoutingContext ctx = asRoutingContext(c);
 		// if hhRoutingConfig == null - process old routing
 		if (hhRoutingConfig != null) {
 			setHHNativeFilterAndParameters(c);
 		}
 		final float CPP_NO_DIRECTION = -2 * (float) Math.PI;
-		return nativeRouting(c, hhRoutingConfig, c.config.initialDirection == null ?
+		return nativeRouting(ctx, hhRoutingConfig, c.config.initialDirection == null ?
 				CPP_NO_DIRECTION : c.config.initialDirection.floatValue(),
 				regions, basemap, c.requestNativePrepareResult);
 	}
 
-	private void setHHNativeFilterAndParameters(RoutingContext ctx) {
+	/**
+	 * java_wrap.cpp resolves the request's fields on net/osmand/router/RoutingContext, so this
+	 * implementation can only hand the core one of those. Binding them on
+	 * net.osmand.shared.routing.RoutingRequest instead is what would let shared code build the
+	 * request itself, and that is a paired change in OsmAnd-core-legacy which has not been made.
+	 * Until it is, say so here rather than let the core read fields off the wrong class.
+	 */
+	private static RoutingContext asRoutingContext(RoutingRequest request) {
+		if (!(request instanceof RoutingContext)) {
+			throw new IllegalArgumentException("The C++ router binds RoutingContext, and this is a "
+					+ request.getClass().getName());
+		}
+		return (RoutingContext) request;
+	}
+
+	private void setHHNativeFilterAndParameters(RoutingRequest ctx) {
 		GeneralRouter gr = (GeneralRouter) ctx.getRouter();
 
 		TreeMap<String, String> tags = HHRoutePlanner.getFilteredTags(gr);
@@ -334,6 +353,15 @@ public class NativeLibrary {
 	protected static native NativeRouteSearchResult loadRoutingData(RouteRegion reg, String regName, int regfp, RouteSubregion subreg,
 	                                                                boolean loadObjects);
 
+	/**
+	 * What [NativeRouting] asks for. It cannot be called deleteNativeRoutingContext: that name
+	 * belongs to the static native below, and JNI binds it by the name it is declared under.
+	 */
+	@Override
+	public void releaseNativeRoutingContext(long handle) {
+		deleteNativeRoutingContext(handle);
+	}
+
 	public static native void deleteNativeRoutingContext(long handle);
 
 	protected static native void deleteRenderingContextHandle(long handle);
@@ -380,8 +408,9 @@ public class NativeLibrary {
 		return searchRenderedObjects(context, x, y, notvisible);
 	}
 
-	public boolean needRequestPrivateAccessRouting(RoutingContext ctx, int[] x31Coordinates, int[] y31Coordinates){
-		return nativeNeedRequestPrivateAccessRouting(ctx, x31Coordinates, y31Coordinates);
+	@Override
+	public boolean needRequestPrivateAccessRouting(RoutingRequest ctx, int[] x31Coordinates, int[] y31Coordinates){
+		return nativeNeedRequestPrivateAccessRouting(asRoutingContext(ctx), x31Coordinates, y31Coordinates);
 	}
 	protected static native boolean nativeNeedRequestPrivateAccessRouting(RoutingContext ctx, int[] x31Coordinates, int[] y31Coordinates);
 

--- a/OsmAnd-java/src/main/java/net/osmand/router/GpxRouteApproximation.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/GpxRouteApproximation.java
@@ -175,7 +175,7 @@ public class GpxRouteApproximation {
 	}
 
 	private GpxRouteApproximation searchGpxSegments(GpxRouteApproximation gctx, List<RoutePlannerFrontEnd.GpxPoint> gpxPoints) throws IOException, InterruptedException {
-		NativeLibrary nativeLib = gctx.ctx.nativeLib;
+		NativeLibrary nativeLib = (NativeLibrary) gctx.ctx.nativeLib;
 		if (nativeLib != null && router.isUseNativeApproximation()) {
 			gctx = nativeLib.runNativeSearchGpxRoute(gctx, gpxPoints, true);
 		} else {
@@ -201,7 +201,7 @@ public class GpxRouteApproximation {
 
 	private GpxRouteApproximation searchGpxRouteByRouting(GpxRouteApproximation gctx, List<RoutePlannerFrontEnd.GpxPoint> gpxPoints) throws IOException, InterruptedException {
 		long timeToCalculate = System.nanoTime();
-		NativeLibrary nativeLib = gctx.ctx.nativeLib;
+		NativeLibrary nativeLib = (NativeLibrary) gctx.ctx.nativeLib;
 		if (nativeLib != null && router.isUseNativeApproximation()) {
 			gctx = nativeLib.runNativeSearchGpxRoute(gctx, gpxPoints, false);
 		} else {

--- a/OsmAnd-java/src/main/java/net/osmand/router/RoutePlannerFrontEnd.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RoutePlannerFrontEnd.java
@@ -17,6 +17,7 @@ import net.osmand.ResultMatcher;
 import net.osmand.binary.BinaryMapIndexReader;
 import net.osmand.shared.routing.RouteRegion;
 import net.osmand.shared.routing.RouteDataObject;
+import net.osmand.shared.routing.NativeRouting;
 import net.osmand.shared.routing.RouteCalculationMode;
 import net.osmand.shared.routing.RouteCalculationProgress;
 import net.osmand.shared.routing.RoutingConfiguration;
@@ -115,7 +116,7 @@ public class RoutePlannerFrontEnd {
 		}
 	}
 
-	public RoutingContext buildRoutingContext(RoutingConfiguration config, NativeLibrary nativeLibrary, BinaryMapIndexReader[] map, RouteCalculationMode rm) {
+	public RoutingContext buildRoutingContext(RoutingConfiguration config, NativeRouting nativeLibrary, BinaryMapIndexReader[] map, RouteCalculationMode rm) {
 		if (rm == null) {
 			rm = config.router.getProfile() == GeneralRouterProfile.CAR ? RouteCalculationMode.COMPLEX
 					: RouteCalculationMode.NORMAL;
@@ -123,7 +124,7 @@ public class RoutePlannerFrontEnd {
 		return new RoutingContext(config, nativeLibrary, map, rm);
 	}
 
-	public RoutingContext buildRoutingContext(RoutingConfiguration config, NativeLibrary nativeLibrary, BinaryMapIndexReader[] map) {
+	public RoutingContext buildRoutingContext(RoutingConfiguration config, NativeRouting nativeLibrary, BinaryMapIndexReader[] map) {
 		return buildRoutingContext(config, nativeLibrary, map, null);
 	}
 
@@ -588,7 +589,7 @@ public class RoutePlannerFrontEnd {
 
 	private HHNetworkRouteRes calculateHHRoute(HHRoutePlanner<NetworkDBPoint> routePlanner, RoutingContext ctx,
 			LatLon start, LatLon end, Double dir) throws InterruptedException, IOException {
-		NativeLibrary nativeLib = ctx.nativeLib;
+		NativeRouting nativeLib = ctx.nativeLib;
 		ctx.nativeLib = null; // keep null to interfere with detailed 
 		try {
 			HHRoutingConfig cfg = HHRoutePlanner.prepareDefaultRoutingConfig(hhRoutingConfig);

--- a/OsmAnd-java/src/main/java/net/osmand/router/RoutingContext.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RoutingContext.java
@@ -44,6 +44,7 @@ import net.osmand.shared.util.collections.KTIntObjectIterator;
 import net.osmand.shared.routing.RouteSegmentResult;
 import net.osmand.shared.routing.VehicleRouter;
 import net.osmand.shared.routing.GeneralRouter;
+import net.osmand.shared.routing.NativeRouting;
 import net.osmand.shared.routing.RoutingRequest;
 
 
@@ -59,8 +60,7 @@ public class RoutingContext extends RoutingRequest {
 	public final Map<BinaryMapIndexReader, List<RouteSubregion>> map = new LinkedHashMap<BinaryMapIndexReader, List<RouteSubregion>>();
 	public final Map<RouteRegion, BinaryMapIndexReader> reverseMap = new LinkedHashMap<RouteRegion, BinaryMapIndexReader>();
 	private RouteConditionalHelper conditionalHelper = new RouteConditionalHelper();
-	public NativeLibrary nativeLib;
-	
+
 	// 1. What is left of the request here: the pieces the java planner owns.
 	// The rest is on RoutingRequest, which the C++ router reads.
 	public int dijkstraMode;
@@ -107,7 +107,7 @@ public class RoutingContext extends RoutingRequest {
 		this.calculationProgress = cp.calculationProgress;
 	}
 	
-	RoutingContext(RoutingConfiguration config, NativeLibrary nativeLibrary, BinaryMapIndexReader[] list, RouteCalculationMode calcMode) {
+	RoutingContext(RoutingConfiguration config, NativeRouting nativeLibrary, BinaryMapIndexReader[] list, RouteCalculationMode calcMode) {
 		super(config, calcMode);
 		for (BinaryMapIndexReader mr : list) {
 			List<RouteRegion> rr = mr.getRoutingIndexes();
@@ -295,7 +295,8 @@ public class RoutingContext extends RoutingRequest {
 			}
 		} else {
 			
-			NativeRouteSearchResult ns = nativeLib.loadRouteRegion(ts.subregion, loadObjectsInMemory);
+			// the java planner's own tile loading, which only the JNI library can serve
+			NativeRouteSearchResult ns = ((NativeLibrary) nativeLib).loadRouteRegion(ts.subregion, loadObjectsInMemory);
 //			System.out.println(ts.subregion.shiftToData + " " + Arrays.toString(ns.objects));
 			ts.setLoadedNative(ns, this);
 		}
@@ -928,8 +929,10 @@ public class RoutingContext extends RoutingRequest {
 	}
 
 	public synchronized void deleteNativeRoutingContext() {
-		if (nativeRoutingContext != 0) {
-			NativeLibrary.deleteNativeRoutingContext(nativeRoutingContext);
+		// nativeLib is briefly nulled out around the base route in RoutePlannerFrontEnd, and this
+		// also runs from finalize(), so do not assume it is still there
+		if (nativeRoutingContext != 0 && nativeLib != null) {
+			nativeLib.releaseNativeRoutingContext(nativeRoutingContext);
 		}
 		nativeRoutingContext = 0;
 	}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/NativeRouting.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/NativeRouting.kt
@@ -1,0 +1,46 @@
+package net.osmand.shared.routing
+
+/**
+ * The C++ router, as the rest of the code is allowed to see it.
+ *
+ * There is one implementation of the routing itself - the C++ in OsmAnd-core-legacy - and two ways
+ * of reaching it. Android and the jvm go through JNI, where `NativeLibrary` implements this and the
+ * arguments cross the boundary as java objects. iOS links the same C++ and calls it directly, so
+ * its implementation converts instead of marshalling. Everything in these signatures is a shared
+ * type, which is what lets the caller stop caring which of the two it got.
+ *
+ * This is not the java planner. That one stays in `net.osmand.router` as the fallback for when
+ * there is no native library at all - the server and the tools, and SAFE_MODE on android - and it
+ * is not behind this interface because nothing outside java calls it.
+ */
+interface NativeRouting {
+
+	/**
+	 * Calculates a route and returns its segments, raw: the turns are worked out afterwards.
+	 *
+	 * [regions] are the route regions of the files to search, which the core matches back to its
+	 * own by file pointer and length so it can attach them to the roads it returns; it opens the
+	 * files itself. [basemap] asks for the coarse network a basemap carries. A null [hhConfig]
+	 * means the plain A* rather than the hierarchical search.
+	 *
+	 * Returns null when the route could not be calculated.
+	 */
+	fun runNativeRouting(
+		request: RoutingRequest,
+		hhConfig: HHRoutingConfig?,
+		regions: Array<RouteRegion>,
+		basemap: Boolean
+	): Array<RouteSegmentResult>?
+
+	/**
+	 * Whether any of the given points can only be reached across a road the profile treats as
+	 * private, so the caller can offer to allow them for this route.
+	 */
+	fun needRequestPrivateAccessRouting(request: RoutingRequest, x31: IntArray, y31: IntArray): Boolean
+
+	/**
+	 * Releases the C++ side of a calculation. The handle is the one the core left in
+	 * [RoutingRequest.nativeRoutingContext]; zero means there is nothing to release.
+	 */
+	fun releaseNativeRoutingContext(handle: Long)
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RoutingRequest.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RoutingRequest.kt
@@ -28,7 +28,14 @@ open class RoutingRequest(
 	@JvmField val calculationMode: RouteCalculationMode
 ) {
 
-	// 0. The native session, so several routes can reuse one C++ context
+	// 0. The native router and its session, so several routes can reuse one C++ context
+
+	/**
+	 * The C++ router, or null when there is none and the java planner has to do the work: the
+	 * server and the tools always, android in SAFE_MODE. Read as "is native routing available"
+	 * in a dozen places.
+	 */
+	@JvmField var nativeLib: NativeRouting? = null
 
 	@JvmField var nativeRoutingContext: Long = 0
 


### PR DESCRIPTION
Stacked on #25952, so the diff to read is the last commit.

There is **one** implementation of the routing itself — the C++ in OsmAnd-core-legacy — and **two** ways of reaching it:

| | how |
|---|---|
| android, jvm | JNI, `NativeLibrary` marshals java objects across |
| iOS | links the same C++ and calls `router->searchRoute(...)` directly |

Nothing shared can name either of them, so nothing shared can ask for a route. `NativeRouting` is that ask, in shared types only: run a route and get the segments back raw, ask whether a private road stands in the way, release the C++ session.

`NativeLibrary` implements it, and `RoutingContext.nativeLib` moves up onto `RoutingRequest` typed as the interface — so the dozen `ctx.nativeLib != null` checks in the planner do not change at all.

### What the interface deliberately does not carry

- **`loadRouteRegion`**, which fills the java planner's tile cache. That is the fallback's own machinery, not the route calculation, and only the JNI library serves it — `RoutingContext` casts for it in the one place it is used.
- **`runNativeSearchGpxRoute`**, which takes `GpxRouteApproximation` and the planner's `GpxPoint`. Neither is a shared type yet, so `GpxRouteApproximation` casts too.
- **the java planner**, which stays in `net.osmand.router` as the fallback for when there is no native library at all — the server, the tools, SAFE_MODE on android — and which nothing outside java calls.

### Two names that could not be kept

- `deleteNativeRoutingContext` is a **static native**, and JNI binds it by the name it is declared under. So the interface method is `releaseNativeRoutingContext` and the static keeps its name; renaming it would have broken native routing at runtime with nothing failing to build.
- `RoutingContext.deleteNativeRoutingContext()` now goes through the instance. `RoutePlannerFrontEnd` briefly nulls `nativeLib` around the base route, and this also runs from `finalize()`, so it checks for null first — the static call could not fail that way.

### The one thing left loaded, and where it gets unloaded

The interface says `RoutingRequest`, but `java_wrap.cpp` still resolves the request's fields on `net/osmand/router/RoutingContext`. So this implementation can only hand the core one of those. Binding them on `RoutingRequest` instead is a paired core-legacy change, and it belongs with **step 19**, where shared code first builds a request of its own. Until then `NativeLibrary` says so and throws, rather than letting the core read fields off the wrong class.

**No core-legacy change in this step** — the second in a row.

### Checks

459 routing tests in `OsmAnd-java` pass, the app compiles, `java-tools` compiles across all five modules **unchanged**, `OsmAnd-shared` passes on the jvm. On iOS the only failures are the six already failing on this branch's base (`GpxUtilitiesLoad`, `KGeoPointParserUtil`, `NetworkAPI`).