### PR TITLE
Align plugin apps with main app AndroidX versions for target API 36

### DIFF
--- a/plugins/Osmand-Nautical/AndroidManifest.xml
+++ b/plugins/Osmand-Nautical/AndroidManifest.xml
@@ -2,8 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 	package="net.osmand.nauticalPlugin"
 	android:installLocation="auto"
-	android:versionCode="12"
-	android:versionName="1.2">
+	android:versionCode="13"
+	android:versionName="1.3">
 
 	<uses-feature
 		android:name="android.hardware.touchscreen"

--- a/plugins/Osmand-Nautical/build.gradle
+++ b/plugins/Osmand-Nautical/build.gradle
@@ -67,6 +67,6 @@ repositories {
 }
 
 dependencies {
-	implementation 'androidx.appcompat:appcompat:1.6.1'
-	implementation 'com.google.android.material:material:1.9.0'
+	implementation 'androidx.appcompat:appcompat:1.7.1'
+	implementation 'com.google.android.material:material:1.14.0'
 }

--- a/plugins/Osmand-SRTMPlugin/AndroidManifest.xml
+++ b/plugins/Osmand-SRTMPlugin/AndroidManifest.xml
@@ -2,8 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 	package="net.osmand.srtmPlugin.paid"
 	android:installLocation="auto"
-	android:versionCode="12"
-	android:versionName="1.2">
+	android:versionCode="13"
+	android:versionName="1.3">
 
 	<uses-feature
 		android:name="android.hardware.touchscreen"

--- a/plugins/Osmand-SRTMPlugin/build.gradle
+++ b/plugins/Osmand-SRTMPlugin/build.gradle
@@ -68,6 +68,6 @@ repositories {
 }
 
 dependencies {
-	implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.9.0'
+	implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'com.google.android.material:material:1.14.0'
 }

--- a/plugins/Osmand-Skimaps/AndroidManifest.xml
+++ b/plugins/Osmand-Skimaps/AndroidManifest.xml
@@ -2,8 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 	package="net.osmand.skimapsPlugin"
 	android:installLocation="auto"
-	android:versionCode="12"
-	android:versionName="1.2">
+	android:versionCode="13"
+	android:versionName="1.3">
 
 	<uses-feature
 		android:name="android.hardware.touchscreen"

--- a/plugins/Osmand-Skimaps/build.gradle
+++ b/plugins/Osmand-Skimaps/build.gradle
@@ -69,6 +69,6 @@ repositories {
 }
 
 dependencies {
-	implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.9.0'
+	implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'com.google.android.material:material:1.14.0'
 }


### PR DESCRIPTION
## Problem

The three plugin apps (`Osmand-Nautical`, `Osmand-Skimaps`, `Osmand-SRTMPlugin`) were **already** at target API 36 before this change — they read `osmand_targetSdk` from `versions.gradle`, which `566d1135` ("Update target API to 36 (#25796)", 2026-08-31) raised from 35 to 36. Verified on unmodified `r5.4` (`87eecebf`):

```
$ ./gradlew :plugins:Osmand-SRTMPlugin:assembleDebug   # BUILD SUCCESSFUL
$ grep -E 'targetSdkVersion|minSdkVersion' \
    plugins/Osmand-SRTMPlugin/build/intermediates/merged_manifest/debug/*/AndroidManifest.xml
        android:minSdkVersion="24"
        android:targetSdkVersion="36" />
```

What `566d1135` did **not** carry over to the plugin modules is the other half of that commit: it bumped `androidx.appcompat` to 1.7.1 and `com.google.android.material` to 1.14.0 for `:OsmAnd` only. The three plugin apps stayed on appcompat 1.6.1 / material 1.9.0 — versions that predate API 35/36 window-inset handling — while their manifests now declare `targetSdkVersion="36"`.

So the plugin apps ship as target-36 apps built against pre-36 AndroidX. Nothing observable is broken today (see Verification), but the plugin apps and the main app no longer agree on the library that supplies their theme and their only widget.

## Fix

Bump both dependencies in all three plugin modules to the versions the main app already uses on `r5.4`, and bump `versionCode` 12 -> 13 / `versionName` 1.2 -> 1.3 so the retargeted APKs can be uploaded.

The two Android 16 opt-outs `566d1135` added to `OsmAnd/AndroidManifest.xml` are deliberately **not** copied to the plugins, because neither behavior change applies to them:

