### PR TITLE
Copy TurnType and ExitInfo to OsmAnd-shared

### DIFF
--- a/OsmAnd-java/src/test/java/net/osmand/shared/compat/Same.java
+++ b/OsmAnd-java/src/test/java/net/osmand/shared/compat/Same.java
@@ -1,0 +1,53 @@
+package net.osmand.shared.compat;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+
+/**
+ * Compares what two calls do, not only what they return: a value, or the exception they throw.
+ * Java's routing code throws on some inputs (a point without types, an attribute that is not a
+ * number, an estimate between two points off the route), and the copy has to do the same there.
+ */
+final class Same {
+
+	interface Call {
+		Object get() throws Exception;
+	}
+
+	private Same() {
+	}
+
+	/** Doubles that come out of the same formula in a different association order: equal to a few ulps. */
+	static void close(String m, double java, double copy) {
+		double tolerance = 8 * Math.ulp(Math.max(Math.abs(java), Math.abs(copy)));
+		assertEquals(m, java, copy, tolerance);
+	}
+
+	static void close(String m, float java, float copy) {
+		float tolerance = 8 * Math.ulp(Math.max(Math.abs(java), Math.abs(copy)));
+		assertEquals(m, java, copy, tolerance);
+	}
+
+	static void outcome(String m, Call java, Call copy) {
+		assertEquals(m, describe(java), describe(copy));
+	}
+
+	private static String describe(Call call) {
+		try {
+			Object value = call.get();
+			if (value instanceof int[]) {
+				return Arrays.toString((int[]) value);
+			}
+			if (value instanceof float[]) {
+				return Arrays.toString((float[]) value);
+			}
+			if (value instanceof Object[]) {
+				return Arrays.deepToString((Object[]) value);
+			}
+			return String.valueOf(value);
+		} catch (Throwable t) {
+			return "threw " + t.getClass().getName();
+		}
+	}
+}

