### PR TITLE
AIS plugin: online plane sources (ADS-B Exchange, OpenSky)

### DIFF
--- a/OsmAnd/res/drawable/ic_ais_plane_plain.xml
+++ b/OsmAnd/res/drawable/ic_ais_plane_plain.xml
@@ -1,0 +1,11 @@
+<!-- Aircraft silhouette without the halo and outline of mm_ais_plane, in white so the layer can
+     tint it by altitude. Same 48dp viewport, so rotation and anchoring stay unchanged. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+  <path
+      android:pathData="M24,8C25.1046,8 26,8.8954 26,10V17.25L40,26V30L26,24.75V33.5L32,38V40L24,38L16,40V38L22,33.5V24.75L8,30V26L22,17.25V10C22,8.8954 22.8954,8 24,8Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/OsmAnd/res/drawable/ic_ais_plane_plain.xml
+++ b/OsmAnd/res/drawable/ic_ais_plane_plain.xml
@@ -1,5 +1,7 @@
-<!-- Aircraft silhouette without the halo and outline of mm_ais_plane, in white so the layer can
-     tint it by altitude. Same 48dp viewport, so rotation and anchoring stay unchanged. -->
+<!-- Aircraft silhouette without the halo of mm_ais_plane, carrying a thin outline instead of its
+     heavy one. The fill is white so the layer can tint it by altitude; the outline is black, which
+     survives that tint unchanged because the tint is applied as a multiplication.
+     Same 48dp viewport as mm_ais_plane, so rotation and anchoring stay unchanged. -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="48dp"
     android:height="48dp"
@@ -7,5 +9,9 @@
     android:viewportHeight="48">
   <path
       android:pathData="M24,8C25.1046,8 26,8.8954 26,10V17.25L40,26V30L26,24.75V33.5L32,38V40L24,38L16,40V38L22,33.5V24.75L8,30V26L22,17.25V10C22,8.8954 22.8954,8 24,8Z"
-      android:fillColor="#ffffff"/>
+      android:fillColor="#ffffff"
+      android:strokeColor="#000000"
+      android:strokeWidth="1.1"
+      android:strokeLineJoin="round"
+      android:strokeLineCap="round"/>
 </vector>

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -681,6 +681,13 @@
     <string name="ais_cpa_warning_time_description">If the TCPA (Time to Closest Point of Approach) with another vessel falls below the defined threshold, the vessel is highlighted in red.</string>
     <string name="ais_cpa_warning_distance">Warning distance for the Closes Point of Approach (CPA)</string>
     <string name="ais_cpa_warning_distance_description">Vessels are highlighted in red if the CPA (Closest Point of Approach) is below the defined threshold and the TCPA (Time to CPA) falls within the warning time set in the \'Warning time to reach the CPA\' setting.</string>
+    <string name="ais_url_sources">Online data sources (URL)</string>
+    <string name="ais_url_sources_description">Add a named URL source per data type (planes or ships), the same way you add an online routing engine. Only PLANES sources (OpenSky-compatible JSON) are fetched so far.</string>
+    <string name="ais_add_url_source">Add source</string>
+    <string name="ais_show_ships">Show ships</string>
+    <string name="ais_show_ships_description">Show vessels received over NMEA or from a SHIPS source.</string>
+    <string name="ais_show_planes">Show planes</string>
+    <string name="ais_show_planes_description">Show aircraft received from a PLANES source.</string>
     <string name="plugin_ais_tracker_name">AIS vessel tracker</string>
     <string name="plugin_ais_tracker_description">Displays AIS positions and information about nearby vessels. AIS data is received over the network from an external AIS receiver.</string>
     <string name="plugin_ais_tracker_disclaimer">DISCLAIMER\n\nThis plugin is a hobby project and is not intended for use in critical applications. It does not guarantee reliability or accuracy. Do not rely on this software for navigation, safety of life, or any other essential operations.</string>

--- a/OsmAnd/res/values/strings.xml
+++ b/OsmAnd/res/values/strings.xml
@@ -682,8 +682,9 @@
     <string name="ais_cpa_warning_distance">Warning distance for the Closes Point of Approach (CPA)</string>
     <string name="ais_cpa_warning_distance_description">Vessels are highlighted in red if the CPA (Closest Point of Approach) is below the defined threshold and the TCPA (Time to CPA) falls within the warning time set in the \'Warning time to reach the CPA\' setting.</string>
     <string name="ais_url_sources">Online data sources (URL)</string>
-    <string name="ais_url_sources_description">Add a named URL source per data type (planes or ships), the same way you add an online routing engine. Only PLANES sources (OpenSky-compatible JSON) are fetched so far.</string>
+    <string name="ais_url_sources_description">Add a named URL source per data type (planes or ships), the same way you add an online routing engine. Only PLANES sources are fetched so far, in OpenSky or ADS-B Exchange JSON format.</string>
     <string name="ais_add_url_source">Add source</string>
+    <string name="ais_source_api_key">API key (optional)</string>
     <string name="ais_show_ships">Show ships</string>
     <string name="ais_show_ships_description">Show vessels received over NMEA or from a SHIPS source.</string>
     <string name="ais_show_planes">Show planes</string>

--- a/OsmAnd/res/xml/ais_settings.xml
+++ b/OsmAnd/res/xml/ais_settings.xml
@@ -91,4 +91,21 @@
         android:title="@string/ais_display_own_position"
         tools:summary="@string/ais_display_own_position_description" />
 