| Opt-out in main app | Why the plugin apps do not need it |
| --- | --- |
| `android:enableOnBackInvokedCallback="false"` | Predictive back opt-out. None of the three activities overrides `onBackPressed()` or handles `KEYCODE_BACK`; default back just finishes the activity, which is identical under predictive back. Adding the opt-out would only disable the system animation. |
| `<property android:name="android.window.PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY" android:value="true"/>` | Opt-out from the >=600dp "orientation / resizability / aspect ratio ignored" change. None of the three declares `screenOrientation`, `resizeableActivity="false"` or an aspect-ratio bound, and all three declare `<supports-screens android:resizeable="true">`. Checked at 1066dp below. |

Edge-to-edge enforcement likewise does not bite: all three activities use `Theme.AppCompat.Light.Dialog`, so the window is floating and is never overlapped by the system bars.

## Verification

Emulator: Pixel 10 Pro AVD, Android 16 / **API 36** (`ro.build.version.release=16`, `ro.build.version.sdk=36`), x86_64, 1280x2856 @ 480dpi (426dp wide). No physical device was used.

```bash
export JAVA_HOME=<jdk21>
./gradlew :plugins:Osmand-Nautical:assembleDebug \
          :plugins:Osmand-Skimaps:assembleDebug \
          :plugins:Osmand-SRTMPlugin:assembleDebug

# release path (signing key is Jenkins-only, so compile + manifest merge only)
./gradlew :plugins:Osmand-Nautical:compileReleaseJavaWithJavac :plugins:Osmand-Nautical:processReleaseMainManifest \
          :plugins:Osmand-Skimaps:compileReleaseJavaWithJavac :plugins:Osmand-Skimaps:processReleaseMainManifest \
          :plugins:Osmand-SRTMPlugin:compileReleaseJavaWithJavac :plugins:Osmand-SRTMPlugin:processReleaseMainManifest

for m in Osmand-Nautical Osmand-Skimaps Osmand-SRTMPlugin; do
  adb -s emulator-5554 install -r -g plugins/$m/build/outputs/apk/debug/$m-debug.apk
done
adb -s emulator-5554 shell am start -W -n net.osmand.nauticalPlugin/net.osmand.nautical.NauticalActivity
adb -s emulator-5554 shell am start -W -n net.osmand.skimapsPlugin/net.osmand.skimaps.SkiMapsActivity
adb -s emulator-5554 shell am start -W -n net.osmand.srtmPlugin.paid/net.osmand.srtmPlugin.SRTMPluginActivity
adb -s emulator-5554 logcat -d -b crash
```

| Observable fact | Before (`87eecebf`) | After |
| --- | --- | --- |
| `:plugins:*:assembleDebug` | BUILD SUCCESSFUL (56s) | BUILD SUCCESSFUL (52s) |
| release `compile*` + `processReleaseMainManifest` | BUILD SUCCESSFUL | BUILD SUCCESSFUL (29s) |
| merged manifest (debug + release), all three | `minSdk=24` `targetSdk=36` | `minSdk=24` `targetSdk=36` |
| installed `versionCode` / `versionName` | 12 / 1.2 | **13 / 1.3** |
| resolved appcompat | 1.6.1 | **1.7.1** |
| resolved material | 1.9.0 | **1.14.0** |
| `am start` all three on API 36 | `Status: ok` | `Status: ok` |
| `logcat -d -b crash` | empty | empty |
| dialog rendering @426dp | correct, floating, not clipped | unchanged |
| dialog rendering @1066dp (`wm size 1600x2560; wm density 240`) | correct, floating, not stretched | unchanged |

`androidx.appcompat:appcompat:1.7.1` and `com.google.android.material:material:1.14.0` confirmed on `debugRuntimeClasspath` via `./gradlew :plugins:Osmand-SRTMPlugin:dependencies --configuration debugRuntimeClasspath`.

### Signing and upgrade path

Because this PR bumps `versionCode`, the signer and the in-place upgrade were checked rather than assumed. Old and new APKs were built from `origin/r5.4` and from this branch and compared:

```bash
$SDK/build-tools/36.0.0/apksigner verify --print-certs -v <apk>
adb -s emulator-5554 install    old/<module>-debug.apk   # versionCode 12
adb -s emulator-5554 install -r new/<module>-debug.apk   # versionCode 13, note: no -d
```

| Check | Result |
| --- | --- |
| signer certificate, all three plugins, old vs new | identical — SHA-256 `3465867d3403deb7a32472c8cee2acb8f8a876d5ffaccfcde51f2829bb6d03c7`, SHA-1 `e6fa470be4ae7a71e798d53643a9094c18d00cdc` |
| signature scheme | v2, unchanged on both sides |
| in-place upgrade old → new (`install -r`, no `-d`) | `Success` on all three; versionCode 12 → 13; no `INSTALL_FAILED_UPDATE_INCOMPATIBLE` |
| `signingConfig` / `storeFile` / `keyAlias` / `storePassword` lines in the diff | none — signing configuration untouched |

