### PR TITLE
Mirror main app Android 16 opt-outs and AndroidX versions in Tracker

### DIFF
--- a/OsmAnd-telegram/AndroidManifest.xml
+++ b/OsmAnd-telegram/AndroidManifest.xml
@@ -32,7 +32,10 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:hasFragileUserData="true"
-        android:requestLegacyExternalStorage="true">
+        android:requestLegacyExternalStorage="true"
+        android:enableOnBackInvokedCallback="false">
+
+        <property android:name="android.window.PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY" android:value="true" />
 
         <activity android:name=".ui.TrackerLogcatActivity" />
         <activity

--- a/OsmAnd-telegram/build.gradle
+++ b/OsmAnd-telegram/build.gradle
@@ -173,8 +173,8 @@ dependencies {
 	implementation fileTree(dir: 'libs', include: ['*.jar'])
 
 	implementation 'androidx.multidex:multidex:2.0.1'
-	implementation 'androidx.appcompat:appcompat:1.6.1'
-	implementation 'com.google.android.material:material:1.9.0'
+	implementation 'androidx.appcompat:appcompat:1.7.1'
+	implementation 'com.google.android.material:material:1.14.0'
 	implementation 'androidx.browser:browser:1.0.0'
 	implementation 'androidx.annotation:annotation:1.6.0'
 	implementation 'commons-logging:commons-logging-api:1.1'


### PR DESCRIPTION
Follow-up to #25966, which did the same for the three small plugin apps.

## Problem

Like the plugin apps, `OsmAnd-telegram` (Tracker) was **already** at target API 36 before this change — it reads `osmand_targetSdk` from `versions.gradle`, which `566d1135` ("Update target API to 36 (#25796)", 2026-08-31) raised to 36. Confirmed on unmodified `r5.4` (`87eecebf`), debug merged manifest:

```
android:minSdkVersion="24"
android:targetSdkVersion="36" />
```

What `566d1135` did not carry over to Tracker is either half of what it did for `:OsmAnd`:

1. It bumped `androidx.appcompat` to 1.7.1 and `com.google.android.material` to 1.14.0 for `:OsmAnd` only. Tracker stayed on appcompat 1.6.1 / material 1.9.0.
2. It added two Android 16 manifest opt-outs to `OsmAnd/AndroidManifest.xml` — `android:enableOnBackInvokedCallback="false"` and `<property android:name="android.window.PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY" android:value="true"/>`. Tracker had neither.

Unlike the plugin apps, Tracker is a real full-screen app with a launcher entry, so the Android 16 window behavior changes do reach it.

**Nothing is observably broken at target 36 today, and this PR does not claim otherwise.** Tracker was already migrated to edge-to-edge in `OsmAnd-telegram/src/net/osmand/telegram/utils/TelegramInsets.kt`, using the modern APIs — `WindowCompat.setDecorFitsSystemWindows(window, false)`, `WindowInsetsCompat.Type.systemBars()`, `Type.displayCutout()`, `WindowCompat.getInsetsController` — so edge-to-edge enforcement is something it opts into deliberately rather than something that breaks it. Back also already behaves correctly (measured below). The gap this closes is a compatibility-footing one: Tracker declares target 36 while being built against pre-36 AndroidX and without the compat opt-outs the main app relies on.

## Fix

Align the two dependencies with the versions `:OsmAnd` already uses on `r5.4`, and declare the same two opt-outs on `<application>`.

Both opt-outs are **precautionary parity, not bug fixes**, and the PR is explicit about that:

- `enableOnBackInvokedCallback="false"` — Tracker has no `Activity.onBackPressed()` override. The one back override it does have, the anonymous `Dialog` in `LoginDialogFragment.onCreateDialog` (`LoginDialogFragment.kt:188-194`), keeps working under predictive back anyway, because `android.app.Dialog` registers a default `OnBackInvokedCallback` that routes to `onBackPressed()`. Verified below: back already finished the activity correctly *before* this change.
- `PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY` — Tracker declares no `screenOrientation` on any activity, no `resizeableActivity="false"` and no aspect-ratio bound, so the >=600dp change has nothing to override.

They are declared so Tracker sits on the same compatibility footing as the main app for the remainder of the target-36 window. Both stop applying at target 37 (see Known gap).

No `versionCode` bump here, unlike #25966: Tracker takes its version from `APK_NUMBER_VERSION` / `APK_VERSION` at build time (`OsmAnd-telegram/build.gradle`), not from a manifest literal.

## Verification

Two platforms, both with the app at target 36:

- **Emulator** — Pixel 10 Pro AVD, Android 16 / **API 36** (`ro.build.version.sdk=36`), x86_64, 1280x2856 @ 480dpi.
- **Physical device** — **Pixel 8 Pro, Android 17 / API 37** (`ro.build.version.sdk=37`), arm64-v8a, 1008x2244 @ 360dpi (density 2.25), Ukrainian locale, **3-button navigation**, signed in to a real Telegram account.

Built the `fat` ABI flavour so one APK covers both. Debug carries `applicationIdSuffix ".debug"`, so `net.osmand.telegram.debug` never touched a real Tracker install.

```bash
export JAVA_HOME=<jdk21>
./gradlew :OsmAnd-telegram:assembleFatDebug

adb -s <serial> install -r -g OsmAnd-telegram/build/outputs/apk/fat/debug/OsmAnd-telegram-fat-debug.apk
adb -s <serial> shell am start -W -n net.osmand.telegram.debug/net.osmand.telegram.ui.MainActivity
adb -s <serial> shell input keyevent KEYCODE_BACK
adb -s <serial> shell dumpsys activity activities | grep -m1 ResumedActivity
adb -s <serial> shell dumpsys window | grep -E 'type=statusBars|type=navigationBars'
adb -s <serial> shell uiautomator dump /sdcard/ui.xml
adb -s <serial> logcat -d -b crash
```

### Build and manifest

| Observable fact | Before (`87eecebf`) | After |
| --- | --- | --- |
| `:OsmAnd-telegram:assembleFatDebug` | BUILD SUCCESSFUL (4m04s, 55 tasks) | BUILD SUCCESSFUL (2m24s incremental) |
| merged manifest | `minSdk=24` `targetSdk=36` | `minSdk=24` `targetSdk=36` |
| `enableOnBackInvokedCallback` in merged manifest | absent | **`"false"`** |
| `PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY` | absent | **present** |
| resolved appcompat (`fatDebugRuntimeClasspath`) | 1.6.1 | **1.7.1** |
| resolved material | 1.9.0 | **1.14.0** |

`git diff --check` clean; `AndroidManifest.xml` re-parsed as well-formed XML after editing.

### Runtime

| Observable fact | Before (`87eecebf`) | After |
| --- | --- | --- |
| `am start` MainActivity, API 36 emulator | `Status: ok` | `Status: ok` |
| `am start` MainActivity, Pixel 8 Pro / API 37 | not run | `Status: ok` |
| `KEYCODE_BACK` on login screen, API 36 | activity finished, returned to previous task | activity finished, returned to launcher |
| `logcat -d -b crash`, both platforms | empty | empty |
| `ANR in net.osmand.telegram` | none | none |
| login screen edge-to-edge, API 36 emulator | correct | unchanged |
| login screen edge-to-edge, Pixel 8 Pro / API 37 | not run | correct |

### Inset geometry, signed in, Pixel 8 Pro / API 37

Measured from `dumpsys window` insets plus `uiautomator dump` view bounds, so these are numbers rather than eyeballed screenshots. Platform insets on this device:

```
InsetsSource type=statusBars      frame=[0,0][1008,113]      (113px)
InsetsSource type=navigationBars  frame=[0,2136][1008,2244]  (108px = 48dp @ 2.25)
```

| Screen | Full-bleed root (edge-to-edge active) | Interactive content vs. system bars |
| --- | --- | --- |
| MainActivity, all three tabs | `action_bar_root [0,0][1008,2244]` — spans the whole display | `bottom_navigation [0,2010][1008,2244]` draws its background to the bottom edge, but its tap targets `action_my_location` / `action_live_now` / `action_timeline` all end at **y=2129**, clearing the nav bar inset at 2136. Geometry identical on all three tabs. |
| GPX info (`UserGpxInfoFragment`) | `scroll_view [0,0][1008,2244]` | `image_container [0,0][1008,439]` intentionally draws behind the status bar, while the only header control, `back_button`, starts at **y=113** — exactly the status bar inset height. |
| Bottom sheet (OsmAnd-version chooser, via `BottomSheetDialog`) | `content_container [0,1457][1008,2244]` reaches the bottom edge | scrollable content ends at **y=2019**, 117px clear of the nav bar inset. |

Screens reached while signed in: the "My location" contact/group picker, "Live now", "Timeline", the GPX info screen for a recorded track, and the OsmAnd-version bottom sheet. No clipped or overlapped content anywhere; crash buffer empty throughout.

Screenshots of the signed-in screens are deliberately **not attached** — they contain the tester's Telegram contact and chat names. The geometry above is the substitute, and it is stronger evidence than a screenshot for this particular question.

## Known gap, not addressed here

1. **Active-sharing states were not exercised.** Verification stopped short of enabling location sharing or the Timeline monitoring toggle, because both would have started broadcasting the tester's real location to real Telegram chats. So the sharing-in-progress UI (the duration/expiry controls and the active-share row) is unverified.
2. **Both opt-outs expire at target 37.** `enableOnBackInvokedCallback="false"` and `PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY` are documented as temporary and stop being honoured when an app targets API 37. The Pixel 8 Pro used above already runs API 37, so the next target bump makes these no-ops in both apps — the main app included.
3. **`TelegramInsets.kt` still sets `statusBarColor` / `navigationBarColor`.** Both are deprecated and are no-ops for apps targeting 35+. They are set to `Color.TRANSPARENT`, which is exactly what the platform enforces, so nothing renders differently — dead code, left alone in a parity change.
4. **`android:screenOrientation="unspecified"` sits on `<application>`** in `OsmAnd-telegram/AndroidManifest.xml`, where it is not a valid attribute (it belongs on `<activity>`). Harmless and pre-existing; not touched.
5. **`androidx.annotation:annotation:1.6.0` and `androidx.recyclerview:recyclerview:1.1.0` left as-is.** The main app does not declare either explicitly, so there is no version to mirror; appcompat 1.7.1 pulls newer ones transitively and Gradle picks the higher.
6. Not verified: release signing (Jenkins-only key), Android versions other than 16 and 17, landscape orientation, tablet / >=600dp layouts, and gesture navigation (the device tested uses 3-button navigation, which produces the larger bottom inset of the two).

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Update the target API for the plugin apps to match the main OsmAnd app, referring to the Android 16 behavior-changes page.
2. Do the small plugins first, check that they build correctly, and open a PR for them; update Tracker in a separate PR afterwards.
3. Do it on `r5.4`.
4. When asked how far the Tracker change should go: mirror the main app's opt-outs plus the dependency bump; and offering to perform the Telegram login on the Pixel for verification.
5. Confirmation that the login was done, so the signed-in screens could be verified.

Decided by the agent, not requested explicitly:
- Establishing first that Tracker was already at target 36, and re-scoping accordingly.
- Reporting that neither opt-out fixes an observed break, and measuring back behaviour before the change rather than asserting the risk. An earlier claim that `LoginDialogFragment`'s `Dialog.onBackPressed()` override was at risk was wrong and is corrected above.
- Not bumping `versionCode` here (CI supplies it), unlike #25966.
- Verifying on the API 37 Pixel 8 Pro in addition to the API 36 emulator, and using the `.debug` application id so no real Tracker install was touched.
- Using measured inset/view geometry as the published evidence and withholding the signed-in screenshots, which contain personal contact data.
- Not enabling location sharing or monitoring during verification (Known gap 1), since both have real-world side effects.
- Leaving items 3-5 under Known gap unfixed to keep this a parity change.
