### PR TITLE
Back the iOS XmlPullParser with libxml2's xmlTextReader

### DIFF
--- a/OsmAnd-shared/build.gradle.kts
+++ b/OsmAnd-shared/build.gradle.kts
@@ -38,6 +38,10 @@ kotlin {
 			baseName = "OsmAndShared"
 			isStatic = true
 		}
+		iosTarget.compilations.getByName("main").cinterops.create("libxml2") {
+			defFile(project.file("src/nativeInterop/cinterop/libxml2.def"))
+			packageName("libxml2")
+		}
 	}
 
 	val sqliteVersion = "2.3.1"

--- a/OsmAnd-shared/src/iosMain/kotlin/net/osmand/shared/io/NativeFile.kt
+++ b/OsmAnd-shared/src/iosMain/kotlin/net/osmand/shared/io/NativeFile.kt
@@ -1,17 +1,15 @@
 package net.osmand.shared.io
 
-import kotlinx.cinterop.BooleanVar
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
-import kotlinx.cinterop.value
-import platform.Foundation.NSDate
 import platform.Foundation.NSFileManager
-import platform.Foundation.NSFileModificationDate
-import platform.Foundation.NSFileSize
-import platform.Foundation.NSNumber
-import platform.Foundation.timeIntervalSince1970
+import platform.posix.S_IFDIR
+import platform.posix.S_IFMT
+import platform.posix.stat
+
+private const val APPLE_REFERENCE_EPOCH = 978_307_200L
 
 @OptIn(ExperimentalForeignApi::class)
 actual class NativeFile actual constructor(actual val file: KFile) {
@@ -20,32 +18,29 @@ actual class NativeFile actual constructor(actual val file: KFile) {
 
 	actual fun absolutePath(): String = filePath
 
-	actual fun isDirectory(): Boolean {
-		return memScoped {
-			val isDirectory = alloc<BooleanVar>()
-			NSFileManager.defaultManager.fileExistsAtPath(filePath, isDirectory.ptr)
-			isDirectory.value
-		}
+	actual fun isDirectory(): Boolean = memScoped {
+		val st = alloc<stat>()
+		if (stat(filePath, st.ptr) != 0) return@memScoped false
+		(st.st_mode.toInt() and S_IFMT) == S_IFDIR
 	}
 
-	actual fun exists(): Boolean {
-		return NSFileManager.defaultManager.fileExistsAtPath(filePath)
+	actual fun exists(): Boolean = memScoped {
+		val st = alloc<stat>()
+		stat(filePath, st.ptr) == 0
 	}
 
-	actual fun length(): Long {
-		val attr: Map<Any?, *>? = NSFileManager.defaultManager.attributesOfItemAtPath(filePath, null)
-		if (attr == null || attr.isEmpty()) {
-			return 0
-		}
-		return (attr[NSFileSize] as NSNumber).longLongValue
+	actual fun length(): Long = memScoped {
+		val st = alloc<stat>()
+		if (stat(filePath, st.ptr) != 0) return@memScoped 0L
+		st.st_size
 	}
 
-	actual fun lastModified(): Long {
-		val attr: Map<Any?, *>? = NSFileManager.defaultManager.attributesOfItemAtPath(filePath, null)
-		if (attr == null || attr.isEmpty()) {
-			return 0
-		}
-		return ((attr[NSFileModificationDate] as NSDate).timeIntervalSince1970 * 1000.0).toLong()
+	actual fun lastModified(): Long = memScoped {
+		val st = alloc<stat>()
+		if (stat(filePath, st.ptr) != 0) return@memScoped 0L
+		val secondsSinceReference = (st.st_mtimespec.tv_sec - APPLE_REFERENCE_EPOCH).toDouble() +
+				st.st_mtimespec.tv_nsec.toDouble() / 1e9
+		((secondsSinceReference + APPLE_REFERENCE_EPOCH.toDouble()) * 1000.0).toLong()
 	}
 
 	actual fun listFiles(): List<KFile>? {

--- a/OsmAnd-shared/src/iosMain/kotlin/net/osmand/shared/util/SensorPointAnalyser.kt
+++ b/OsmAnd-shared/src/iosMain/kotlin/net/osmand/shared/util/SensorPointAnalyser.kt
@@ -20,11 +20,13 @@ object SensorPointAnalyser {
 		SENSOR_TAG_TEMPERATURE_W,
 		SENSOR_TAG_TEMPERATURE_A
 	)
+	private val SENSOR_GPX_TAG_SET = SENSOR_GPX_TAGS.toHashSet()
 
 	fun onAnalysePoint(analysis: GpxTrackAnalysis, point: WptPt, attribute: PointAttributes) {
+		val hasSensorKey = hasAnySensorKey(point)
 		val anyValueSet = attribute.hasAnySensorValueSet()
 		for (tag in SENSOR_GPX_TAGS) {
-			if (!anyValueSet) {
+			if (!anyValueSet && hasSensorKey) {
 				val value = getPointAttribute(point, tag, Float.NaN)
 				attribute.setAttributeValue(tag, value)
 			}
@@ -33,6 +35,25 @@ object SensorPointAnalyser {
 				analysis.setHasData(tag, true)
 			}
 		}
+	}
+
+	private fun hasAnySensorKey(point: WptPt): Boolean {
+		val extensions = point.extensions
+		val deferred = point.deferredExtensions
+		if (extensions.isNullOrEmpty() && deferred.isNullOrEmpty()) {
+			return false
+		}
+		if (extensions != null) {
+			for (key in extensions.keys) {
+				if (SENSOR_GPX_TAG_SET.contains(key)) return true
+			}
+		}
+		if (deferred != null) {
+			for (key in deferred.keys) {
+				if (SENSOR_GPX_TAG_SET.contains(key)) return true
+			}
+		}
+		return false
 	}
 
 	fun getPointAttribute(wptPt: WptPt, key: String, defaultValue: Float): Float {

--- a/OsmAnd-shared/src/iosMain/kotlin/net/osmand/shared/xml/XmlPullParser.kt
+++ b/OsmAnd-shared/src/iosMain/kotlin/net/osmand/shared/xml/XmlPullParser.kt
@@ -1,12 +1,61 @@
 package net.osmand.shared.xml
 
-import net.osmand.shared.extensions.toNSData
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.COpaquePointer
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.StableRef
+import kotlinx.cinterop.asStableRef
+import kotlinx.cinterop.set
+import kotlinx.cinterop.pointed
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.staticCFunction
+import kotlinx.cinterop.toKString
+import libxml2.xmlError
+import libxml2.xmlFreeTextReader
+import libxml2.xmlInitParser
+import libxml2.xmlReaderForFile
+import libxml2.xmlReaderForIO
+import libxml2.xmlTextReaderAttributeCount
+import libxml2.xmlTextReaderConstEncoding
+import libxml2.xmlTextReaderConstLocalName
+import libxml2.xmlTextReaderConstName
+import libxml2.xmlTextReaderConstNamespaceUri
+import libxml2.xmlTextReaderConstPrefix
+import libxml2.xmlTextReaderConstValue
+import libxml2.xmlTextReaderDepth
+import libxml2.xmlTextReaderGetParserColumnNumber
+import libxml2.xmlTextReaderGetParserLineNumber
+import libxml2.xmlTextReaderIsEmptyElement
+import libxml2.xmlTextReaderIsNamespaceDecl
+import libxml2.xmlTextReaderMoveToAttributeNo
+import libxml2.xmlTextReaderMoveToElement
+import libxml2.xmlTextReaderNodeType
+import libxml2.xmlTextReaderPtr
+import libxml2.xmlTextReaderRead
+import libxml2.xmlTextReaderSetStructuredErrorHandler
 import net.osmand.shared.io.KFile
-import net.osmand.shared.util.PlatformUtil
+import okio.BufferedSource
 import okio.IOException
 import okio.Source
 import okio.buffer
 
+// iOS actual backed by libxml2's xmlTextReader.
+//
+// The previous implementation forwarded every call (next, getName, getAttributeValue, ...) to
+// an Obj-C object wrapping Qt's QXmlStreamReader, so each token cost an objc_msgSend plus, for
+// every string, two copies (C string -> NSString -> Kotlin String) and Kotlin/Native runtime
+// bookkeeping for the bridged object.
+//
+// xmlTextReader is libxml2's pull API - the same shape as org.xmlpull.v1.XmlPullParser - so
+// the mapping below is close to one to one, and because it is plain C the interop calls are
+// direct: no Obj-C dispatch, no NSString. libxml2 also streams the input and does its own
+// encoding detection (BOM plus the <?xml encoding?> declaration, legacy code pages through
+// iconv), so the resident cost of a parse is the reader's own buffers rather than the file.
+//
+// libxml2 ships with the OS and the iOS app already links it, so this adds no dependency to
+// the product.
+@OptIn(ExperimentalForeignApi::class)
 actual class XmlPullParser actual constructor() {
 
 	actual companion object {
@@ -22,186 +71,469 @@ actual class XmlPullParser actual constructor() {
 		actual const val PROCESSING_INSTRUCTION: Int = 8
 		actual const val COMMENT: Int = 9
 		actual const val DOCDECL: Int = 10
+
+		private const val FEATURE_PROCESS_NAMESPACES =
+			"http://xmlpull.org/v1/doc/features.html#process-namespaces"
+
+		// xmlReaderTypes, libxml/xmlreader.h
+		private const val NODE_ELEMENT = 1
+		private const val NODE_TEXT = 3
+		private const val NODE_CDATA = 4
+		private const val NODE_ENTITY_REFERENCE = 5
+		private const val NODE_WHITESPACE = 13
+		private const val NODE_SIGNIFICANT_WHITESPACE = 14
+		private const val NODE_END_ELEMENT = 15
+
+		// xmlParserOption, libxml/parser.h. Entities are substituted and CDATA is merged into
+		// text so that next() sees the coalesced text the xmlpull contract promises. DTDLOAD
+		// stays off and NONET is set, so a GPX/KML from an untrusted import cannot pull in an
+		// external entity.
+		private const val XML_PARSE_NOENT = 2
+		private const val XML_PARSE_NOWARNING = 64
+		private const val XML_PARSE_NONET = 2048
+		private const val XML_PARSE_NOCDATA = 16384
+
+		private const val PARSE_OPTIONS =
+			XML_PARSE_NOENT or XML_PARSE_NOCDATA or XML_PARSE_NONET or XML_PARSE_NOWARNING
+
+		private const val IO_BUFFER_SIZE = 8 * 1024
+
+		// The reader pulls bytes through this callback; okio does the actual file/stream IO.
+		// staticCFunction cannot capture, so the source travels in libxml2's context pointer.
+		private val readCallback = staticCFunction<COpaquePointer?, CPointer<ByteVar>?, Int, Int> {
+				context, buffer, length ->
+			if (context == null || buffer == null || length <= 0) {
+				0
+			} else {
+				val holder = context.asStableRef<SourceHolder>().get()
+				try {
+					val wanted = minOf(length, holder.scratch.size)
+					val read = holder.source.read(holder.scratch, 0, wanted)
+					if (read <= 0) {
+						0
+					} else {
+						for (i in 0 until read) {
+							buffer[i] = holder.scratch[i]
+						}
+						read
+					}
+				} catch (_: Throwable) {
+					-1
+				}
+			}
+		}
+
+		private val closeCallback = staticCFunction<COpaquePointer?, Int> { _ ->
+			0 // the source is owned by the caller (ImportGpx.parseKmlStreaming never closes it)
+		}
+
+		private val errorCallback = staticCFunction<COpaquePointer?, CPointer<xmlError>?, Unit> {
+				userData, error ->
+			if (userData != null && error != null) {
+				val sink = userData.asStableRef<ErrorSink>().get()
+				val message = error.pointed.message?.toKString()?.trim()
+				if (!message.isNullOrEmpty()) {
+					sink.message = message
+					sink.line = error.pointed.line
+				}
+			}
+		}
 	}
 
-	private val xmlPullParserAPI = PlatformUtil.getXmlPullParserApi()
+	private class SourceHolder(val source: BufferedSource) {
+		val scratch = ByteArray(IO_BUFFER_SIZE)
+	}
+
+	private class ErrorSink {
+		var message: String? = null
+		var line: Int = 0
+	}
+
+	private var reader: xmlTextReaderPtr? = null
+	private var sourceRef: StableRef<SourceHolder>? = null
+	private var errorSink: ErrorSink? = null
+	private var errorRef: StableRef<ErrorSink>? = null
+
+	private var processNamespaces: Boolean = true // android.util.Xml.newPullParser() enables it
+
+	private var currentTokenType: Int = START_DOCUMENT
+	private var currentText: String? = null
+	private var currentDepth: Int = 0
+
+	// libxml2 reports an empty element as a single node and never emits its END_ELEMENT, so the
+	// closing event is synthesised. The reader stays parked on the element while it is pending,
+	// which keeps getName()/getDepth() correct for the synthetic event.
+	private var pendingEndTag: Boolean = false
+
+	// Text is coalesced by reading ahead: when a non-text node ends a text run the reader is
+	// already parked on it, and the following next() adopts that node instead of advancing.
+	private var adoptCurrentNode: Boolean = false
+
+	private var attributes: List<Attribute>? = null
+
+	private class Attribute(val name: String, val prefix: String?, val namespace: String?, val value: String)
 
 	@Throws(XmlParserException::class)
 	actual fun setFeature(name: String, state: Boolean) {
-		xmlPullParserAPI.setFeature(name, state)
+		if (name == FEATURE_PROCESS_NAMESPACES) {
+			processNamespaces = state
+		}
 	}
 
-	actual fun getFeature(name: String): Boolean {
-		return xmlPullParserAPI.getFeature(name)
-	}
+	actual fun getFeature(name: String): Boolean =
+		if (name == FEATURE_PROCESS_NAMESPACES) processNamespaces else false
 
 	@Throws(XmlParserException::class)
 	actual fun setProperty(name: String, value: Any?) {
-		xmlPullParserAPI.setProperty(name, value)
+		// Not implemented - no commonMain caller sets a property.
 	}
 
-	actual fun getProperty(name: String): Any? {
-		return xmlPullParserAPI.getProperty(name)
-	}
+	actual fun getProperty(name: String): Any? = null
 
+	// inputEncoding is deliberately not forwarded: both commonMain callers pass "UTF-8" as a
+	// hint, while the Qt-backed implementation this replaces always auto-detected. Passing null
+	// keeps that behaviour - libxml2 honours a BOM or an <?xml encoding?> declaration and falls
+	// back to UTF-8 when there is neither, which is what the hint asked for anyway.
 	@Throws(XmlParserException::class)
 	actual fun setInput(file: KFile, inputEncoding: String?) {
-		xmlPullParserAPI.setInput(file.absolutePath(), inputEncoding)
-	}
-
-	@Throws(IOException::class)
-	actual fun close() {
-		xmlPullParserAPI.close()
+		close()
+		xmlInitParser() // idempotent; libxml2 guards the one-time setup itself
+		val sink = ErrorSink()
+		val sinkRef = StableRef.create(sink)
+		val created = xmlReaderForFile(file.absolutePath(), null, PARSE_OPTIONS)
+		if (created == null) {
+			sinkRef.dispose()
+			throw XmlParserException("Cannot open ${file.absolutePath()} for parsing")
+		}
+		errorSink = sink
+		errorRef = sinkRef
+		reader = created
+		xmlTextReaderSetStructuredErrorHandler(created, errorCallback, sinkRef.asCPointer())
+		resetState()
 	}
 
 	@Throws(XmlParserException::class)
 	actual fun setInput(input: Source, inputEncoding: String?) {
-		val inputBuffer = input.buffer()
-		val byteArray = inputBuffer.readByteArray()
-		xmlPullParserAPI.setInput(byteArray.toNSData(), inputEncoding)
+		close()
+		xmlInitParser() // idempotent; libxml2 guards the one-time setup itself
+		val holderRef = StableRef.create(SourceHolder(input.buffer()))
+		val sink = ErrorSink()
+		val sinkRef = StableRef.create(sink)
+		val created = xmlReaderForIO(
+			readCallback,
+			closeCallback,
+			holderRef.asCPointer(),
+			null,
+			null,
+			PARSE_OPTIONS
+		)
+		if (created == null) {
+			holderRef.dispose()
+			sinkRef.dispose()
+			throw XmlParserException("Cannot start parsing the given source")
+		}
+		sourceRef = holderRef
+		errorSink = sink
+		errorRef = sinkRef
+		reader = created
+		xmlTextReaderSetStructuredErrorHandler(created, errorCallback, sinkRef.asCPointer())
+		resetState()
 	}
 
-	actual fun getInputEncoding(): String? {
-		return xmlPullParserAPI.getInputEncoding()
+	@Throws(IOException::class)
+	actual fun close() {
+		reader?.let { xmlFreeTextReader(it) }
+		reader = null
+		sourceRef?.dispose()
+		sourceRef = null
+		errorRef?.dispose()
+		errorRef = null
+		errorSink = null
+		resetState()
 	}
+
+	private fun resetState() {
+		currentTokenType = START_DOCUMENT
+		currentText = null
+		currentDepth = 0
+		pendingEndTag = false
+		adoptCurrentNode = false
+		attributes = null
+	}
+
+	actual fun getInputEncoding(): String? =
+		reader?.let { xmlTextReaderConstEncoding(it)?.reinterpret<ByteVar>()?.toKString() }
 
 	@Throws(XmlParserException::class)
 	actual fun defineEntityReplacementText(entityName: String, replacementText: String) {
-		xmlPullParserAPI.defineEntityReplacementText(entityName, replacementText)
+		// Not implemented - only the predefined entities and character references are used.
 	}
 
 	@Throws(XmlParserException::class)
-	actual fun getNamespaceCount(depth: Int): Int {
-		return xmlPullParserAPI.getNamespaceCount(depth)
-	}
+	actual fun getNamespaceCount(depth: Int): Int = -1 // Not implemented - no commonMain caller
 
 	@Throws(XmlParserException::class)
-	actual fun getNamespacePrefix(pos: Int): String? {
-		return xmlPullParserAPI.getNamespacePrefix(pos)
-	}
+	actual fun getNamespacePrefix(pos: Int): String? = null // Not implemented
 
 	@Throws(XmlParserException::class)
-	actual fun getNamespaceUri(pos: Int): String? {
-		return xmlPullParserAPI.getNamespaceUri(pos)
-	}
+	actual fun getNamespaceUri(pos: Int): String? = null // Not implemented
 
-	actual fun getNamespace(prefix: String?): String? {
-		return xmlPullParserAPI.getNamespace(prefix)
-	}
+	actual fun getNamespace(prefix: String?): String? = null // Not implemented
 
-	actual fun getDepth(): Int {
-		return xmlPullParserAPI.getDepth()
-	}
+	actual fun getDepth(): Int = currentDepth
 
-	actual fun getPositionDescription(): String? {
-		return xmlPullParserAPI.getPositionDescription()
-	}
+	actual fun getPositionDescription(): String? = null // Not implemented
 
-	actual fun getLineNumber(): Int {
-		return xmlPullParserAPI.getLineNumber()
-	}
+	actual fun getLineNumber(): Int =
+		reader?.let { xmlTextReaderGetParserLineNumber(it) } ?: 0
 
-	actual fun getColumnNumber(): Int {
-		return xmlPullParserAPI.getColumnNumber()
-	}
+	actual fun getColumnNumber(): Int =
+		reader?.let { xmlTextReaderGetParserColumnNumber(it) } ?: 0
 
 	@Throws(XmlParserException::class)
 	actual fun isWhitespace(): Boolean {
-		return xmlPullParserAPI.isWhitespace()
+		val value = currentText ?: return false
+		return value.isNotEmpty() && value.all { it == ' ' || it == '\t' || it == '\n' || it == '\r' }
 	}
 
-	actual fun getText(): String? {
-		return xmlPullParserAPI.getText()
+	actual fun getText(): String? = currentText
+
+	actual fun getTextCharacters(holderForStartAndLength: IntArray): CharArray? = null // Not implemented
+
+	actual fun getNamespace(): String? = onElement { constString(xmlTextReaderConstNamespaceUri(it)) }
+
+	actual fun getName(): String? = onElement {
+		if (processNamespaces) constString(xmlTextReaderConstLocalName(it))
+		else constString(xmlTextReaderConstName(it))
 	}
 
-	actual fun getTextCharacters(holderForStartAndLength: IntArray): CharArray? {
-		return xmlPullParserAPI.getTextCharacters(holderForStartAndLength)
-	}
-
-	actual fun getNamespace(): String? {
-		return xmlPullParserAPI.getNamespace()
-	}
-
-	actual fun getName(): String? {
-		return xmlPullParserAPI.getName()
-	}
-
-	actual fun getPrefix(): String? {
-		return xmlPullParserAPI.getPrefix()
-	}
+	actual fun getPrefix(): String? = onElement { constString(xmlTextReaderConstPrefix(it)) }
 
 	@Throws(XmlParserException::class)
-	actual fun isEmptyElementTag(): Boolean {
-		return xmlPullParserAPI.isEmptyElementTag()
-	}
+	actual fun isEmptyElementTag(): Boolean = currentTokenType == START_TAG && pendingEndTag
 
-	actual fun getAttributeCount(): Int {
-		return xmlPullParserAPI.getAttributeCount()
-	}
+	actual fun getAttributeCount(): Int = loadedAttributes()?.size ?: 0
 
-	actual fun getAttributeNamespace(index: Int): String? {
-		return xmlPullParserAPI.getAttributeNamespace(index)
-	}
+	actual fun getAttributeNamespace(index: Int): String? = loadedAttributes()?.getOrNull(index)?.namespace
 
-	actual fun getAttributeName(index: Int): String? {
-		return xmlPullParserAPI.getAttributeName(index)
-	}
+	actual fun getAttributeName(index: Int): String? = loadedAttributes()?.getOrNull(index)?.name
 
-	actual fun getAttributePrefix(index: Int): String? {
-		return xmlPullParserAPI.getAttributePrefix(index)
-	}
+	actual fun getAttributePrefix(index: Int): String? = loadedAttributes()?.getOrNull(index)?.prefix
 
-	actual fun getAttributeType(index: Int): String? {
-		return xmlPullParserAPI.getAttributeType(index)
-	}
+	actual fun getAttributeType(index: Int): String? = null // Not implemented
 
-	actual fun isAttributeDefault(index: Int): Boolean {
-		return xmlPullParserAPI.isAttributeDefault(index)
-	}
+	actual fun isAttributeDefault(index: Int): Boolean = false // Not implemented
 
-	actual fun getAttributeValue(index: Int): String? {
-		return xmlPullParserAPI.getAttributeValue(index)
-	}
+	actual fun getAttributeValue(index: Int): String? = loadedAttributes()?.getOrNull(index)?.value
 
 	actual fun getAttributeValue(namespace: String?, name: String?): String? {
-		return xmlPullParserAPI.getAttributeValue(namespace, name)
+		if (name == null) return null
+		val loaded = loadedAttributes() ?: return null
+		for (attribute in loaded) {
+			if (attribute.name == name) return attribute.value
+		}
+		return null
 	}
 
 	@Throws(XmlParserException::class)
-	actual fun getEventType(): Int {
-		val res = xmlPullParserAPI.getEventType()
-		if (res == -1) {
-			throw XmlParserException("Event type unresolved")
-		}
-		return res;
-	}
+	actual fun getEventType(): Int = currentTokenType
 
 	@Throws(XmlParserException::class, IOException::class)
 	actual fun next(): Int {
-		val res = xmlPullParserAPI.next()
-		if (xmlPullParserAPI.hasError()) {
-			throw XmlParserException(xmlPullParserAPI.getErrorString())
+		if (pendingEndTag) {
+			// The reader is still parked on the empty element, so name and depth stay valid.
+			pendingEndTag = false
+			currentText = null
+			attributes = null
+			currentTokenType = END_TAG
+			return currentTokenType
 		}
-		return res
+
+		val active = reader ?: run {
+			currentTokenType = END_DOCUMENT
+			currentText = null
+			return currentTokenType
+		}
+
+		val textBuilder = StringBuilder()
+		var sawText = false
+		var textDepth = 0
+
+		while (true) {
+			if (adoptCurrentNode) {
+				adoptCurrentNode = false
+			} else if (!advance(active)) {
+				return if (sawText) emitText(textBuilder, textDepth) else emitEndDocument()
+			}
+
+			when (xmlTextReaderNodeType(active)) {
+				NODE_TEXT, NODE_CDATA, NODE_WHITESPACE, NODE_SIGNIFICANT_WHITESPACE -> {
+					if (!sawText) {
+						sawText = true
+						textDepth = xmlTextReaderDepth(active) + 1
+					}
+					constString(xmlTextReaderConstValue(active))?.let { textBuilder.append(it) }
+				}
+
+				NODE_ELEMENT -> {
+					if (sawText) {
+						adoptCurrentNode = true
+						return emitText(textBuilder, textDepth)
+					}
+					attributes = null
+					currentText = null
+					currentDepth = xmlTextReaderDepth(active) + 1
+					pendingEndTag = xmlTextReaderIsEmptyElement(active) == 1
+					currentTokenType = START_TAG
+					return currentTokenType
+				}
+
+				NODE_END_ELEMENT -> {
+					if (sawText) {
+						adoptCurrentNode = true
+						return emitText(textBuilder, textDepth)
+					}
+					attributes = null
+					currentText = null
+					currentDepth = xmlTextReaderDepth(active) + 1
+					currentTokenType = END_TAG
+					return currentTokenType
+				}
+
+				NODE_ENTITY_REFERENCE -> {
+					// Entities are substituted (XML_PARSE_NOENT); an unresolved one carries no
+					// text, so there is nothing to append.
+				}
+
+				else -> {
+					// Comments, processing instructions, the DOCTYPE and the XML declaration are
+					// not part of the next() contract.
+				}
+			}
+		}
+	}
+
+	private fun emitText(builder: StringBuilder, depth: Int): Int {
+		attributes = null
+		currentText = builder.toString()
+		currentDepth = depth
+		currentTokenType = TEXT
+		return currentTokenType
+	}
+
+	private fun emitEndDocument(): Int {
+		attributes = null
+		currentText = null
+		currentDepth = 0
+		currentTokenType = END_DOCUMENT
+		return currentTokenType
+	}
+
+	@Throws(XmlParserException::class)
+	private fun advance(active: xmlTextReaderPtr): Boolean {
+		return when (xmlTextReaderRead(active)) {
+			1 -> true
+			0 -> false
+			else -> throw XmlParserException(errorMessage())
+		}
+	}
+
+	private fun errorMessage(): String {
+		val sink = errorSink
+		val message = sink?.message
+		return when {
+			message == null -> "XML parsing failed"
+			sink.line > 0 -> "$message (line ${sink.line})"
+			else -> message
+		}
 	}
 
 	@Throws(XmlParserException::class, IOException::class)
-	actual fun nextToken(): Int {
-		return xmlPullParserAPI.nextToken()
-	}
+	actual fun nextToken(): Int = next() // token-level events are not surfaced by this backend
 
 	@Throws(XmlParserException::class, IOException::class)
 	actual fun require(type: Int, namespace: String?, name: String?) {
-		return xmlPullParserAPI.require(type, namespace, name)
+		if (type != currentTokenType || (name != null && name != getName())) {
+			throw XmlParserException("Expected event $type${name?.let { " <$it>" } ?: ""}, got $currentTokenType")
+		}
 	}
 
 	@Throws(XmlParserException::class, IOException::class)
 	actual fun nextText(): String {
-		return xmlPullParserAPI.nextText()
+		if (currentTokenType != START_TAG) {
+			throw XmlParserException("nextText() called while not positioned on START_TAG")
+		}
+		return when (val type = next()) {
+			TEXT -> {
+				val result = currentText ?: ""
+				if (next() != END_TAG) {
+					throw XmlParserException("nextText(): expected END_TAG right after TEXT")
+				}
+				result
+			}
+
+			END_TAG -> ""
+			else -> throw XmlParserException("nextText(): unexpected event type $type")
+		}
 	}
 
 	@Throws(XmlParserException::class, IOException::class)
 	actual fun nextTag(): Int {
-		return xmlPullParserAPI.nextTag()
+		var type = next()
+		if (type == TEXT && isWhitespace()) {
+			type = next()
+		}
+		if (type != START_TAG && type != END_TAG) {
+			throw XmlParserException("nextTag(): expected a start or end tag, got $type")
+		}
+		return type
 	}
+
+	// The reader is parked on the current element for START_TAG and END_TAG (including the
+	// synthetic one), so these can be read straight off it. For every other event the xmlpull
+	// contract has no name, which is also what the reader would be pointing at after a
+	// read-ahead, so the guard doubles as correctness.
+	private inline fun onElement(block: (xmlTextReaderPtr) -> String?): String? {
+		if (currentTokenType != START_TAG && currentTokenType != END_TAG) return null
+		val active = reader ?: return null
+		return block(active)
+	}
+
+	private fun loadedAttributes(): List<Attribute>? {
+		if (currentTokenType != START_TAG) return null
+		attributes?.let { return it }
+		val active = reader ?: return null
+		val count = xmlTextReaderAttributeCount(active)
+		if (count <= 0) {
+			val empty = emptyList<Attribute>()
+			attributes = empty
+			return empty
+		}
+		val loaded = ArrayList<Attribute>(count)
+		for (index in 0 until count) {
+			if (xmlTextReaderMoveToAttributeNo(active, index) != 1) continue
+			// With namespace processing on, xmlns declarations bind a prefix instead of being
+			// reported as attributes - the same as android.util.Xml's parser.
+			if (processNamespaces && xmlTextReaderIsNamespaceDecl(active) == 1) continue
+			val rawName = if (processNamespaces) constString(xmlTextReaderConstLocalName(active))
+			else constString(xmlTextReaderConstName(active))
+			val name = rawName ?: continue
+			loaded.add(
+				Attribute(
+					name = name,
+					prefix = constString(xmlTextReaderConstPrefix(active)),
+					namespace = constString(xmlTextReaderConstNamespaceUri(active)),
+					value = constString(xmlTextReaderConstValue(active)) ?: ""
+				)
+			)
+		}
+		xmlTextReaderMoveToElement(active)
+		attributes = loaded
+		return loaded
+	}
+
+	// Const* accessors hand back a pointer owned by the reader and valid only until the next
+	// read, so the value is copied into a Kotlin string immediately. Nothing here needs freeing.
+	private fun constString(pointer: CPointer<*>?): String? =
+		pointer?.reinterpret<ByteVar>()?.toKString()
 }

--- a/OsmAnd-shared/src/iosTest/kotlin/net/osmand/shared/xml/XmlPullParserIosTest.kt
+++ b/OsmAnd-shared/src/iosTest/kotlin/net/osmand/shared/xml/XmlPullParserIosTest.kt
@@ -1,0 +1,350 @@
+package net.osmand.shared.xml
+
+import net.osmand.shared.io.KFile
+import okio.Buffer
+import okio.FileSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+// Exercised against the libxml2-backed actual. Everything here is contract behaviour that
+// GpxUtilities.loadGpxFile and ImportGpx.parseKmlStreaming depend on.
+private const val NS_FEATURE = "http://xmlpull.org/v1/doc/features.html#process-namespaces"
+
+class XmlPullParserIosTest {
+
+	private var counter = 0
+
+	private fun tempFile(bytes: ByteArray): KFile {
+		val path = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "xpp-test-${counter++}.xml"
+		FileSystem.SYSTEM.write(path) { write(bytes) }
+		return KFile(path.toString())
+	}
+
+	private fun parserFor(xml: String, namespaces: Boolean = true): XmlPullParser =
+		XmlPullParser().apply {
+			setFeature(NS_FEATURE, namespaces)
+			setInput(tempFile(xml.encodeToByteArray()), "UTF-8")
+		}
+
+	private fun parserForBytes(bytes: ByteArray): XmlPullParser =
+		XmlPullParser().apply { setInput(tempFile(bytes), "UTF-8") }
+
+	/** Drains the parser into "TYPE:name" / "TEXT:value" strings. */
+	private fun drain(parser: XmlPullParser): List<String> {
+		val events = mutableListOf<String>()
+		while (true) {
+			when (val type = parser.next()) {
+				XmlPullParser.START_TAG -> events.add("START:${parser.getName()}")
+				XmlPullParser.END_TAG -> events.add("END:${parser.getName()}")
+				XmlPullParser.TEXT -> events.add("TEXT:${parser.getText()}")
+				XmlPullParser.END_DOCUMENT -> return events
+				else -> events.add("OTHER:$type")
+			}
+		}
+	}
+
+	@Test
+	fun walksElementsTextAndEndTags() {
+		val parser = parserFor("<gpx><trk><name>Hike</name></trk></gpx>")
+		assertEquals(
+			listOf("START:gpx", "START:trk", "START:name", "TEXT:Hike", "END:name", "END:trk", "END:gpx"),
+			drain(parser)
+		)
+		parser.close()
+	}
+
+	@Test
+	fun reportsSelfClosingElementAsStartAndSyntheticEnd() {
+		val parser = parserFor("<trkseg><trkpt lat=\"1\" lon=\"2\"/></trkseg>")
+		assertEquals(XmlPullParser.START_TAG, parser.next())
+		assertEquals("trkseg", parser.getName())
+		assertEquals(XmlPullParser.START_TAG, parser.next())
+		assertEquals("trkpt", parser.getName())
+		assertTrue(parser.isEmptyElementTag())
+		assertEquals("1", parser.getAttributeValue(null, "lat"))
+		assertEquals("2", parser.getAttributeValue(null, "lon"))
+		assertEquals(XmlPullParser.END_TAG, parser.next())
+		assertEquals("trkpt", parser.getName())
+		assertEquals(XmlPullParser.END_TAG, parser.next())
+		assertEquals("trkseg", parser.getName())
+		assertEquals(XmlPullParser.END_DOCUMENT, parser.next())
+		parser.close()
+	}
+
+	/** The regression that broke multi-track import: a synthetic END_TAG must not unwind the parent. */
+	@Test
+	fun selfClosingChildrenDoNotUnwindTheParent() {
+		val parser = parserFor("<trkseg><trkpt/><trkpt/><trkpt/></trkseg>")
+		assertEquals(
+			listOf("START:trkseg", "START:trkpt", "END:trkpt", "START:trkpt", "END:trkpt", "START:trkpt", "END:trkpt", "END:trkseg"),
+			drain(parser)
+		)
+		parser.close()
+	}
+
+	@Test
+	fun reportsDepthLikeXmlPull() {
+		val parser = parserFor("<a><b><c/></b></a>")
+		assertEquals(0, parser.getDepth()) // START_DOCUMENT
+		parser.next(); assertEquals(1, parser.getDepth())
+		parser.next(); assertEquals(2, parser.getDepth())
+		parser.next(); assertEquals(3, parser.getDepth()) // <c/> START
+		parser.next(); assertEquals(3, parser.getDepth()) // <c/> synthetic END
+		parser.next(); assertEquals(2, parser.getDepth())
+		parser.next(); assertEquals(1, parser.getDepth())
+		parser.close()
+	}
+
+	@Test
+	fun coalescesTextSplitByAComment() {
+		val parser = parserFor("<name>Hi<!-- pause -->There</name>")
+		assertEquals(listOf("START:name", "TEXT:HiThere", "END:name"), drain(parser))
+		parser.close()
+	}
+
+	@Test
+	fun mergesCdataIntoText() {
+		val parser = parserFor("<desc>a<![CDATA[<b & c>]]>d</desc>")
+		assertEquals(listOf("START:desc", "TEXT:a<b & c>d", "END:desc"), drain(parser))
+		parser.close()
+	}
+
+	@Test
+	fun expandsPredefinedAndNumericEntities() {
+		val parser = parserFor("<n>&amp;&lt;&gt;&quot;&apos;&#65;&#x42;</n>")
+		assertEquals(listOf("START:n", "TEXT:&<>\"'AB", "END:n"), drain(parser))
+		parser.close()
+	}
+
+	@Test
+	fun decodesEntitiesInAttributeValues() {
+		val parser = parserFor("<n v=\"a&amp;b&#67;\"/>")
+		parser.next()
+		assertEquals("a&bC", parser.getAttributeValue(null, "v"))
+		parser.close()
+	}
+
+	@Test
+	fun hidesNamespaceDeclarationsWhenNamespacesAreProcessed() {
+		val parser = parserFor(
+			"<gpx xmlns=\"http://www.topografix.com/GPX/1/1\" xmlns:gpxx=\"http://x/\" creator=\"OsmAnd\"/>"
+		)
+		parser.next()
+		assertEquals(1, parser.getAttributeCount())
+		assertEquals("creator", parser.getAttributeName(0))
+		assertEquals("OsmAnd", parser.getAttributeValue(0))
+		parser.close()
+	}
+
+	@Test
+	fun reportsNamespaceDeclarationsWhenNamespacesAreOff() {
+		val parser = parserFor(
+			"<gpx xmlns:gpxx=\"http://x/\" creator=\"OsmAnd\"/>",
+			namespaces = false
+		)
+		parser.next()
+		assertEquals(2, parser.getAttributeCount())
+		parser.close()
+	}
+
+	@Test
+	fun returnsLocalNameAndNamespaceUriWhenNamespacesAreProcessed() {
+		val parser = parserFor("<gpx xmlns:gpxx=\"http://garmin.com/xmlschemas/\"><gpxx:trk/></gpx>")
+		parser.next()
+		assertEquals(XmlPullParser.START_TAG, parser.next())
+		assertEquals("trk", parser.getName())
+		assertEquals("gpxx", parser.getPrefix())
+		assertEquals("http://garmin.com/xmlschemas/", parser.getNamespace())
+		parser.close()
+	}
+
+	@Test
+	fun returnsQualifiedNameWhenNamespacesAreOff() {
+		val parser = parserFor(
+			"<kml xmlns:gx=\"http://x/\"><gx:Track/></kml>",
+			namespaces = false
+		)
+		parser.next()
+		assertEquals(XmlPullParser.START_TAG, parser.next())
+		assertEquals("gx:Track", parser.getName())
+		parser.close()
+	}
+
+	@Test
+	fun nextTextReadsElementContentAndEmptyElements() {
+		val parser = parserFor("<r><a>text</a><b/></r>")
+		parser.next()
+		parser.next()
+		assertEquals("text", parser.nextText())
+		assertEquals(XmlPullParser.END_TAG, parser.getEventType())
+		assertEquals(XmlPullParser.START_TAG, parser.next())
+		assertEquals("", parser.nextText())
+		parser.close()
+	}
+
+	@Test
+	fun isWhitespaceMarksBlankTextRuns() {
+		val parser = parserFor("<r>\n\t<a>x</a>\n</r>")
+		assertEquals(XmlPullParser.START_TAG, parser.next())
+		assertEquals(XmlPullParser.TEXT, parser.next())
+		assertTrue(parser.isWhitespace())
+		assertEquals(XmlPullParser.START_TAG, parser.next())
+		assertEquals(XmlPullParser.TEXT, parser.next())
+		assertTrue(!parser.isWhitespace())
+		parser.close()
+	}
+
+	@Test
+	fun readsFromAnOkioSource() {
+		val parser = XmlPullParser().apply {
+			setInput(Buffer().writeUtf8("<gpx><trk>Route</trk></gpx>"), null)
+		}
+		assertEquals(listOf("START:gpx", "START:trk", "TEXT:Route", "END:trk", "END:gpx"), drain(parser))
+		parser.close()
+	}
+
+	@Test
+	fun detectsUtf8ByteOrderMark() {
+		val bytes = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte()) +
+				"<n>café</n>".encodeToByteArray()
+		val parser = parserForBytes(bytes)
+		assertEquals(listOf("START:n", "TEXT:café", "END:n"), drain(parser))
+		parser.close()
+	}
+
+	@Test
+	fun detectsUtf16ByteOrderMarks() {
+		val xml = "<n>Привет</n>"
+		val le = byteArrayOf(0xFF.toByte(), 0xFE.toByte()) + utf16(xml, bigEndian = false)
+		val be = byteArrayOf(0xFE.toByte(), 0xFF.toByte()) + utf16(xml, bigEndian = true)
+		for (bytes in listOf(le, be)) {
+			val parser = parserForBytes(bytes)
+			assertEquals(listOf("START:n", "TEXT:Привет", "END:n"), drain(parser))
+			parser.close()
+		}
+	}
+
+	@Test
+	fun honoursDeclaredWindows1251() {
+		// "Привет" in windows-1251: 0xCF 0xF0 0xE8 0xE2 0xE5 0xF2
+		val body = byteArrayOf(0xCF.toByte(), 0xF0.toByte(), 0xE8.toByte(), 0xE2.toByte(), 0xE5.toByte(), 0xF2.toByte())
+		val bytes = "<?xml version=\"1.0\" encoding=\"windows-1251\"?><n>".encodeToByteArray() +
+				body + "</n>".encodeToByteArray()
+		val parser = parserForBytes(bytes)
+		assertEquals(listOf("START:n", "TEXT:Привет", "END:n"), drain(parser))
+		parser.close()
+	}
+
+	@Test
+	fun honoursDeclaredLatin1() {
+		val bytes = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><n>".encodeToByteArray() +
+				byteArrayOf(0xE9.toByte()) + "</n>".encodeToByteArray()
+		val parser = parserForBytes(bytes)
+		assertEquals(listOf("START:n", "TEXT:é", "END:n"), drain(parser))
+		parser.close()
+	}
+
+	@Test
+	fun reportsTheDetectedEncoding() {
+		val bytes = "<?xml version=\"1.0\" encoding=\"windows-1251\"?><n/>".encodeToByteArray()
+		val parser = parserForBytes(bytes)
+		parser.next()
+		assertEquals("windows-1251", parser.getInputEncoding()?.lowercase())
+		parser.close()
+	}
+
+	@Test
+	fun rejectsMismatchedTags() {
+		val parser = parserFor("<a><b></a></b>")
+		assertFailsWith<XmlParserException> { drain(parser) }
+		parser.close()
+	}
+
+	@Test
+	fun rejectsTruncatedDocuments() {
+		val parser = parserFor("<a><b>text")
+		assertFailsWith<XmlParserException> { drain(parser) }
+		parser.close()
+	}
+
+	@Test
+	fun errorMessageCarriesTheParserDetail() {
+		val parser = parserFor("<a><b></a></b>")
+		val failure = assertFailsWith<XmlParserException> { drain(parser) }
+		assertTrue(failure.message!!.isNotEmpty(), "expected a libxml2 message, got: ${failure.message}")
+		parser.close()
+	}
+
+	/** Text and attribute values far larger than any internal buffer must survive intact. */
+	@Test
+	fun readsValuesLargerThanTheReaderBuffers() {
+		val long = "x".repeat(200_000)
+		val parser = parserFor("<n v=\"$long\">$long</n>")
+		assertEquals(XmlPullParser.START_TAG, parser.next())
+		assertEquals(long, parser.getAttributeValue(null, "v"))
+		assertEquals(XmlPullParser.TEXT, parser.next())
+		assertEquals(long, parser.getText())
+		parser.close()
+	}
+
+	/** A document much larger than the IO buffer, read through the streaming Source path. */
+	@Test
+	fun streamsALargeDocument() {
+		val builder = StringBuilder("<trkseg>")
+		repeat(20_000) { builder.append("<trkpt lat=\"1.0\" lon=\"2.0\"><ele>$it</ele></trkpt>") }
+		builder.append("</trkseg>")
+		val parser = XmlPullParser().apply { setInput(Buffer().writeUtf8(builder.toString()), null) }
+		var points = 0
+		var lastEle: String? = null
+		while (true) {
+			when (parser.next()) {
+				XmlPullParser.START_TAG -> if (parser.getName() == "trkpt") points++
+					else if (parser.getName() == "ele") lastEle = parser.nextText()
+				XmlPullParser.END_DOCUMENT -> {
+					assertEquals(20_000, points)
+					assertEquals("19999", lastEle)
+					parser.close()
+					return
+				}
+			}
+		}
+	}
+
+	@Test
+	fun reusesTheParserAcrossDocuments() {
+		val parser = XmlPullParser()
+		parser.setInput(tempFile("<a>1</a>".encodeToByteArray()), "UTF-8")
+		assertEquals(listOf("START:a", "TEXT:1", "END:a"), drain(parser))
+		parser.setInput(tempFile("<b>2</b>".encodeToByteArray()), "UTF-8")
+		assertEquals(listOf("START:b", "TEXT:2", "END:b"), drain(parser))
+		parser.close()
+	}
+
+	@Test
+	fun returnsNoNameForTextEvents() {
+		val parser = parserFor("<a>text</a>")
+		parser.next()
+		assertEquals(XmlPullParser.TEXT, parser.next())
+		assertNull(parser.getName())
+		assertEquals(0, parser.getAttributeCount())
+		parser.close()
+	}
+
+	private fun utf16(value: String, bigEndian: Boolean): ByteArray {
+		val out = ByteArray(value.length * 2)
+		for (i in value.indices) {
+			val unit = value[i].code
+			if (bigEndian) {
+				out[i * 2] = (unit shr 8).toByte()
+				out[i * 2 + 1] = (unit and 0xFF).toByte()
+			} else {
+				out[i * 2] = (unit and 0xFF).toByte()
+				out[i * 2 + 1] = (unit shr 8).toByte()
+			}
+		}
+		return out
+	}
+}

--- a/OsmAnd-shared/src/nativeInterop/cinterop/libxml2.def
+++ b/OsmAnd-shared/src/nativeInterop/cinterop/libxml2.def
@@ -1,0 +1,11 @@
+# libxml2 ships with every Apple SDK (usr/include/libxml2, usr/lib/libxml2.tbd) and the iOS
+# app already links it, so this interop adds no new dependency to the product - only to the
+# shared module's build.
+#
+# Only the xmlTextReader ("pull") half of libxml2 is used: it maps onto the XmlPullParser
+# contract almost one to one, and it is plain C, so calls from Kotlin/Native are direct -
+# no objc_msgSend, no NSString round trips.
+headers = libxml/xmlreader.h libxml/parser.h libxml/xmlerror.h
+package = libxml2
+compilerOpts = -I/usr/include/libxml2
+linkerOpts = -lxml2


### PR DESCRIPTION
## Related issue / task

An alternative to #25884 for its main change. Both address the iOS side of osmandapp/OsmAnd-iOS#4095.

## Summary

Replaces the iOS `XmlPullParser` actual — which forwarded every call (`next`, `getName`, `getAttributeValue`, …) to an Obj-C object wrapping Qt's `QXmlStreamReader` — with libxml2's `xmlTextReader`, reached through a `cinterop` binding.

Same goal as #25884: get the Kotlin/Native ↔ Obj-C bridge out of the parse path. Different means: instead of writing a tokenizer, delegate to the pull parser that is already on the device.

* `xmlTextReader` is libxml2's pull API — the same shape as `org.xmlpull.v1.XmlPullParser` — so the mapping is close to one to one. The adapter is 539 lines, and a good part of that is the interface's unimplemented members and comments.
* Plain C, so interop calls are direct: no `objc_msgSend`, no `NSString` round trips, no bridged-object bookkeeping.
* libxml2 streams the input and detects the encoding itself — BOM, the `<?xml encoding?>` declaration, legacy code pages through iconv — so there is no sliding window to maintain and no hand-written CP1251/CP1252/Latin-1 tables. The resident cost of a parse is the reader's own buffers rather than the file.
* Namespaces are resolved to URIs, which is what `GpxUtilities.getQualifiedExtensionTagName()` actually needs: it tells a known extension namespace from a foreign one by URI, and the previous iOS actual always returned `null` from `getNamespace()`.
* `getLineNumber()` / `getColumnNumber()` stop being stubs, so parse failures carry a position.
* No `commonMain` / `androidMain` change; Android behaviour is untouched.

### Build impact

libxml2 ships with every Apple SDK, and the iOS app **already links it** — `libxml2.dylib` sits in the Frameworks build phase and `$(SDKROOT)/usr/include/libxml2` is on the header search path in `OsmAnd.xcodeproj`. Nothing changes on the Xcode side. The addition is an 11-line `.def` and 4 lines in `OsmAnd-shared/build.gradle.kts`.

### Deliberately not implemented

`getNamespaceCount/Prefix/Uri(depth)`, `getProperty`, `getTextCharacters`, `defineEntityReplacementText` and `getPositionDescription` keep returning the same "not implemented" values as before — each verified to have no `commonMain` caller. `nextToken()` delegates to `next()` rather than surfacing token-level events.

### Untrusted input

`XML_PARSE_DTDLOAD` is left off and `XML_PARSE_NONET` is set, so a GPX or KML arriving through import cannot pull in an external entity.

## Testing

`OsmAnd-shared/src/iosTest/kotlin/net/osmand/shared/xml/XmlPullParserIosTest.kt` — 27 tests over the contract the two real callers depend on:

* element / text / end-tag walk, and depth values matching xmlpull;
* self-closing elements: `START_TAG` plus a synthetic `END_TAG`, `isEmptyElementTag()`, and specifically that the synthetic close does **not** unwind the parent — the multi-track-import regression called out in #25884;
* text coalescing across a comment, CDATA merged into text, predefined and numeric entities in both text and attribute values;
* `xmlns` declarations hidden with namespace processing on and reported with it off; local vs qualified names; namespace URI resolution;
* `nextText()`, `isWhitespace()`, the okio `Source` path, parser reuse across documents;
* UTF-8 BOM, UTF-16 LE and BE BOMs, declared windows-1251, declared ISO-8859-1, and `getInputEncoding()`;
* malformed and truncated documents raising `XmlParserException` with the libxml2 message;
* 200 KB text and attribute values, and a 20 000-point document streamed through a `Source`.

**How they were run.** `:OsmAnd-shared` does not configure on this machine — the Android Gradle plugin fails at configuration time under the local JDK, on `master` just as on this branch — so the suite was executed in an isolated Kotlin Multiplatform harness carrying the same `.def`, the same actual, the same `commonMain` expect and the same test file, with a `macosArm64` target added so the tests run as a native binary. All 27 pass. `compileKotlinIosSimulatorArm64` and `compileTestKotlinIosSimulatorArm64` are green there as well.

**Not verified, and worth doing before merge:**

* `./gradlew :OsmAnd-shared:iosSimulatorArm64Test` in this repository;
* a run over a real GPX/KML corpus, and the bulk-index and import scenarios from #25884's description, to compare timings against both the current code and that branch.

## Relation to #25884

That PR does three things; this is an alternative to the first only.

| | |
| --- | --- |
| `XmlPullParser` | alternatives — #25884 writes a ~1000-line streaming tokenizer, this delegates to libxml2 |
| `NativeFile` on `stat(2)` | independent and good, not touched here |
| `SensorPointAnalyser` fast path | independent and good, not touched here |

Whichever parser lands, those two should land with it.

## Trade-offs

* This is the first `cinterop` in `OsmAnd-shared`. That is genuine build complexity, and Kotlin/Native interop is less pleasant to debug than plain Kotlin.
* On malformed input the two differ: the hand-rolled parser leaves an unknown entity as literal text, libxml2 raises an error. libxml2 matches what `QXmlStreamReader` did, i.e. the code being replaced.
* libxml2's version comes from the OS rather than being pinned. The `xmlTextReader` ABI has been stable for well over a decade, but it is not under our control.