Caveat: these are **debug**-signed builds (`keystores/debug.keystore`, so `CN=Android Debug`), because the release key `/var/lib/jenkins/osmand_key` is Jenkins-only and unavailable locally. The release signer is therefore unverified by measurement — but it is unchanged by construction, since the diff contains no signing configuration.

Also worth stating for the reviewer: `versionCode` 13 is only correct if no plugin build above 12 has already been uploaded. Unlike these plugin modules, the API demo app in `osmandapp/osmand-api-demo` takes its `versionCode` from `APK_NUMBER_VERSION` with a `100` fallback, and that mismatch has already produced an `INSTALL_FAILED_VERSION_DOWNGRADE` there. Confirm the highest published plugin `versionCode` in Play Console before release.

## Known gap, not addressed here

1. **The plugin apps have no launcher entry.** In all three manifests the activity's `<intent-filter>` with `ACTION_MAIN` / `CATEGORY_LAUNCHER` is commented out, so `cmd package resolve-activity -a android.intent.action.MAIN -c android.intent.category.LAUNCHER <pkg>` returns "No activity found" for each. The "Thank you for installing / Install OsmAnd" dialog is therefore reachable only by an explicit intent from another app, not by the user.
2. **Package visibility blocks the plugin -> OsmAnd redirect.** With `net.osmand` 5.4.0 installed on the emulator, all three activities still show the "please install OsmAnd Maps & Navigation" dialog instead of redirecting. `net.osmand.plus.activities.MapActivity` is present, `exported=true`, and resolves from shell, so the cause is Android 11+ package-visibility filtering: the plugin manifests declare no `<queries>`, so `resolveActivity()` returns `null`. This is not an API 36 regression (it dates from targetSdk 30) and, given (1), it sits on a code path the user cannot reach — so it is reported rather than fixed here. The direction that actually matters is unaffected: the main app declares `<queries>` for all plugin packages (`OsmAnd/AndroidManifest.xml:59-64`), so purchase detection works.
3. **`material` is not referenced by any of the three plugin apps, but cannot simply be dropped.** Nothing in their `src/` or `res/` mentions it — they use `androidx.appcompat.widget.AppCompatButton` and `Theme.AppCompat.Light.Dialog`. Removing the dependency was tried and **fails the build**: `checkDebugDuplicateClasses` reports ~20 duplicate classes between `kotlin-stdlib:1.8.22` and `kotlin-stdlib-jdk7`/`kotlin-stdlib-jdk8:1.6.21`, so `material` is currently acting as a de-facto version aligner for the Kotlin stdlib on this classpath. Dropping it would need an explicit `kotlin-stdlib` constraint or BOM, which is out of scope here. Worth a follow-up, because keeping it is not free: the bump costs **+1415 KB per plugin APK** (5223 KB → 6639 KB, +27%) for a library none of them reference.
4. **`plugins/*/project.properties` still says `target=android-19`** — dead Ant-era config, not read by Gradle. Left untouched.
5. `OsmAnd-telegram` (Tracker) is not touched here; it is a separate PR.
6. Not verified: release APK signing (Jenkins-only key), any physical device, and Android versions other than 16.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Update the target API for the plugin apps to match the main OsmAnd app, referring to the Android 16 behavior-changes page.
2. Do the small plugins first, check that they build correctly, and open a PR for them; update Tracker in a separate PR afterwards.
3. Do it on `r5.4`.

Decided by the agent, not requested explicitly:
- Establishing first that `targetSdk` was already 36, and re-scoping the change to the AndroidX versions that `566d1135` bumped for the main app only.
- Not copying the two Android 16 manifest opt-outs to the plugin apps, with the reasoning and the 1066dp check above.
- The `versionCode` 12 -> 13 / `versionName` 1.2 -> 1.3 bump, following `b4361b15` ("Bump plugin versions"). Drop it if the plugin apps are not being republished from this branch.
- Bumping `material` for parity instead of dropping it as unused. An earlier revision of this description claimed it could simply be dropped; that was wrong, and Known gap 3 now records the actual build failure and the measured size cost.
- Verifying the signer certificate and the in-place 12 → 13 upgrade rather than assuming the `versionCode` bump was safe.
- Verifying on an emulator and leaving the attached physical device alone.
