### PR TITLE
Keep downloaded Favorites folders during Cloud sync

### DIFF
--- a/OsmAnd/src/net/osmand/plus/backup/BackupImporter.java
+++ b/OsmAnd/src/net/osmand/plus/backup/BackupImporter.java
@@ -18,7 +18,6 @@ import net.osmand.plus.settings.backend.backup.SettingsItemReader;
 import net.osmand.plus.settings.backend.backup.SettingsItemType;
 import net.osmand.plus.settings.backend.backup.SettingsItemsFactory;
 import net.osmand.plus.settings.backend.backup.items.CollectionSettingsItem;
-import net.osmand.plus.settings.backend.backup.items.FavoritesSettingsItem;
 import net.osmand.plus.settings.backend.backup.items.FileSettingsItem;
 import net.osmand.plus.settings.backend.backup.items.FileSettingsItem.FileSubtype;
 import net.osmand.plus.settings.backend.backup.items.GpxSettingsItem;
@@ -176,7 +175,7 @@ class BackupImporter {
 							((CollectionSettingsItem<?>) item).processDuplicateItems();
 						}
 						item.apply();
-						applied = isAppliedLocally(item);
+						applied = item.isAppliedLocally();
 					}
 					if (applied) {
 						updateFileM5Digest(remoteFile, item, file);
@@ -209,10 +208,6 @@ class BackupImporter {
 		} finally {
 			Algorithms.closeStream(is);
 		}
-	}
-
-	private static boolean isAppliedLocally(@NonNull SettingsItem item) {
-		return !(item instanceof FavoritesSettingsItem favoritesItem) || favoritesItem.isAppliedLocally();
 	}
 
 	private void updateFileM5Digest(@NonNull RemoteFile remoteFile, @NonNull SettingsItem item, @Nullable File file) {

--- a/OsmAnd/src/net/osmand/plus/backup/BackupImporter.java
+++ b/OsmAnd/src/net/osmand/plus/backup/BackupImporter.java
@@ -18,6 +18,7 @@ import net.osmand.plus.settings.backend.backup.SettingsItemReader;
 import net.osmand.plus.settings.backend.backup.SettingsItemType;
 import net.osmand.plus.settings.backend.backup.SettingsItemsFactory;
 import net.osmand.plus.settings.backend.backup.items.CollectionSettingsItem;
+import net.osmand.plus.settings.backend.backup.items.FavoritesSettingsItem;
 import net.osmand.plus.settings.backend.backup.items.FileSettingsItem;
 import net.osmand.plus.settings.backend.backup.items.FileSettingsItem.FileSubtype;
 import net.osmand.plus.settings.backend.backup.items.GpxSettingsItem;
@@ -169,15 +170,24 @@ class BackupImporter {
 				if (!error) {
 					is = new FileInputStream(tempFile);
 					File file = reader.readFromStream(is, tempFile, remoteFile.getName());
+					boolean applied = true;
 					if (forceReadData) {
 						if (item instanceof CollectionSettingsItem<?>) {
 							((CollectionSettingsItem<?>) item).processDuplicateItems();
 						}
 						item.apply();
+						applied = isAppliedLocally(item);
 					}
-					updateFileM5Digest(remoteFile, item, file);
-					updateFileUploadTime(remoteFile, item);
-					FavoritesBackupMerger.onDownloadSuccess(app, item, remoteFile);
+					if (applied) {
+						updateFileM5Digest(remoteFile, item, file);
+						updateFileUploadTime(remoteFile, item);
+						FavoritesBackupMerger.onDownloadSuccess(app, item, remoteFile);
+					} else {
+						// Leaving the upload time unrecorded makes the next sync download the file
+						// again, instead of reading the missing local file as a local deletion.
+						item.getWarnings().add(app.getString(R.string.settings_item_read_error, item.getName()));
+						LOG.error("Downloaded item was not applied locally: " + item.getName());
+					}
 					if (PluginsHelper.isDevelopment()) {
 						UploadedFileInfo info = backupHelper.getUploadedFileInfo(remoteFile.getType(), remoteFile.getName());
 						LOG.debug(" importItemFile file info " + info);
@@ -199,6 +209,10 @@ class BackupImporter {
 		} finally {
 			Algorithms.closeStream(is);
 		}
+	}
+
+	private static boolean isAppliedLocally(@NonNull SettingsItem item) {
+		return !(item instanceof FavoritesSettingsItem favoritesItem) || favoritesItem.isAppliedLocally();
 	}
 
 	private void updateFileM5Digest(@NonNull RemoteFile remoteFile, @NonNull SettingsItem item, @Nullable File file) {

--- a/OsmAnd/src/net/osmand/plus/backup/FavoritesBackupMerger.java
+++ b/OsmAnd/src/net/osmand/plus/backup/FavoritesBackupMerger.java
@@ -38,8 +38,6 @@ final class FavoritesBackupMerger {
 
 	private static final Log LOG = PlatformUtil.getLog(FavoritesBackupMerger.class);
 	private static final String SNAPSHOT_DIR = "favorites_sync";
-	// Upload callbacks run in parallel, while applying a group mutates shared Favorites state.
-	private static final Object MERGE_FINISH_LOCK = new Object();
 
 	private FavoritesBackupMerger() {
 	}
@@ -92,9 +90,8 @@ final class FavoritesBackupMerger {
 		}
 		try {
 			if (favoritesItem instanceof MergeUploadItem mergeItem) {
-				synchronized (MERGE_FINISH_LOCK) {
-					mergeItem.finishUpload(fileName, uploadTime);
-				}
+				// Upload callbacks run in parallel, while applying a group mutates shared state.
+				app.getFavoritesHelper().runBulkUpdate(() -> mergeItem.finishUpload(fileName, uploadTime));
 			} else if (favoritesItem.getLocalModifiedTime() == favoritesItem.getLastModifiedTime()) {
 				saveSnapshot(app, favoritesItem.getSingleGroup(), fileName, uploadTime);
 			} else {

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesHelper.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/FavouritesHelper.java
@@ -69,11 +69,14 @@ public class FavouritesHelper {
 	private final FavouritesFileHelper fileHelper;
 	private final FavoriteSortModesHelper favoriteSortModesHelper;
 
-	private List<FavoriteGroup> favoriteGroups = new ArrayList<>();
-	private Map<String, FavoriteGroup> flatGroups = new LinkedHashMap<>();
-	private List<FavouritePoint> cachedFavoritePoints = new ArrayList<>();
+	// Replaced, never mutated in place - volatile publishes the new instance to other threads.
+	private volatile List<FavoriteGroup> favoriteGroups = new ArrayList<>();
+	private volatile Map<String, FavoriteGroup> flatGroups = new LinkedHashMap<>();
+	private volatile List<FavouritePoint> cachedFavoritePoints = new ArrayList<>();
 	@Nullable
-	private FavoriteFolderSnapshot favoriteFolderSnapshot;
+	private volatile FavoriteFolderSnapshot favoriteFolderSnapshot;
+
+	private final Object bulkUpdateLock = new Object();
 
 	private List<FavoritesListener> listeners = new ArrayList<>();
 	private final Map<FavouritePoint, AddressLookupRequest> addressRequestMap = new ConcurrentHashMap<>();
@@ -267,6 +270,17 @@ public class FavouritesHelper {
 			return groupColor;
 		}
 		return defaultColor;
+	}
+
+	/**
+	 * Runs a read-modify-write-save sequence over the groups exclusively. Callers that add or
+	 * replace whole groups must use it: favoriteGroups and flatGroups are updated by
+	 * copy-on-write, so concurrent sequences overwrite each other's groups.
+	 */
+	public void runBulkUpdate(@NonNull Runnable action) {
+		synchronized (bulkUpdateLock) {
+			action.run();
+		}
 	}
 
 	public void loadFavorites() {

--- a/OsmAnd/src/net/osmand/plus/myplaces/favorites/SaveFavoritesTask.java
+++ b/OsmAnd/src/net/osmand/plus/myplaces/favorites/SaveFavoritesTask.java
@@ -181,9 +181,12 @@ final class SaveFavoritesTask extends AsyncTask<Void, String, Void> {
 			// Delete external group file if it does not exist in local groups
 			if (!hasLocalGroup) {
 				File file = helper.getExternalFile(fileGroup);
-				if (file.exists() && !file.delete()) {
-					log.warn("Failed to delete orphaned favorites file: " + file.getAbsolutePath());
-					return false;
+				if (file.exists()) {
+					log.info("Deleting orphaned favorites file: " + file.getName());
+					if (!file.delete()) {
+						log.warn("Failed to delete orphaned favorites file: " + file.getAbsolutePath());
+						return false;
+					}
 				}
 			}
 		}

--- a/OsmAnd/src/net/osmand/plus/settings/backend/backup/items/FavoritesSettingsItem.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/backup/items/FavoritesSettingsItem.java
@@ -155,11 +155,8 @@ public class FavoritesSettingsItem extends CollectionSettingsItem<FavoriteGroup>
 		favoritesHelper.runBulkUpdate(this::applyGroups);
 	}
 
-	/**
-	 * Reports whether every group this item applied is present locally. Backup import must not
-	 * record a download as complete when it is not: the group has no local file, and the next
-	 * sync would read that as a deletion and remove the group from the Cloud.
-	 */
+	/** Every group applied must be present once apply() has reloaded the groups from disk. */
+	@Override
 	public boolean isAppliedLocally() {
 		for (String name : appliedGroupNames) {
 			if (favoritesHelper.getGroup(name) == null) {

--- a/OsmAnd/src/net/osmand/plus/settings/backend/backup/items/FavoritesSettingsItem.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/backup/items/FavoritesSettingsItem.java
@@ -49,6 +49,7 @@ public class FavoritesSettingsItem extends CollectionSettingsItem<FavoriteGroup>
 
 	private FavouritesHelper favoritesHelper;
 	private FavoriteGroup personalGroup;
+	private List<String> appliedGroupNames;
 	@Nullable
 	private Map<String, String> hrefRewrites;
 
@@ -69,6 +70,7 @@ public class FavoritesSettingsItem extends CollectionSettingsItem<FavoriteGroup>
 		super.init();
 		favoritesHelper = app.getFavoritesHelper();
 		existingItems = new ArrayList<>(favoritesHelper.getFavoriteGroups());
+		appliedGroupNames = new ArrayList<>();
 	}
 
 	@NonNull
@@ -150,6 +152,24 @@ public class FavoritesSettingsItem extends CollectionSettingsItem<FavoriteGroup>
 
 	@Override
 	public void apply() {
+		favoritesHelper.runBulkUpdate(this::applyGroups);
+	}
+
+	/**
+	 * Reports whether every group this item applied is present locally. Backup import must not
+	 * record a download as complete when it is not: the group has no local file, and the next
+	 * sync would read that as a deletion and remove the group from the Cloud.
+	 */
+	public boolean isAppliedLocally() {
+		for (String name : appliedGroupNames) {
+			if (favoritesHelper.getGroup(name) == null) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private void applyGroups() {
 		List<FavoriteGroup> newItems = getNewItems();
 		if (personalGroup != null) {
 			duplicateItems.add(personalGroup);
@@ -189,6 +209,8 @@ public class FavoritesSettingsItem extends CollectionSettingsItem<FavoriteGroup>
 							group.getIconName(), group.getBackgroundType());
 				}
 				localGroup.copyAppearance(group);
+				// addFavoriteGroup() may resolve the name, so collect it from the local group.
+				appliedGroupNames.add(localGroup.getName());
 
 				PointsGroup pointsGroup = group.toPointsGroup(app);
 				for (FavouritePoint point : group.getPoints()) {

--- a/OsmAnd/src/net/osmand/plus/settings/backend/backup/items/SettingsItem.java
+++ b/OsmAnd/src/net/osmand/plus/settings/backend/backup/items/SettingsItem.java
@@ -154,6 +154,15 @@ public abstract class SettingsItem {
 		// non implemented
 	}
 
+	/**
+	 * Whether apply() produced the local state this item represents. Backup import must not record
+	 * a download as complete when it did not: the item has no local file, and the next sync would
+	 * read that as a local deletion and remove it from the Cloud.
+	 */
+	public boolean isAppliedLocally() {
+		return true;
+	}
+
 	public void delete() {
 		// non implemented
 	}

--- a/OsmAnd/test/java/net/osmand/test/junit/FavoritesImportConcurrencyTest.kt
+++ b/OsmAnd/test/java/net/osmand/test/junit/FavoritesImportConcurrencyTest.kt
@@ -1,0 +1,141 @@
+package net.osmand.test.junit
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import net.osmand.data.FavouritePoint
+import net.osmand.plus.OsmandApplication
+import net.osmand.plus.myplaces.favorites.FavoriteGroup
+import net.osmand.plus.myplaces.favorites.FavouritesHelper
+import net.osmand.plus.settings.backend.backup.items.FavoritesSettingsItem
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * Regression test for issue #3335 - Cloud sync dropped downloaded favourite folders and then
+ * uploaded them as deletions, which removed them from every other device.
+ *
+ * `BackupImporter.importItems()` downloads one file per settings item on a four thread pool and
+ * calls `SettingsItem.apply()` from the worker thread. For favourites that means several threads
+ * run `FavoritesSettingsItem.apply()` at once against the one shared [FavouritesHelper], whose
+ * `favoriteGroups` and `flatGroups` are updated by copy-on-write: each thread reads the current
+ * collection, copies it, adds its own group and assigns the copy back. Two threads that read the
+ * same base both write a copy holding only their own addition, so one group is lost.
+ *
+ * Losing the group also loses its file. `apply()` finishes with a full save, and
+ * `SaveFavoritesTask.cleanupOrphanedGroupFiles()` deletes every `favorites-*.gpx` whose group is
+ * absent from the saved snapshot - so a thread saving a snapshot that never had another thread's
+ * group deletes that group's file even when it was already written correctly.
+ *
+ * The damage the issue reports comes one sync later. `BackupImporter` records the download as
+ * complete either way, so the next `GenerateBackupInfoTask` finds a remote file, an upload record
+ * and no local file, reads that as a local deletion and uploads `filesize = -1`.
+ *
+ * The test drives `apply()` directly on a pool of the same size as the importer's, because the
+ * race is between the applies and needs neither the network nor an account. [GROUPS] groups are
+ * enough that some pair of threads interleaves on nearly every run; before the fix a handful of
+ * them are missing afterwards, and the assertions name them.
+ *
+ * Both the in-memory group and its file are checked. They fail for different reasons - the lost
+ * update leaves no group to save, the orphan cleanup removes a file that was written - and
+ * `apply()` reloads from disk at the end, so either failure ends with both missing.
+ */
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class FavoritesImportConcurrencyTest {
+
+	companion object {
+		/** Marks the groups this test creates, so cleanup never touches the user's own. */
+		private const val GROUP_PREFIX = "test-3335-"
+
+		/** Groups applied concurrently. See the class comment for why one is not enough. */
+		private const val GROUPS = 30
+
+		/** `BackupImporter.createExecutor()` uses `ThreadPoolTaskExecutor`'s default pool size. */
+		private const val THREADS = 4
+
+		private const val POINTS_PER_GROUP = 3
+		private const val APPLY_TIMEOUT_SEC = 120L
+		private const val APP_INIT_TIMEOUT_SEC = 120L
+	}
+
+	private lateinit var app: OsmandApplication
+	private lateinit var favoritesHelper: FavouritesHelper
+
+	@Before
+	fun setup() {
+		app = InstrumentationRegistry.getInstrumentation().targetContext
+			.applicationContext as OsmandApplication
+		val deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(APP_INIT_TIMEOUT_SEC)
+		while (app.isApplicationInitializing && System.currentTimeMillis() < deadline) {
+			Thread.sleep(200)
+		}
+		favoritesHelper = app.favoritesHelper
+		removeTestGroups()
+	}
+
+	@Test
+	fun concurrentApplyKeepsEveryGroup() {
+		val names = (0 until GROUPS).map { GROUP_PREFIX + it }
+		val items = names.map { name ->
+			FavoritesSettingsItem(app, mutableListOf(group(name)))
+		}
+
+		val executor = Executors.newFixedThreadPool(THREADS)
+		try {
+			// The importer applies each downloaded item on its own worker thread.
+			val futures = items.map { item ->
+				executor.submit {
+					item.processDuplicateItems()
+					item.apply()
+				}
+			}
+			executor.shutdown()
+			assertTrue("the applies did not finish in time",
+				executor.awaitTermination(APPLY_TIMEOUT_SEC, TimeUnit.SECONDS))
+			futures.forEach { it.get() }
+		} finally {
+			executor.shutdownNow()
+		}
+
+		val missingGroups = names.filter { favoritesHelper.getGroup(it) == null }
+		val missingFiles = names.filter { name ->
+			val group = FavoriteGroup(name, ArrayList(), 0, true, false)
+			!favoritesHelper.fileHelper.getExternalFile(group).exists()
+		}
+
+		assertEquals("groups dropped by concurrent apply()", emptyList<String>(), missingGroups)
+		assertEquals("group files missing after concurrent apply()", emptyList<String>(), missingFiles)
+	}
+
+	@After
+	fun cleanup() {
+		removeTestGroups()
+	}
+
+	private fun removeTestGroups() {
+		val groups = favoritesHelper.favoriteGroups.filter { it.name.startsWith(GROUP_PREFIX) }
+		if (groups.isEmpty()) {
+			return
+		}
+		groups.forEach { favoritesHelper.deleteGroup(it, false) }
+		favoritesHelper.saveCurrentPointsIntoFile(false)
+		favoritesHelper.loadFavorites()
+	}
+
+	/** The altitude is set so that `addFavourite()` does not start an altitude lookup for it. */
+	private fun group(name: String): FavoriteGroup {
+		val points = ArrayList<FavouritePoint>()
+		for (i in 0 until POINTS_PER_GROUP) {
+			points.add(FavouritePoint(50.0 + i / 1000.0, 4.0 + i / 1000.0, "$name-$i", name,
+				10.0, (i + 1) * 1_000L))
+		}
+		return FavoriteGroup(name, points, 0, true, false)
+	}
+}


### PR DESCRIPTION
Fixes osmandapp/OsmAnd-Issues#3335

## Root cause

`BackupImporter.importItems()` runs one `ItemFileImportTask` per remote file on a four thread
pool and calls `SettingsItem.apply()` from the worker thread. For Favorites that means several
threads run `FavoritesSettingsItem.apply()` at once against the single shared `FavouritesHelper`,
which had no synchronization at all - not even `volatile` on the fields the applies mutate.

`favoriteGroups` and `flatGroups` are updated by copy-on-write: read the current collection, copy
it, add the group, assign the copy back. Two threads that read the same base each write a copy
holding only their own addition, so one group is lost. Nothing publishes the write either, so a
thread can also keep observing a collection that no longer has another thread's group.

Losing the group loses its file as well. `apply()` ends with a full save, and
`SaveFavoritesTask.cleanupOrphanedGroupFiles()` deletes every `favorites-*.gpx` whose group is
absent from the saved snapshot - so a thread saving a snapshot that never contained another
thread's group deletes that group's file even when it had just been written correctly.

The Cloud deletion comes one sync later. `importItemFile()` called `updateFileUploadTime()`
unconditionally after `apply()`, so the backup DB recorded the download as complete. The next
`GenerateBackupInfoTask` then found a remote file, an upload record whose time is not older than
the remote one, and no local file, took that for a local deletion and put the file into
`filesToDelete` - uploading `filesize = -1` and removing the folder from every other device.

Only Cloud sync is affected: the other two `apply()` call sites, `ImportFileTask:116` and
`ImportBackupTask:149`, iterate items on one thread.

iOS hit the same race in its own importer (concurrency 10 there) and fixed it in
osmandapp/OsmAnd-iOS@cbbb908 by wrapping the add/sort/save/load sequence of
`OAFavoritesSettingsItem` in `@synchronized`. Android never got the equivalent, and the upload
half of the same insight is already here in `FavoritesBackupMerger` (#25839).

## Solution

- `FavouritesHelper.runBulkUpdate()` runs a read-modify-write-save sequence over the groups under
  one monitor. `FavoritesSettingsItem.apply()` now runs its whole body through it, so concurrent
  applies no longer overwrite each other.
- The copy-on-write fields are `volatile`, so replacing a collection is published to other threads.
- `FavoritesBackupMerger` uses the same monitor instead of its own `MERGE_FINISH_LOCK`: the upload
  merge finishes by calling `apply()`, so both halves belong under one lock rather than two.
- `SettingsItem.isAppliedLocally()` reports whether `apply()` produced the local state the item
  represents, answering true by default; `FavoritesSettingsItem` overrides it to check that every
  group it applied is present after `apply()` reloaded from disk. `BackupImporter` records the
  upload time, the md5 digest and the merge snapshot only when it is. An item that did not land is
  left with no upload record, so the next sync downloads it again instead of reading the missing
  file as a deletion.
- `cleanupOrphanedGroupFiles()` logs the favourites files it deletes. It used to log only on
  failure, which is why the report could not tell whether the file was never written or written
  and then removed.

## Verification

macOS 26.6.2 (arm64), JDK 17.0.17, emulator `Pixel_9a` on Android 15 (API 35), variant
`gplayFreeOpenglArm64Debug`, branch head `90bbcbaa76` on `origin/master` `bb1fb65af1`.

`FavoritesImportConcurrencyTest` applies 30 single-group items on a pool of the importer's size
and asserts that every group and every group file survives.

```
./gradlew :OsmAnd:connectedGplayFreeOpenglArm64DebugAndroidTest \
    -Pandroid.testInstrumentationRunnerArguments.class=net.osmand.test.junit.FavoritesImportConcurrencyTest
```

- Baseline, production change reverted and only the test kept - FAILED, 15 of the 30 groups gone:

  ```
  java.lang.AssertionError: groups dropped by concurrent apply() expected:<[]> but was:
  <[test-3335-4, test-3335-5, test-3335-6, test-3335-9, test-3335-12, test-3335-13,
    test-3335-14, test-3335-17, test-3335-20, test-3335-21, test-3335-22, test-3335-24,
    test-3335-25, test-3335-27, test-3335-28]>
  ```

- With the fix - BUILD SUCCESSFUL, seven consecutive runs, no failures (four before
  `isAppliedLocally()` moved to `SettingsItem`, three after).
- `./gradlew :OsmAnd:compileGplayFreeOpenglArm64DebugJavaWithJavac
  :OsmAnd:compileGplayFreeOpenglArm64DebugAndroidTestKotlin
  :OsmAnd:compileGplayFreeOpenglArm64DebugAndroidTestJavaWithJavac` - BUILD SUCCESSFUL.
- `./gradlew :OsmAnd:assembleGplayFreeOpenglArm64Debug` - BUILD SUCCESSFUL.

### End to end against a real Cloud account

Same emulator, a test OsmAnd Cloud account holding **54 favourite folders** (19 already on the
account plus 35 fixtures, 342 points, ASCII names, 1-20 points each, including a one point
`Haarlem` and a twenty point `Amsterdam lights 2022` as in the report). Local state was reset
between runs to the state the report starts from - `files/favorites/` emptied, the internal
`favourites_bak.gpx`, the `favorites_sync` snapshots and the `backup_files` database removed -
which leaves the account signed in and the Cloud untouched. Both runs started from an identical
`BackupInfo { filesToDownload=55, filesToUpload=0, filesToDelete=0 }`.

| | `master` | this PR |
|---|---|---|
| `downloadFile … END` logged | 54 | 54 |
| files in `files/favorites/` | **51** | **54** |
| Local changes shown after the sync | **3** | **0** |
| `filesToDelete` on the next sync | **3** | **0** |
| folders deleted from the Cloud by the second sync | **3** | **0** |

On `master` the second sync uploaded the deletions:

```
OperationLog deleteFile END (118 ms) favorites-Amsterdam lights 2022.gpx {pool-30-thread-2}
OperationLog deleteFile END (5221 ms) favorites-Culemborg.gpx {pool-30-thread-1}
OperationLog deleteFile END (5227 ms) favorites-Museums Amster.gpx {pool-30-thread-3}
```

All three had been downloaded successfully in the first sync and were simply never on disk
afterwards - the same shape as the report, `Amsterdam lights 2022` included. They were restored
from the Cloud Trash before the second run.

With this PR the same sequence downloaded all 54, kept all 54, reported no local changes, and the
second sync uploaded no deletions at all. Neither of the two new log lines fired, so no item
failed to apply and no orphaned file was deleted.

No UI or interaction change, so there is no before/after UI evidence to collect. Human review of
the change itself is of course still pending.

## What is not established

The end state of the two loss paths is identical - `apply()` reloads from disk, so a group that
lost the update and a group whose file was deleted both end up missing from memory and from
`files/favorites/`. Neither the report, the new test, nor the Cloud run can tell them apart, since
all three assert on the outcome. Both paths are closed by the same lock; the added deletion log
makes the next occurrence distinguishable.

The Cloud run reproduced the loss on the first attempt at 54 folders, but it is still a race: a
single passing run does not prove a fixed build can never lose one. The instrumentation test is
the repeatable half of the evidence.

## Follow-ups, deliberately not in this PR

Different cause, so they belong in their own change:

- A restore of N folders runs N full saves. Each one re-reads the whole favourites directory,
  rewrites the internal file and writes a backup zip, and `getBackupFile()` keeps only
  `BACKUP_MAX_PER_DAY = 2` backups for the day - so restoring a large account churns the
  favourites backup folder and drops backups made earlier that day. iOS batches the applies
  (`+applyItems:`); Android could do the same and save once.
- `FavouritesHelper` is still not safe for general concurrent mutation. This PR makes the import
  path exclusive and publishes the field writes; it does not make every mutator thread safe.