+    <PreferenceCategory
+        android:key="ais_url_sources_category"
+        android:layout="@layout/preference_category_with_descr"
+        android:title="@string/ais_url_sources" />
+
+    <net.osmand.plus.settings.preferences.ListPreferenceEx
+        android:key="ais_show_ships"
+        android:layout="@layout/preference_with_descr"
+        android:title="@string/ais_show_ships"
+        tools:summary="@string/ais_show_ships_description" />
+
+    <net.osmand.plus.settings.preferences.ListPreferenceEx
+        android:key="ais_show_planes"
+        android:layout="@layout/preference_with_descr"
+        android:title="@string/ais_show_planes"
+        tools:summary="@string/ais_show_planes_description" />
+
 </PreferenceScreen>

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisImagesCache.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisImagesCache.java
@@ -24,14 +24,22 @@ public class AisImagesCache {
 
 	@Nullable
 	public Bitmap getBitmap(@DrawableRes int drawableId) {
+		return getBitmap(drawableId, 1f);
+	}
+
+	/**
+	 * @param extraScale on top of the text scale, for symbols drawn smaller than the rest
+	 */
+	@Nullable
+	public Bitmap getBitmap(@DrawableRes int drawableId, float extraScale) {
 		Bitmap bitmap = null;
 		if (drawableId != 0) {
-			float textScale = OsmandMapLayer.getTextScale(app);
-			long key = ((long) drawableId << 32L) + (int)(textScale * 1000);
+			float scale = OsmandMapLayer.getTextScale(app) * extraScale;
+			long key = ((long) drawableId << 32L) + (int) (scale * 1000);
 			bitmap = bitmapCache.get(key);
 			if (bitmap == null) {
 				Drawable icon = app.getUIUtilities().getIcon(drawableId);
-				bitmap = AndroidUtils.drawableToBitmap(icon, textScale, true);
+				bitmap = AndroidUtils.drawableToBitmap(icon, scale, true);
 				bitmapCache.put(key, bitmap);
 			}
 		}

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisObjectDrawable.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisObjectDrawable.java
@@ -1,5 +1,6 @@
 package net.osmand.plus.plugins.aistracker;
 
+import static net.osmand.shared.aistracker.AisObjectConstants.INVALID_ALTITUDE;
 import static net.osmand.shared.aistracker.AisObjectConstants.INVALID_COG;
 import static net.osmand.shared.aistracker.AisObjectConstants.INVALID_HEADING;
 
@@ -108,13 +109,23 @@ public class AisObjectDrawable {
 		return renderKey != null && !renderKey.equals(getCurrentRenderKey());
 	}
 
+	/** Aircraft are drawn a fifth smaller than vessels, and without the halo/outline the shared
+	 * AIS icon carries, so a dense sky stays readable. */
+	private static final float PLANE_ICON_SCALE = 0.8f;
+	private static final int PLANE_ALTITUDE_MID = 5000;
+	private static final int PLANE_ALTITUDE_HIGH = 12000;
+	private static final int PLANE_COLOR_GROUND = Color.rgb(0x9E, 0x9E, 0x9E);
+	private static final int PLANE_COLOR_LOW = Color.rgb(0x2E, 0xCC, 0x40);
+	private static final int PLANE_COLOR_MID = Color.rgb(0xFF, 0xDC, 0x00);
+	private static final int PLANE_COLOR_HIGH = Color.rgb(0xE5, 0x39, 0x35);
+
 	public static int selectBitmap(@NonNull AisObjType type) {
 		return switch (type) {
 			case AIS_VESSEL, AIS_VESSEL_SPORT, AIS_VESSEL_FAST, AIS_VESSEL_PASSENGER,
 				 AIS_VESSEL_FREIGHT, AIS_VESSEL_COMMERCIAL, AIS_VESSEL_AUTHORITIES, AIS_VESSEL_SAR,
 				 AIS_VESSEL_OTHER, AIS_INVALID -> R.drawable.mm_ais_vessel;
 			case AIS_LANDSTATION -> R.drawable.mm_ais_land;
-			case AIS_AIRPLANE -> R.drawable.mm_ais_plane;
+			case AIS_AIRPLANE -> R.drawable.ic_ais_plane_plain;
 			case AIS_SART -> R.drawable.mm_ais_sar;
 			case AIS_ATON -> R.drawable.mm_ais_aton;
 			case AIS_ATON_VIRTUAL -> R.drawable.mm_ais_aton_virt;
@@ -161,20 +172,51 @@ public class AisObjectDrawable {
 	}
 
 	private void prepareBitmap() {
+		boolean plane = ais.getObjectClass() == AisObjType.AIS_AIRPLANE && visualState != 2;
 		if (visualState == 1) {
 			bitmap = null;
 		} else {
 			bitmap = imagesCache.getBitmap(visualState == 2
-					? R.drawable.mm_ais_vessel_cross
-					: selectBitmap(ais.getObjectClass()));
+							? R.drawable.mm_ais_vessel_cross
+							: selectBitmap(ais.getObjectClass()),
+					plane ? PLANE_ICON_SCALE : 1f);
 		}
 		if (ownObject) {
 			bitmapColor = Color.BLACK;
 		} else if (visualState == 2) {
 			bitmapColor = 0;
+		} else if (plane) {
+			bitmapColor = selectAltitudeColor(ais.getAltitude());
 		} else {
 			bitmapColor = selectColor(ais.getObjectClass());
 		}
+	}
+
+	/**
+	 * Aircraft are told apart by how high they are: grey on the ground (or with no altitude
+	 * reported), then green near the ground through yellow at cruising climb to red high up.
+	 *
+	 * @param altitude metres above sea level, 0 meaning on the ground
+	 */
+	public static int selectAltitudeColor(int altitude) {
+		if (altitude == INVALID_ALTITUDE || altitude <= 0) {
+			return PLANE_COLOR_GROUND;
+		}
+		if (altitude >= PLANE_ALTITUDE_HIGH) {
+			return PLANE_COLOR_HIGH;
+		}
+		return altitude < PLANE_ALTITUDE_MID
+				? blend(PLANE_COLOR_LOW, PLANE_COLOR_MID, (float) altitude / PLANE_ALTITUDE_MID)
+				: blend(PLANE_COLOR_MID, PLANE_COLOR_HIGH,
+				(float) (altitude - PLANE_ALTITUDE_MID) / (PLANE_ALTITUDE_HIGH - PLANE_ALTITUDE_MID));
+	}
+
+	private static int blend(int from, int to, float ratio) {
+		float r = Math.max(0, Math.min(1, ratio));
+		return Color.rgb(
+				Math.round(Color.red(from) + (Color.red(to) - Color.red(from)) * r),
+				Math.round(Color.green(from) + (Color.green(to) - Color.green(from)) * r),
+				Math.round(Color.blue(from) + (Color.blue(to) - Color.blue(from)) * r));
 	}
 
 	private void updatePaint(@NonNull Paint paint, boolean cpaWarning) {

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisPlaneDataFetcher.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisPlaneDataFetcher.java
@@ -325,7 +325,11 @@ public class AisPlaneDataFetcher {
 			if (Double.isNaN(lon) || Double.isNaN(lat)) {
 				continue;
 			}
-			double altitudeMeters = row.length() > 13 && !row.isNull(13)
+			// on_ground, so the layer can tell a taxiing aircraft from one that simply reports
+			// no altitude
+			boolean onGround = row.optBoolean(8, false);
+			double altitudeMeters = onGround ? 0
+					: row.length() > 13 && !row.isNull(13)
 					? row.optDouble(13, Double.NaN) : row.optDouble(7, Double.NaN);
 			double velocityMs = row.isNull(9) ? Double.NaN : row.optDouble(9, Double.NaN);
 			double cog = row.isNull(10) ? INVALID_COG : row.optDouble(10, INVALID_COG);
@@ -352,10 +356,13 @@ public class AisPlaneDataFetcher {
 			if (Double.isNaN(lat) || Double.isNaN(lon)) {
 				continue;
 			}
-			// alt_baro is "ground" for aircraft on the ground, hence optDouble with a NaN default
+			// alt_baro is the string "ground" for aircraft on the ground - 0 marks them as landed,
+			// which the layer draws differently from an aircraft that reports no altitude at all
+			boolean onGround = "ground".equals(plane.optString("alt_baro", ""));
 			double altitudeFeet = plane.isNull("alt_geom")
 					? plane.optDouble("alt_baro", Double.NaN) : plane.optDouble("alt_geom", Double.NaN);
-			double altitudeMeters = Double.isNaN(altitudeFeet) ? Double.NaN : altitudeFeet * FEET_TO_METERS;
+			double altitudeMeters = onGround ? 0
+					: Double.isNaN(altitudeFeet) ? Double.NaN : altitudeFeet * FEET_TO_METERS;
 			// ground speed is already in knots here, unlike OpenSky
 			double sog = plane.isNull("gs") ? Double.NaN : plane.optDouble("gs", Double.NaN);
 			double cog = plane.isNull("track") ? INVALID_COG : plane.optDouble("track", INVALID_COG);

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisPlaneDataFetcher.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisPlaneDataFetcher.java
@@ -27,6 +27,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * Fetches aircraft positions from a plane {@link AisUrlSource} and turns them into
@@ -68,6 +69,14 @@ public class AisPlaneDataFetcher {
 	// the ADS-B services cap the radius at 250 nm
 	private static final double MAX_RADIUS_NM = 250;
 
+	private static final String NUMBER = "-?\\d+(?:\\.\\d+)?";
+	private static final Pattern PLACEHOLDER =
+			Pattern.compile("\\{(LAT|LON|DIST|LAMIN|LOMIN|LAMAX|LOMAX)}");
+	private static final Pattern LAT_LON_DIST_PATH =
+			Pattern.compile("/lat/" + NUMBER + "/lon/" + NUMBER + "/dist/" + NUMBER);
+	private static final Pattern POINT_PATH =
+			Pattern.compile("/point/" + NUMBER + "/" + NUMBER + "/" + NUMBER);
+
 	private AisPlaneDataFetcher() {
 	}
 
@@ -87,13 +96,53 @@ public class AisPlaneDataFetcher {
 		// radius covering the viewport corner, which is what centre+radius services ask for
 		double distNm = Math.min(MAX_RADIUS_NM, Math.max(MIN_RADIUS_NM,
 				MapUtils.getDistance(centerLat, centerLon, north, east) / METERS_PER_NM));
-		return url.replace("{LAMIN}", format(south))
-				.replace("{LAMAX}", format(north))
-				.replace("{LOMIN}", format(west))
-				.replace("{LOMAX}", format(east))
-				.replace("{LAT}", format(centerLat))
-				.replace("{LON}", format(centerLon))
-				.replace("{DIST}", String.valueOf(Math.round(distNm)));
+		String dist = String.valueOf(Math.round(distNm));
+
+		if (PLACEHOLDER.matcher(url).find()) {
+			return url.replace("{LAMIN}", format(south))
+					.replace("{LAMAX}", format(north))
+					.replace("{LOMIN}", format(west))
+					.replace("{LOMAX}", format(east))
+					.replace("{LAT}", format(centerLat))
+					.replace("{LON}", format(centerLon))
+					.replace("{DIST}", dist);
+		}
+		return replaceLiteralCoordinates(url, format(centerLat), format(centerLon), dist,
+				format(south), format(west), format(north), format(east));
+	}
+
+	/**
+	 * A URL without placeholders - typed by hand or saved before placeholders existed - still has
+	 * to follow the map, so coordinates written in the shapes these services use are rewritten to
+	 * the current area. Anything unrecognised is left alone.
+	 */
+	@NonNull
+	private static String replaceLiteralCoordinates(@NonNull String url, @NonNull String lat,
+	                                                 @NonNull String lon, @NonNull String dist,
+	                                                 @NonNull String lamin, @NonNull String lomin,
+	                                                 @NonNull String lamax, @NonNull String lomax) {
+		String result = url;
+		// /lat/50.03/lon/8.56/dist/50 - adsb.lol, adsb.fi, ADS-B Exchange
+		result = LAT_LON_DIST_PATH.matcher(result)
+				.replaceAll("/lat/" + lat + "/lon/" + lon + "/dist/" + dist);
+		// /point/50.03/8.56/50 - airplanes.live
+		result = POINT_PATH.matcher(result).replaceAll("/point/" + lat + "/" + lon + "/" + dist);
+		// lamin=45&lomin=5&lamax=55&lomax=20 - OpenSky, in whatever order they appear
+		result = replaceQueryValue(result, "lamin", lamin);
+		result = replaceQueryValue(result, "lomin", lomin);
+		result = replaceQueryValue(result, "lamax", lamax);
+		result = replaceQueryValue(result, "lomax", lomax);
+		if (!result.equals(url)) {
+			Log.d(TAG, "rewrote fixed coordinates to the current map area: " + result);
+		}
+		return result;
+	}
+
+	@NonNull
+	private static String replaceQueryValue(@NonNull String url, @NonNull String param,
+	                                         @NonNull String value) {
+		return Pattern.compile("([?&]" + param + "=)" + NUMBER)
+				.matcher(url).replaceAll("$1" + value);
 	}
 
 	@NonNull

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisPlaneDataFetcher.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisPlaneDataFetcher.java
@@ -33,7 +33,8 @@ import java.util.List;
  * <ul>
  *     <li>OpenSky Network - {@code {"states": [[icao24, callsign, .., lon, lat, ..], ..]}},
  *     speed in m/s and altitude in metres;</li>
- *     <li>ADS-B Exchange / airplanes.live - {@code {"ac": [{"hex": .., "lat": .., "gs": ..}, ..]}},
+ *     <li>ADS-B Exchange and the community services serving the same payload (adsb.lol under
+ *     {@code "ac"}, adsb.fi under {@code "aircraft"}) - {@code [{"hex": .., "lat": .., "gs": ..}]},
  *     speed in knots and altitude in feet.</li>
  * </ul>
  * Runs synchronously - callers are expected to invoke this from a background thread.
@@ -71,7 +72,11 @@ public class AisPlaneDataFetcher {
 			if (states != null) {
 				return parseOpenSky(states);
 			}
+			// same payload, different wrapper key depending on the service
 			JSONArray aircraft = root.optJSONArray("ac");
+			if (aircraft == null) {
+				aircraft = root.optJSONArray("aircraft");
+			}
 			if (aircraft != null) {
 				return parseAdsb(aircraft);
 			}

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisPlaneDataFetcher.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisPlaneDataFetcher.java
@@ -27,6 +27,8 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 /**
@@ -70,12 +72,18 @@ public class AisPlaneDataFetcher {
 	private static final double MAX_RADIUS_NM = 250;
 
 	private static final String NUMBER = "-?\\d+(?:\\.\\d+)?";
+	// both braces escaped: Android's ICU regex engine rejects a bare '}', unlike the JVM one
 	private static final Pattern PLACEHOLDER =
-			Pattern.compile("\\{(LAT|LON|DIST|LAMIN|LOMIN|LAMAX|LOMAX)}");
+			Pattern.compile("\\{(LAT|LON|DIST|LAMIN|LOMIN|LAMAX|LOMAX)\\}");
 	private static final Pattern LAT_LON_DIST_PATH =
 			Pattern.compile("/lat/" + NUMBER + "/lon/" + NUMBER + "/dist/" + NUMBER);
 	private static final Pattern POINT_PATH =
 			Pattern.compile("/point/" + NUMBER + "/" + NUMBER + "/" + NUMBER);
+
+	private static final int HTTP_TOO_MANY_REQUESTS = 429;
+	private static final long RATE_LIMIT_BACKOFF_MS = 60_000L;
+	/** Host -> when it is fair to ask again, after that host answered 429. */
+	private static final Map<String, Long> RATE_LIMITED_UNTIL = new ConcurrentHashMap<>();
 
 	private AisPlaneDataFetcher() {
 	}
@@ -210,6 +218,13 @@ public class AisPlaneDataFetcher {
 			url = url.replace(API_KEY_PLACEHOLDER, source.apiKey);
 		}
 		String loggedUrl = hideKey(url, source.apiKey);
+		String host = getHost(url);
+		Long backoffUntil = host == null ? null : RATE_LIMITED_UNTIL.get(host);
+		if (backoffUntil != null && System.currentTimeMillis() < backoffUntil) {
+			Log.d(TAG, "'" + source.name + "': skipping, " + host + " rate-limited us, backing off for "
+					+ (backoffUntil - System.currentTimeMillis()) / 1000 + " s more");
+			return null;
+		}
 		HttpURLConnection connection = null;
 		long started = System.currentTimeMillis();
 		try {
@@ -237,7 +252,16 @@ public class AisPlaneDataFetcher {
 						? shorten(readStream(connection.getErrorStream())) : "";
 				Log.w(TAG, "'" + source.name + "' responded " + responseCode + " "
 						+ connection.getResponseMessage() + " " + error);
+				if (responseCode == HTTP_TOO_MANY_REQUESTS && host != null) {
+					// keep hammering a service that just asked us to stop and it will only get worse
+					RATE_LIMITED_UNTIL.put(host, System.currentTimeMillis() + RATE_LIMIT_BACKOFF_MS);
+					Log.w(TAG, "pausing requests to " + host + " for "
+							+ RATE_LIMIT_BACKOFF_MS / 1000 + " s");
+				}
 				return null;
+			}
+			if (host != null) {
+				RATE_LIMITED_UNTIL.remove(host);
 			}
 			String body = readStream(connection.getInputStream());
 			Log.d(TAG, "'" + source.name + "' responded " + responseCode + ", " + body.length()
@@ -263,6 +287,15 @@ public class AisPlaneDataFetcher {
 			}
 		}
 		return builder.toString();
+	}
+
+	@Nullable
+	private static String getHost(@NonNull String url) {
+		try {
+			return new URI(url).getHost();
+		} catch (URISyntaxException e) {
+			return null;
+		}
 	}
 
 	@Nullable

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisPlaneDataFetcher.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisPlaneDataFetcher.java
@@ -4,8 +4,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import net.osmand.PlatformUtil;
+import net.osmand.osm.io.NetworkUtils;
 import net.osmand.plus.OsmandApplication;
-import net.osmand.plus.utils.AndroidNetworkUtils;
+import net.osmand.plus.Version;
 import net.osmand.shared.aistracker.AisObject;
 import net.osmand.util.Algorithms;
 
@@ -14,16 +15,27 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Fetches aircraft positions from an OpenSky-Network-compatible JSON URL
- * ({@code {"states": [[icao24, callsign, origin_country, time_position, last_contact,
- * longitude, latitude, baro_altitude, on_ground, velocity, true_track, ...], ...]}}) and turns
- * them into {@link AisObject} instances (message type 9 = airborne SAR/aircraft position report)
- * so they can be fed straight into the existing AIS rendering/tap-menu pipeline alongside ships.
+ * Fetches aircraft positions from a plane {@link AisUrlSource} and turns them into
+ * {@link AisObject} instances (message type 9 = airborne position report), so aircraft reuse the
+ * existing AIS rendering and tap-menu pipeline alongside vessels.
  * <p>
+ * Two response layouts are recognised, picked by what the server actually returns:
+ * <ul>
+ *     <li>OpenSky Network - {@code {"states": [[icao24, callsign, .., lon, lat, ..], ..]}},
+ *     speed in m/s and altitude in metres;</li>
+ *     <li>ADS-B Exchange / airplanes.live - {@code {"ac": [{"hex": .., "lat": .., "gs": ..}, ..]}},
+ *     speed in knots and altitude in feet.</li>
+ * </ul>
  * Runs synchronously - callers are expected to invoke this from a background thread.
  */
 public class AisPlaneDataFetcher {
@@ -37,62 +49,173 @@ public class AisPlaneDataFetcher {
 	private static final double INVALID_SOG = 1023.0;
 	private static final int MSG_TYPE_AIRCRAFT_POSITION = 9;
 
+	private static final String API_KEY_PLACEHOLDER = "{API_KEY}";
+	private static final String RAPIDAPI_HOST_SUFFIX = ".p.rapidapi.com";
+	private static final int CONNECT_TIMEOUT = 15000;
+	private static final int READ_TIMEOUT = 30000;
+	private static final double FEET_TO_METERS = 0.3048;
+	private static final double MS_TO_KNOTS = 3600.0 / 1852.0;
+
 	private AisPlaneDataFetcher() {
 	}
 
 	@NonNull
-	public static List<AisObject> fetchOpenSkyCompatible(@NonNull OsmandApplication app, @NonNull String url) {
-		List<AisObject> result = new ArrayList<>();
-		String json = AndroidNetworkUtils.sendRequest(app, url, null, "AIS planes source", false, false);
-		if (Algorithms.isEmpty(json)) {
-			return result;
+	public static List<AisObject> fetch(@NonNull OsmandApplication app, @NonNull AisUrlSource source) {
+		String response = request(app, source);
+		if (Algorithms.isEmpty(response)) {
+			return new ArrayList<>();
 		}
 		try {
-			JSONObject root = new JSONObject(json);
+			JSONObject root = new JSONObject(response);
 			JSONArray states = root.optJSONArray("states");
-			if (states == null) {
-				return result;
+			if (states != null) {
+				return parseOpenSky(states);
 			}
-			for (int i = 0; i < states.length(); i++) {
-				JSONArray row = states.optJSONArray(i);
-				if (row == null || row.length() < 11) {
-					continue;
-				}
-				AisObject ais = parseState(row);
-				if (ais != null) {
-					result.add(ais);
-				}
+			JSONArray aircraft = root.optJSONArray("ac");
+			if (aircraft != null) {
+				return parseAdsb(aircraft);
 			}
+			LOG.warn("Unrecognised plane source response for " + source.name);
 		} catch (JSONException e) {
-			LOG.warn("Failed to parse AIS planes source response", e);
+			LOG.warn("Failed to parse plane source response for " + source.name, e);
+		}
+		return new ArrayList<>();
+	}
+
+	@Nullable
+	private static String request(@NonNull OsmandApplication app, @NonNull AisUrlSource source) {
+		String url = source.url.contains(API_KEY_PLACEHOLDER)
+				? source.url.replace(API_KEY_PLACEHOLDER, source.apiKey)
+				: source.url;
+		HttpURLConnection connection = null;
+		try {
+			connection = NetworkUtils.getHttpURLConnection(url);
+			connection.setRequestMethod("GET");
+			connection.setRequestProperty("Accept-Charset", "UTF-8");
+			connection.setRequestProperty("User-Agent", Version.getFullVersion(app));
+			connection.setConnectTimeout(CONNECT_TIMEOUT);
+			connection.setReadTimeout(READ_TIMEOUT);
+			// RapidAPI-hosted services (ADS-B Exchange among them) expect the key as a header
+			// rather than a query parameter.
+			String rapidApiHost = getRapidApiHost(url);
+			if (rapidApiHost != null && !Algorithms.isEmpty(source.apiKey)) {
+				connection.setRequestProperty("X-RapidAPI-Key", source.apiKey);
+				connection.setRequestProperty("X-RapidAPI-Host", rapidApiHost);
+			}
+			connection.connect();
+			if (connection.getResponseCode() != HttpURLConnection.HTTP_OK) {
+				LOG.warn("Plane source " + source.name + " responded "
+						+ connection.getResponseCode() + " " + connection.getResponseMessage());
+				return null;
+			}
+			StringBuilder builder = new StringBuilder();
+			try (BufferedReader reader = new BufferedReader(
+					new InputStreamReader(connection.getInputStream(), "UTF-8"))) {
+				String line;
+				while ((line = reader.readLine()) != null) {
+					builder.append(line);
+				}
+			}
+			return builder.toString();
+		} catch (IOException e) {
+			LOG.warn("Failed to read plane source " + source.name, e);
+			return null;
+		} finally {
+			if (connection != null) {
+				connection.disconnect();
+			}
+		}
+	}
+
+	@Nullable
+	private static String getRapidApiHost(@NonNull String url) {
+		try {
+			String host = new URI(url).getHost();
+			return host != null && host.endsWith(RAPIDAPI_HOST_SUFFIX) ? host : null;
+		} catch (URISyntaxException e) {
+			return null;
+		}
+	}
+
+	@NonNull
+	private static List<AisObject> parseOpenSky(@NonNull JSONArray states) {
+		List<AisObject> result = new ArrayList<>();
+		for (int i = 0; i < states.length(); i++) {
+			JSONArray row = states.optJSONArray(i);
+			if (row == null || row.length() < 11 || row.isNull(5) || row.isNull(6)) {
+				continue;
+			}
+			Integer mmsi = parseIcao24(row.optString(0, ""));
+			if (mmsi == null) {
+				continue;
+			}
+			double lon = row.optDouble(5, Double.NaN);
+			double lat = row.optDouble(6, Double.NaN);
+			if (Double.isNaN(lon) || Double.isNaN(lat)) {
+				continue;
+			}
+			double altitudeMeters = row.length() > 13 && !row.isNull(13)
+					? row.optDouble(13, Double.NaN) : row.optDouble(7, Double.NaN);
+			double velocityMs = row.isNull(9) ? Double.NaN : row.optDouble(9, Double.NaN);
+			double cog = row.isNull(10) ? INVALID_COG : row.optDouble(10, INVALID_COG);
+			result.add(createAisObject(mmsi, lat, lon, altitudeMeters,
+					Double.isNaN(velocityMs) ? Double.NaN : velocityMs * MS_TO_KNOTS, cog));
 		}
 		return result;
 	}
 
+	@NonNull
+	private static List<AisObject> parseAdsb(@NonNull JSONArray aircraft) {
+		List<AisObject> result = new ArrayList<>();
+		for (int i = 0; i < aircraft.length(); i++) {
+			JSONObject plane = aircraft.optJSONObject(i);
+			if (plane == null || plane.isNull("lat") || plane.isNull("lon")) {
+				continue;
+			}
+			Integer mmsi = parseIcao24(plane.optString("hex", ""));
+			if (mmsi == null) {
+				continue;
+			}
+			double lat = plane.optDouble("lat", Double.NaN);
+			double lon = plane.optDouble("lon", Double.NaN);
+			if (Double.isNaN(lat) || Double.isNaN(lon)) {
+				continue;
+			}
+			// alt_baro is "ground" for aircraft on the ground, hence optDouble with a NaN default
+			double altitudeFeet = plane.isNull("alt_geom")
+					? plane.optDouble("alt_baro", Double.NaN) : plane.optDouble("alt_geom", Double.NaN);
+			double altitudeMeters = Double.isNaN(altitudeFeet) ? Double.NaN : altitudeFeet * FEET_TO_METERS;
+			// ground speed is already in knots here, unlike OpenSky
+			double sog = plane.isNull("gs") ? Double.NaN : plane.optDouble("gs", Double.NaN);
+			double cog = plane.isNull("track") ? INVALID_COG : plane.optDouble("track", INVALID_COG);
+			result.add(createAisObject(mmsi, lat, lon, altitudeMeters, sog, cog));
+		}
+		return result;
+	}
+
+	@NonNull
+	private static AisObject createAisObject(int mmsi, double lat, double lon,
+	                                          double altitudeMeters, double sogKnots, double cog) {
+		int altitude = Double.isNaN(altitudeMeters) ? INVALID_ALTITUDE : (int) Math.round(altitudeMeters);
+		double sog = Double.isNaN(sogKnots) ? INVALID_SOG : sogKnots;
+		return new AisObject(mmsi, MSG_TYPE_AIRCRAFT_POSITION, 0, altitude, cog, sog, lat, lon);
+	}
+
+	/**
+	 * ICAO 24-bit address doubles as the MMSI for aircraft: it tops out at 0xFFFFFF, well below
+	 * the 9-digit range real vessel MMSIs live in, so the two cannot collide in the shared index.
+	 */
 	@Nullable
-	private static AisObject parseState(@NonNull JSONArray row) {
-		String icao24 = row.optString(0, "");
-		if (Algorithms.isEmpty(icao24) || row.isNull(5) || row.isNull(6)) {
+	private static Integer parseIcao24(@NonNull String icao24) {
+		// ADS-B Exchange prefixes non-ICAO (e.g. TIS-B) addresses with "~"
+		String hex = icao24.trim().replace("~", "");
+		if (Algorithms.isEmpty(hex)) {
 			return null;
 		}
-		int mmsi;
 		try {
-			mmsi = Integer.parseInt(icao24.trim(), 16);
+			return Integer.parseInt(hex, 16);
 		} catch (NumberFormatException e) {
 			return null;
 		}
-		double lon = row.optDouble(5, Double.NaN);
-		double lat = row.optDouble(6, Double.NaN);
-		if (Double.isNaN(lon) || Double.isNaN(lat)) {
-			return null;
-		}
-		double altitudeMeters = row.length() > 13 && !row.isNull(13)
-				? row.optDouble(13, Double.NaN) : row.optDouble(7, Double.NaN);
-		int altitude = Double.isNaN(altitudeMeters) ? INVALID_ALTITUDE : (int) Math.round(altitudeMeters);
-		double velocityMs = row.isNull(9) ? Double.NaN : row.optDouble(9, Double.NaN);
-		// AisObject stores speed-over-ground in knots (see AisObject.getAisLocation()).
-		double sog = Double.isNaN(velocityMs) ? INVALID_SOG : velocityMs * 3600.0 / 1852.0;
-		double cog = row.isNull(10) ? INVALID_COG : row.optDouble(10, INVALID_COG);
-		return new AisObject(mmsi, MSG_TYPE_AIRCRAFT_POSITION, 0, altitude, cog, sog, lat, lon);
 	}
 }

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisPlaneDataFetcher.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisPlaneDataFetcher.java
@@ -5,11 +5,13 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import net.osmand.data.QuadRect;
 import net.osmand.osm.io.NetworkUtils;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.Version;
 import net.osmand.shared.aistracker.AisObject;
 import net.osmand.util.Algorithms;
+import net.osmand.util.MapUtils;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -24,6 +26,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Fetches aircraft positions from a plane {@link AisUrlSource} and turns them into
@@ -60,16 +63,55 @@ public class AisPlaneDataFetcher {
 	private static final int READ_TIMEOUT = 30000;
 	private static final double FEET_TO_METERS = 0.3048;
 	private static final double MS_TO_KNOTS = 3600.0 / 1852.0;
+	private static final double METERS_PER_NM = 1852.0;
+	private static final double MIN_RADIUS_NM = 5;
+	// the ADS-B services cap the radius at 250 nm
+	private static final double MAX_RADIUS_NM = 250;
 
 	private AisPlaneDataFetcher() {
 	}
 
+	/**
+	 * Placeholders filled in from the visible map area, so a source follows the map instead of
+	 * being pinned to whatever coordinates were typed when it was created. Bounding-box services
+	 * (OpenSky) and centre+radius services (the ADS-B family) each take the set they need.
+	 */
 	@NonNull
-	public static List<AisObject> fetch(@NonNull OsmandApplication app, @NonNull AisUrlSource source) {
-		String response = request(app, source);
+	public static String applyMapArea(@NonNull String url, @NonNull QuadRect latLonBounds) {
+		double north = latLonBounds.top;
+		double south = latLonBounds.bottom;
+		double west = latLonBounds.left;
+		double east = latLonBounds.right;
+		double centerLat = (north + south) / 2;
+		double centerLon = (west + east) / 2;
+		// radius covering the viewport corner, which is what centre+radius services ask for
+		double distNm = Math.min(MAX_RADIUS_NM, Math.max(MIN_RADIUS_NM,
+				MapUtils.getDistance(centerLat, centerLon, north, east) / METERS_PER_NM));
+		return url.replace("{LAMIN}", format(south))
+				.replace("{LAMAX}", format(north))
+				.replace("{LOMIN}", format(west))
+				.replace("{LOMAX}", format(east))
+				.replace("{LAT}", format(centerLat))
+				.replace("{LON}", format(centerLon))
+				.replace("{DIST}", String.valueOf(Math.round(distNm)));
+	}
+
+	@NonNull
+	private static String format(double value) {
+		return String.format(Locale.US, "%.4f", value);
+	}
+
+	/**
+	 * @return the aircraft in view, empty when the service legitimately reports none, or null when
+	 * the request failed - callers must not treat a failure as "everything is gone".
+	 */
+	@Nullable
+	public static List<AisObject> fetch(@NonNull OsmandApplication app, @NonNull AisUrlSource source,
+	                                     @NonNull QuadRect latLonBounds) {
+		String response = request(app, source, latLonBounds);
 		if (Algorithms.isEmpty(response)) {
 			Log.d(TAG, "'" + source.name + "': empty response, nothing to parse");
-			return new ArrayList<>();
+			return null;
 		}
 		try {
 			JSONObject root = new JSONObject(response);
@@ -96,7 +138,7 @@ public class AisPlaneDataFetcher {
 		} catch (JSONException e) {
 			Log.w(TAG, "'" + source.name + "': response is not JSON: " + shorten(response), e);
 		}
-		return new ArrayList<>();
+		return null;
 	}
 
 	@NonNull
@@ -112,10 +154,12 @@ public class AisPlaneDataFetcher {
 	}
 
 	@Nullable
-	private static String request(@NonNull OsmandApplication app, @NonNull AisUrlSource source) {
-		String url = source.url.contains(API_KEY_PLACEHOLDER)
-				? source.url.replace(API_KEY_PLACEHOLDER, source.apiKey)
-				: source.url;
+	private static String request(@NonNull OsmandApplication app, @NonNull AisUrlSource source,
+	                               @NonNull QuadRect latLonBounds) {
+		String url = applyMapArea(source.url, latLonBounds);
+		if (url.contains(API_KEY_PLACEHOLDER)) {
+			url = url.replace(API_KEY_PLACEHOLDER, source.apiKey);
+		}
 		String loggedUrl = hideKey(url, source.apiKey);
 		HttpURLConnection connection = null;
 		long started = System.currentTimeMillis();

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisPlaneDataFetcher.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisPlaneDataFetcher.java
@@ -1,22 +1,23 @@
 package net.osmand.plus.plugins.aistracker;
 
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import net.osmand.PlatformUtil;
 import net.osmand.osm.io.NetworkUtils;
 import net.osmand.plus.OsmandApplication;
 import net.osmand.plus.Version;
 import net.osmand.shared.aistracker.AisObject;
 import net.osmand.util.Algorithms;
 
-import org.apache.commons.logging.Log;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URI;
@@ -41,7 +42,10 @@ import java.util.List;
  */
 public class AisPlaneDataFetcher {
 
-	private static final Log LOG = PlatformUtil.getLog(AisPlaneDataFetcher.class);
+	/** Shared with AisTrackerPlugin so the whole plane pipeline reads as one log: adb logcat -s AisPlanes */
+	public static final String TAG = "AisPlanes";
+
+	private static final int LOGGED_BODY_LIMIT = 700;
 
 	// net.osmand.shared.aistracker.AisObjectConstants values, duplicated here to avoid
 	// Kotlin-object interop from Java for a handful of constants.
@@ -64,13 +68,17 @@ public class AisPlaneDataFetcher {
 	public static List<AisObject> fetch(@NonNull OsmandApplication app, @NonNull AisUrlSource source) {
 		String response = request(app, source);
 		if (Algorithms.isEmpty(response)) {
+			Log.d(TAG, "'" + source.name + "': empty response, nothing to parse");
 			return new ArrayList<>();
 		}
 		try {
 			JSONObject root = new JSONObject(response);
 			JSONArray states = root.optJSONArray("states");
 			if (states != null) {
-				return parseOpenSky(states);
+				List<AisObject> parsed = parseOpenSky(states);
+				Log.d(TAG, "'" + source.name + "': OpenSky format, " + states.length()
+						+ " states -> " + parsed.size() + " aircraft with a position");
+				return parsed;
 			}
 			// same payload, different wrapper key depending on the service
 			JSONArray aircraft = root.optJSONArray("ac");
@@ -78,13 +86,29 @@ public class AisPlaneDataFetcher {
 				aircraft = root.optJSONArray("aircraft");
 			}
 			if (aircraft != null) {
-				return parseAdsb(aircraft);
+				List<AisObject> parsed = parseAdsb(aircraft);
+				Log.d(TAG, "'" + source.name + "': ADS-B format, " + aircraft.length()
+						+ " entries -> " + parsed.size() + " aircraft with a position");
+				return parsed;
 			}
-			LOG.warn("Unrecognised plane source response for " + source.name);
+			Log.w(TAG, "'" + source.name + "': unrecognised response, no 'states'/'ac'/'aircraft' key."
+					+ " Keys: " + root.keys() + ", body: " + shorten(response));
 		} catch (JSONException e) {
-			LOG.warn("Failed to parse plane source response for " + source.name, e);
+			Log.w(TAG, "'" + source.name + "': response is not JSON: " + shorten(response), e);
 		}
 		return new ArrayList<>();
+	}
+
+	@NonNull
+	private static String shorten(@NonNull String body) {
+		return body.length() <= LOGGED_BODY_LIMIT ? body
+				: body.substring(0, LOGGED_BODY_LIMIT) + "... (" + body.length() + " chars)";
+	}
+
+	/** Never log the credential itself. */
+	@NonNull
+	private static String hideKey(@NonNull String url, @NonNull String apiKey) {
+		return Algorithms.isEmpty(apiKey) ? url : url.replace(apiKey, "***");
 	}
 
 	@Nullable
@@ -92,7 +116,9 @@ public class AisPlaneDataFetcher {
 		String url = source.url.contains(API_KEY_PLACEHOLDER)
 				? source.url.replace(API_KEY_PLACEHOLDER, source.apiKey)
 				: source.url;
+		String loggedUrl = hideKey(url, source.apiKey);
 		HttpURLConnection connection = null;
+		long started = System.currentTimeMillis();
 		try {
 			connection = NetworkUtils.getHttpURLConnection(url);
 			connection.setRequestMethod("GET");
@@ -103,33 +129,47 @@ public class AisPlaneDataFetcher {
 			// RapidAPI-hosted services (ADS-B Exchange among them) expect the key as a header
 			// rather than a query parameter.
 			String rapidApiHost = getRapidApiHost(url);
-			if (rapidApiHost != null && !Algorithms.isEmpty(source.apiKey)) {
+			boolean rapidApiAuth = rapidApiHost != null && !Algorithms.isEmpty(source.apiKey);
+			if (rapidApiAuth) {
 				connection.setRequestProperty("X-RapidAPI-Key", source.apiKey);
 				connection.setRequestProperty("X-RapidAPI-Host", rapidApiHost);
 			}
+			Log.d(TAG, "GET '" + source.name + "' " + loggedUrl
+					+ " (key " + (Algorithms.isEmpty(source.apiKey) ? "not set" : "set")
+					+ (rapidApiAuth ? ", sent as RapidAPI header" : "") + ")");
 			connection.connect();
-			if (connection.getResponseCode() != HttpURLConnection.HTTP_OK) {
-				LOG.warn("Plane source " + source.name + " responded "
-						+ connection.getResponseCode() + " " + connection.getResponseMessage());
+			int responseCode = connection.getResponseCode();
+			if (responseCode != HttpURLConnection.HTTP_OK) {
+				String error = connection.getErrorStream() != null
+						? shorten(readStream(connection.getErrorStream())) : "";
+				Log.w(TAG, "'" + source.name + "' responded " + responseCode + " "
+						+ connection.getResponseMessage() + " " + error);
 				return null;
 			}
-			StringBuilder builder = new StringBuilder();
-			try (BufferedReader reader = new BufferedReader(
-					new InputStreamReader(connection.getInputStream(), "UTF-8"))) {
-				String line;
-				while ((line = reader.readLine()) != null) {
-					builder.append(line);
-				}
-			}
-			return builder.toString();
+			String body = readStream(connection.getInputStream());
+			Log.d(TAG, "'" + source.name + "' responded " + responseCode + ", " + body.length()
+					+ " chars in " + (System.currentTimeMillis() - started) + " ms: " + shorten(body));
+			return body;
 		} catch (IOException e) {
-			LOG.warn("Failed to read plane source " + source.name, e);
+			Log.w(TAG, "'" + source.name + "' request failed: " + loggedUrl, e);
 			return null;
 		} finally {
 			if (connection != null) {
 				connection.disconnect();
 			}
 		}
+	}
+
+	@NonNull
+	private static String readStream(@NonNull InputStream stream) throws IOException {
+		StringBuilder builder = new StringBuilder();
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, "UTF-8"))) {
+			String line;
+			while ((line = reader.readLine()) != null) {
+				builder.append(line);
+			}
+		}
+		return builder.toString();
 	}
 
 	@Nullable

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisPlaneDataFetcher.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisPlaneDataFetcher.java
@@ -1,0 +1,98 @@
+package net.osmand.plus.plugins.aistracker;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import net.osmand.PlatformUtil;
+import net.osmand.plus.OsmandApplication;
+import net.osmand.plus.utils.AndroidNetworkUtils;
+import net.osmand.shared.aistracker.AisObject;
+import net.osmand.util.Algorithms;
+
+import org.apache.commons.logging.Log;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Fetches aircraft positions from an OpenSky-Network-compatible JSON URL
+ * ({@code {"states": [[icao24, callsign, origin_country, time_position, last_contact,
+ * longitude, latitude, baro_altitude, on_ground, velocity, true_track, ...], ...]}}) and turns
+ * them into {@link AisObject} instances (message type 9 = airborne SAR/aircraft position report)
+ * so they can be fed straight into the existing AIS rendering/tap-menu pipeline alongside ships.
+ * <p>
+ * Runs synchronously - callers are expected to invoke this from a background thread.
+ */
+public class AisPlaneDataFetcher {
+
+	private static final Log LOG = PlatformUtil.getLog(AisPlaneDataFetcher.class);
+
+	// net.osmand.shared.aistracker.AisObjectConstants values, duplicated here to avoid
+	// Kotlin-object interop from Java for a handful of constants.
+	private static final int INVALID_ALTITUDE = 4095;
+	private static final double INVALID_COG = 360.0;
+	private static final double INVALID_SOG = 1023.0;
+	private static final int MSG_TYPE_AIRCRAFT_POSITION = 9;
+
+	private AisPlaneDataFetcher() {
+	}
+
+	@NonNull
+	public static List<AisObject> fetchOpenSkyCompatible(@NonNull OsmandApplication app, @NonNull String url) {
+		List<AisObject> result = new ArrayList<>();
+		String json = AndroidNetworkUtils.sendRequest(app, url, null, "AIS planes source", false, false);
+		if (Algorithms.isEmpty(json)) {
+			return result;
+		}
+		try {
+			JSONObject root = new JSONObject(json);
+			JSONArray states = root.optJSONArray("states");
+			if (states == null) {
+				return result;
+			}
+			for (int i = 0; i < states.length(); i++) {
+				JSONArray row = states.optJSONArray(i);
+				if (row == null || row.length() < 11) {
+					continue;
+				}
+				AisObject ais = parseState(row);
+				if (ais != null) {
+					result.add(ais);
+				}
+			}
+		} catch (JSONException e) {
+			LOG.warn("Failed to parse AIS planes source response", e);
+		}
+		return result;
+	}
+
+	@Nullable
+	private static AisObject parseState(@NonNull JSONArray row) {
+		String icao24 = row.optString(0, "");
+		if (Algorithms.isEmpty(icao24) || row.isNull(5) || row.isNull(6)) {
+			return null;
+		}
+		int mmsi;
+		try {
+			mmsi = Integer.parseInt(icao24.trim(), 16);
+		} catch (NumberFormatException e) {
+			return null;
+		}
+		double lon = row.optDouble(5, Double.NaN);
+		double lat = row.optDouble(6, Double.NaN);
+		if (Double.isNaN(lon) || Double.isNaN(lat)) {
+			return null;
+		}
+		double altitudeMeters = row.length() > 13 && !row.isNull(13)
+				? row.optDouble(13, Double.NaN) : row.optDouble(7, Double.NaN);
+		int altitude = Double.isNaN(altitudeMeters) ? INVALID_ALTITUDE : (int) Math.round(altitudeMeters);
+		double velocityMs = row.isNull(9) ? Double.NaN : row.optDouble(9, Double.NaN);
+		// AisObject stores speed-over-ground in knots (see AisObject.getAisLocation()).
+		double sog = Double.isNaN(velocityMs) ? INVALID_SOG : velocityMs * 3600.0 / 1852.0;
+		double cog = row.isNull(10) ? INVALID_COG : row.optDouble(10, INVALID_COG);
+		return new AisObject(mmsi, MSG_TYPE_AIRCRAFT_POSITION, 0, altitude, cog, sog, lat, lon);
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerLayer.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerLayer.java
@@ -411,6 +411,11 @@ public class AisTrackerLayer extends OsmandMapLayer implements IContextMenuProvi
 
 		ViewportSignature viewport = new ViewportSignature(tileBox);
 		boolean viewportChanged = !viewport.equals(lastViewport);
+		if (viewportChanged) {
+			// plane sources query by area, so a moved map needs a fresh batch; the plugin decides
+			// whether it is time to ask, this call never restarts its poll timer
+			plugin.onMapAreaChanged();
+		}
 		long now = SystemClock.elapsedRealtime();
 		boolean intervalElapsed = lastRenderTimeMs == 0 || now - lastRenderTimeMs >= RENDER_UPDATE_INTERVAL_MS;
 		if ((dataDirty || viewportChanged) && intervalElapsed) {

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerLayer.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerLayer.java
@@ -89,6 +89,10 @@ public class AisTrackerLayer extends OsmandMapLayer implements IContextMenuProvi
 	private static final long PLANE_LOG_INTERVAL_MS = 5000;
 	// aircraft icons are drawn a fifth smaller, so their touch target follows suit
 	private static final float PLANE_FOOTPRINT_FACTOR = 0.8f;
+	// airborne aircraft are never hidden; grounded ones stop being drawn past this many in a pile
+	private static final int GROUND_PLANE_MAX_OVERLAP = 3;
+	/** Altitude AisPlaneDataFetcher assigns to aircraft the feed reports as being on the ground. */
+	private static final int GROUND_ALTITUDE = 0;
 
 	private final AisTrackerPlugin plugin = PluginsHelper.requirePlugin(AisTrackerPlugin.class);
 	private final Paint bitmapPaint = new Paint();
@@ -592,6 +596,9 @@ public class AisTrackerLayer extends OsmandMapLayer implements IContextMenuProvi
 			@Nullable MapRendererView renderer, float footprint, @NonNull RectF renderBounds,
 			@NonNull SelectionResult result) {
 		float planeFootprint = footprint * PLANE_FOOTPRINT_FACTOR;
+		// Parked aircraft sit on top of each other at airports, so unlike airborne ones they are
+		// capped: past a few in the same spot the rest add nothing but clutter.
+		Map<Long, List<AcceptedRect>> groundOccupied = new HashMap<>();
 		for (RenderRecord record : planes) {
 			if (result.desired.size() >= MAX_RENDERED_OBJECTS) {
 				return;
@@ -608,13 +615,63 @@ public class AisTrackerLayer extends OsmandMapLayer implements IContextMenuProvi
 			if (!renderBounds.contains(screenPoint.x, screenPoint.y)) {
 				continue;
 			}
-			record.screenX = screenPoint.x;
-			record.screenY = screenPoint.y;
-			record.iconRect = new RectF(screenPoint.x - planeFootprint / 2,
+			RectF rect = new RectF(screenPoint.x - planeFootprint / 2,
 					screenPoint.y - planeFootprint / 2, screenPoint.x + planeFootprint / 2,
 					screenPoint.y + planeFootprint / 2);
+			boolean onGround = record.object.getAltitude() == GROUND_ALTITUDE;
+			if (onGround) {
+				if (countOverlaps(groundOccupied, record.mmsi, rect, planeFootprint, renderBounds)
+						>= GROUND_PLANE_MAX_OVERLAP) {
+					result.collisionRejected++;
+					continue;
+				}
+				occupy(groundOccupied, new AcceptedRect(record.mmsi, rect, false), planeFootprint,
+						renderBounds);
+			}
+			record.screenX = screenPoint.x;
+			record.screenY = screenPoint.y;
+			record.iconRect = rect;
 			record.hasScreenPoint = true;
 			result.desired.put(record.mmsi, record);
+		}
+	}
+
+	private static int countOverlaps(@NonNull Map<Long, List<AcceptedRect>> occupied, int mmsi,
+			@NonNull RectF rect, float cellSize, @NonNull RectF bounds) {
+		Set<Integer> inspected = new HashSet<>();
+		int overlaps = 0;
+		int minCellX = (int) Math.floor((rect.left - bounds.left) / cellSize);
+		int maxCellX = (int) Math.floor((rect.right - bounds.left) / cellSize);
+		int minCellY = (int) Math.floor((rect.top - bounds.top) / cellSize);
+		int maxCellY = (int) Math.floor((rect.bottom - bounds.top) / cellSize);
+		for (int cellX = minCellX; cellX <= maxCellX; cellX++) {
+			for (int cellY = minCellY; cellY <= maxCellY; cellY++) {
+				List<AcceptedRect> accepted = occupied.get(screenCellKey(cellX, cellY));
+				if (accepted == null) {
+					continue;
+				}
+				for (AcceptedRect other : accepted) {
+					if (other.mmsi != mmsi && inspected.add(other.mmsi)
+							&& RectF.intersects(rect, other.rect)) {
+						overlaps++;
+					}
+				}
+			}
+		}
+		return overlaps;
+	}
+
+	private static void occupy(@NonNull Map<Long, List<AcceptedRect>> occupied,
+			@NonNull AcceptedRect accepted, float cellSize, @NonNull RectF bounds) {
+		int minCellX = (int) Math.floor((accepted.rect.left - bounds.left) / cellSize);
+		int maxCellX = (int) Math.floor((accepted.rect.right - bounds.left) / cellSize);
+		int minCellY = (int) Math.floor((accepted.rect.top - bounds.top) / cellSize);
+		int maxCellY = (int) Math.floor((accepted.rect.bottom - bounds.top) / cellSize);
+		for (int cellX = minCellX; cellX <= maxCellX; cellX++) {
+			for (int cellY = minCellY; cellY <= maxCellY; cellY++) {
+				occupied.computeIfAbsent(screenCellKey(cellX, cellY), ignored -> new ArrayList<>())
+						.add(accepted);
+			}
 		}
 	}
 

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerLayer.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerLayer.java
@@ -56,6 +56,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -86,6 +87,8 @@ public class AisTrackerLayer extends OsmandMapLayer implements IContextMenuProvi
 	private static final double ZOOM_EPSILON = 0.02;
 	private static final boolean SHOW_RENDER_LOGS = false;
 	private static final long PLANE_LOG_INTERVAL_MS = 5000;
+	// aircraft icons are drawn a fifth smaller, so their touch target follows suit
+	private static final float PLANE_FOOTPRINT_FACTOR = 0.8f;
 
 	private final AisTrackerPlugin plugin = PluginsHelper.requirePlugin(AisTrackerPlugin.class);
 	private final Paint bitmapPaint = new Paint();
@@ -462,6 +465,18 @@ public class AisTrackerLayer extends OsmandMapLayer implements IContextMenuProvi
 				? Math.min(MAX_RENDERED_OBJECTS, columns * rows)
 				: selectedRecord == null ? 0 : 1;
 
+		// Aircraft bypass the vessel pipeline entirely: they are small, they cluster along the same
+		// airways, and hiding the overlapping ones would drop most of the sky. They are admitted
+		// below without collision checks or the per-cell thinning vessels go through.
+		List<RenderRecord> planeCandidates = new ArrayList<>();
+		for (Iterator<RenderRecord> iterator = candidates.iterator(); iterator.hasNext(); ) {
+			RenderRecord record = iterator.next();
+			if (record != selectedRecord && record.object.getObjectClass() == AIS_AIRPLANE) {
+				planeCandidates.add(record);
+				iterator.remove();
+			}
+		}
+
 		Set<Integer> incumbentKeys = new HashSet<>(objectDrawables.keySet());
 		List<RenderRecord> incumbents = new ArrayList<>();
 		for (RenderRecord record : candidates) {
@@ -565,7 +580,53 @@ public class AisTrackerLayer extends OsmandMapLayer implements IContextMenuProvi
 			trySelect(record, false, tileBox, renderer, footprint, renderBounds, renderBudget,
 					incumbentKeys, occupied, result);
 		}
+		admitPlanes(planeCandidates, tileBox, renderer, footprint, renderBounds, result);
 		return result;
+	}
+
+	/**
+	 * Admits every aircraft in view, overlapping or not, capped only by the layer's hard ceiling.
+	 * They neither take part in the collision grid nor block vessels from it.
+	 */
+	private void admitPlanes(@NonNull List<RenderRecord> planes, @NonNull RotatedTileBox tileBox,
+			@Nullable MapRendererView renderer, float footprint, @NonNull RectF renderBounds,
+			@NonNull SelectionResult result) {
+		float planeFootprint = footprint * PLANE_FOOTPRINT_FACTOR;
+		for (RenderRecord record : planes) {
+			if (result.desired.size() >= MAX_RENDERED_OBJECTS) {
+				return;
+			}
+			record.updateSelectionState(plugin);
+			record.hasScreenPoint = false;
+			record.cpaWarning = false;
+			AisLatLon position = record.object.getPosition();
+			if (position == null) {
+				continue;
+			}
+			result.projected++;
+			PointF screenPoint = projectToScreen(record, position, tileBox, renderer);
+			if (!renderBounds.contains(screenPoint.x, screenPoint.y)) {
+				continue;
+			}
+			record.screenX = screenPoint.x;
+			record.screenY = screenPoint.y;
+			record.iconRect = new RectF(screenPoint.x - planeFootprint / 2,
+					screenPoint.y - planeFootprint / 2, screenPoint.x + planeFootprint / 2,
+					screenPoint.y + planeFootprint / 2);
+			record.hasScreenPoint = true;
+			result.desired.put(record.mmsi, record);
+		}
+	}
+
+	@NonNull
+	private PointF projectToScreen(@NonNull RenderRecord record, @NonNull AisLatLon position,
+			@NonNull RotatedTileBox tileBox, @Nullable MapRendererView renderer) {
+		if (renderer != null) {
+			return NativeUtilities.getPixelFrom31(renderer, tileBox, new PointI(record.x31, record.y31));
+		}
+		double longitude = normalizeLongitudeNear(position.getLongitude(), tileBox.getLongitude());
+		return new PointF(tileBox.getPixXFromLatLon(position.getLatitude(), longitude),
+				tileBox.getPixYFromLatLon(position.getLatitude(), longitude));
 	}
 
 	@NonNull
@@ -661,16 +722,7 @@ public class AisTrackerLayer extends OsmandMapLayer implements IContextMenuProvi
 		if (position == null) {
 			return;
 		}
-		PointF screenPoint;
-		if (renderer != null) {
-			screenPoint = NativeUtilities.getPixelFrom31(renderer, tileBox,
-					new PointI(record.x31, record.y31));
-		} else {
-			double longitude = normalizeLongitudeNear(position.getLongitude(), tileBox.getLongitude());
-			screenPoint = new PointF(
-					tileBox.getPixXFromLatLon(position.getLatitude(), longitude),
-					tileBox.getPixYFromLatLon(position.getLatitude(), longitude));
-		}
+		PointF screenPoint = projectToScreen(record, position, tileBox, renderer);
 		float x = screenPoint.x;
 		float y = screenPoint.y;
 		if (!renderBounds.contains(x, y)) {

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerLayer.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerLayer.java
@@ -225,7 +225,7 @@ public class AisTrackerLayer extends OsmandMapLayer implements IContextMenuProvi
 				removeFromBucket(previous);
 			}
 			AisLatLon position = ais.getPosition();
-			if (position != null && !isOwnObjectHidden(ais)) {
+			if (position != null && !isOwnObjectHidden(ais) && !isHiddenByTypeFilter(ais)) {
 				int x31 = MapUtils.get31TileNumberX(position.getLongitude());
 				int y31 = MapUtils.get31TileNumberY(position.getLatitude());
 				RenderRecord record = new RenderRecord(ais, x31, y31, nextVersion++);
@@ -266,7 +266,7 @@ public class AisTrackerLayer extends OsmandMapLayer implements IContextMenuProvi
 			spatialBuckets.clear();
 			for (AisObject ais : snapshot) {
 				AisLatLon position = ais.getPosition();
-				if (position != null && !isOwnObjectHidden(ais)) {
+				if (position != null && !isOwnObjectHidden(ais) && !isHiddenByTypeFilter(ais)) {
 					int x31 = MapUtils.get31TileNumberX(position.getLongitude());
 					int y31 = MapUtils.get31TileNumberY(position.getLatitude());
 					RenderRecord record = new RenderRecord(ais, x31, y31, nextVersion++);
@@ -303,6 +303,19 @@ public class AisTrackerLayer extends OsmandMapLayer implements IContextMenuProvi
 
 	private boolean isOwnObjectHidden(@NonNull AisObject ais) {
 		return isOwnObject(ais) && !plugin.AIS_DISPLAY_OWN_POSITION.get();
+	}
+
+	private boolean isHiddenByTypeFilter(@NonNull AisObject ais) {
+		boolean isPlane = ais.getObjectClass() == AIS_AIRPLANE;
+		return isPlane ? !plugin.AIS_SHOW_PLANES.get() : !plugin.AIS_SHOW_SHIPS.get();
+	}
+
+	/**
+	 * Call after toggling AIS_SHOW_SHIPS/AIS_SHOW_PLANES so already-indexed objects are
+	 * re-evaluated against the new filter without waiting for the next AIS message per object.
+	 */
+	public void refreshTypeFilter() {
+		refreshOwnObjectVisibility();
 	}
 
 	public void refreshOwnObjectVisibility() {

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerLayer.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerLayer.java
@@ -85,6 +85,7 @@ public class AisTrackerLayer extends OsmandMapLayer implements IContextMenuProvi
 	private static final long RENDER_UPDATE_INTERVAL_MS = 200;
 	private static final double ZOOM_EPSILON = 0.02;
 	private static final boolean SHOW_RENDER_LOGS = false;
+	private static final long PLANE_LOG_INTERVAL_MS = 5000;
 
 	private final AisTrackerPlugin plugin = PluginsHelper.requirePlugin(AisTrackerPlugin.class);
 	private final Paint bitmapPaint = new Paint();
@@ -105,6 +106,7 @@ public class AisTrackerLayer extends OsmandMapLayer implements IContextMenuProvi
 	private boolean refreshScheduled;
 	private long nextVersion = 1;
 	private long lastRenderTimeMs;
+	private long lastPlaneLogTimeMs;
 	private ViewportSignature lastViewport;
 	private Integer selectedMmsi;
 	private int peakDrawableCount;
@@ -303,6 +305,39 @@ public class AisTrackerLayer extends OsmandMapLayer implements IContextMenuProvi
 
 	private boolean isOwnObjectHidden(@NonNull AisObject ais) {
 		return isOwnObject(ais) && !plugin.AIS_DISPLAY_OWN_POSITION.get();
+	}
+
+	/**
+	 * Why aircraft are or are not on screen: how many are indexed, how many the current viewport
+	 * actually draws, and whether the zoom is below the threshold that suppresses them entirely.
+	 * Throttled, since reconcile() runs several times a second while the map moves.
+	 */
+	private void logPlaneVisibility(@NonNull RotatedTileBox tileBox) {
+		long now = SystemClock.elapsedRealtime();
+		if (now - lastPlaneLogTimeMs < PLANE_LOG_INTERVAL_MS) {
+			return;
+		}
+		lastPlaneLogTimeMs = now;
+		int indexedPlanes = 0;
+		synchronized (indexLock) {
+			for (RenderRecord record : objectRecords.values()) {
+				if (record.object.getObjectClass() == AIS_AIRPLANE) {
+					indexedPlanes++;
+				}
+			}
+		}
+		int renderedPlanes = 0;
+		for (RenderRecord record : renderedRecords.values()) {
+			if (record.object.getObjectClass() == AIS_AIRPLANE) {
+				renderedPlanes++;
+			}
+		}
+		int zoom = tileBox.getZoom();
+		// fully qualified: this class already imports commons-logging Log for its own LOG field
+		android.util.Log.d(AisPlaneDataFetcher.TAG, "layer: " + indexedPlanes + " aircraft indexed, "
+				+ renderedPlanes + " drawn, zoom " + zoom
+				+ (zoom < START_ZOOM ? " (below minimum " + START_ZOOM + ", aircraft are hidden)" : "")
+				+ ", 'Show planes' " + (plugin.AIS_SHOW_PLANES.get() ? "on" : "OFF"));
 	}
 
 	private boolean isHiddenByTypeFilter(@NonNull AisObject ais) {
@@ -773,6 +808,7 @@ public class AisTrackerLayer extends OsmandMapLayer implements IContextMenuProvi
 			}
 		}
 		renderedRecords = new LinkedHashMap<>(selection.desired);
+		logPlaneVisibility(tileBox);
 		peakDrawableCount = Math.max(peakDrawableCount, objectDrawables.size());
 
 		showLog(selection, actualDesired, previous);

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerPlugin.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerPlugin.java
@@ -10,9 +10,11 @@ import static net.osmand.plus.settings.fragments.SettingsScreenType.AIS_SETTINGS
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.util.Log;
+import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 
 import net.osmand.Location;
 import net.osmand.PlatformUtil;
@@ -30,6 +32,13 @@ import net.osmand.plus.settings.backend.preferences.CommonPreference;
 import net.osmand.plus.settings.fragments.SettingsScreenType;
 import net.osmand.plus.utils.AndroidUtils;
 import net.osmand.plus.views.OsmandMapTileView;
+import net.osmand.plus.widgets.ctxmenu.ContextMenuAdapter;
+import net.osmand.plus.widgets.ctxmenu.callback.ItemClickListener;
+import net.osmand.plus.widgets.ctxmenu.callback.OnDataChangeUiAdapter;
+import net.osmand.plus.widgets.ctxmenu.callback.OnRowItemClick;
+import net.osmand.plus.widgets.ctxmenu.data.ContextMenuItem;
+import net.osmand.plus.utils.UiUtilities;
+import net.osmand.render.RenderingRuleProperty;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -93,6 +102,16 @@ public class AisTrackerPlugin extends OsmandPlugin {
 	public static final Boolean AIS_DISPLAY_OWN_POSITION_DEFAULT = false;
     public final CommonPreference<Boolean> AIS_RECEIVE_IN_BACKGROUND;
     public static final Boolean AIS_RECEIVE_IN_BACKGROUND_DEFAULT = false;
+	public static final String AIS_URL_SOURCES_ID = "ais_url_sources"; // see xml/ais_settings.xml
+	public static final String AIS_SHOW_SHIPS_ID = "ais_show_ships"; // see xml/ais_settings.xml
+	public static final String AIS_SHOW_PLANES_ID = "ais_show_planes"; // see xml/ais_settings.xml
+	public final CommonPreference<String> AIS_URL_SOURCES;
+	public final CommonPreference<Boolean> AIS_SHOW_SHIPS;
+	public final CommonPreference<Boolean> AIS_SHOW_PLANES;
+	// Anonymous OpenSky access is capped at ~400 requests/day; keep this conservative by default
+	// until a user-run aggregator with its own key/limits is configured.
+	private static final long PLANE_POLL_INTERVAL_MS = 60_000L;
+	private Timer planePollTimer;
 
 	/* timestamp of last AIS message received for all instances: */
 	private long lastMessageReceived = 0;
@@ -233,6 +252,9 @@ public class AisTrackerPlugin extends OsmandPlugin {
 		AIS_OWN_MMSI = registerIntPreference(AIS_OWN_MMSI_ID, AIS_DEFAULT_OWN_MMSI);
 		AIS_DISPLAY_OWN_POSITION = registerBooleanPreference(AIS_DISPLAY_OWN_POSITION_ID, AIS_DISPLAY_OWN_POSITION_DEFAULT);
 		AIS_RECEIVE_IN_BACKGROUND = registerBooleanPreference(AIS_RECEIVE_IN_BACKGROUND_ID, AIS_RECEIVE_IN_BACKGROUND_DEFAULT);
+		AIS_URL_SOURCES = registerStringPreference(AIS_URL_SOURCES_ID, "").makeGlobal();
+		AIS_SHOW_SHIPS = registerBooleanPreference(AIS_SHOW_SHIPS_ID, true).makeGlobal();
+		AIS_SHOW_PLANES = registerBooleanPreference(AIS_SHOW_PLANES_ID, true).makeGlobal();
 		AIS_NMEA_IP_ADDRESS.addListener(addrPrefListener);
 		AIS_NMEA_PROTOCOL.addListener(protocolPortPrefListener);
 		AIS_NMEA_TCP_PORT.addListener(protocolPortPrefListener);
@@ -358,6 +380,7 @@ public class AisTrackerPlugin extends OsmandPlugin {
 		if (AIS_RECEIVE_IN_BACKGROUND.get()) {
 			AndroidUtils.requestNotificationPermissionIfNeeded(activity);
 		}
+		startPlanePolling();
 	}
 
 	@Override
@@ -367,6 +390,110 @@ public class AisTrackerPlugin extends OsmandPlugin {
 		} else {
 			updateAisBackgroundService();
 			app.runInUIThread(this::stopAisListenerIfBackgroundServiceFailed, 1500);
+		}
+		stopPlanePolling();
+	}
+
+	@NonNull
+	public List<AisUrlSource> getUrlSources() {
+		return AisUrlSource.parseList(AIS_URL_SOURCES.get());
+	}
+
+	public void addOrUpdateUrlSource(@NonNull AisUrlSource source) {
+		List<AisUrlSource> sources = getUrlSources();
+		boolean replaced = false;
+		for (int i = 0; i < sources.size(); i++) {
+			if (sources.get(i).id.equals(source.id)) {
+				sources.set(i, source);
+				replaced = true;
+				break;
+			}
+		}
+		if (!replaced) {
+			sources.add(source);
+		}
+		AIS_URL_SOURCES.set(AisUrlSource.serializeList(sources));
+		restartPlanePolling();
+	}
+
+	public void removeUrlSource(@NonNull String id) {
+		List<AisUrlSource> sources = getUrlSources();
+		sources.removeIf(source -> source.id.equals(id));
+		AIS_URL_SOURCES.set(AisUrlSource.serializeList(sources));
+		restartPlanePolling();
+	}
+
+	public void setSourceEnabled(@NonNull String id, boolean enabled) {
+		List<AisUrlSource> sources = getUrlSources();
+		for (int i = 0; i < sources.size(); i++) {
+			if (sources.get(i).id.equals(id)) {
+				sources.set(i, sources.get(i).withEnabled(enabled));
+				break;
+			}
+		}
+		AIS_URL_SOURCES.set(AisUrlSource.serializeList(sources));
+		restartPlanePolling();
+		AisTrackerLayer currentLayer = layer;
+		if (currentLayer != null) {
+			currentLayer.refreshTypeFilter();
+		}
+	}
+
+	@NonNull
+	private List<AisUrlSource> getPlaneSources() {
+		List<AisUrlSource> planes = new ArrayList<>();
+		for (AisUrlSource source : getUrlSources()) {
+			if (source.type == AisUrlSource.Type.PLANES && source.enabled) {
+				planes.add(source);
+			}
+		}
+		return planes;
+	}
+
+	public void feedExternalAisObject(@NonNull AisObject ais) {
+		aisDataManager.onAisObjectReceived(ais);
+	}
+
+	public void restartPlanePolling() {
+		stopPlanePolling();
+		startPlanePolling();
+	}
+
+	private void startPlanePolling() {
+		stopPlanePolling();
+		if (getPlaneSources().isEmpty()) {
+			return;
+		}
+		planePollTimer = new Timer();
+		planePollTimer.schedule(new TimerTask() {
+			@Override
+			public void run() {
+				pollPlaneSources();
+			}
+		}, 0, PLANE_POLL_INTERVAL_MS);
+	}
+
+	private void stopPlanePolling() {
+		if (planePollTimer != null) {
+			planePollTimer.cancel();
+			planePollTimer = null;
+		}
+	}
+
+	private void pollPlaneSources() {
+		if (!AIS_SHOW_PLANES.get()) {
+			return;
+		}
+		List<AisObject> received = new ArrayList<>();
+		for (AisUrlSource source : getPlaneSources()) {
+			received.addAll(AisPlaneDataFetcher.fetchOpenSkyCompatible(app, source.url));
+		}
+		if (!received.isEmpty()) {
+			app.runInUIThread(() -> {
+				for (AisObject ais : received) {
+					feedExternalAisObject(ais);
+				}
+			});
 		}
 	}
 
@@ -408,6 +535,89 @@ public class AisTrackerPlugin extends OsmandPlugin {
 	@Nullable
 	public AisTrackerLayer getLayer() {
 		return layer;
+	}
+
+	@Override
+	protected void registerLayerContextMenuActions(@NonNull ContextMenuAdapter adapter,
+	                                               @NonNull MapActivity mapActivity,
+	                                               List<RenderingRuleProperty> customRules) {
+		if (!isEnabled()) {
+			return;
+		}
+		addTypeToggleItem(adapter, mapActivity, AISTRACKER_ID + ".show_ships",
+				R.string.ais_show_ships, R.drawable.mm_sport_sailing, AIS_SHOW_SHIPS);
+		addTypeToggleItem(adapter, mapActivity, AISTRACKER_ID + ".show_planes",
+				R.string.ais_show_planes, R.drawable.ic_action_aircraft, AIS_SHOW_PLANES);
+		if (!getUrlSources().isEmpty()) {
+			addSourcesPickerItem(adapter, mapActivity);
+		}
+	}
+
+	private void addSourcesPickerItem(@NonNull ContextMenuAdapter adapter, @NonNull MapActivity mapActivity) {
+		OnRowItemClick listener = new OnRowItemClick() {
+			@Override
+			public boolean onRowItemClick(@NonNull OnDataChangeUiAdapter uiAdapter,
+			                              @NonNull View view, @NonNull ContextMenuItem item) {
+				showSourcesPickerDialog(mapActivity);
+				return false;
+			}
+
+			@Override
+			public boolean onContextMenuClick(@Nullable OnDataChangeUiAdapter uiAdapter, @Nullable View view,
+			                                  @NonNull ContextMenuItem item, boolean isChecked) {
+				return false;
+			}
+		};
+		adapter.addItem(new ContextMenuItem(AISTRACKER_ID + ".sources_picker")
+				.setTitleId(R.string.ais_url_sources, mapActivity)
+				.setIcon(R.drawable.ic_action_layers)
+				.setListener(listener));
+	}
+
+	private void showSourcesPickerDialog(@NonNull MapActivity mapActivity) {
+		List<AisUrlSource> sources = getUrlSources();
+		CharSequence[] items = new CharSequence[sources.size()];
+		boolean[] checked = new boolean[sources.size()];
+		for (int i = 0; i < sources.size(); i++) {
+			AisUrlSource source = sources.get(i);
+			items[i] = source.name + " (" + source.type.name().toLowerCase() + ")";
+			checked[i] = source.enabled;
+		}
+		Context themedContext = UiUtilities.getThemedContext(mapActivity, mapActivity.isNightMode());
+		new AlertDialog.Builder(themedContext)
+				.setTitle(R.string.ais_url_sources)
+				.setMultiChoiceItems(items, checked, (dialog, which, isChecked) ->
+						setSourceEnabled(sources.get(which).id, isChecked))
+				.setPositiveButton(R.string.shared_string_ok, null)
+				.show();
+	}
+
+	private void addTypeToggleItem(@NonNull ContextMenuAdapter adapter, @NonNull MapActivity mapActivity,
+	                               @NonNull String id, int titleId, int iconId,
+	                               @NonNull CommonPreference<Boolean> pref) {
+		ItemClickListener listener = new ItemClickListener() {
+			@Override
+			public boolean onContextMenuClick(@Nullable OnDataChangeUiAdapter uiAdapter, @Nullable View view,
+			                                  @NonNull ContextMenuItem item, boolean isChecked) {
+				pref.set(!pref.get());
+				AisTrackerLayer currentLayer = layer;
+				if (currentLayer != null) {
+					currentLayer.refreshTypeFilter();
+				}
+				item.setSelected(pref.get());
+				item.setColor(app, pref.get() ? R.color.osmand_orange : ContextMenuItem.INVALID_ID);
+				if (uiAdapter != null) {
+					uiAdapter.onDataSetChanged();
+				}
+				return false;
+			}
+		};
+		adapter.addItem(new ContextMenuItem(id)
+				.setTitleId(titleId, mapActivity)
+				.setSelected(pref.get())
+				.setColor(app, pref.get() ? R.color.osmand_orange : ContextMenuItem.INVALID_ID)
+				.setIcon(iconId)
+				.setListener(listener));
 	}
 
 	public void onAisObjectReceived(@NonNull AisObject ais) {

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerPlugin.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerPlugin.java
@@ -486,7 +486,7 @@ public class AisTrackerPlugin extends OsmandPlugin {
 		}
 		List<AisObject> received = new ArrayList<>();
 		for (AisUrlSource source : getPlaneSources()) {
-			received.addAll(AisPlaneDataFetcher.fetchOpenSkyCompatible(app, source.url));
+			received.addAll(AisPlaneDataFetcher.fetch(app, source));
 		}
 		if (!received.isEmpty()) {
 			app.runInUIThread(() -> {

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerPlugin.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerPlugin.java
@@ -461,9 +461,15 @@ public class AisTrackerPlugin extends OsmandPlugin {
 
 	private void startPlanePolling() {
 		stopPlanePolling();
-		if (getPlaneSources().isEmpty()) {
+		List<AisUrlSource> sources = getPlaneSources();
+		if (sources.isEmpty()) {
+			int configured = getUrlSources().size();
+			Log.d(AisPlaneDataFetcher.TAG, "polling not started: no enabled PLANES source ("
+					+ configured + " source(s) configured in total)");
 			return;
 		}
+		Log.d(AisPlaneDataFetcher.TAG, "polling started for " + sources.size()
+				+ " source(s) every " + PLANE_POLL_INTERVAL_MS / 1000 + " s");
 		planePollTimer = new Timer();
 		planePollTimer.schedule(new TimerTask() {
 			@Override
@@ -482,19 +488,29 @@ public class AisTrackerPlugin extends OsmandPlugin {
 
 	private void pollPlaneSources() {
 		if (!AIS_SHOW_PLANES.get()) {
+			Log.d(AisPlaneDataFetcher.TAG, "poll skipped: 'Show planes' is off");
+			return;
+		}
+		if (!isActive()) {
+			Log.d(AisPlaneDataFetcher.TAG, "poll skipped: plugin is not active");
 			return;
 		}
 		List<AisObject> received = new ArrayList<>();
 		for (AisUrlSource source : getPlaneSources()) {
 			received.addAll(AisPlaneDataFetcher.fetch(app, source));
 		}
-		if (!received.isEmpty()) {
-			app.runInUIThread(() -> {
-				for (AisObject ais : received) {
-					feedExternalAisObject(ais);
-				}
-			});
+		if (received.isEmpty()) {
+			Log.d(AisPlaneDataFetcher.TAG, "poll finished: no aircraft received");
+			return;
 		}
+		app.runInUIThread(() -> {
+			for (AisObject ais : received) {
+				feedExternalAisObject(ais);
+			}
+			Log.d(AisPlaneDataFetcher.TAG, "fed " + received.size() + " aircraft to the layer; "
+					+ "tracked objects now: " + getAisObjects().size()
+					+ ", layer " + (layer == null ? "NOT attached (nothing will be drawn)" : "attached"));
+		});
 	}
 
 	@Override

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerPlugin.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerPlugin.java
@@ -500,7 +500,7 @@ public class AisTrackerPlugin extends OsmandPlugin {
 		planePollTimer.schedule(new TimerTask() {
 			@Override
 			public void run() {
-				pollPlaneSources();
+				safePollPlaneSources();
 			}
 		}, 0, PLANE_POLL_INTERVAL_MS);
 	}
@@ -524,7 +524,22 @@ public class AisTrackerPlugin extends OsmandPlugin {
 		if (System.currentTimeMillis() - lastPlaneRequestTime < MIN_PLANE_REQUEST_SPACING_MS) {
 			return;
 		}
-		new Thread(this::pollPlaneSources, "ais-planes-viewport").start();
+		new Thread(this::safePollPlaneSources, "ais-planes-viewport").start();
+	}
+
+	/**
+	 * Polling runs on a timer thread, where an uncaught exception takes the whole app down - a
+	 * misbehaving source must never be able to do that.
+	 */
+	private void safePollPlaneSources() {
+		try {
+			pollPlaneSources();
+		} catch (Throwable e) {
+			Log.e(AisPlaneDataFetcher.TAG, "poll failed", e);
+			synchronized (planeRequestLock) {
+				planeRequestInProgress = false;
+			}
+		}
 	}
 
 	private void pollPlaneSources() {

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerPlugin.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerPlugin.java
@@ -1,6 +1,7 @@
 package net.osmand.plus.plugins.aistracker;
 
 import net.osmand.plus.render.RendererRegistry;
+import net.osmand.shared.aistracker.AisObjType;
 import net.osmand.shared.aistracker.AisObject;
 
 import static net.osmand.plus.NavigationService.USED_BY_AIS;
@@ -17,6 +18,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 
 import net.osmand.Location;
+import net.osmand.data.QuadRect;
 import net.osmand.PlatformUtil;
 import net.osmand.StateChangedListener;
 import net.osmand.plus.NavigationService;
@@ -44,9 +46,11 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -108,10 +112,13 @@ public class AisTrackerPlugin extends OsmandPlugin {
 	public final CommonPreference<String> AIS_URL_SOURCES;
 	public final CommonPreference<Boolean> AIS_SHOW_SHIPS;
 	public final CommonPreference<Boolean> AIS_SHOW_PLANES;
-	// Anonymous OpenSky access is capped at ~400 requests/day; keep this conservative by default
-	// until a user-run aggregator with its own key/limits is configured.
-	private static final long PLANE_POLL_INTERVAL_MS = 60_000L;
+	private static final long PLANE_POLL_INTERVAL_MS = 15_000L;
+	// floor between requests, so panning around cannot outpace the poll itself
+	private static final long MIN_PLANE_REQUEST_SPACING_MS = 5_000L;
 	private Timer planePollTimer;
+	private final Object planeRequestLock = new Object();
+	private volatile boolean planeRequestInProgress;
+	private volatile long lastPlaneRequestTime;
 
 	/* timestamp of last AIS message received for all instances: */
 	private long lastMessageReceived = 0;
@@ -204,6 +211,25 @@ public class AisTrackerPlugin extends OsmandPlugin {
 		@NonNull
 		public synchronized List<AisObject> getAisObjects() {
 			return new ArrayList<>(objects.values());
+		}
+
+		/**
+		 * Drops the aircraft that the latest batch no longer reports, leaving every other object
+		 * untouched - vessels come from the NMEA listener and have nothing to do with this.
+		 *
+		 * @return how many aircraft were removed
+		 */
+		public synchronized int removeAircraftMissingFrom(@NonNull Set<Integer> receivedMmsi) {
+			int removed = 0;
+			for (Iterator<Map.Entry<Integer, AisObject>> iterator = objects.entrySet().iterator(); iterator.hasNext(); ) {
+				AisObject obj = iterator.next().getValue();
+				if (obj.getObjectClass() == AisObjType.AIS_AIRPLANE && !receivedMmsi.contains(obj.getMmsi())) {
+					iterator.remove();
+					removed++;
+					AisTrackerPlugin.this.onAisObjectRemoved(obj);
+				}
+			}
+			return removed;
 		}
 
 		public synchronized void removeLostObjects() {
@@ -486,6 +512,21 @@ public class AisTrackerPlugin extends OsmandPlugin {
 		}
 	}
 
+	/**
+	 * Called by the layer when the visible area changed. Fetches for the new area without touching
+	 * the poll timer, so panning cannot turn into a request storm - the periodic poll keeps its own
+	 * cadence and the viewport-driven extra request is spaced out on top of it.
+	 */
+	public void onMapAreaChanged() {
+		if (planePollTimer == null || planeRequestInProgress) {
+			return;
+		}
+		if (System.currentTimeMillis() - lastPlaneRequestTime < MIN_PLANE_REQUEST_SPACING_MS) {
+			return;
+		}
+		new Thread(this::pollPlaneSources, "ais-planes-viewport").start();
+	}
+
 	private void pollPlaneSources() {
 		if (!AIS_SHOW_PLANES.get()) {
 			Log.d(AisPlaneDataFetcher.TAG, "poll skipped: 'Show planes' is off");
@@ -495,20 +536,58 @@ public class AisTrackerPlugin extends OsmandPlugin {
 			Log.d(AisPlaneDataFetcher.TAG, "poll skipped: plugin is not active");
 			return;
 		}
-		List<AisObject> received = new ArrayList<>();
-		for (AisUrlSource source : getPlaneSources()) {
-			received.addAll(AisPlaneDataFetcher.fetch(app, source));
+		QuadRect latLonBounds = app.getOsmandMap().getMapView().getRotatedTileBox().getLatLonBounds();
+		if (latLonBounds == null) {
+			Log.d(AisPlaneDataFetcher.TAG, "poll skipped: map area is not known yet");
+			return;
 		}
-		if (received.isEmpty()) {
-			Log.d(AisPlaneDataFetcher.TAG, "poll finished: no aircraft received");
+		synchronized (planeRequestLock) {
+			if (planeRequestInProgress) {
+				Log.d(AisPlaneDataFetcher.TAG, "poll skipped: a request is already running");
+				return;
+			}
+			planeRequestInProgress = true;
+		}
+		try {
+			lastPlaneRequestTime = System.currentTimeMillis();
+			List<AisObject> received = new ArrayList<>();
+			boolean allSourcesFailed = true;
+			for (AisUrlSource source : getPlaneSources()) {
+				List<AisObject> fromSource = AisPlaneDataFetcher.fetch(app, source, latLonBounds);
+				if (fromSource != null) {
+					allSourcesFailed = false;
+					received.addAll(fromSource);
+				}
+			}
+			applyPlaneBatch(received, allSourcesFailed);
+		} finally {
+			synchronized (planeRequestLock) {
+				planeRequestInProgress = false;
+			}
+		}
+	}
+
+	/**
+	 * Aircraft already on the map are updated in place rather than re-added, and only those missing
+	 * from a successful batch are dropped - that keeps the layer from rebuilding its symbols and
+	 * blinking on every poll. A failed batch changes nothing, so a network hiccup does not wipe the
+	 * map.
+	 */
+	private void applyPlaneBatch(@NonNull List<AisObject> received, boolean requestFailed) {
+		if (requestFailed) {
+			Log.d(AisPlaneDataFetcher.TAG, "poll failed, keeping the aircraft already on the map");
 			return;
 		}
 		app.runInUIThread(() -> {
+			Set<Integer> receivedMmsi = new HashSet<>();
 			for (AisObject ais : received) {
+				receivedMmsi.add(ais.getMmsi());
 				feedExternalAisObject(ais);
 			}
-			Log.d(AisPlaneDataFetcher.TAG, "fed " + received.size() + " aircraft to the layer; "
-					+ "tracked objects now: " + getAisObjects().size()
+			int removed = aisDataManager.removeAircraftMissingFrom(receivedMmsi);
+			Log.d(AisPlaneDataFetcher.TAG, "batch applied: " + received.size() + " aircraft in view, "
+					+ removed + " gone from the batch removed; tracked objects now: "
+					+ getAisObjects().size()
 					+ ", layer " + (layer == null ? "NOT attached (nothing will be drawn)" : "attached"));
 		});
 	}

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerSettingsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerSettingsFragment.java
@@ -12,6 +12,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.EditText;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
@@ -125,17 +126,12 @@ public class AisTrackerSettingsFragment extends BaseSettingsFragment {
 	private void showTemplatePickerDialog() {
 		List<AisUrlSourceTemplate> templates = AisUrlSourceTemplate.all();
 		Context themedContext = UiUtilities.getThemedContext(getActivity(), isNightMode());
-		// two-line rows so the cost/access note is visible while picking, not after
 		ArrayAdapter<AisUrlSourceTemplate> adapter = new ArrayAdapter<>(themedContext,
 				android.R.layout.simple_list_item_2, android.R.id.text1, templates) {
 			@NonNull
 			@Override
 			public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
-				View view = super.getView(position, convertView, parent);
-				AisUrlSourceTemplate template = templates.get(position);
-				((TextView) view.findViewById(android.R.id.text1)).setText(template.displayName);
-				((TextView) view.findViewById(android.R.id.text2)).setText(template.note);
-				return view;
+				return createTemplateRow(templates.get(position));
 			}
 		};
 		new AlertDialog.Builder(themedContext)
@@ -143,6 +139,54 @@ public class AisTrackerSettingsFragment extends BaseSettingsFragment {
 				.setAdapter(adapter, (dialog, which) -> showSourceDialog(templates.get(which), null))
 				.setNegativeButton(R.string.shared_string_cancel, null)
 				.show();
+	}
+
+	/**
+	 * Name plus access note, with an info button opening the project page. The row itself stays
+	 * unfocusable so tapping anywhere else still selects the template.
+	 */
+	@NonNull
+	private View createTemplateRow(@NonNull AisUrlSourceTemplate template) {
+		Context themedContext = UiUtilities.getThemedContext(getActivity(), isNightMode());
+		float density = getResources().getDisplayMetrics().density;
+		int padding = (int) (16 * density);
+
+		LinearLayout row = new LinearLayout(themedContext);
+		row.setOrientation(LinearLayout.HORIZONTAL);
+		row.setGravity(Gravity.CENTER_VERTICAL);
+		row.setPadding(padding, padding / 2, padding / 2, padding / 2);
+		row.setDescendantFocusability(ViewGroup.FOCUS_BLOCK_DESCENDANTS);
+
+		LinearLayout textColumn = new LinearLayout(themedContext);
+		textColumn.setOrientation(LinearLayout.VERTICAL);
+		textColumn.setLayoutParams(new LinearLayout.LayoutParams(0,
+				ViewGroup.LayoutParams.WRAP_CONTENT, 1f));
+
+		TextView title = new TextView(themedContext);
+		title.setText(template.displayName);
+		title.setTextColor(ColorUtilities.getPrimaryTextColor(app, isNightMode()));
+		textColumn.addView(title);
+
+		TextView note = new TextView(themedContext);
+		note.setText(template.note);
+		note.setTextColor(ColorUtilities.getSecondaryTextColor(app, isNightMode()));
+		note.setTextSize(12);
+		textColumn.addView(note);
+		row.addView(textColumn);
+
+		if (template.projectUrl != null) {
+			ImageView infoButton = new ImageView(themedContext);
+			infoButton.setImageDrawable(app.getUIUtilities().getIcon(R.drawable.ic_action_info_dark,
+					ColorUtilities.getLinksColorId(isNightMode())));
+			infoButton.setContentDescription(template.projectUrl);
+			infoButton.setPadding(padding / 2, padding / 2, padding / 2, padding / 2);
+			infoButton.setFocusable(false);
+			infoButton.setClickable(true);
+			infoButton.setOnClickListener(v ->
+					AndroidUtils.openUrl(requireActivity(), template.projectUrl, isNightMode()));
+			row.addView(infoButton);
+		}
+		return row;
 	}
 
 	private void showSourceDialog(@Nullable AisUrlSourceTemplate template, @Nullable AisUrlSource existing) {

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerSettingsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerSettingsFragment.java
@@ -150,12 +150,11 @@ public class AisTrackerSettingsFragment extends BaseSettingsFragment {
 		urlInput.setText(existing != null ? existing.url : template != null ? template.urlTemplate : "");
 		layout.addView(urlInput);
 
-		EditText apiKeyInput = null;
-		if (existing == null && template != null && template.apiKeyLabel != null) {
-			apiKeyInput = new EditText(themedContext);
-			apiKeyInput.setHint(template.apiKeyLabel);
-			layout.addView(apiKeyInput);
-		}
+		EditText apiKeyInput = new EditText(themedContext);
+		apiKeyInput.setHint(template != null && template.apiKeyLabel != null
+				? template.apiKeyLabel : getString(R.string.ais_source_api_key));
+		apiKeyInput.setText(existing != null ? existing.apiKey : "");
+		layout.addView(apiKeyInput);
 
 		RadioGroup typeGroup = new RadioGroup(themedContext);
 		typeGroup.setOrientation(RadioGroup.HORIZONTAL);
@@ -174,27 +173,23 @@ public class AisTrackerSettingsFragment extends BaseSettingsFragment {
 		shipsButton.setChecked(currentType == AisUrlSource.Type.SHIPS);
 		layout.addView(typeGroup);
 
-		final EditText finalApiKeyInput = apiKeyInput;
 		AlertDialog.Builder builder = new AlertDialog.Builder(themedContext)
 				.setTitle(existing != null ? R.string.shared_string_edit : R.string.ais_add_url_source)
 				.setView(layout)
 				.setPositiveButton(R.string.shared_string_save, (dialog, which) -> {
 					String name = nameInput.getText().toString().trim();
 					String url = urlInput.getText().toString().trim();
-					if (finalApiKeyInput != null) {
-						// leaving the key blank must still produce a usable URL (e.g. a
-						// source that works anonymously, or one edited by hand afterwards)
-						String key = finalApiKeyInput.getText().toString().trim();
-						url = url.replace("{API_KEY}", key);
-					}
+					// the key stays editable on the source instead of being baked into the URL;
+					// leaving it blank is fine, sources that need no key still work
+					String apiKey = apiKeyInput.getText().toString().trim();
 					if (name.isEmpty() || url.isEmpty()) {
 						return;
 					}
 					AisUrlSource.Type type = shipsButton.isChecked()
 							? AisUrlSource.Type.SHIPS : AisUrlSource.Type.PLANES;
 					AisUrlSource toSave = existing != null
-							? existing.withValues(type, name, url)
-							: AisUrlSource.create(type, name, url);
+							? existing.withValues(type, name, url, apiKey)
+							: AisUrlSource.create(type, name, url, apiKey);
 					plugin.addOrUpdateUrlSource(toSave);
 					refreshUrlSourcesList();
 				})

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerSettingsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerSettingsFragment.java
@@ -6,13 +6,16 @@ import static java.lang.Math.ceil;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.text.TextUtils;
+import android.graphics.Paint;
 import android.view.Gravity;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -25,6 +28,8 @@ import net.osmand.plus.plugins.PluginsHelper;
 import net.osmand.plus.settings.fragments.BaseSettingsFragment;
 import net.osmand.plus.settings.preferences.EditTextPreferenceEx;
 import net.osmand.plus.settings.preferences.ListPreferenceEx;
+import net.osmand.plus.utils.AndroidUtils;
+import net.osmand.plus.utils.ColorUtilities;
 import net.osmand.plus.utils.UiUtilities;
 
 import java.text.MessageFormat;
@@ -119,14 +124,23 @@ public class AisTrackerSettingsFragment extends BaseSettingsFragment {
 
 	private void showTemplatePickerDialog() {
 		List<AisUrlSourceTemplate> templates = AisUrlSourceTemplate.all();
-		CharSequence[] items = new CharSequence[templates.size()];
-		for (int i = 0; i < templates.size(); i++) {
-			items[i] = templates.get(i).displayName;
-		}
 		Context themedContext = UiUtilities.getThemedContext(getActivity(), isNightMode());
+		// two-line rows so the cost/access note is visible while picking, not after
+		ArrayAdapter<AisUrlSourceTemplate> adapter = new ArrayAdapter<>(themedContext,
+				android.R.layout.simple_list_item_2, android.R.id.text1, templates) {
+			@NonNull
+			@Override
+			public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+				View view = super.getView(position, convertView, parent);
+				AisUrlSourceTemplate template = templates.get(position);
+				((TextView) view.findViewById(android.R.id.text1)).setText(template.displayName);
+				((TextView) view.findViewById(android.R.id.text2)).setText(template.note);
+				return view;
+			}
+		};
 		new AlertDialog.Builder(themedContext)
 				.setTitle(R.string.ais_add_url_source)
-				.setItems(items, (dialog, which) -> showSourceDialog(templates.get(which), null))
+				.setAdapter(adapter, (dialog, which) -> showSourceDialog(templates.get(which), null))
 				.setNegativeButton(R.string.shared_string_cancel, null)
 				.show();
 	}
@@ -139,6 +153,24 @@ public class AisTrackerSettingsFragment extends BaseSettingsFragment {
 		LinearLayout layout = new LinearLayout(themedContext);
 		layout.setOrientation(LinearLayout.VERTICAL);
 		layout.setPadding(padding, padding / 2, padding, 0);
+
+		if (template != null) {
+			TextView descriptionView = new TextView(themedContext);
+			descriptionView.setText(template.note + ".\n" + template.description);
+			descriptionView.setTextColor(ColorUtilities.getSecondaryTextColor(app, isNightMode()));
+			layout.addView(descriptionView);
+
+			if (template.projectUrl != null) {
+				TextView linkView = new TextView(themedContext);
+				linkView.setText(template.projectUrl);
+				linkView.setTextColor(ColorUtilities.getLinksColor(app, isNightMode()));
+				linkView.setPaintFlags(linkView.getPaintFlags() | Paint.UNDERLINE_TEXT_FLAG);
+				linkView.setPadding(0, padding / 4, 0, padding / 4);
+				linkView.setOnClickListener(v ->
+						AndroidUtils.openUrl(requireActivity(), template.projectUrl, isNightMode()));
+				layout.addView(linkView);
+			}
+		}
 
 		EditText nameInput = new EditText(themedContext);
 		nameInput.setHint(R.string.shared_string_name);

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerSettingsFragment.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisTrackerSettingsFragment.java
@@ -6,11 +6,19 @@ import static java.lang.Math.ceil;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.text.TextUtils;
+import android.view.Gravity;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.preference.Preference;
+import androidx.preference.PreferenceCategory;
 
 import net.osmand.plus.R;
 import net.osmand.plus.plugins.PluginsHelper;
@@ -20,10 +28,15 @@ import net.osmand.plus.settings.preferences.ListPreferenceEx;
 import net.osmand.plus.utils.UiUtilities;
 
 import java.text.MessageFormat;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class AisTrackerSettingsFragment extends BaseSettingsFragment {
+
+	private static final String URL_SOURCES_CATEGORY_KEY = "ais_url_sources_category";
+	private static final String ADD_URL_SOURCE_KEY = "ais_add_url_source";
+	private static final String URL_SOURCE_KEY_PREFIX = "ais_url_source_";
 
 	private final AisTrackerPlugin plugin = PluginsHelper.requirePlugin(AisTrackerPlugin.class);
 
@@ -41,6 +54,181 @@ public class AisTrackerSettingsFragment extends BaseSettingsFragment {
 		setupShipLostTimeout();
 		setupCpaWarningDistance(cpaWarningEnabled);
 		setupDisplayOwnPosition(ownMmsi);
+		setupUrlSources();
+		setupShowShips();
+		setupShowPlanes();
+	}
+
+	private void setupUrlSources() {
+		refreshUrlSourcesList();
+	}
+
+	private void refreshUrlSourcesList() {
+		PreferenceCategory category = findPreference(URL_SOURCES_CATEGORY_KEY);
+		if (category == null) {
+			return;
+		}
+		category.setSummary(R.string.ais_url_sources_description);
+		category.removeAll();
+
+		// Clicks are dispatched from onPreferenceClick() by key, not through per-preference
+		// listeners: BaseSettingsFragment.registerPreferences() runs after setupPreferences()
+		// and replaces every preference's click listener with the fragment itself.
+		for (AisUrlSource source : plugin.getUrlSources()) {
+			Preference item = new Preference(requireContext());
+			item.setKey(URL_SOURCE_KEY_PREFIX + source.id);
+			item.setPersistent(false);
+			item.setTitle(source.name + (source.enabled ? "" : " (" + getString(R.string.shared_string_hidden) + ")"));
+			item.setSummary((source.type == AisUrlSource.Type.PLANES
+					? getString(R.string.ais_show_planes) : getString(R.string.ais_show_ships))
+					+ " — " + source.url);
+			item.setIcon(source.type == AisUrlSource.Type.PLANES
+					? R.drawable.ic_action_aircraft : R.drawable.mm_sport_sailing);
+			item.setOnPreferenceClickListener(this);
+			category.addPreference(item);
+		}
+
+		Preference addItem = new Preference(requireContext());
+		addItem.setKey(ADD_URL_SOURCE_KEY);
+		addItem.setPersistent(false);
+		addItem.setTitle(R.string.ais_add_url_source);
+		addItem.setIcon(R.drawable.ic_action_plus);
+		addItem.setOnPreferenceClickListener(this);
+		category.addPreference(addItem);
+	}
+
+	@Override
+	public boolean onPreferenceClick(Preference preference) {
+		String key = preference.getKey();
+		if (ADD_URL_SOURCE_KEY.equals(key)) {
+			showTemplatePickerDialog();
+			return true;
+		}
+		if (key != null && key.startsWith(URL_SOURCE_KEY_PREFIX)) {
+			String id = key.substring(URL_SOURCE_KEY_PREFIX.length());
+			for (AisUrlSource source : plugin.getUrlSources()) {
+				if (source.id.equals(id)) {
+					showSourceDialog(null, source);
+					break;
+				}
+			}
+			return true;
+		}
+		return super.onPreferenceClick(preference);
+	}
+
+	private void showTemplatePickerDialog() {
+		List<AisUrlSourceTemplate> templates = AisUrlSourceTemplate.all();
+		CharSequence[] items = new CharSequence[templates.size()];
+		for (int i = 0; i < templates.size(); i++) {
+			items[i] = templates.get(i).displayName;
+		}
+		Context themedContext = UiUtilities.getThemedContext(getActivity(), isNightMode());
+		new AlertDialog.Builder(themedContext)
+				.setTitle(R.string.ais_add_url_source)
+				.setItems(items, (dialog, which) -> showSourceDialog(templates.get(which), null))
+				.setNegativeButton(R.string.shared_string_cancel, null)
+				.show();
+	}
+
+	private void showSourceDialog(@Nullable AisUrlSourceTemplate template, @Nullable AisUrlSource existing) {
+		Context themedContext = UiUtilities.getThemedContext(getActivity(), isNightMode());
+		float density = getResources().getDisplayMetrics().density;
+		int padding = (int) (20 * density);
+
+		LinearLayout layout = new LinearLayout(themedContext);
+		layout.setOrientation(LinearLayout.VERTICAL);
+		layout.setPadding(padding, padding / 2, padding, 0);
+
+		EditText nameInput = new EditText(themedContext);
+		nameInput.setHint(R.string.shared_string_name);
+		nameInput.setText(existing != null ? existing.name : template != null ? template.displayName : "");
+		layout.addView(nameInput);
+
+		EditText urlInput = new EditText(themedContext);
+		urlInput.setHint("URL");
+		urlInput.setText(existing != null ? existing.url : template != null ? template.urlTemplate : "");
+		layout.addView(urlInput);
+
+		EditText apiKeyInput = null;
+		if (existing == null && template != null && template.apiKeyLabel != null) {
+			apiKeyInput = new EditText(themedContext);
+			apiKeyInput.setHint(template.apiKeyLabel);
+			layout.addView(apiKeyInput);
+		}
+
+		RadioGroup typeGroup = new RadioGroup(themedContext);
+		typeGroup.setOrientation(RadioGroup.HORIZONTAL);
+		typeGroup.setGravity(Gravity.CENTER_VERTICAL);
+		RadioButton planesButton = new RadioButton(themedContext);
+		planesButton.setId(View.generateViewId());
+		planesButton.setText(R.string.ais_show_planes);
+		RadioButton shipsButton = new RadioButton(themedContext);
+		shipsButton.setId(View.generateViewId());
+		shipsButton.setText(R.string.ais_show_ships);
+		typeGroup.addView(planesButton);
+		typeGroup.addView(shipsButton);
+		AisUrlSource.Type currentType = existing != null ? existing.type
+				: template != null ? template.type : AisUrlSource.Type.PLANES;
+		planesButton.setChecked(currentType == AisUrlSource.Type.PLANES);
+		shipsButton.setChecked(currentType == AisUrlSource.Type.SHIPS);
+		layout.addView(typeGroup);
+
+		final EditText finalApiKeyInput = apiKeyInput;
+		AlertDialog.Builder builder = new AlertDialog.Builder(themedContext)
+				.setTitle(existing != null ? R.string.shared_string_edit : R.string.ais_add_url_source)
+				.setView(layout)
+				.setPositiveButton(R.string.shared_string_save, (dialog, which) -> {
+					String name = nameInput.getText().toString().trim();
+					String url = urlInput.getText().toString().trim();
+					if (finalApiKeyInput != null) {
+						// leaving the key blank must still produce a usable URL (e.g. a
+						// source that works anonymously, or one edited by hand afterwards)
+						String key = finalApiKeyInput.getText().toString().trim();
+						url = url.replace("{API_KEY}", key);
+					}
+					if (name.isEmpty() || url.isEmpty()) {
+						return;
+					}
+					AisUrlSource.Type type = shipsButton.isChecked()
+							? AisUrlSource.Type.SHIPS : AisUrlSource.Type.PLANES;
+					AisUrlSource toSave = existing != null
+							? existing.withValues(type, name, url)
+							: AisUrlSource.create(type, name, url);
+					plugin.addOrUpdateUrlSource(toSave);
+					refreshUrlSourcesList();
+				})
+				.setNegativeButton(R.string.shared_string_cancel, null);
+		if (existing != null) {
+			AisUrlSource toDelete = existing;
+			builder.setNeutralButton(R.string.shared_string_delete, (dialog, which) -> {
+				plugin.removeUrlSource(toDelete.id);
+				refreshUrlSourcesList();
+			});
+		}
+		builder.show();
+	}
+
+	private void setupShowShips() {
+		Boolean[] entryValues = {true, false};
+		String[] entries = {getString(R.string.shared_string_yes), getString(R.string.shared_string_no)};
+		ListPreferenceEx showShips = findPreference(plugin.AIS_SHOW_SHIPS.getId());
+		if (showShips != null) {
+			showShips.setEntries(entries);
+			showShips.setEntryValues(entryValues);
+			showShips.setDescription(R.string.ais_show_ships_description);
+		}
+	}
+
+	private void setupShowPlanes() {
+		Boolean[] entryValues = {true, false};
+		String[] entries = {getString(R.string.shared_string_yes), getString(R.string.shared_string_no)};
+		ListPreferenceEx showPlanes = findPreference(plugin.AIS_SHOW_PLANES.getId());
+		if (showPlanes != null) {
+			showPlanes.setEntries(entries);
+			showPlanes.setEntryValues(entryValues);
+			showPlanes.setDescription(R.string.ais_show_planes_description);
+		}
 	}
 
 	private int setupProtocol() {
@@ -233,6 +421,10 @@ public class AisTrackerSettingsFragment extends BaseSettingsFragment {
 		if (changed && refreshOwnObjectVisibility) {
 			app.runInUIThread(this::updateOwnObjectVisibility);
 		}
+		if (changed && (preference.getKey().equals(AisTrackerPlugin.AIS_SHOW_SHIPS_ID)
+				|| preference.getKey().equals(AisTrackerPlugin.AIS_SHOW_PLANES_ID))) {
+			app.runInUIThread(this::updateTypeFilter);
+		}
 		return changed;
 	}
 
@@ -240,6 +432,13 @@ public class AisTrackerSettingsFragment extends BaseSettingsFragment {
 		AisTrackerLayer layer = plugin.getLayer();
 		if (layer != null) {
 			layer.refreshOwnObjectVisibility();
+		}
+	}
+
+	private void updateTypeFilter() {
+		AisTrackerLayer layer = plugin.getLayer();
+		if (layer != null) {
+			layer.refreshTypeFilter();
 		}
 	}
 

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisUrlSource.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisUrlSource.java
@@ -1,0 +1,126 @@
+package net.osmand.plus.plugins.aistracker;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import net.osmand.util.Algorithms;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * A user-configured "pull data from this URL" source for the AIS layer - a name + URL + type
+ * (PLANES/SHIPS), added/edited/removed one at a time through a dialog in the plugin's settings,
+ * the same way an online routing engine or a custom raster map source is configured. Stored as a
+ * JSON array in a single string preference (same storage pattern as
+ * {@code OsmandSettings.ONLINE_ROUTING_ENGINES}).
+ */
+public class AisUrlSource {
+
+	public enum Type {
+		PLANES,
+		SHIPS
+	}
+
+	@NonNull
+	public final String id;
+	@NonNull
+	public final Type type;
+	@NonNull
+	public final String name;
+	@NonNull
+	public final String url;
+	/** Per-source visibility, toggled from the "AIS sources" picker in Configure Map. */
+	public final boolean enabled;
+
+	public AisUrlSource(@NonNull String id, @NonNull Type type, @NonNull String name, @NonNull String url, boolean enabled) {
+		this.id = id;
+		this.type = type;
+		this.name = name;
+		this.url = url;
+		this.enabled = enabled;
+	}
+
+	@NonNull
+	public static AisUrlSource create(@NonNull Type type, @NonNull String name, @NonNull String url) {
+		return new AisUrlSource(UUID.randomUUID().toString(), type, name, url, true);
+	}
+
+	@NonNull
+	public AisUrlSource withValues(@NonNull Type type, @NonNull String name, @NonNull String url) {
+		return new AisUrlSource(id, type, name, url, enabled);
+	}
+
+	@NonNull
+	public AisUrlSource withEnabled(boolean enabled) {
+		return new AisUrlSource(id, type, name, url, enabled);
+	}
+
+	@NonNull
+	public JSONObject toJson() throws JSONException {
+		JSONObject json = new JSONObject();
+		json.put("id", id);
+		json.put("type", type.name());
+		json.put("name", name);
+		json.put("url", url);
+		json.put("enabled", enabled);
+		return json;
+	}
+
+	@Nullable
+	private static AisUrlSource fromJson(@NonNull JSONObject json) {
+		String id = json.optString("id", "");
+		String typeStr = json.optString("type", "");
+		String name = json.optString("name", "");
+		String url = json.optString("url", "");
+		boolean enabled = json.optBoolean("enabled", true);
+		if (Algorithms.isEmpty(id) || Algorithms.isEmpty(name) || Algorithms.isEmpty(url)) {
+			return null;
+		}
+		Type type;
+		try {
+			type = Type.valueOf(typeStr);
+		} catch (IllegalArgumentException e) {
+			return null;
+		}
+		return new AisUrlSource(id, type, name, url, enabled);
+	}
+
+	@NonNull
+	public static List<AisUrlSource> parseList(@Nullable String json) {
+		List<AisUrlSource> result = new ArrayList<>();
+		if (Algorithms.isEmpty(json)) {
+			return result;
+		}
+		try {
+			JSONArray array = new JSONArray(json);
+			for (int i = 0; i < array.length(); i++) {
+				AisUrlSource source = fromJson(array.getJSONObject(i));
+				if (source != null) {
+					result.add(source);
+				}
+			}
+		} catch (JSONException e) {
+			// ignore malformed preference value
+		}
+		return result;
+	}
+
+	@NonNull
+	public static String serializeList(@NonNull List<AisUrlSource> sources) {
+		JSONArray array = new JSONArray();
+		for (AisUrlSource source : sources) {
+			try {
+				array.put(source.toJson());
+			} catch (JSONException e) {
+				// skip
+			}
+		}
+		return array.toString();
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisUrlSource.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisUrlSource.java
@@ -35,30 +35,41 @@ public class AisUrlSource {
 	public final String name;
 	@NonNull
 	public final String url;
+	/**
+	 * Optional credential. Substituted into {@link #url} in place of {@code {API_KEY}} when the
+	 * URL carries that placeholder, otherwise sent as a header for hosts that expect one
+	 * (see AisPlaneDataFetcher). May be empty - sources that need no key still work.
+	 */
+	@NonNull
+	public final String apiKey;
 	/** Per-source visibility, toggled from the "AIS sources" picker in Configure Map. */
 	public final boolean enabled;
 
-	public AisUrlSource(@NonNull String id, @NonNull Type type, @NonNull String name, @NonNull String url, boolean enabled) {
+	public AisUrlSource(@NonNull String id, @NonNull Type type, @NonNull String name,
+	                     @NonNull String url, @NonNull String apiKey, boolean enabled) {
 		this.id = id;
 		this.type = type;
 		this.name = name;
 		this.url = url;
+		this.apiKey = apiKey;
 		this.enabled = enabled;
 	}
 
 	@NonNull
-	public static AisUrlSource create(@NonNull Type type, @NonNull String name, @NonNull String url) {
-		return new AisUrlSource(UUID.randomUUID().toString(), type, name, url, true);
+	public static AisUrlSource create(@NonNull Type type, @NonNull String name, @NonNull String url,
+	                                   @NonNull String apiKey) {
+		return new AisUrlSource(UUID.randomUUID().toString(), type, name, url, apiKey, true);
 	}
 
 	@NonNull
-	public AisUrlSource withValues(@NonNull Type type, @NonNull String name, @NonNull String url) {
-		return new AisUrlSource(id, type, name, url, enabled);
+	public AisUrlSource withValues(@NonNull Type type, @NonNull String name, @NonNull String url,
+	                                @NonNull String apiKey) {
+		return new AisUrlSource(id, type, name, url, apiKey, enabled);
 	}
 
 	@NonNull
 	public AisUrlSource withEnabled(boolean enabled) {
-		return new AisUrlSource(id, type, name, url, enabled);
+		return new AisUrlSource(id, type, name, url, apiKey, enabled);
 	}
 
 	@NonNull
@@ -68,6 +79,7 @@ public class AisUrlSource {
 		json.put("type", type.name());
 		json.put("name", name);
 		json.put("url", url);
+		json.put("apiKey", apiKey);
 		json.put("enabled", enabled);
 		return json;
 	}
@@ -78,6 +90,7 @@ public class AisUrlSource {
 		String typeStr = json.optString("type", "");
 		String name = json.optString("name", "");
 		String url = json.optString("url", "");
+		String apiKey = json.optString("apiKey", "");
 		boolean enabled = json.optBoolean("enabled", true);
 		if (Algorithms.isEmpty(id) || Algorithms.isEmpty(name) || Algorithms.isEmpty(url)) {
 			return null;
@@ -88,7 +101,7 @@ public class AisUrlSource {
 		} catch (IllegalArgumentException e) {
 			return null;
 		}
-		return new AisUrlSource(id, type, name, url, enabled);
+		return new AisUrlSource(id, type, name, url, apiKey, enabled);
 	}
 
 	@NonNull

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisUrlSourceTemplate.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisUrlSourceTemplate.java
@@ -62,13 +62,20 @@ public class AisUrlSourceTemplate {
 						"Needs a RapidAPI subscription key, sent as a header. Edit lat/lon/dist in "
 								+ "the URL below to your area (dist is in nautical miles)."),
 				new AisUrlSourceTemplate(
-						"airplanes.live (free, no key)",
+						"adsb.lol (free, no key)",
 						AisUrlSource.Type.PLANES,
-						"https://api.airplanes.live/v2/point/50.45/30.52/250",
+						"https://api.adsb.lol/v2/lat/50.03/lon/8.56/dist/50",
 						null,
-						"Community ADS-B feed in the same format as ADS-B Exchange, no key needed. "
-								+ "Edit lat/lon/radius in the URL below (radius is in nautical miles, "
-								+ "max 250)."),
+						"Community feed in the ADS-B Exchange format, no key needed - the easiest "
+								+ "way to try planes out. Edit lat/lon/dist in the URL below "
+								+ "(dist is in nautical miles)."),
+				new AisUrlSourceTemplate(
+						"adsb.fi (free, no key)",
+						AisUrlSource.Type.PLANES,
+						"https://opendata.adsb.fi/api/v2/lat/50.03/lon/8.56/dist/50/",
+						null,
+						"Another community feed in the same format, no key needed. Edit "
+								+ "lat/lon/dist in the URL below (dist is in nautical miles)."),
 				new AisUrlSourceTemplate(
 						"Private aggregator (key in URL)",
 						AisUrlSource.Type.PLANES,

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisUrlSourceTemplate.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisUrlSourceTemplate.java
@@ -19,8 +19,9 @@ public class AisUrlSourceTemplate {
 	public final AisUrlSource.Type type;
 	@NonNull
 	public final String urlTemplate;
-	/** Null when the template needs no key; otherwise the label for an extra "key" input whose
-	 * value replaces {@code {API_KEY}} in {@link #urlTemplate} before the source is saved. */
+	/** Label for the key input, or null when this source needs no key. The value is stored on the
+	 * source and applied at request time - substituted into the URL when it carries
+	 * {@code {API_KEY}}, sent as a header otherwise (see AisPlaneDataFetcher). */
 	@Nullable
 	public final String apiKeyLabel;
 	@NonNull
@@ -53,6 +54,21 @@ public class AisUrlSourceTemplate {
 						null,
 						"No key needed, but a global query costs more of the daily anonymous quota "
 								+ "per request than a bounding-box one - prefer the bounding-box template."),
+				new AisUrlSourceTemplate(
+						"ADS-B Exchange (RapidAPI key)",
+						AisUrlSource.Type.PLANES,
+						"https://adsbexchange-com1.p.rapidapi.com/v2/lat/50.45/lon/30.52/dist/250/",
+						"RapidAPI key",
+						"Needs a RapidAPI subscription key, sent as a header. Edit lat/lon/dist in "
+								+ "the URL below to your area (dist is in nautical miles)."),
+				new AisUrlSourceTemplate(
+						"airplanes.live (free, no key)",
+						AisUrlSource.Type.PLANES,
+						"https://api.airplanes.live/v2/point/50.45/30.52/250",
+						null,
+						"Community ADS-B feed in the same format as ADS-B Exchange, no key needed. "
+								+ "Edit lat/lon/radius in the URL below (radius is in nautical miles, "
+								+ "max 250)."),
 				new AisUrlSourceTemplate(
 						"Private aggregator (key in URL)",
 						AisUrlSource.Type.PLANES,

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisUrlSourceTemplate.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisUrlSourceTemplate.java
@@ -53,49 +53,49 @@ public class AisUrlSourceTemplate {
 				new AisUrlSourceTemplate(
 						"adsb.lol",
 						AisUrlSource.Type.PLANES,
-						"https://api.adsb.lol/v2/lat/50.03/lon/8.56/dist/50",
+						"https://api.adsb.lol/v2/lat/{LAT}/lon/{LON}/dist/{DIST}",
 						null,
 						"Free, no key - easiest way to try planes out",
-						"Community feed in the ADS-B Exchange format. Edit lat/lon/dist in the URL "
-								+ "below (dist is in nautical miles).",
+						"Community feed in the ADS-B Exchange format. {LAT}/{LON}/{DIST} are filled "
+								+ "in from the visible map area on every request.",
 						"https://adsb.lol"),
 				new AisUrlSourceTemplate(
 						"adsb.fi",
 						AisUrlSource.Type.PLANES,
-						"https://opendata.adsb.fi/api/v2/lat/50.03/lon/8.56/dist/50/",
+						"https://opendata.adsb.fi/api/v2/lat/{LAT}/lon/{LON}/dist/{DIST}/",
 						null,
 						"Free, no key",
-						"Community feed in the same format as ADS-B Exchange. Edit lat/lon/dist in "
-								+ "the URL below (dist is in nautical miles).",
+						"Community feed in the same format as ADS-B Exchange. {LAT}/{LON}/{DIST} are "
+								+ "filled in from the visible map area on every request.",
 						"https://adsb.fi"),
 				new AisUrlSourceTemplate(
 						"ADS-B Exchange",
 						AisUrlSource.Type.PLANES,
-						"https://adsbexchange-com1.p.rapidapi.com/v2/lat/50.03/lon/8.56/dist/50/",
+						"https://adsbexchange-com1.p.rapidapi.com/v2/lat/{LAT}/lon/{LON}/dist/{DIST}/",
 						"RapidAPI key",
 						"Paid RapidAPI subscription - the keyless endpoint returns NO_AUTH",
-						"The key is sent as a header. Edit lat/lon/dist in the URL below (dist is "
-								+ "in nautical miles). Feeding your own receiver to ADS-B Exchange "
-								+ "is what gets you free API access.",
+						"The key is sent as a header. {LAT}/{LON}/{DIST} are filled in from the "
+								+ "visible map area on every request. Feeding your own receiver to "
+								+ "ADS-B Exchange is what gets you free API access.",
 						"https://www.adsbexchange.com/data/"),
 				new AisUrlSourceTemplate(
 						"airplanes.live",
 						AisUrlSource.Type.PLANES,
-						"https://api.airplanes.live/v2/point/50.03/8.56/50",
+						"https://api.airplanes.live/v2/point/{LAT}/{LON}/{DIST}",
 						null,
 						"Needs approval - answers 403 until access is granted",
 						"Same format as ADS-B Exchange, but the API asks projects to request access "
-								+ "by email first. Edit lat/lon/radius in the URL below (radius is "
-								+ "in nautical miles, max 250).",
+								+ "by email first. {LAT}/{LON}/{DIST} are filled in from the visible "
+								+ "map area on every request.",
 						"https://airplanes.live/api-guide/"),
 				new AisUrlSourceTemplate(
 						"OpenSky Network - bounding box",
 						AisUrlSource.Type.PLANES,
-						"https://opensky-network.org/api/states/all?lamin=45&lomin=5&lamax=55&lomax=20",
+						"https://opensky-network.org/api/states/all?lamin={LAMIN}&lomin={LOMIN}&lamax={LAMAX}&lomax={LOMAX}",
 						null,
 						"Free, no key - about 400 requests a day anonymously",
-						"Edit lamin/lomin/lamax/lomax in the URL below to your region. Registering "
-								+ "a free account raises the daily allowance.",
+						"{LAMIN}/{LOMIN}/{LAMAX}/{LOMAX} are filled in from the visible map area on "
+								+ "every request. Registering a free account raises the daily allowance.",
 						"https://openskynetwork.github.io/opensky-api/rest.html"),
 				new AisUrlSourceTemplate(
 						"OpenSky Network - whole world",
@@ -109,11 +109,12 @@ public class AisUrlSourceTemplate {
 				new AisUrlSourceTemplate(
 						"Private aggregator",
 						AisUrlSource.Type.PLANES,
-						"https://example.com/api/planes?key={API_KEY}",
+						"https://example.com/api/planes?key={API_KEY}&lat={LAT}&lon={LON}&dist={DIST}",
 						"API key",
 						"Your own server, key passed as a query parameter",
 						"Edit the URL below (host, path, params) to match your server. The response "
-								+ "must be in OpenSky or ADS-B Exchange JSON format.",
+								+ "must be in OpenSky or ADS-B Exchange JSON format. Placeholders "
+								+ "{LAT} {LON} {DIST} {LAMIN} {LOMIN} {LAMAX} {LOMAX} follow the map.",
 						null),
 				new AisUrlSourceTemplate(
 						"Custom",
@@ -122,7 +123,8 @@ public class AisUrlSourceTemplate {
 						null,
 						"Start blank",
 						"Fill in everything yourself. The response must be in OpenSky or ADS-B "
-								+ "Exchange JSON format.",
+								+ "Exchange JSON format. Placeholders {LAT} {LON} {DIST} {LAMIN} "
+								+ "{LOMIN} {LAMAX} {LOMAX} are filled in from the visible map area.",
 						null)
 		);
 	}

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisUrlSourceTemplate.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisUrlSourceTemplate.java
@@ -1,0 +1,71 @@
+package net.osmand.plus.plugins.aistracker;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A ready-made "add source" starting point offered when creating a new {@link AisUrlSource}
+ * (name/URL/type prefilled, still fully editable before saving), the same idea as picking a
+ * known online routing engine type before filling in your own API key.
+ */
+public class AisUrlSourceTemplate {
+
+	@NonNull
+	public final String displayName;
+	@NonNull
+	public final AisUrlSource.Type type;
+	@NonNull
+	public final String urlTemplate;
+	/** Null when the template needs no key; otherwise the label for an extra "key" input whose
+	 * value replaces {@code {API_KEY}} in {@link #urlTemplate} before the source is saved. */
+	@Nullable
+	public final String apiKeyLabel;
+	@NonNull
+	public final String description;
+
+	public AisUrlSourceTemplate(@NonNull String displayName, @NonNull AisUrlSource.Type type,
+	                             @NonNull String urlTemplate, @Nullable String apiKeyLabel,
+	                             @NonNull String description) {
+		this.displayName = displayName;
+		this.type = type;
+		this.urlTemplate = urlTemplate;
+		this.apiKeyLabel = apiKeyLabel;
+		this.description = description;
+	}
+
+	@NonNull
+	public static List<AisUrlSourceTemplate> all() {
+		return Arrays.asList(
+				new AisUrlSourceTemplate(
+						"OpenSky Network - bounding box (free, anonymous)",
+						AisUrlSource.Type.PLANES,
+						"https://opensky-network.org/api/states/all?lamin=40&lomin=-10&lamax=55&lomax=20",
+						null,
+						"No key needed. ~400 requests/day anonymously. Edit lamin/lomin/lamax/lomax "
+								+ "in the URL below to your region before saving."),
+				new AisUrlSourceTemplate(
+						"OpenSky Network - whole world (free, anonymous)",
+						AisUrlSource.Type.PLANES,
+						"https://opensky-network.org/api/states/all",
+						null,
+						"No key needed, but a global query costs more of the daily anonymous quota "
+								+ "per request than a bounding-box one - prefer the bounding-box template."),
+				new AisUrlSourceTemplate(
+						"Private aggregator (key in URL)",
+						AisUrlSource.Type.PLANES,
+						"https://example.com/api/planes?key={API_KEY}",
+						"API key",
+						"Template for your own server/aggregator that expects the key as a query "
+								+ "parameter. Edit the URL below (host, path, params) to match your server."),
+				new AisUrlSourceTemplate(
+						"Custom",
+						AisUrlSource.Type.PLANES,
+						"",
+						null,
+						"Start blank and fill in everything yourself.")
+		);
+	}
+}

--- a/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisUrlSourceTemplate.java
+++ b/OsmAnd/src/net/osmand/plus/plugins/aistracker/AisUrlSourceTemplate.java
@@ -24,71 +24,106 @@ public class AisUrlSourceTemplate {
 	 * {@code {API_KEY}}, sent as a header otherwise (see AisPlaneDataFetcher). */
 	@Nullable
 	public final String apiKeyLabel;
+	/** One line on cost/access, shown next to the name while picking a template. */
+	@NonNull
+	public final String note;
+	/** What to adjust in the prefilled URL, shown once the template is picked. */
 	@NonNull
 	public final String description;
+	/** Project page to read up on the service, opened from the source dialog. */
+	@Nullable
+	public final String projectUrl;
 
 	public AisUrlSourceTemplate(@NonNull String displayName, @NonNull AisUrlSource.Type type,
 	                             @NonNull String urlTemplate, @Nullable String apiKeyLabel,
-	                             @NonNull String description) {
+	                             @NonNull String note, @NonNull String description,
+	                             @Nullable String projectUrl) {
 		this.displayName = displayName;
 		this.type = type;
 		this.urlTemplate = urlTemplate;
 		this.apiKeyLabel = apiKeyLabel;
+		this.note = note;
 		this.description = description;
+		this.projectUrl = projectUrl;
 	}
 
 	@NonNull
 	public static List<AisUrlSourceTemplate> all() {
 		return Arrays.asList(
 				new AisUrlSourceTemplate(
-						"OpenSky Network - bounding box (free, anonymous)",
-						AisUrlSource.Type.PLANES,
-						"https://opensky-network.org/api/states/all?lamin=40&lomin=-10&lamax=55&lomax=20",
-						null,
-						"No key needed. ~400 requests/day anonymously. Edit lamin/lomin/lamax/lomax "
-								+ "in the URL below to your region before saving."),
-				new AisUrlSourceTemplate(
-						"OpenSky Network - whole world (free, anonymous)",
-						AisUrlSource.Type.PLANES,
-						"https://opensky-network.org/api/states/all",
-						null,
-						"No key needed, but a global query costs more of the daily anonymous quota "
-								+ "per request than a bounding-box one - prefer the bounding-box template."),
-				new AisUrlSourceTemplate(
-						"ADS-B Exchange (RapidAPI key)",
-						AisUrlSource.Type.PLANES,
-						"https://adsbexchange-com1.p.rapidapi.com/v2/lat/50.45/lon/30.52/dist/250/",
-						"RapidAPI key",
-						"Needs a RapidAPI subscription key, sent as a header. Edit lat/lon/dist in "
-								+ "the URL below to your area (dist is in nautical miles)."),
-				new AisUrlSourceTemplate(
-						"adsb.lol (free, no key)",
+						"adsb.lol",
 						AisUrlSource.Type.PLANES,
 						"https://api.adsb.lol/v2/lat/50.03/lon/8.56/dist/50",
 						null,
-						"Community feed in the ADS-B Exchange format, no key needed - the easiest "
-								+ "way to try planes out. Edit lat/lon/dist in the URL below "
-								+ "(dist is in nautical miles)."),
+						"Free, no key - easiest way to try planes out",
+						"Community feed in the ADS-B Exchange format. Edit lat/lon/dist in the URL "
+								+ "below (dist is in nautical miles).",
+						"https://adsb.lol"),
 				new AisUrlSourceTemplate(
-						"adsb.fi (free, no key)",
+						"adsb.fi",
 						AisUrlSource.Type.PLANES,
 						"https://opendata.adsb.fi/api/v2/lat/50.03/lon/8.56/dist/50/",
 						null,
-						"Another community feed in the same format, no key needed. Edit "
-								+ "lat/lon/dist in the URL below (dist is in nautical miles)."),
+						"Free, no key",
+						"Community feed in the same format as ADS-B Exchange. Edit lat/lon/dist in "
+								+ "the URL below (dist is in nautical miles).",
+						"https://adsb.fi"),
 				new AisUrlSourceTemplate(
-						"Private aggregator (key in URL)",
+						"ADS-B Exchange",
+						AisUrlSource.Type.PLANES,
+						"https://adsbexchange-com1.p.rapidapi.com/v2/lat/50.03/lon/8.56/dist/50/",
+						"RapidAPI key",
+						"Paid RapidAPI subscription - the keyless endpoint returns NO_AUTH",
+						"The key is sent as a header. Edit lat/lon/dist in the URL below (dist is "
+								+ "in nautical miles). Feeding your own receiver to ADS-B Exchange "
+								+ "is what gets you free API access.",
+						"https://www.adsbexchange.com/data/"),
+				new AisUrlSourceTemplate(
+						"airplanes.live",
+						AisUrlSource.Type.PLANES,
+						"https://api.airplanes.live/v2/point/50.03/8.56/50",
+						null,
+						"Needs approval - answers 403 until access is granted",
+						"Same format as ADS-B Exchange, but the API asks projects to request access "
+								+ "by email first. Edit lat/lon/radius in the URL below (radius is "
+								+ "in nautical miles, max 250).",
+						"https://airplanes.live/api-guide/"),
+				new AisUrlSourceTemplate(
+						"OpenSky Network - bounding box",
+						AisUrlSource.Type.PLANES,
+						"https://opensky-network.org/api/states/all?lamin=45&lomin=5&lamax=55&lomax=20",
+						null,
+						"Free, no key - about 400 requests a day anonymously",
+						"Edit lamin/lomin/lamax/lomax in the URL below to your region. Registering "
+								+ "a free account raises the daily allowance.",
+						"https://openskynetwork.github.io/opensky-api/rest.html"),
+				new AisUrlSourceTemplate(
+						"OpenSky Network - whole world",
+						AisUrlSource.Type.PLANES,
+						"https://opensky-network.org/api/states/all",
+						null,
+						"Free, no key - costs more of the daily allowance per request",
+						"A global query spends several times the allowance of a bounding-box one, "
+								+ "so prefer the bounding-box template unless you really need it.",
+						"https://openskynetwork.github.io/opensky-api/rest.html"),
+				new AisUrlSourceTemplate(
+						"Private aggregator",
 						AisUrlSource.Type.PLANES,
 						"https://example.com/api/planes?key={API_KEY}",
 						"API key",
-						"Template for your own server/aggregator that expects the key as a query "
-								+ "parameter. Edit the URL below (host, path, params) to match your server."),
+						"Your own server, key passed as a query parameter",
+						"Edit the URL below (host, path, params) to match your server. The response "
+								+ "must be in OpenSky or ADS-B Exchange JSON format.",
+						null),
 				new AisUrlSourceTemplate(
 						"Custom",
 						AisUrlSource.Type.PLANES,
 						"",
 						null,
-						"Start blank and fill in everything yourself.")
+						"Start blank",
+						"Fill in everything yourself. The response must be in OpenSky or ADS-B "
+								+ "Exchange JSON format.",
+						null)
 		);
 	}
 }


### PR DESCRIPTION
## Summary

The AIS plugin could only receive NMEA over UDP/TCP from a receiver on the local network. This adds pull-based online sources, so aircraft (and, once a format is picked, vessels) can come from a web service instead.

Sources are named entries with a type and a URL, created from ready-made templates and editable afterwards, the same way an online routing engine is configured. They are stored as JSON in a single preference. Aircraft are mapped onto `AisObject` message type 9, which the AIS layer already understands, so they reuse the existing rendering, tap menu and lost-object handling rather than growing a parallel pipeline.

## Services surveyed

Every entry below was checked against the live endpoint while building this, not just read off the docs.

| Service | Key | Cost | Limits and caveats |
| --- | --- | --- | --- |
| [adsb.lol](https://adsb.lol) | none | free | Community feed, ADS-B Exchange payload under `ac`. Answered `429 Too Many Requests` at a 15 s poll with a ~200 nmi radius, so the plugin pauses a host that rate-limits it for a minute. |
| [adsb.fi](https://adsb.fi) | none | free | Same payload, wrapped in `aircraft` instead of `ac`. |
| [ADS-B Exchange](https://www.adsbexchange.com/data/) | RapidAPI key, sent as a header | paid RapidAPI subscription; free API access for people feeding their own receiver | The keyless endpoint `adsbexchange.com/api/aircraft/json/...` now answers `{"NO_AUTH"}`, so it cannot be used as a free source. |
| [airplanes.live](https://airplanes.live/api-guide/) | none | free, but gated | Same payload as ADS-B Exchange. The API answers `403` and asks projects to request access by email first, so the template is labelled accordingly. |
| [OpenSky Network](https://openskynetwork.github.io/opensky-api/rest.html) | anonymous, or OAuth2 client credentials | free | ~400 credits/day anonymous, 4000 registered, 8000 for active feeders, 14400/hour licensed. A query costs 1–4 credits depending on the bounding box, so the global template spends the allowance several times faster than the bounding-box one. Position resolution 10 s. |

Two response layouts cover all of them, and the parser picks by what the server actually returns: OpenSky (`states`, speed in m/s, altitude in metres) and the ADS-B Exchange family (`ac`/`aircraft`, speed in knots, altitude in feet).

## How it behaves

- **Follows the map.** URLs take `{LAT} {LON} {DIST}` or `{LAMIN} {LOMIN} {LAMAX} {LOMAX}`, filled in from the visible area on every request. A URL with fixed coordinates written in one of the shapes these services use is rewritten too, so sources saved before placeholders existed keep working.
- **Polls every 15 s.** A moved map asks for a fresh batch without restarting the timer, with a floor between requests so panning cannot outpace the poll.
- **Updates in place.** A batch updates aircraft that are still reported and removes only those missing from it, so the layer adds and drops single symbols instead of rebuilding them. A failed request is not an empty batch, so a network hiccup does not clear the map.
- **Draws every aircraft in view.** Aircraft skip the collision grid built for 20,000 vessels, which was hiding most of them (41 of 158 at zoom 7). Grounded ones are capped at three overlapping in a spot, since they pile up at airports.
- **Colour reads altitude:** grey on the ground or with none reported, green near the ground, yellow around 5 km, red from 12 km up.
- **Configure Map** carries Show ships / Show planes, plus a picker for switching individual sources on and off once any exist.

Only PLANES sources are fetched so far. A SHIPS source can be created and stored, but nothing parses one yet — the obvious candidates are WebSocket streams, which need a different transport than the one-shot GET used here.

## Test plan

- [ ] Plugins → AIS vessel tracker → enable → Settings → Add source → pick a keyless template (adsb.lol is the quickest) → Save
- [ ] Aircraft appear over a busy area, coloured by altitude, and keep up as the map is panned and zoomed
- [ ] Configure Map → toggle Show planes and the per-source picker
- [ ] Tap an aircraft and check the context menu card
- [ ] `adb logcat -s AisPlanes` shows the request URL, the response and what the layer did with it; credentials are masked there

Checked on a device against adsb.lol and adsb.fi. ADS-B Exchange was not exercised end to end, since it needs a paid key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