--- a/OsmAnd-java/src/test/java/net/osmand/shared/compat/TurnTypeCompatTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/shared/compat/TurnTypeCompatTest.java
@@ -1,0 +1,166 @@
+package net.osmand.shared.compat;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import net.osmand.shared.routing.TurnType;
+
+import org.junit.Test;
+
+import java.util.LinkedHashSet;
+import java.util.Random;
+
+/**
+ * {@link TurnType} is a copy of {@link net.osmand.router.TurnType}; this runs the two side by side.
+ *
+ * Everything a turn type does is arithmetic on small ints - the manoeuvre code, the packing of up to
+ * three turns and an active bit into one int per lane, and the string forms of both - so the check
+ * is exhaustive over the codes and randomised over the lane edits.
+ */
+public class TurnTypeCompatTest {
+
+	private static final int CODES = 20; // every defined code is below 15; the rest is how unknown codes are treated
+
+	private static final String[] NAMES = {"C", "TL", "TSLL", "TSHL", "TR", "TSLR", "TSHR", "KL", "KR", "TU",
+			"TRU", "OFFR", "RNDB", "RNLB", "RNDB1", "RNDB3", "RNLB2", "RNDB12", "junk", "", "rndb2", "c"};
+
+	private static final String[] LANE_WORDS = {"left", "through", "right", "slight_left", "slight_right",
+			"sharp_left", "sharp_right", "reverse", "merge_to_left", "merge_to_right", "none", "", "junk", "LEFT"};
+
+	@Test
+	public void testCodePredicatesAgree() {
+		for (int t = -1; t <= CODES; t++) {
+			String m = "code " + t;
+			assertEquals(m, net.osmand.router.TurnType.isLeftTurn(t), TurnType.isLeftTurn(t));
+			assertEquals(m, net.osmand.router.TurnType.isLeftTurnNoUTurn(t), TurnType.isLeftTurnNoUTurn(t));
+			assertEquals(m, net.osmand.router.TurnType.isRightTurn(t), TurnType.isRightTurn(t));
+			assertEquals(m, net.osmand.router.TurnType.isRightTurnNoUTurn(t), TurnType.isRightTurnNoUTurn(t));
+			assertEquals(m, net.osmand.router.TurnType.isSlightTurn(t), TurnType.isSlightTurn(t));
+			assertEquals(m, net.osmand.router.TurnType.isKeepDirectionTurn(t), TurnType.isKeepDirectionTurn(t));
+			assertEquals(m, net.osmand.router.TurnType.isSharpOrReverse(t), TurnType.isSharpOrReverse(t));
+			assertEquals(m, net.osmand.router.TurnType.isSharpLeftOrUTurn(t), TurnType.isSharpLeftOrUTurn(t));
+			assertEquals(m, net.osmand.router.TurnType.isSharpRightOrUTurn(t), TurnType.isSharpRightOrUTurn(t));
+			assertEquals(m, net.osmand.router.TurnType.orderFromLeftToRight(t), TurnType.orderFromLeftToRight(t));
+			assertEquals(m, net.osmand.router.TurnType.getPrev(t), TurnType.getPrev(t));
+			assertEquals(m, net.osmand.router.TurnType.getNext(t), TurnType.getNext(t));
+		}
+		for (String w : LANE_WORDS) {
+			assertEquals(w, net.osmand.router.TurnType.convertType(w), TurnType.convertType(w));
+		}
+	}
+
+	@Test
+	public void testInstancesAgreeOnEveryCodeAndName() {
+		for (int t = 0; t <= CODES; t++) {
+			for (boolean left : new boolean[] {false, true}) {
+				assertSame("valueOf(" + t + ", " + left + ")",
+						net.osmand.router.TurnType.valueOf(t, left), TurnType.valueOf(t, left));
+			}
+		}
+		for (String s : NAMES) {
+			for (boolean left : new boolean[] {false, true}) {
+				assertSame("fromString(" + s + ", " + left + ")",
+						net.osmand.router.TurnType.fromString(s, left), TurnType.fromString(s, left));
+			}
+		}
+		for (int out = 0; out <= 6; out++) {
+			for (float angle : new float[] {-179, -90, -30, 0, 30, 90, 179}) {
+				for (boolean left : new boolean[] {false, true}) {
+					assertSame("getExitTurn(" + out + ", " + angle + ", " + left + ")",
+							net.osmand.router.TurnType.getExitTurn(out, angle, left), TurnType.getExitTurn(out, angle, left));
+				}
+			}
+		}
+		assertSame("straight", net.osmand.router.TurnType.straight(), TurnType.straight());
+	}
+
+	@Test
+	public void testLanePackingAgreesUnderRandomEdits() {
+		Random random = new Random(20260913);
+		for (int n = 0; n < 4000; n++) {
+			int[] a = new int[1 + random.nextInt(6)];
+			int[] b = new int[a.length];
+			for (int k = 0; k < 12; k++) {
+				int lane = random.nextInt(a.length);
+				int turn = random.nextInt(16);
+				switch (random.nextInt(7)) {
+					case 0: net.osmand.router.TurnType.setPrimaryTurnAndReset(a, lane, turn); TurnType.setPrimaryTurnAndReset(b, lane, turn); break;
+					case 1: net.osmand.router.TurnType.setPrimaryTurn(a, lane, turn); TurnType.setPrimaryTurn(b, lane, turn); break;
+					case 2: net.osmand.router.TurnType.setSecondaryTurn(a, lane, turn); TurnType.setSecondaryTurn(b, lane, turn); break;
+					case 3: net.osmand.router.TurnType.setTertiaryTurn(a, lane, turn); TurnType.setTertiaryTurn(b, lane, turn); break;
+					case 4: net.osmand.router.TurnType.setPrimaryTurnShiftOthers(a, lane, turn); TurnType.setPrimaryTurnShiftOthers(b, lane, turn); break;
+					case 5: net.osmand.router.TurnType.setSecondaryToPrimary(a, lane); TurnType.setSecondaryToPrimary(b, lane); break;
+					default: net.osmand.router.TurnType.setTertiaryToPrimary(a, lane); TurnType.setTertiaryToPrimary(b, lane); break;
+				}
+				if (random.nextInt(3) == 0) {
+					a[lane] |= 1;
+					b[lane] |= 1;
+				}
+				assertArrayEquals(a, b);
+				for (int i = 0; i < a.length; i++) {
+					String m = "lane " + a[i];
+					assertEquals(m, net.osmand.router.TurnType.getPrimaryTurn(a[i]), TurnType.getPrimaryTurn(b[i]));
+					assertEquals(m, net.osmand.router.TurnType.getSecondaryTurn(a[i]), TurnType.getSecondaryTurn(b[i]));
+					assertEquals(m, net.osmand.router.TurnType.getTertiaryTurn(a[i]), TurnType.getTertiaryTurn(b[i]));
+					assertEquals(m, net.osmand.router.TurnType.hasAnySlightTurnLane(a[i]), TurnType.hasAnySlightTurnLane(b[i]));
+					assertEquals(m, net.osmand.router.TurnType.hasAnyTurnLane(a[i], turn), TurnType.hasAnyTurnLane(b[i], turn));
+					LinkedHashSet<Integer> js = new LinkedHashSet<>();
+					LinkedHashSet<Integer> ks = new LinkedHashSet<>();
+					net.osmand.router.TurnType.collectTurnTypes(a[i], js);
+					TurnType.collectTurnTypes(b[i], ks);
+					assertEquals(m, new java.util.ArrayList<>(js), new java.util.ArrayList<>(ks));
+				}
+			}
+			String js = net.osmand.router.TurnType.lanesToString(a);
+			assertEquals(js, TurnType.lanesToString(b));
+			Same.outcome(js, () -> net.osmand.router.TurnType.lanesFromString(js), () -> TurnType.lanesFromString(js));
+
+			// a turn carrying these lanes counts and describes them the same way
+			int code = random.nextInt(15);
+			int type = random.nextInt(15);
+			net.osmand.router.TurnType jt = net.osmand.router.TurnType.valueOf(code, random.nextBoolean());
+			TurnType kt = TurnType.valueOf(jt.getValue(), jt.isLeftSide());
+			jt.setLanes(a);
+			kt.setLanes(b);
+			jt.setTurnAngle(random.nextInt(360) - 180);
+			kt.setTurnAngle(jt.getTurnAngle());
+			jt.setSkipToSpeak(random.nextBoolean());
+			kt.setSkipToSpeak(jt.isSkipToSpeak());
+			assertSame("with lanes " + js, jt, kt);
+			assertEquals(js, jt.countTurnTypeDirections(type, true), kt.countTurnTypeDirections(type, true));
+			assertEquals(js, jt.countTurnTypeDirections(type, false), kt.countTurnTypeDirections(type, false));
+		}
+	}
+
+	@Test
+	public void testLanesFromStringAgreesOnOddInput() {
+		for (String s : new String[] {"", "|", "||", "C", "TL", "C|TR", "C|", "|C", "C||TR", "+C,TL|TR", "C,TL,TR,KL", ",C", "C,", "junk", "C|junk|TR", " C | TR ", "+", "+|+"}) {
+			Same.outcome(s, () -> net.osmand.router.TurnType.lanesFromString(s), () -> TurnType.lanesFromString(s));
+		}
+	}
+
+	private static void assertSame(String m, net.osmand.router.TurnType j, TurnType k) {
+		if (j == null || k == null) {
+			assertEquals(m, j == null, k == null);
+			return;
+		}
+		assertEquals(m + " value", j.getValue(), k.getValue());
+		assertEquals(m + " exitOut", j.getExitOut(), k.getExitOut());
+		assertEquals(m + " turnAngle", j.getTurnAngle(), k.getTurnAngle(), 0f);
+		assertEquals(m + " skipToSpeak", j.isSkipToSpeak(), k.isSkipToSpeak());
+		assertEquals(m + " leftSide", j.isLeftSide(), k.isLeftSide());
+		assertEquals(m + " roundabout", j.isRoundAbout(), k.isRoundAbout());
+		assertEquals(m + " keepLeft", j.keepLeft(), k.keepLeft());
+		assertEquals(m + " keepRight", j.keepRight(), k.keepRight());
+		assertEquals(m + " goAhead", j.goAhead(), k.goAhead());
+		assertEquals(m + " possibleLeft", j.isPossibleLeftTurn(), k.isPossibleLeftTurn());
+		assertEquals(m + " possibleRight", j.isPossibleRightTurn(), k.isPossibleRightTurn());
+		assertArrayEquals(m + " lanes", j.getLanes(), k.getLanes());
+		Same.outcome(m + " countDirections", j::countDirections, k::countDirections);
+		Same.outcome(m + " activeCommonLaneTurn", j::getActiveCommonLaneTurn, k::getActiveCommonLaneTurn);
+		assertEquals(m + " xml", j.toXmlString(), k.toXmlString());
+		if (!j.toString().contains("@")) { // java falls back to Object.toString for a code it has no words for
+			assertEquals(m + " toString", j.toString(), k.toString());
+		}
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/ExitInfo.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/ExitInfo.kt
@@ -1,0 +1,11 @@
+package net.osmand.shared.routing
+
+/** Motorway exit reference and street name attached to a turn. */
+class ExitInfo {
+
+	var ref: String? = null
+
+	var exitStreetName: String? = null
+
+	fun isEmpty(): Boolean = ref == null && exitStreetName == null
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/TurnType.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/TurnType.kt
@@ -1,0 +1,518 @@
+package net.osmand.shared.routing
+
+import kotlin.jvm.JvmStatic
+import net.osmand.shared.util.KAlgorithms
+import net.osmand.shared.util.LoggerFactory
+
+/**
+ * A manoeuvre: which way to go, plus the lane layout it applies to.
+ *
+ * A copy of `net.osmand.router.TurnType`, which stays in OsmAnd-java: android, tools and the C++ core keep using
+ * the original, and this copy is for iOS. Keep the two identical; `TurnTypeCompatTest` checks that they behave
+ * the same.
+ *
+ * Lanes are packed into an int per lane:
+ * - bit 0: whether the lane is active for this manoeuvre;
+ * - bits 1-4: primary turn, the one drawn on the map;
+ * - bits 5-9: secondary turn;
+ * - bits 10 and up: tertiary turn.
+ */
+class TurnType(
+	val value: Int,
+	var exitOut: Int,
+	// clockwise head rotation, assuming the previous direction was north
+	var turnAngle: Float,
+	var isSkipToSpeak: Boolean,
+	var lanes: IntArray?,
+	var isPossibleLeftTurn: Boolean,
+	var isPossibleRightTurn: Boolean
+) {
+
+	var otherTurnAngles: List<Float>? = null
+
+	private constructor(value: Int) : this(value, 0, 0f, false, null, false, false)
+
+	fun isLeftSide(): Boolean = value == RNLB || value == TRU
+
+	fun isRoundAbout(): Boolean = value == RNDB || value == RNLB
+
+	fun keepLeft(): Boolean = value == KL
+
+	fun keepRight(): Boolean = value == KR
+
+	fun goAhead(): Boolean = value == C
+
+	fun getActiveCommonLaneTurn(): Int {
+		val lanes = this.lanes
+		if (lanes == null || lanes.isEmpty()) {
+			return -1
+		}
+		for (lane in lanes) {
+			if (lane % 2 == 1) {
+				return getPrimaryTurn(lane)
+			}
+		}
+		return -1
+	}
+
+	fun countTurnTypeDirections(type: Int, onlyActive: Boolean): Int {
+		val lanes = this.lanes ?: return 0
+		var count = 0
+		for (lane in lanes) {
+			val active = lane % 2 == 1
+			if (onlyActive && !active) {
+				continue
+			}
+			var primary = getPrimaryTurn(lane)
+			if (primary == 0) {
+				primary = C
+			}
+			if (primary == type) {
+				count++
+			}
+			if (onlyActive) {
+				continue
+			}
+			if (getSecondaryTurn(lane) == type) {
+				count++
+			}
+			if (getTertiaryTurn(lane) == type) {
+				count++
+			}
+		}
+		return count
+	}
+
+	fun countDirections(): Int {
+		val directions = HashSet<Int>()
+		for (lane in lanes!!) {
+			var primary = getPrimaryTurn(lane)
+			if (primary == 0) {
+				primary = C
+			}
+			directions.add(primary)
+			val secondary = getSecondaryTurn(lane)
+			if (secondary > 0) {
+				directions.add(secondary)
+			}
+			val tertiary = getTertiaryTurn(lane)
+			if (tertiary > 0) {
+				directions.add(tertiary)
+			}
+		}
+		return directions.size
+	}
+
+	fun toXmlString(): String = when (value) {
+		C -> "C"
+		TL -> "TL"
+		TSLL -> "TSLL"
+		TSHL -> "TSHL"
+		TR -> "TR"
+		TSLR -> "TSLR"
+		TSHR -> "TSHR"
+		KL -> "KL"
+		KR -> "KR"
+		TU -> "TU"
+		TRU -> "TRU"
+		OFFR -> "OFFR"
+		RNDB -> "RNDB$exitOut"
+		RNLB -> "RNLB$exitOut"
+		else -> "C"
+	}
+
+	override fun toString(): String {
+		var vl: String? = if (isRoundAbout()) {
+			"Take $exitOut exit"
+		} else when (value) {
+			C -> "Go ahead"
+			TSLL -> "Turn slightly left"
+			TL -> "Turn left"
+			TSHL -> "Turn sharply left"
+			TSLR -> "Turn slightly right"
+			TR -> "Turn right"
+			TSHR -> "Turn sharply right"
+			TU, TRU -> "Make uturn"
+			KL -> "Keep left"
+			KR -> "Keep right"
+			OFFR -> "Off route"
+			else -> null
+		}
+		if (vl != null) {
+			val lanes = this.lanes
+			if (lanes != null && lanes.isNotEmpty()) {
+				vl += " (" + lanesToString(lanes) + ")"
+			}
+			return vl
+		}
+		return super.toString()
+	}
+
+	companion object {
+
+		private val LOG = LoggerFactory.getLogger("TurnType")
+
+		/** Continue, go straight. */
+		const val C = 1
+
+		/** Turn left. */
+		const val TL = 2
+
+		/** Turn slightly left. */
+		const val TSLL = 3
+
+		/** Turn sharply left. */
+		const val TSHL = 4
+
+		/** Turn right. */
+		const val TR = 5
+
+		/** Turn slightly right. */
+		const val TSLR = 6
+
+		/** Turn sharply right. */
+		const val TSHR = 7
+
+		/** Keep left. */
+		const val KL = 8
+
+		/** Keep right. */
+		const val KR = 9
+
+		/** U-turn. */
+		const val TU = 10
+
+		/** Right U-turn. */
+		const val TRU = 11
+
+		/** Off route. */
+		const val OFFR = 12
+
+		/** Roundabout. */
+		const val RNDB = 13
+
+		/** Roundabout, left hand traffic. */
+		const val RNLB = 14
+
+		private val TURNS_ORDER = intArrayOf(TU, TSHL, TL, TSLL, C, TSLR, TR, TSHR, TRU)
+
+		@JvmStatic
+		fun straight(): TurnType = valueOf(C, false)
+
+		@JvmStatic
+		fun valueOf(value: Int, leftSide: Boolean): TurnType {
+			var vs = value
+			if (vs == TU && leftSide) {
+				vs = TRU
+			} else if (vs == RNDB && leftSide) {
+				vs = RNLB
+			}
+			return TurnType(vs)
+		}
+
+		@JvmStatic
+		fun fromString(s: String?, leftSide: Boolean): TurnType {
+			var t: TurnType? = when (s) {
+				"C" -> valueOf(C, leftSide)
+				"TL" -> valueOf(TL, leftSide)
+				"TSLL" -> valueOf(TSLL, leftSide)
+				"TSHL" -> valueOf(TSHL, leftSide)
+				"TR" -> valueOf(TR, leftSide)
+				"TSLR" -> valueOf(TSLR, leftSide)
+				"TSHR" -> valueOf(TSHR, leftSide)
+				"KL" -> valueOf(KL, leftSide)
+				"KR" -> valueOf(KR, leftSide)
+				"TU" -> valueOf(TU, leftSide)
+				"TRU" -> valueOf(TRU, leftSide)
+				"OFFR" -> valueOf(OFFR, leftSide)
+				else -> null
+			}
+			if (t == null && s != null &&
+				(s.startsWith("EXIT") || s.startsWith("RNDB") || s.startsWith("RNLB"))
+			) {
+				try {
+					val type = if (s.contains("RNLB")) RNLB else RNDB
+					t = getExitTurn(type, s.substring(4).toInt(), 0f, leftSide)
+				} catch (e: NumberFormatException) {
+					LOG.error("Cannot parse the exit number of '$s'", e)
+				}
+			}
+			return t ?: straight()
+		}
+
+		@JvmStatic
+		fun getExitTurn(out: Int, angle: Float, leftSide: Boolean): TurnType {
+			val turn = valueOf(RNDB, leftSide)
+			turn.exitOut = out
+			turn.turnAngle = angle
+			return turn
+		}
+
+		@JvmStatic
+		private fun getExitTurn(type: Int, out: Int, angle: Float, leftSide: Boolean): TurnType {
+			if (type != RNDB && type != RNLB) {
+				return getExitTurn(out, angle, leftSide)
+			}
+			val turn = valueOf(type, leftSide)
+			turn.exitOut = out
+			turn.turnAngle = angle
+			return turn
+		}
+
+		// ------------------------------------------------------------ lane packing
+
+		/** Sets the primary turn and clears the secondary and tertiary ones. */
+		@JvmStatic
+		fun setPrimaryTurnAndReset(lanes: IntArray, lane: Int, turnType: Int) {
+			lanes[lane] = turnType shl 1
+		}
+
+		@JvmStatic
+		fun setPrimaryTurn(lanes: IntArray, lane: Int, turnType: Int) {
+			lanes[lane] = lanes[lane] and (15 shl 1).inv()
+			lanes[lane] = lanes[lane] or (turnType shl 1)
+		}
+
+		@JvmStatic
+		fun getPrimaryTurn(laneValue: Int): Int = (laneValue shr 1) and ((1 shl 4) - 1)
+
+		@JvmStatic
+		fun setSecondaryTurn(lanes: IntArray, lane: Int, turnType: Int) {
+			lanes[lane] = lanes[lane] and (15 shl 5).inv()
+			lanes[lane] = lanes[lane] or (turnType shl 5)
+		}
+
+		@JvmStatic
+		fun getSecondaryTurn(laneValue: Int): Int = (laneValue shr 5) and ((1 shl 5) - 1)
+
+		@JvmStatic
+		fun setTertiaryTurn(lanes: IntArray, lane: Int, turnType: Int) {
+			lanes[lane] = lanes[lane] and (15 shl 10).inv()
+			lanes[lane] = lanes[lane] or (turnType shl 10)
+		}
+
+		@JvmStatic
+		fun getTertiaryTurn(laneValue: Int): Int = laneValue shr 10
+
+		@JvmStatic
+		fun setPrimaryTurnShiftOthers(lanes: IntArray, lane: Int, turnType: Int) {
+			val primary = getPrimaryTurn(lanes[lane])
+			val secondary = getSecondaryTurn(lanes[lane])
+			// the tertiary turn is lost here
+			setPrimaryTurnAndReset(lanes, lane, turnType)
+			setSecondaryTurn(lanes, lane, primary)
+			setTertiaryTurn(lanes, lane, secondary)
+		}
+
+		@JvmStatic
+		fun setSecondaryToPrimary(lanes: IntArray, lane: Int) {
+			val secondary = getSecondaryTurn(lanes[lane])
+			val primary = getPrimaryTurn(lanes[lane])
+			setPrimaryTurn(lanes, lane, secondary)
+			setSecondaryTurn(lanes, lane, primary)
+		}
+
+		@JvmStatic
+		fun setTertiaryToPrimary(lanes: IntArray, lane: Int) {
+			val secondary = getSecondaryTurn(lanes[lane])
+			val primary = getPrimaryTurn(lanes[lane])
+			val tertiary = getTertiaryTurn(lanes[lane])
+			setPrimaryTurn(lanes, lane, tertiary)
+			setSecondaryTurn(lanes, lane, primary)
+			setTertiaryTurn(lanes, lane, secondary)
+		}
+
+		@JvmStatic
+		fun lanesToString(lanes: IntArray): String {
+			val builder = StringBuilder()
+			for (h in lanes.indices) {
+				if (h > 0) {
+					builder.append("|")
+				}
+				if (lanes[h] % 2 == 1) {
+					builder.append("+")
+				}
+				var primary = getPrimaryTurn(lanes[h])
+				if (primary == 0) {
+					primary = 1
+				}
+				builder.append(valueOf(primary, false).toXmlString())
+				val secondary = getSecondaryTurn(lanes[h])
+				if (secondary != 0) {
+					builder.append(",").append(valueOf(secondary, false).toXmlString())
+				}
+				val tertiary = getTertiaryTurn(lanes[h])
+				if (tertiary != 0) {
+					builder.append(",").append(valueOf(tertiary, false).toXmlString())
+				}
+			}
+			return builder.toString()
+		}
+
+		@JvmStatic
+		fun lanesFromString(lanesString: String?): IntArray? {
+			if (KAlgorithms.isEmpty(lanesString)) {
+				return null
+			}
+			val lanesArr = splitLikeJava(lanesString!!, "|")
+			val lanes = IntArray(lanesArr.size)
+			for (l in lanesArr.indices) {
+				val turns = splitLikeJava(lanesArr[l], ",")
+				var primaryTurn: TurnType? = null
+				var secondaryTurn: TurnType? = null
+				var tertiaryTurn: TurnType? = null
+				var plus = false
+				for (i in turns.indices) {
+					var turn = turns[i]
+					when (i) {
+						0 -> {
+							plus = turn.isNotEmpty() && turn[0] == '+'
+							if (plus) {
+								turn = turn.substring(1)
+							}
+							primaryTurn = fromString(turn, false)
+						}
+						1 -> secondaryTurn = fromString(turn, false)
+						2 -> tertiaryTurn = fromString(turn, false)
+					}
+				}
+				setPrimaryTurnAndReset(lanes, l, primaryTurn!!.value)
+				if (secondaryTurn != null) {
+					setSecondaryTurn(lanes, l, secondaryTurn.value)
+				}
+				if (tertiaryTurn != null) {
+					setTertiaryTurn(lanes, l, tertiaryTurn.value)
+				}
+				if (plus) {
+					lanes[l] = lanes[l] or 1
+				}
+			}
+			return lanes
+		}
+
+		/**
+		 * java's `String.split(regex)`: trailing empty parts are dropped, except that an input the
+		 * delimiter never matches - the empty string included - is one part, itself. Kotlin's `split`
+		 * keeps every part, so `"|C"` would lose its first, empty lane here and `""` would have none.
+		 */
+		private fun splitLikeJava(s: String, delimiter: String): List<String> {
+			val parts = s.split(delimiter)
+			return if (parts.size == 1) parts else parts.dropLastWhile { it.isEmpty() }
+		}
+
+		// ------------------------------------------------------------ classification
+
+		@JvmStatic
+		fun isLeftTurn(type: Int): Boolean =
+			type == TL || type == TSHL || type == TSLL || type == TU || type == KL
+
+		@JvmStatic
+		fun isLeftTurnNoUTurn(type: Int): Boolean =
+			type == TL || type == TSHL || type == TSLL || type == KL
+
+		@JvmStatic
+		fun isRightTurn(type: Int): Boolean =
+			type == TR || type == TSHR || type == TSLR || type == TRU || type == KR
+
+		@JvmStatic
+		fun isRightTurnNoUTurn(type: Int): Boolean =
+			type == TR || type == TSHR || type == TSLR || type == KR
+
+		@JvmStatic
+		fun isSlightTurn(type: Int): Boolean =
+			type == TSLL || type == TSLR || type == C || type == KL || type == KR
+
+		@JvmStatic
+		fun isKeepDirectionTurn(type: Int): Boolean = type == C || type == KL || type == KR
+
+		@JvmStatic
+		fun isSharpOrReverse(type: Int): Boolean =
+			type == TSHL || type == TSHR || type == TU || type == TRU
+
+		@JvmStatic
+		fun isSharpLeftOrUTurn(type: Int): Boolean = type == TSHL || type == TU
+
+		@JvmStatic
+		fun isSharpRightOrUTurn(type: Int): Boolean =
+			// turn:lanes=reverse is transformed to TU only
+			type == TSHR || type == TRU || type == TU
+
+		@JvmStatic
+		fun hasAnySlightTurnLane(type: Int): Boolean =
+			isSlightTurn(getPrimaryTurn(type)) ||
+					isSlightTurn(getSecondaryTurn(type)) ||
+					isSlightTurn(getTertiaryTurn(type))
+
+		@JvmStatic
+		fun hasAnyTurnLane(type: Int, turn: Int): Boolean =
+			getPrimaryTurn(type) == turn ||
+					getSecondaryTurn(type) == turn ||
+					getTertiaryTurn(type) == turn
+
+		@JvmStatic
+		fun collectTurnTypes(lane: Int, set: LinkedHashSet<Int>) {
+			var turn = getPrimaryTurn(lane)
+			if (turn != 0) {
+				set.add(turn)
+			}
+			turn = getSecondaryTurn(lane)
+			if (turn != 0) {
+				set.add(turn)
+			}
+			turn = getTertiaryTurn(lane)
+			if (turn != 0) {
+				set.add(turn)
+			}
+		}
+
+		@JvmStatic
+		fun orderFromLeftToRight(type: Int): Int = when (type) {
+			TU -> -5
+			TSHL -> -4
+			TL -> -3
+			TSLL -> -2
+			KL -> -1
+			TRU -> 5
+			TSHR -> 4
+			TR -> 3
+			TSLR -> 2
+			KR -> 1
+			else -> 0
+		}
+
+		@JvmStatic
+		fun convertType(lane: String): Int = when (lane) {
+			// merge is recognised as continue, even though it may be drawn differently
+			"merge_to_left", "merge_to_right", "none", "through" -> C
+			"slight_right" -> TSLR
+			"slight_left" -> TSLL
+			"right" -> TR
+			"left" -> TL
+			"sharp_right" -> TSHR
+			"sharp_left" -> TSHL
+			"reverse" -> TU
+			// unknown string
+			else -> C
+		}
+
+		@JvmStatic
+		fun getPrev(turn: Int): Int {
+			for (i in TURNS_ORDER.indices.reversed()) {
+				if (TURNS_ORDER[i] == turn && i > 0) {
+					return TURNS_ORDER[i - 1]
+				}
+			}
+			return turn
+		}
+
+		@JvmStatic
+		fun getNext(turn: Int): Int {
+			for (i in TURNS_ORDER.indices) {
+				if (TURNS_ORDER[i] == turn && i + 1 < TURNS_ORDER.size) {
+					return TURNS_ORDER[i + 1]
+				}
+			}
+			return turn
+		}
+	}
+}

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/routing/TurnTypeTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/routing/TurnTypeTest.kt
@@ -1,0 +1,266 @@
+package net.osmand.shared.routing
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TurnTypeTest {
+
+	private val allTurns = intArrayOf(
+		TurnType.C, TurnType.TL, TurnType.TSLL, TurnType.TSHL, TurnType.TR, TurnType.TSLR,
+		TurnType.TSHR, TurnType.KL, TurnType.KR, TurnType.TU, TurnType.TRU, TurnType.OFFR
+	)
+
+	@Test
+	fun testValueOfMapsToLeftSideVariants() {
+		assertEquals(TurnType.TRU, TurnType.valueOf(TurnType.TU, true).value)
+		assertEquals(TurnType.TU, TurnType.valueOf(TurnType.TU, false).value)
+		assertEquals(TurnType.RNLB, TurnType.valueOf(TurnType.RNDB, true).value)
+		assertEquals(TurnType.RNDB, TurnType.valueOf(TurnType.RNDB, false).value)
+		// every other type is unaffected by the side of the road
+		assertEquals(TurnType.TL, TurnType.valueOf(TurnType.TL, true).value)
+	}
+
+	@Test
+	fun testStraight() {
+		val straight = TurnType.straight()
+		assertEquals(TurnType.C, straight.value)
+		assertTrue(straight.goAhead())
+		assertFalse(straight.isRoundAbout())
+		assertNull(straight.lanes)
+	}
+
+	@Test
+	fun testXmlStringRoundTrip() {
+		for (turn in allTurns) {
+			val xml = TurnType.valueOf(turn, false).toXmlString()
+			assertEquals(turn, TurnType.fromString(xml, false).value, "round trip of $xml")
+		}
+	}
+
+	@Test
+	fun testRoundaboutXmlCarriesTheExit() {
+		val turn = TurnType.getExitTurn(3, 45f, false)
+		assertTrue(turn.isRoundAbout())
+		assertEquals(3, turn.exitOut)
+		assertEquals(45f, turn.turnAngle)
+		assertEquals("RNDB3", turn.toXmlString())
+
+		val parsed = TurnType.fromString("RNDB3", false)
+		assertTrue(parsed.isRoundAbout())
+		assertEquals(3, parsed.exitOut)
+
+		val left = TurnType.fromString("RNLB2", false)
+		assertEquals(TurnType.RNLB, left.value)
+		assertEquals(2, left.exitOut)
+		assertTrue(left.isLeftSide())
+
+		assertEquals(5, TurnType.fromString("EXIT5", false).exitOut)
+	}
+
+	@Test
+	fun testFromStringFallsBackToStraight() {
+		assertEquals(TurnType.C, TurnType.fromString(null, false).value)
+		assertEquals(TurnType.C, TurnType.fromString("", false).value)
+		assertEquals(TurnType.C, TurnType.fromString("nonsense", false).value)
+		// a roundabout without a number cannot be parsed and must not blow up
+		assertEquals(TurnType.C, TurnType.fromString("RNDB", false).value)
+		assertEquals(TurnType.C, TurnType.fromString("EXITx", false).value)
+	}
+
+	@Test
+	fun testLanePackingIsIndependentPerSlot() {
+		val lanes = IntArray(1)
+		TurnType.setPrimaryTurnAndReset(lanes, 0, TurnType.TL)
+		assertEquals(TurnType.TL, TurnType.getPrimaryTurn(lanes[0]))
+		assertEquals(0, TurnType.getSecondaryTurn(lanes[0]))
+		assertEquals(0, TurnType.getTertiaryTurn(lanes[0]))
+		assertEquals(0, lanes[0] % 2, "the active bit must stay clear")
+
+		TurnType.setSecondaryTurn(lanes, 0, TurnType.TSLR)
+		TurnType.setTertiaryTurn(lanes, 0, TurnType.TU)
+		assertEquals(TurnType.TL, TurnType.getPrimaryTurn(lanes[0]))
+		assertEquals(TurnType.TSLR, TurnType.getSecondaryTurn(lanes[0]))
+		assertEquals(TurnType.TU, TurnType.getTertiaryTurn(lanes[0]))
+
+		// overwriting one slot must leave the others alone
+		TurnType.setPrimaryTurn(lanes, 0, TurnType.TR)
+		assertEquals(TurnType.TR, TurnType.getPrimaryTurn(lanes[0]))
+		assertEquals(TurnType.TSLR, TurnType.getSecondaryTurn(lanes[0]))
+		assertEquals(TurnType.TU, TurnType.getTertiaryTurn(lanes[0]))
+
+		// setPrimaryTurnAndReset clears the rest again
+		TurnType.setPrimaryTurnAndReset(lanes, 0, TurnType.KL)
+		assertEquals(TurnType.KL, TurnType.getPrimaryTurn(lanes[0]))
+		assertEquals(0, TurnType.getSecondaryTurn(lanes[0]))
+		assertEquals(0, TurnType.getTertiaryTurn(lanes[0]))
+	}
+
+	@Test
+	fun testActiveBitSurvivesTurnUpdates() {
+		val lanes = IntArray(1)
+		TurnType.setPrimaryTurnAndReset(lanes, 0, TurnType.TL)
+		lanes[0] = lanes[0] or 1
+		TurnType.setSecondaryTurn(lanes, 0, TurnType.TR)
+		TurnType.setTertiaryTurn(lanes, 0, TurnType.TU)
+		TurnType.setPrimaryTurn(lanes, 0, TurnType.C)
+		assertEquals(1, lanes[0] % 2, "the lane must still be active")
+	}
+
+	@Test
+	fun testShiftAndSwapHelpers() {
+		val lanes = IntArray(1)
+		TurnType.setPrimaryTurnAndReset(lanes, 0, TurnType.TL)
+		TurnType.setSecondaryTurn(lanes, 0, TurnType.TR)
+		TurnType.setTertiaryTurn(lanes, 0, TurnType.TU)
+
+		TurnType.setPrimaryTurnShiftOthers(lanes, 0, TurnType.KR)
+		assertEquals(TurnType.KR, TurnType.getPrimaryTurn(lanes[0]))
+		assertEquals(TurnType.TL, TurnType.getSecondaryTurn(lanes[0]))
+		assertEquals(TurnType.TR, TurnType.getTertiaryTurn(lanes[0]))
+
+		TurnType.setSecondaryToPrimary(lanes, 0)
+		assertEquals(TurnType.TL, TurnType.getPrimaryTurn(lanes[0]))
+		assertEquals(TurnType.KR, TurnType.getSecondaryTurn(lanes[0]))
+
+		TurnType.setTertiaryToPrimary(lanes, 0)
+		assertEquals(TurnType.TR, TurnType.getPrimaryTurn(lanes[0]))
+		assertEquals(TurnType.TL, TurnType.getSecondaryTurn(lanes[0]))
+		assertEquals(TurnType.KR, TurnType.getTertiaryTurn(lanes[0]))
+	}
+
+	@Test
+	fun testLanesStringRoundTrip() {
+		val lanes = IntArray(3)
+		TurnType.setPrimaryTurnAndReset(lanes, 0, TurnType.TL)
+		lanes[0] = lanes[0] or 1
+		TurnType.setPrimaryTurnAndReset(lanes, 1, TurnType.C)
+		TurnType.setSecondaryTurn(lanes, 1, TurnType.TSLR)
+		TurnType.setPrimaryTurnAndReset(lanes, 2, TurnType.TR)
+		TurnType.setSecondaryTurn(lanes, 2, TurnType.TSHR)
+		TurnType.setTertiaryTurn(lanes, 2, TurnType.TU)
+
+		val asString = TurnType.lanesToString(lanes)
+		assertEquals("+TL|C,TSLR|TR,TSHR,TU", asString)
+		assertContentEquals(lanes, TurnType.lanesFromString(asString))
+	}
+
+	@Test
+	fun testLanesFromStringEdgeCases() {
+		assertNull(TurnType.lanesFromString(null))
+		assertNull(TurnType.lanesFromString(""))
+		val single = TurnType.lanesFromString("C")
+		assertEquals(1, single!!.size)
+		assertEquals(TurnType.C, TurnType.getPrimaryTurn(single[0]))
+		// a trailing separator must not produce an extra lane, matching Java's String.split
+		assertEquals(2, TurnType.lanesFromString("C|TR|")!!.size)
+	}
+
+	@Test
+	fun testCountingDirections() {
+		val turn = TurnType.valueOf(TurnType.C, false)
+		assertEquals(0, turn.countTurnTypeDirections(TurnType.C, false), "no lanes means no directions")
+
+		val lanes = IntArray(3)
+		TurnType.setPrimaryTurnAndReset(lanes, 0, TurnType.TL)
+		lanes[0] = lanes[0] or 1
+		TurnType.setPrimaryTurnAndReset(lanes, 1, TurnType.C)
+		TurnType.setSecondaryTurn(lanes, 1, TurnType.TL)
+		TurnType.setPrimaryTurnAndReset(lanes, 2, TurnType.TL)
+		turn.lanes = lanes
+
+		assertEquals(3, turn.countTurnTypeDirections(TurnType.TL, false))
+		assertEquals(1, turn.countTurnTypeDirections(TurnType.TL, true), "only the active lane counts")
+		assertEquals(2, turn.countDirections(), "TL and C")
+		assertEquals(TurnType.TL, turn.getActiveCommonLaneTurn())
+	}
+
+	@Test
+	fun testClassificationHelpers() {
+		assertTrue(TurnType.isLeftTurn(TurnType.TU))
+		assertFalse(TurnType.isLeftTurnNoUTurn(TurnType.TU))
+		assertTrue(TurnType.isRightTurn(TurnType.TRU))
+		assertFalse(TurnType.isRightTurnNoUTurn(TurnType.TRU))
+		assertTrue(TurnType.isSlightTurn(TurnType.C))
+		assertTrue(TurnType.isKeepDirectionTurn(TurnType.KR))
+		assertFalse(TurnType.isKeepDirectionTurn(TurnType.TL))
+		assertTrue(TurnType.isSharpOrReverse(TurnType.TSHL))
+		assertTrue(TurnType.isSharpLeftOrUTurn(TurnType.TU))
+		assertTrue(TurnType.isSharpRightOrUTurn(TurnType.TU))
+		assertFalse(TurnType.isSharpLeftOrUTurn(TurnType.TSHR))
+
+		val lane = IntArray(1)
+		TurnType.setPrimaryTurnAndReset(lane, 0, TurnType.TL)
+		TurnType.setSecondaryTurn(lane, 0, TurnType.TSLR)
+		assertTrue(TurnType.hasAnySlightTurnLane(lane[0]))
+		assertTrue(TurnType.hasAnyTurnLane(lane[0], TurnType.TL))
+		assertFalse(TurnType.hasAnyTurnLane(lane[0], TurnType.TU))
+
+		val collected = LinkedHashSet<Int>()
+		TurnType.collectTurnTypes(lane[0], collected)
+		assertEquals(setOf(TurnType.TL, TurnType.TSLR), collected)
+	}
+
+	@Test
+	fun testOrderFromLeftToRight() {
+		val ordered = listOf(
+			TurnType.TU, TurnType.TSHL, TurnType.TL, TurnType.TSLL, TurnType.KL,
+			TurnType.C, TurnType.KR, TurnType.TSLR, TurnType.TR, TurnType.TSHR, TurnType.TRU
+		)
+		val positions = ordered.map { TurnType.orderFromLeftToRight(it) }
+		assertEquals(positions.sorted(), positions, "left to right order must be monotonic")
+	}
+
+	@Test
+	fun testPrevAndNextWalkTheTurnOrder() {
+		assertEquals(TurnType.TSHL, TurnType.getNext(TurnType.TU))
+		assertEquals(TurnType.TU, TurnType.getPrev(TurnType.TSHL))
+		assertEquals(TurnType.C, TurnType.getNext(TurnType.TSLL))
+		// the ends of the order stay put
+		assertEquals(TurnType.TU, TurnType.getPrev(TurnType.TU))
+		assertEquals(TurnType.TRU, TurnType.getNext(TurnType.TRU))
+		// a type outside the order is returned unchanged
+		assertEquals(TurnType.OFFR, TurnType.getNext(TurnType.OFFR))
+	}
+
+	@Test
+	fun testConvertType() {
+		assertEquals(TurnType.C, TurnType.convertType("none"))
+		assertEquals(TurnType.C, TurnType.convertType("through"))
+		assertEquals(TurnType.C, TurnType.convertType("merge_to_left"))
+		assertEquals(TurnType.C, TurnType.convertType("merge_to_right"))
+		assertEquals(TurnType.TSLR, TurnType.convertType("slight_right"))
+		assertEquals(TurnType.TSLL, TurnType.convertType("slight_left"))
+		assertEquals(TurnType.TR, TurnType.convertType("right"))
+		assertEquals(TurnType.TL, TurnType.convertType("left"))
+		assertEquals(TurnType.TSHR, TurnType.convertType("sharp_right"))
+		assertEquals(TurnType.TSHL, TurnType.convertType("sharp_left"))
+		assertEquals(TurnType.TU, TurnType.convertType("reverse"))
+		assertEquals(TurnType.C, TurnType.convertType("something_new"))
+	}
+
+	@Test
+	fun testToStringMentionsLanes() {
+		val turn = TurnType.valueOf(TurnType.TL, false)
+		assertEquals("Turn left", turn.toString())
+		val lanes = IntArray(1)
+		TurnType.setPrimaryTurnAndReset(lanes, 0, TurnType.TL)
+		turn.lanes = lanes
+		assertEquals("Turn left (TL)", turn.toString())
+		assertEquals("Take 2 exit", TurnType.getExitTurn(2, 0f, false).toString())
+	}
+
+	@Test
+	fun testExitInfo() {
+		val info = ExitInfo()
+		assertTrue(info.isEmpty())
+		info.ref = "12"
+		assertFalse(info.isEmpty())
+		info.ref = null
+		info.exitStreetName = "Some street"
+		assertFalse(info.isEmpty())
+	}
+}


### PR DESCRIPTION
Part of the routing-to-OsmAnd-shared series: the java classes stay in `OsmAnd-java` and android, tools and the C++ core keep using them; each step adds a copy to `OsmAnd-shared` and a test that the copy behaves like the original. The copies are for iOS, which will call them instead of its own C++ turn preparation.

`TurnType` and `ExitInfo`. `TurnTypeCompatTest` runs the copy beside `net.osmand.router.TurnType`: every code, every name, every lane packing operation under 4 000 random edit sequences, and the string forms of both.

The comparison found one difference in the copy as it was: `lanesFromString` split with Kotlin's `split`, which keeps every part, where java's drops trailing empty parts but keeps an unmatched input - the empty string included - as one part. `"|C"` lost its first lane and threw. Fixed with a split that follows java's rule.

Supersedes #25901.
