### PR TITLE
Routing to OsmAnd-shared, step 19: a shared entry point for a native route

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/NativeLibrary.java
+++ b/OsmAnd-java/src/main/java/net/osmand/NativeLibrary.java
@@ -238,30 +238,14 @@ public class NativeLibrary implements NativeRouting {
 
 	@Override
 	public RouteSegmentResult[] runNativeRouting(RoutingRequest c, HHRoutingConfig hhRoutingConfig, RouteRegion[] regions, boolean basemap) {
-		RoutingContext ctx = asRoutingContext(c);
 		// if hhRoutingConfig == null - process old routing
 		if (hhRoutingConfig != null) {
 			setHHNativeFilterAndParameters(c);
 		}
 		final float CPP_NO_DIRECTION = -2 * (float) Math.PI;
-		return nativeRouting(ctx, hhRoutingConfig, c.config.initialDirection == null ?
+		return nativeRouting(c, hhRoutingConfig, c.config.initialDirection == null ?
 				CPP_NO_DIRECTION : c.config.initialDirection.floatValue(),
 				regions, basemap, c.requestNativePrepareResult);
-	}
-
-	/**
-	 * java_wrap.cpp resolves the request's fields on net/osmand/router/RoutingContext, so this
-	 * implementation can only hand the core one of those. Binding them on
-	 * net.osmand.shared.routing.RoutingRequest instead is what would let shared code build the
-	 * request itself, and that is a paired change in OsmAnd-core-legacy which has not been made.
-	 * Until it is, say so here rather than let the core read fields off the wrong class.
-	 */
-	private static RoutingContext asRoutingContext(RoutingRequest request) {
-		if (!(request instanceof RoutingContext)) {
-			throw new IllegalArgumentException("The C++ router binds RoutingContext, and this is a "
-					+ request.getClass().getName());
-		}
-		return (RoutingContext) request;
 	}
 
 	private void setHHNativeFilterAndParameters(RoutingRequest ctx) {
@@ -370,7 +354,7 @@ public class NativeLibrary implements NativeRouting {
 
 	protected static native RouteDataObject[] getRouteDataObjects(RouteRegion reg, long rs, int x31, int y31);
 
-	protected static native RouteSegmentResult[] nativeRouting(RoutingContext c, HHRoutingConfig hhRoutingConfig,
+	protected static native RouteSegmentResult[] nativeRouting(RoutingRequest c, HHRoutingConfig hhRoutingConfig,
 	                                                           float initDirection, RouteRegion[] regions,
 	                                                           boolean basemap, boolean requestNativePrepareResult);
 
@@ -410,9 +394,9 @@ public class NativeLibrary implements NativeRouting {
 
 	@Override
 	public boolean needRequestPrivateAccessRouting(RoutingRequest ctx, int[] x31Coordinates, int[] y31Coordinates){
-		return nativeNeedRequestPrivateAccessRouting(asRoutingContext(ctx), x31Coordinates, y31Coordinates);
+		return nativeNeedRequestPrivateAccessRouting(ctx, x31Coordinates, y31Coordinates);
 	}
-	protected static native boolean nativeNeedRequestPrivateAccessRouting(RoutingContext ctx, int[] x31Coordinates, int[] y31Coordinates);
+	protected static native boolean nativeNeedRequestPrivateAccessRouting(RoutingRequest ctx, int[] x31Coordinates, int[] y31Coordinates);
 
 	protected static native ByteBuffer getGeotiffTile(
 		String tilePath, String outColorFilename, String midColorFilename, int type, int size, int zoom, int x, int y);

--- a/OsmAnd-java/src/main/java/net/osmand/router/RoutePlannerFrontEnd.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/RoutePlannerFrontEnd.java
@@ -17,6 +17,7 @@ import net.osmand.ResultMatcher;
 import net.osmand.binary.BinaryMapIndexReader;
 import net.osmand.shared.routing.RouteRegion;
 import net.osmand.shared.routing.RouteDataObject;
+import net.osmand.shared.routing.NativeRouteCalculation;
 import net.osmand.shared.routing.NativeRouting;
 import net.osmand.shared.routing.RouteCalculationMode;
 import net.osmand.shared.routing.RouteCalculationProgress;
@@ -731,7 +732,7 @@ public class RoutePlannerFrontEnd {
 			ctx.targetSegmentInd  = end.segStart;
 			return runNativeRouting(ctx, recalculationEnd, null);
 		} else {
-			refreshProgressDistance(ctx);
+			NativeRouteCalculation.INSTANCE.refreshProgressDistance(ctx);
 			// Split into 2 methods to let GC work in between
 			ctx.finalRouteSegment = new BinaryRoutePlanner().searchRouteInternal(ctx, start, recalculationEnd != null ? recalculationEnd : end, null);
 			RouteResultPreparation rrp = new RouteResultPreparation();
@@ -781,42 +782,23 @@ public class RoutePlannerFrontEnd {
 		return recalculationEnd;
 	}
 
-	private void refreshProgressDistance(RoutingContext ctx) {
-		if (ctx.calculationProgress != null) {
-			ctx.calculationProgress.distanceFromBegin = 0;
-			ctx.calculationProgress.distanceFromEnd = 0;
-			ctx.calculationProgress.reverseSegmentQueueSize = 0;
-			ctx.calculationProgress.directSegmentQueueSize = 0;
-			float rd = (float) MapUtils.squareRootDist31(ctx.startX, ctx.startY, ctx.targetX, ctx.targetY);
-			float speed = 0.9f * ctx.config.router.getMaxSpeed();
-			ctx.calculationProgress.totalEstimatedDistance = (float) (rd / speed);
-		}
-
-	}
 
 	private RouteCalcResult runNativeRouting(final RoutingContext ctx, RouteSegment recalculationEnd, HHRoutingConfig hhConfig) throws IOException {
-		refreshProgressDistance(ctx);
 		if (recalculationEnd != null) {
 			if (TRACE_ROUTING) {
 				log.info("RecalculationEnd = " + recalculationEnd.road + " ind=" + recalculationEnd.getSegmentStart() + "->" + recalculationEnd.getSegmentEnd());
 			}
 		}
+		// the reader map is the java planner's, so the regions to search are gathered here and
+		// handed to the shared entry point, which knows nothing about readers
 		RouteRegion[] regions = ctx.reverseMap.keySet().toArray(new RouteRegion[0]);
 		// long time = System.currentTimeMillis();
-		if (ctx.intermediatesX == null || ctx.intermediatesY == null) {
-			ctx.intermediatesX = new int[0];
-			ctx.intermediatesY = new int[0];
-		}
-		RouteSegmentResult[] res = ctx.nativeLib.runNativeRouting(ctx, hhConfig, regions, ctx.calculationMode == RouteCalculationMode.BASE);
+		List<RouteSegmentResult> result = NativeRouteCalculation.INSTANCE.calculate(ctx, hhConfig, regions);
 		if (TRACE_ROUTING) {
 			log.info("Native routing result!");
-			for (RouteSegmentResult r : res) {
+			for (RouteSegmentResult r : result) {
 				log.info("Road = " + r.getObject().id / 64 + " " + r.getStartPointIndex() + "->" + r.getEndPointIndex());
 			}
-		}
-		//	log.info("Native routing took " + (System.currentTimeMillis() - time) / 1000f + " seconds");
-		List<RouteSegmentResult> result = new ArrayList<>(Arrays.asList(res));
-		if (TRACE_ROUTING) {
 			log.info("RecalculationEnd result!");
 		}
 		addPrecalculatedToResult(recalculationEnd, result);

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/NativeRouteCalculation.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/NativeRouteCalculation.kt
@@ -1,0 +1,67 @@
+package net.osmand.shared.routing
+
+import net.osmand.shared.util.KMapUtils
+
+/**
+ * Asking the C++ router for a route, from code that does not know which platform it is on.
+ *
+ * Everything here works on a [RoutingRequest] and a [NativeRouting], so android, the jvm and iOS
+ * take the same path into the same C++ and get the same segments back. What comes back is raw: the
+ * turns are worked out afterwards, and that part is still two implementations, one per platform.
+ *
+ * The java planner is not reachable from here and does not need to be. It is the fallback for when
+ * there is no native library at all, it lives in `net.osmand.router`, and only java calls it.
+ */
+object NativeRouteCalculation {
+
+	/**
+	 * Resets what the progress reports about distance and queues, and sets the estimate the
+	 * progress bar is drawn from: straight line distance over nine tenths of the profile's top
+	 * speed. Both routers start from this, so the java planner calls it too.
+	 */
+	fun refreshProgressDistance(request: RoutingRequest) {
+		val progress = request.calculationProgress ?: return
+		progress.distanceFromBegin = 0f
+		progress.distanceFromEnd = 0f
+		progress.reverseSegmentQueueSize = 0
+		progress.directSegmentQueueSize = 0
+		val rd = KMapUtils.squareRootDist31(request.startX, request.startY, request.targetX, request.targetY).toFloat()
+		val speed = 0.9f * request.config.router.getMaxSpeed()
+		progress.totalEstimatedDistance = rd / speed
+	}
+
+	/**
+	 * Calculates a route and returns its segments in the order they are driven.
+	 *
+	 * [regions] are the route regions of the files to search: the core opens the files itself and
+	 * matches its own regions back to these by file pointer and length, so it can attach them to
+	 * the roads it returns. A null [hhConfig] asks for the plain A* rather than the hierarchical
+	 * search.
+	 *
+	 * The list is the caller's to modify - a recalculated route has the piece already driven
+	 * spliced back onto the front of it.
+	 *
+	 * @throws IllegalStateException when the request carries no native router. The caller decides
+	 * whether to fall back, and only java has anything to fall back to.
+	 */
+	fun calculate(
+		request: RoutingRequest,
+		hhConfig: HHRoutingConfig?,
+		regions: Array<RouteRegion>
+	): MutableList<RouteSegmentResult> {
+		val nativeLib = request.nativeLib
+			?: throw IllegalStateException("There is no native router to calculate this route with")
+
+		refreshProgressDistance(request)
+		if (request.intermediatesX == null || request.intermediatesY == null) {
+			request.intermediatesX = IntArray(0)
+			request.intermediatesY = IntArray(0)
+		}
+
+		val basemap = request.calculationMode == RouteCalculationMode.BASE
+		// the core answers with an empty array when it finds nothing; null would be a broken
+		// implementation, and an empty route says the same thing to every caller here
+		val segments = nativeLib.runNativeRouting(request, hhConfig, regions, basemap) ?: return mutableListOf()
+		return segments.toMutableList()
+	}
+}


### PR DESCRIPTION
Stacked on #25958, so the diff to read is the last commit.

`NativeRouteCalculation` takes a `RoutingRequest` and a `NativeRouting` and gives back the segments. Nothing in it names a platform, so android, the jvm and iOS take the same path into the same C++ and get the same route.

What comes back is **raw**: the turns are still worked out afterwards, and that is still two implementations, one per platform. Removing that second one is step 20.

### What moved in

Three things that were inline in `RoutePlannerFrontEnd`:

- the progress reset and the straight line estimate the progress bar is drawn from;
- the normalisation of absent intermediates;
- the call itself.

`refreshProgressDistance` is shared with the java fallback, which calls it in the other branch, so there is one copy of that arithmetic now rather than one per planner.

### What could not

The **list of regions to search** is gathered from the reader map, which belongs to the java planner, so the caller passes it in. The core only needs it to match its own regions back to the java objects by file pointer and length — it opens the files itself.

Splicing the already driven part back onto a recalculated route stays behind too: it walks `BinaryRoutePlanner.RouteSegment`.

### The paired change, and what it unlocks

osmandapp/OsmAnd-core-legacy#362 reads the request's fields off `net/osmand/shared/routing/RoutingRequest` instead of the java subclass. That is what lets a request built by shared code be routed at all, and it is why `NativeLibrary` no longer refuses one — the guard added in #25958 is gone and the native declarations take a `RoutingRequest`.

### The native path is not covered by the tests here

Worth saying plainly. The routing tests fall back to the java planner when `core-legacy/binaries` is absent, which it is on this machine, so the **459 passing tests exercise the java side of this change and not the JNI side.**

What was checked instead:

- all twenty two bound field names and descriptors against the compiled `RoutingRequest` — 22 of 22;
- that each of the twenty one native methods in `NativeLibrary` still has a `Java_net_osmand_NativeLibrary_<name>` in `java_wrap.cpp`, with none of them overloaded, so widening a declared parameter type moved no symbol.

The app compiles, `java-tools` compiles unchanged, `OsmAnd-shared` passes on the jvm. On iOS the only failures are the six already failing on this branch's base.