### PR TITLE
Android Auto: fix Free Ride auto-start against weak GPS and add zoom-in

### DIFF
--- a/OsmAnd/src/net/osmand/plus/OsmAndConstants.java
+++ b/OsmAnd/src/net/osmand/plus/OsmAndConstants.java
@@ -12,4 +12,5 @@ public interface OsmAndConstants {
 	int UI_HANDLER_MAP_HUD = 10000;
 	int EXPLORE_PLACES_UPDATE = 11000;
 	int AUTO_BACKUP = 12000;
+	int UI_HANDLER_ANDROID_AUTO = 13000;
 }

--- a/OsmAnd/src/net/osmand/plus/auto/screens/LandingScreen.kt
+++ b/OsmAnd/src/net/osmand/plus/auto/screens/LandingScreen.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import net.osmand.Location
+import net.osmand.plus.OsmAndConstants
 import net.osmand.plus.OsmAndLocationProvider.OsmAndLocationListener
 import net.osmand.plus.R
 import net.osmand.plus.auto.NavigationSession
@@ -51,17 +52,31 @@ class LandingScreen(
      * so the map is shown without any interaction with the head unit. See issue #25783.
      */
     override fun updateLocation(location: Location?) {
-        if (autoFreeRideStarted || app.routingHelper.isRouteCalculated
-            || location == null || !location.hasSpeed() || location.speed < AUTO_FREE_RIDE_MIN_SPEED) {
+        if (autoFreeRideStarted || app.routingHelper.isRouteCalculated) {
             movingSinceTime = 0
             return
         }
-        val time = System.currentTimeMillis()
+        if (location == null) {
+            // Location temporarily unavailable - keep the already running timer going.
+            return
+        }
         if (movingSinceTime == 0L) {
-            movingSinceTime = time
-        } else if (time - movingSinceTime >= AUTO_FREE_RIDE_DELAY) {
+            // A confirmed speed above the threshold is required to start counting.
+            if (!location.hasSpeed() || location.speed < AUTO_FREE_RIDE_MIN_SPEED) {
+                return
+            }
+            movingSinceTime = System.currentTimeMillis()
+            // Fire even if no further location updates arrive (e.g. GPS signal lost entirely).
+            app.runInUIThreadAndCancelPrevious(
+                AUTO_FREE_RIDE_CHECK_MSG_ID, { checkFreeRideDelayElapsed() }, AUTO_FREE_RIDE_DELAY)
+        }
+    }
+
+    /** Scheduled AUTO_FREE_RIDE_DELAY after the timer started; re-checks state before acting. */
+    private fun checkFreeRideDelayElapsed() {
+        if (movingSinceTime != 0L && System.currentTimeMillis() - movingSinceTime >= AUTO_FREE_RIDE_DELAY) {
             movingSinceTime = 0
-            app.runInUIThread { startFreeRide() }
+            startFreeRide()
         }
     }
 
@@ -69,6 +84,7 @@ class LandingScreen(
         if (!autoFreeRideStarted && lifecycle.currentState == Lifecycle.State.RESUMED
             && !app.routingHelper.isRouteCalculated) {
             autoFreeRideStarted = true
+            app.mapViewTrackingUtilities.backToLocationImpl()
             onCategoryClick(PlaceCategory.FREE_MODE)
         }
     }
@@ -239,5 +255,7 @@ class LandingScreen(
 
         /** How long the vehicle should move before the free ride mode is started automatically. */
         private const val AUTO_FREE_RIDE_DELAY = 15000L
+
+        private const val AUTO_FREE_RIDE_CHECK_MSG_ID = OsmAndConstants.UI_HANDLER_ANDROID_AUTO + 1
     }
 }


### PR DESCRIPTION
## Summary
- Auto-start of "Free ride" mode while driving (added in #25833) could silently stop working under weak GPS: a location update without a speed reading, or the location disappearing entirely, reset the moving-timer just like a real stop, so the 15s threshold was never reached.
- Speed is now only required to *start* the timer; once it is running, further updates (including ones with no/low speed, or `null` location) no longer reset it — only a real stop condition (route already calculated, or the timer already fired) does.
- The 15s check no longer depends on a location update arriving to be evaluated — it's scheduled via `runInUIThreadAndCancelPrevious` and fires on its own even if GPS drops out completely while the timer is running.
- On auto-start, the map now also zooms in to the current location (`MapViewTrackingUtilities.backToLocationImpl()`), matching what happens when starting regular route navigation.

## Test plan
- [ ] Manual: drive (or simulate GPS) with intermittently missing speed data and confirm Free Ride still auto-starts after ~15s of movement.
- [ ] Manual: let GPS signal drop out completely mid-countdown and confirm Free Ride still auto-starts on schedule.
- [ ] Manual: confirm a real stop (speed genuinely near zero the whole time) does not trigger auto-start.
- [ ] Manual: confirm the map zooms in to the current location when Free Ride auto-starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)