### PR TITLE
fix switching back to system default language

### DIFF
--- a/OsmAnd/src/net/osmand/plus/helpers/LocaleHelper.java
+++ b/OsmAnd/src/net/osmand/plus/helpers/LocaleHelper.java
@@ -79,13 +79,9 @@ public class LocaleHelper {
 			currentLocale = SupportedLocale.normalizeToOsmandLegacy(currentLocale);
 
 			if (!Algorithms.stringsEqual(currentLocale, locale)) {
-				if (Algorithms.isEmpty(currentLocale) && !Algorithms.isEmpty(locale)) {
-					// Ignore empty OS response if vendor firmware rejected a rare tag (e.g., "sc").
-				} else {
-					// Sync with OS if user changed the language via Android App Info.
-					locale = currentLocale;
-					settings.PREFERRED_LOCALE.set(locale);
-				}
+				// Sync with OS if user changed the language via Android App Info.
+				locale = currentLocale;
+				settings.PREFERRED_LOCALE.set(locale);
 			}
 		}
 


### PR DESCRIPTION
clear the previously saved language

[Screen_recording_20260910_162853 (1).webm](https://github.com/user-attachments/assets/0b1c96e4-d063-49e4-9e5b-cd637f5d9dc4)

closes https://github.com/osmandapp/OsmAnd/issues/25887
