### PR TITLE
HH: correct all underestimated shortcuts before recalculating

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/router/HHRoutePlanner.java
+++ b/OsmAnd-java/src/main/java/net/osmand/router/HHRoutePlanner.java
@@ -1249,6 +1249,7 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 		if (progress != null && progress.hhGetCalcCounter() > 0) {
 			progress.hhIterationProgress((double) progress.hhGetCalcCounter() / maxCountReiteration);
 		}
+		boolean costIncreased = false;
 		for (int i = 0; i < route.segments.size(); i++) {
 			if (progress != null && progress.hhGetCalcCounter() == 0) {
 				progress.hhIterationProgress((double) i / route.segments.size()); // DETAILED
@@ -1289,7 +1290,9 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 					}
 					s.segment.dist = f.distanceFromStart;
 					if (!acceptCostIncrease) {
-						return true;
+						// correct every underestimated shortcut of this route before recalculating it
+						costIncreased = true;
+						continue;
 					}
 					s.rtTimeHHSegments = f.distanceFromStart;
 				}
@@ -1304,7 +1307,7 @@ public class HHRoutePlanner<T extends NetworkDBPoint> {
 				}
 			}
 		}
-		return false;
+		return costIncreased;
 	}
 	
 	private void recalculateNetworkCluster(HHRoutingContext<T> hctx, NetworkDBPoint start) throws InterruptedException, IOException {


### PR DESCRIPTION
`retrieveSegmentsGeometry()` returned at the first shortcut whose detailed route cost more than the shortcut, so every recalculation corrected one segment. When the shortcut set does not match the routing parameters — e.g. motorcycle with `avoid_motorway` + `prefer_unpaved`, where HH uses the `prefer_unpaved` shortcuts — long routes ran out of `MAX_COUNT_REITERATION` (30) and failed with "too many cancelled". On the server this is followed by a BRP fallback that runs for minutes.

Now the loop corrects every underestimated shortcut of the route and then recalculates once. The "Route not found" branch still returns immediately, because it changes the cluster.

Measured on planet `route.obf`, HH only, motorcycle + avoid_motorway + prefer_unpaved. Time is HH searches + detailed segment routing:

| route | before | after |
|---|---|---|
| Berlin–Munich | fails, 44 s | 781.7 km, 8 recalculations, 18.5 s |
| Paris–Lyon | fails, 24 s | 556.2 km, 22 recalculations, 23.3 s |
| Munich–Erlangen | 24 recalculations, 7.0 s | same route, 8 recalculations, 4.8 s |
| Lisbon–Porto | 4 recalculations, 1.5 s | same route, 4 recalculations, 3.1 s |

Car without these params (Berlin–Munich, Paris–Lyon): no recalculation, unchanged.

Trade-off: when only a few shortcuts are wrong (Lisbon–Porto), segments of a route that is then discarded are routed too, which is slower. Not checked: `RouteTestingTest`.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Investigate why a motorcycle route with avoid_motorway and prefer_unpaved does not build, and check Berlin–Munich and Paris–Lyon too.
2. Explain why the recalculation returns at the first segment, and measure where the time goes.
3. Open a PR with the original fix only (no detailed-segment cache); the same 3-line change for C++.

Decided by the agent, not requested explicitly: keeping the immediate return in the "Route not found" branch.
