### PR TITLE
Copy OpeningHoursParser to OsmAnd-shared

### DIFF
--- a/OsmAnd-java/src/test/java/net/osmand/shared/compat/OpeningHoursCompatTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/shared/compat/OpeningHoursCompatTest.java
@@ -1,0 +1,112 @@
+package net.osmand.shared.compat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import net.osmand.shared.util.OpeningHoursParser;
+import net.osmand.shared.util.OpeningHoursTime;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * {@link OpeningHoursParser} is a copy of {@link net.osmand.util.OpeningHoursParser}; this parses the
+ * same rules with both and asks both the same questions at the same moments.
+ *
+ * The rules are the ones the java test suite has collected over the years
+ * ({@code opening_hours_rules.txt}), and the moments are a grid of three years at an odd step, so
+ * every weekday, month, hour and a spread of minutes come up, on either side of every boundary a
+ * rule can name - year, month, day of month, nth weekday, holiday, midnight.
+ */
+public class OpeningHoursCompatTest {
+
+	private static final int STEP_MINUTES = 7 * 60 + 13;
+
+	@BeforeClass
+	public static void sameLocaleOnBothSides() {
+		net.osmand.util.OpeningHoursParser.initLocalStrings(Locale.ENGLISH);
+		net.osmand.util.OpeningHoursParser.setTwelveHourFormattingEnabled(false, Locale.ENGLISH);
+		OpeningHoursParser.INSTANCE.initLocalStrings("en");
+		OpeningHoursParser.INSTANCE.setTwelveHourFormattingEnabled(false, "en");
+	}
+
+	static List<String> rules() throws IOException {
+		List<String> rules = new ArrayList<>();
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+				Objects.requireNonNull(OpeningHoursCompatTest.class.getResourceAsStream("/opening_hours_rules.txt")),
+				StandardCharsets.UTF_8))) {
+			String line;
+			while ((line = reader.readLine()) != null) {
+				if (!line.isEmpty()) {
+					rules.add(line.replace("\\\"", "\""));
+				}
+			}
+		}
+		return rules;
+	}
+
+	@Test
+	public void testEveryRuleParsesAndPrintsTheSame() throws IOException {
+		for (String rule : rules()) {
+			net.osmand.util.OpeningHoursParser.OpeningHours j = net.osmand.util.OpeningHoursParser.parseOpenedHours(rule);
+			OpeningHoursParser.OpeningHours k = OpeningHoursParser.INSTANCE.parseOpenedHours(rule);
+			assertEquals(rule, j == null, k == null);
+			if (j != null) {
+				assertEquals(rule, j.toString(), k.toString());
+				assertEquals(rule, j.getRules().size(), k.getRules().size());
+			}
+		}
+	}
+
+	@Test
+	public void testEveryRuleAnswersTheSameAtEveryMoment() throws IOException {
+		List<String> rules = rules();
+		List<net.osmand.util.OpeningHoursParser.OpeningHours> js = new ArrayList<>();
+		List<OpeningHoursParser.OpeningHours> ks = new ArrayList<>();
+		for (String rule : rules) {
+			js.add(net.osmand.util.OpeningHoursParser.parseOpenedHours(rule));
+			ks.add(OpeningHoursParser.INSTANCE.parseOpenedHours(rule));
+		}
+		Calendar cal = Calendar.getInstance();
+		cal.clear();
+		cal.set(2022, Calendar.JANUARY, 1, 0, 0, 0);
+		int moments = 0;
+		while (cal.get(Calendar.YEAR) < 2025) {
+			OpeningHoursTime time = OpeningHoursTime.Companion.of(cal.get(Calendar.YEAR), cal.get(Calendar.MONTH),
+					cal.get(Calendar.DAY_OF_MONTH), cal.get(Calendar.HOUR_OF_DAY), cal.get(Calendar.MINUTE));
+			for (int i = 0; i < rules.size(); i++) {
+				net.osmand.util.OpeningHoursParser.OpeningHours j = js.get(i);
+				OpeningHoursParser.OpeningHours k = ks.get(i);
+				if (j == null) {
+					continue;
+				}
+				String m = rules.get(i) + " at " + cal.getTime();
+				assertEquals(m, j.isOpenedForTime(cal), k.isOpenedForTime(time));
+				assertEquals(m, j.getCurrentRuleTime(cal), k.getCurrentRuleTime(time));
+				List<net.osmand.util.OpeningHoursParser.OpeningHours.Info> ji = j.getInfo(cal);
+				List<OpeningHoursParser.OpeningHours.Info> ki = k.getInfo(time);
+				assertNotNull(m, ki);
+				assertEquals(m, ji.size(), ki.size());
+				for (int s = 0; s < ji.size(); s++) {
+					assertEquals(m + " #" + s, ji.get(s).isOpened(), ki.get(s).isOpened());
+					assertEquals(m + " #" + s, ji.get(s).isOpened24_7(), ki.get(s).isOpened24_7());
+					assertEquals(m + " #" + s, ji.get(s).isFallback(), ki.get(s).isFallback());
+					assertEquals(m + " #" + s, ji.get(s).getInfo(), ki.get(s).getInfo());
+				}
+			}
+			cal.add(Calendar.MINUTE, STEP_MINUTES);
+			moments++;
+		}
+		assertEquals(true, moments > 3000);
+	}
+}

--- a/OsmAnd-java/src/test/resources/opening_hours_rules.txt
+++ b/OsmAnd-java/src/test/resources/opening_hours_rules.txt
@@ -1,0 +1,102 @@
+Mo-Su (sunrise-00:30)-(sunset+00:30)
+Mo-Fr 11:00-22:00; Sa,Su,PH 12:00-22:00; 2022 jul 31-2022 Aug 31 off \"Betriebsferien\"
+Mo-Fr 10:00-18:30; We 10:00-14:00; Sa 10:00-13:00; Dec-Feb Mo-Fr 11:00-17:00; Dec-Feb We off; Dec-Feb Sa 11:00-13:00; Dec 24-Dec 31 off \"Inventurarbeiten\"; PH off
+2024 Jan 1-Dec 31
+2024 Jan 01-Dec 31
+2024 Jan 01-2024 Dec 31
+2024 Jan 01-2025 Dec 31
+2022 Oct 24 - 2023 Oct 30
+2022 Oct 30 - 2023 Oct 24
+2022 Oct 24 - 2023 Aug 30
+11:00-14:00,17:00-22:00; We off; Fr,Sa 11:00-14:00,17:00-00:00
+Mo 09:00-12:00; We,Sa 13:30-17:00, Apr 01-Oct 31 We,Sa 17:00-18:30; PH off
+PH,Mo-Su 09:00-22:00
+Mo-We 07:00-21:00, Th-Fr 07:00-21:30, PH,Sa-Su 08:00-21:00
+Mo-Fr 08:00-12:30, Mo-We 12:30-16:30 \"Sur rendez-vous\", Fr 12:30-15:30 \"Sur rendez-vous\"
+2019 Oct 1 - 2024 dec 31 
+2019 Oct - 2024 dec
+2019 Apr 1 - 2020 Apr 1
+2019 Apr 15 -  2020 Mar 1
+2019 Jul 23 05:00-24:00; 2019 Jul 24-2019 Jul 26 00:00-24:00; 2019 Jul 27 00:00-18:00
+2019 Sep 1 - 2022 Apr 1
+2019 Apr 15 - 2019 Sep 1: Mo-Fr 00:00-24:00
+2019 Sep 1 - 2020 Apr 1
+2019 Apr 15 - 2019 Sep 1
+Apr 15 - Sep 1
+Apr 15 - Sep 1: Mo-Fr 00:00-24:00
+Apr 05-Oct 24: Fr 08:00-16:00
+Oct 24-Apr 05: Fr 08:00-16:00
+Oct 24-Apr 05, Jun 10-Jun 20, Jul 6-12: Fr 08:00-16:00
+Apr 05-24: Fr 08:00-16:00
+Apr 5: Fr 08:00-16:00
+Apr 24-05: Fr 08:00-16:00
+Apr: Fr 08:00-16:00
+Apr-Oct: Fr 08:00-16:00
+Apr, Oct: Fr 08:00-16:00
+Mo-Fr 08:30-14:40
+mo-fr 07:00-19:00; sa 12:00-18:00
+Mo-We, Fr 08:30-14:40,15:00-19:00
+Mo-Sa 08:30-14:40; Tu 08:00 - 14:00
+Mo-Sa 09:00-18:25; Th off
+24/7
+24/7 closed \"Temporarily, for major repairs\"
+Sa-Su 24/7
+Mo-Fr 9-19
+09:00-17:00
+sunrise-sunset
+10:00+
+Su-Th sunset-24:00, 04:00-sunrise; Fr-Sa sunset-sunrise
+Mo 20:00-02:00
+Su 10:00-10:00
+Tu-Th 07:00-2:00; Fr 17:00-4:00; Sa 18:00-05:00; Su,Mo off
+Mo-Th 09:00-03:00; Fr-Sa 09:00-04:00; Su off
+May: 07:00-19:00
+Apr-Sep 8:00-22:00; Oct-Mar 10:00-18:00
+Mo-Fr: 9:00-13:00, 14:00-18:00
+Mo-Su 07:00-23:00; Dec 25 08:00-20:00
+Mo-Su 07:00-23:00; Dec 25 off
+Mo-Su 07:00-23:00; Easter off; Dec 25 off
+Mo-Fr 08:30-17:00; 12:00-12:40 off;
+Mo-Sa 02:00-10:00; Th off
+Mo-Sa 23:00-02:00; Th off
+Mo-Sa 08:30-17:00; Th off
+Mo-Su 07:00-23:00, Fr 08:00-20:00
+07:00-03:00 open \"Restaurant\" || 24/7 open \"McDrive\"
+Mo-Fr 12:00-15:00, Tu-Fr 17:00-23:00, Sa 12:00-23:00, Su 14:00-23:00
+Mo-Fr 08:00-12:00, Mo,Tu,Th 15:00-17:00; PH off
+Mo-Th,Su 09:00-00:30; Fr 09:00-16:30
+Fr,Sa 20:00-04:00
+We-Th 18:00-01:00; Fr-Sa 18:00-03:00; Su 16:00-23:00
+Mo-Su 12:00-22:00; Dec-Feb Mo-Su 13:00-18:00
+Tu-Su 10:00-18:00; Nov-Mar Tu-Su 10:00-16:00
+Mo-Fr 08:30-18:30; Sa 09:00-13:00; Mo-Fr 13:00-14:00 off
+We,Sa 07:00-13:00; Apr-Oct Su[1] 08:00-16:00
+Su[1,3,5] 09:00-10:00; Su[2,4] 18:00-19:00
+Mo-Fr 06:00-18:30; Sa 06:30-13:00; Su 07:30-11:00; PH off
+Mo-Sa 07:00-21:00; Nov-Feb 19:00-21:00 off
+Tu-Sa,PH 10:00-12:00,14:00-19:00; PH Su off
+PH Su 08:30-12:30
+SH Mo-Fr 10:00-14:00
+Jul Su[1] 08:00-18:00
+Nov Su[-1] 08:00-18:00
+Su[1,3] 08:00-12:00
+Tu-Sa,PH 10:00-12:00,14:00-19:00; PH Su off; May 01,Dec 25 off; Jul Su[1] 08:00-18:00; Nov Su[4] 08:00-18:00
+Mo-Fr 08:30-12:30,14:00-19:30; Sa 09:00-12:30; Jul-Aug 19:00-19:30 off; PH off
+Mo-Fr 08:00-18:00; Mo-Fr 12:00-13:00 off
+Tu-Fr 08:00-17:00; Mo-Fr 12:00-13:00 off \"Lunch\"
+Mo-Fr 08:00-20:00; Mo-Fr 10:00-10:30,15:00-15:30 off
+Mo-Su 20:00-02:00; Mo-Su 00:00-01:00 off
+Mo-Fr 09:00-20:00; Sa 09:00-18:00; 2025 Jan 07 - 2025 Feb 26 closed
+07:00-17:00; Mar 07:00-19:00; Apr 07:00-21:00; May-Aug 07:00-22:00; Sep 07:00-21:00; Oct 07:00-19:00
+Mo-Fr 09:00-18:00
+Mo-Fr; PH off
+2024 Jan-Dec
+2024-2025 Jan 1-Dec 31
+2024,2025 Jan 1-Dec 31
+2024
+2024,2026
+2024,2026 Jan 1-Dec 31
+2024,2026-2027 Jan 1-Dec 31
+2024-2025,2027-2028 Jan 1-Dec 31
+2024,2026,2028 Jan 1-Dec 31
+Mo-Fr 09:00-13:00,Tu 14:00-18:00, Th 14:00-17:00; We \"Nach Vereinbarung\"; Sa,Su,PH closed

--- a/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/util/PlatformDateNames.kt
+++ b/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/util/PlatformDateNames.kt
@@ -1,0 +1,36 @@
+package net.osmand.shared.util
+
+import java.text.DateFormat
+import java.text.DateFormatSymbols
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+actual object PlatformDateNames {
+
+	private fun symbols(languageTag: String?): DateFormatSymbols =
+		if (languageTag == null) DateFormatSymbols.getInstance()
+		else DateFormatSymbols.getInstance(Locale.forLanguageTag(languageTag))
+
+	private fun locale(languageTag: String?): Locale =
+		if (languageTag == null) Locale.getDefault() else Locale.forLanguageTag(languageTag)
+
+	actual fun shortMonths(languageTag: String?): Array<String> =
+		symbols(languageTag).shortMonths.map { it ?: "" }.toTypedArray()
+
+	actual fun shortWeekdays(languageTag: String?): Array<String> =
+		symbols(languageTag).shortWeekdays.map { it ?: "" }.toTypedArray()
+
+	actual fun formatTwelveHourTime(minutesOfDay: Int, languageTag: String?, withAmPm: Boolean): String {
+		val locale = locale(languageTag)
+		val format: DateFormat = if (withAmPm) {
+			DateFormat.getTimeInstance(DateFormat.SHORT, locale)
+		} else {
+			SimpleDateFormat("h:mm", locale)
+		}
+		// the value is minutes of a day, not an instant, so read it back in UTC
+		format.timeZone = TimeZone.getTimeZone("UTC")
+		return format.format(Date(minutesOfDay * 60L * 1000L))
+	}
+}

--- a/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/util/PlatformSerializable.kt
+++ b/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/util/PlatformSerializable.kt
@@ -1,0 +1,3 @@
+package net.osmand.shared.util
+
+actual typealias PlatformSerializable = java.io.Serializable

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/OpeningHoursParser.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/OpeningHoursParser.kt
@@ -1,0 +1,2252 @@
+package net.osmand.shared.util
+
+import net.osmand.shared.util.collections.KTIntArrayList
+import kotlin.jvm.JvmStatic
+
+/**
+ * Parses the OSM `opening_hours` tag and answers whether a feature is open at a given time.
+ *
+ * Port of `net.osmand.util.OpeningHoursParser`. Structure and method order follow the Java original
+ * so the two can be read side by side, with two deliberate differences:
+ *
+ * - the wall clock reading is [OpeningHoursTime] instead of `java.util.Calendar`, keeping the same
+ *   field numbering so the rule logic is unchanged;
+ * - the canonical OSM day and month names are constants here. The Java version derived them from
+ *   `DateFormatSymbols.getInstance(Locale.US)`, which made the canonical output of [toRuleString]
+ *   depend on the JVM's locale data. They are fixed OSM vocabulary, not locale data.
+ *
+ * Localized names and 12 hour formatting still come from the platform, through [PlatformDateNames].
+ */
+object OpeningHoursParser {
+
+	/** Canonical OSM weekday tokens, indexed like `Calendar.DAY_OF_WEEK`: 1 is Sunday. */
+	private val daysStr = arrayOf("", "Su", "Mo", "Tu", "We", "Th", "Fr", "Sa")
+
+	/** Canonical OSM month tokens, index 0 is January. */
+	private val monthsStr =
+		arrayOf("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+
+	private var localDaysStr: Array<String> = daysStr
+	private var localMothsStr: Array<String> = monthsStr
+
+	private val additionalStrings = mutableMapOf(
+		"off" to "off",
+		"is_open" to "Open",
+		"is_open_24_7" to "Open 24/7",
+		"is_open_24_7_short" to "24/7",
+		"will_open_at" to "Will open at",
+		"will_open_at_short" to "From",
+		"open_from" to "Open from",
+		"open_from_short" to "From",
+		"will_close_at" to "Will close at",
+		"will_close_at_short" to "Until",
+		"open_till" to "Open until",
+		"open_till_short" to "Until",
+		"will_open_tomorrow_at" to "Will open tomorrow at",
+		"will_open_tomorrow_at_short" to "Tomorrow",
+		"will_open_on" to "Will open on",
+		"will_open_on_short" to "From"
+	)
+
+	private const val LOW_TIME_LIMIT = 120
+	private const val WITHOUT_TIME_LIMIT = -1
+	private const val CURRENT_DAY_TIME_LIMIT = -2
+
+	private const val NO_TIME_MINUTES = -1
+	private const val NO_NTH_WEEKDAY = 0
+	private const val FIRST_NTH_WEEKDAY = 1
+	private const val LAST_NTH_WEEKDAY = 5
+	private const val DAYS_IN_WEEK = 7
+	private const val NTH_WEEKDAY_FROM_END_OFFSET = LAST_NTH_WEEKDAY
+
+	private var twelveHourFormatting = false
+	private var twelveHourLanguageTag: String? = null
+
+	init {
+		initLocalStrings(null)
+	}
+
+	/**
+	 * Reloads the localized day and month names for [languageTag], or the device language when null.
+	 */
+	@JvmStatic
+	fun initLocalStrings(languageTag: String?) {
+		localMothsStr = PlatformDateNames.shortMonths(languageTag)
+		localDaysStr = getLettersStringArray(PlatformDateNames.shortWeekdays(languageTag), 3)
+	}
+
+	@JvmStatic
+	fun setTwelveHourFormattingEnabled(enabled: Boolean, languageTag: String?) {
+		twelveHourFormatting = enabled
+		twelveHourLanguageTag = languageTag
+	}
+
+	/** Sets a localized string such as "off". */
+	@JvmStatic
+	fun setAdditionalString(key: String, value: String) {
+		additionalStrings[key] = value
+	}
+
+	private fun getLettersStringArray(strings: Array<String>, letters: Int): Array<String> =
+		Array(strings.size) { i ->
+			val value = strings[i]
+			val trimmed = if (value.length > letters) value.substring(0, letters) else value
+			KAlgorithms.capitalizeFirstLetter(trimmed) ?: ""
+		}
+
+	private fun getDayIndex(i: Int): Int = when (i) {
+		// the values of Calendar.MONDAY through Calendar.SUNDAY
+		0 -> 2
+		1 -> 3
+		2 -> 4
+		3 -> 5
+		4 -> 6
+		5 -> 7
+		6 -> 1
+		else -> -1
+	}
+
+	/**
+	 * The whole opening hours schema of one feature, able to answer directly whether it is open.
+	 */
+	class OpeningHours : PlatformSerializable {
+
+		private val rules: MutableList<OpeningHoursRule>
+		private var original: String? = null
+		private var sequenceCount = 0
+
+		constructor(rules: MutableList<OpeningHoursRule>) {
+			this.rules = rules
+		}
+
+		constructor() {
+			this.rules = ArrayList()
+		}
+
+		/** A human readable summary of the state at one moment. */
+		class Info {
+
+			var opened = false
+				internal set
+			var opened24_7 = false
+				internal set
+			var fallback = false
+				internal set
+			internal var openingTime: String? = null
+			internal var nearToOpeningTime: String? = null
+			internal var closingTime: String? = null
+			internal var nearToClosingTime: String? = null
+			internal var openingTomorrow: String? = null
+			internal var openingDay: String? = null
+			internal var ruleString: String? = null
+
+			fun isOpened(): Boolean = opened
+
+			fun isOpened24_7(): Boolean = opened24_7
+
+			fun isFallback(): Boolean = fallback
+
+			fun getInfo(): String = getInfo(false)
+
+			fun getShortInfo(): String = getInfo(true)
+
+			private fun getInfo(brief: Boolean): String {
+				return if (isOpened24_7()) {
+					if (!isFallback()) {
+						if (!KAlgorithms.isEmpty(ruleString)) {
+							if (brief) ruleString!! else additional("is_open") + " " + ruleString
+						} else {
+							additional(if (brief) "is_open_24_7_short" else "is_open_24_7")
+						}
+					} else {
+						if (!KAlgorithms.isEmpty(ruleString)) ruleString!! else ""
+					}
+				} else if (!KAlgorithms.isEmpty(nearToOpeningTime)) {
+					formatInfo(if (brief) "will_open_at_short" else "will_open_at", nearToOpeningTime!!)
+				} else if (!KAlgorithms.isEmpty(openingTime)) {
+					formatInfo(if (brief) "open_from_short" else "open_from", openingTime!!)
+				} else if (!KAlgorithms.isEmpty(nearToClosingTime)) {
+					formatInfo(if (brief) "will_close_at_short" else "will_close_at", nearToClosingTime!!)
+				} else if (!KAlgorithms.isEmpty(closingTime)) {
+					formatInfo(if (brief) "open_till_short" else "open_till", closingTime!!)
+				} else if (!KAlgorithms.isEmpty(openingTomorrow)) {
+					formatInfo(if (brief) "will_open_tomorrow_at_short" else "will_open_tomorrow_at", openingTomorrow!!)
+				} else if (!KAlgorithms.isEmpty(openingDay)) {
+					val value = if (brief) openingDay!! else openingDay + "."
+					formatInfo(if (brief) "will_open_on_short" else "will_open_on", value)
+				} else {
+					if (!KAlgorithms.isEmpty(ruleString)) ruleString!! else ""
+				}
+			}
+
+			private fun additional(key: String): String = additionalStrings[key] ?: ""
+
+			private fun formatInfo(key: String, value: String): String {
+				val prefix = additionalStrings[key]
+				return if (KAlgorithms.isEmpty(prefix)) value else "$prefix $value"
+			}
+		}
+
+		fun getInfo(): List<Info>? = getInfo(OpeningHoursTime.now())
+
+		fun getInfo(cal: OpeningHoursTime): List<Info>? {
+			val res = ArrayList<Info>()
+			for (i in 0 until sequenceCount) {
+				res.add(getInfo(cal, i))
+			}
+			return if (res.isEmpty()) null else res
+		}
+
+		fun getCombinedInfo(): Info = getCombinedInfo(OpeningHoursTime.now())
+
+		fun getCombinedInfo(cal: OpeningHoursTime): Info = getInfo(cal, ALL_SEQUENCES)
+
+		private fun getInfo(cal: OpeningHoursTime, sequenceIndex: Int): Info {
+			val info = Info()
+			val opened = isOpenedForTimeV2(cal, sequenceIndex)
+			info.fallback = isFallBackRule(sequenceIndex)
+			info.opened = opened
+			info.ruleString = getCurrentRuleTime(cal, sequenceIndex)
+			if (opened) {
+				info.opened24_7 = isOpened24_7(sequenceIndex)
+				info.closingTime = getClosingTime(cal, sequenceIndex)
+				info.nearToClosingTime = getNearToClosingTime(cal, sequenceIndex)
+			} else {
+				info.openingTime = getOpeningTime(cal, sequenceIndex)
+				info.nearToOpeningTime = getNearToOpeningTime(cal, sequenceIndex)
+				info.openingTomorrow = getOpeningTomorrow(cal, sequenceIndex)
+				info.openingDay = getOpeningDay(cal, sequenceIndex)
+			}
+			return info
+		}
+
+		fun addRule(r: OpeningHoursRule) {
+			rules.add(r)
+		}
+
+		fun addRules(rules: List<OpeningHoursRule>) {
+			this.rules.addAll(rules)
+		}
+
+		fun getSequenceCount(): Int = sequenceCount
+
+		fun setSequenceCount(sequenceCount: Int) {
+			this.sequenceCount = sequenceCount
+		}
+
+		fun getRules(): MutableList<OpeningHoursRule> = rules
+
+		fun getRules(sequenceIndex: Int): MutableList<OpeningHoursRule> {
+			if (sequenceIndex == ALL_SEQUENCES) {
+				return rules
+			}
+			val sequenceRules = ArrayList<OpeningHoursRule>()
+			for (r in rules) {
+				if (r.getSequenceIndex() == sequenceIndex) {
+					sequenceRules.add(r)
+				}
+			}
+			return sequenceRules
+		}
+
+		/**
+		 * Checks whether the feature is open at [cal], starting from the most specific rule.
+		 */
+		fun isOpenedForTimeV2(cal: OpeningHoursTime, sequenceIndex: Int): Boolean {
+			// make an exception for overlapping times, i.e.
+			// (1) Mo 14:00-16:00; Tu off
+			// (2) Mo 14:00-02:00; Tu off
+			// in (2) the first rule must be checked even though it is against the specification,
+			// because many OSM features are still tagged that way
+			val rules = getRules(sequenceIndex)
+			val overlap = hasRulesOverlapDayBackwardCompatible(rules)
+			for (i in rules.indices.reversed()) {
+				val rule = rules[i]
+				if (rule.contains(cal)) {
+					if (isTimeRestrictedOffRule(rule)) {
+						return false
+					}
+					val checkNextNotNeeded = overlap || !isCheckNextNeeded(cal, rules, i, rule)
+					val open = rule.isOpenedForTime(cal)
+					if (open || !checkNextNotNeeded) {
+						return open
+					}
+				}
+			}
+			return false
+		}
+
+		fun isOpenedForTime(cal: OpeningHoursTime): Boolean = isOpenedForTimeV2(cal, ALL_SEQUENCES)
+
+		/** Convenience for callers holding an instant rather than a wall clock reading. */
+		fun isOpenedForTime(epochMillis: Long): Boolean =
+			isOpenedForTime(OpeningHoursTime.ofEpochMillis(epochMillis))
+
+		fun isOpenedForTime(cal: OpeningHoursTime, sequenceIndex: Int): Boolean {
+			// first check the rules that contain the current day, then the rules that contain the
+			// previous day with times overlapping past midnight
+			var isOpenDay = false
+			val rules = getRules(sequenceIndex)
+			for (r in rules) {
+				if (r.containsDay(cal) && r.containsMonth(cal)) {
+					isOpenDay = r.isOpenedForTime(cal, false)
+				}
+			}
+			var isOpenPrevious = false
+			for (r in rules) {
+				if (r.containsPreviousDay(cal) && r.containsMonth(cal)) {
+					isOpenPrevious = r.isOpenedForTime(cal, true)
+				}
+			}
+			return isOpenDay || isOpenPrevious
+		}
+
+		fun isOpened24_7(sequenceIndex: Int): Boolean {
+			var opened24_7 = false
+			for (r in getRules(sequenceIndex)) {
+				opened24_7 = r.isOpened24_7()
+			}
+			return opened24_7
+		}
+
+		fun getNearToOpeningTime(cal: OpeningHoursTime, sequenceIndex: Int): String =
+			getTime(cal, LOW_TIME_LIMIT, true, sequenceIndex)
+
+		fun getOpeningTime(cal: OpeningHoursTime, sequenceIndex: Int): String =
+			getTime(cal, CURRENT_DAY_TIME_LIMIT, true, sequenceIndex)
+
+		fun getNearToClosingTime(cal: OpeningHoursTime, sequenceIndex: Int): String =
+			getTime(cal, LOW_TIME_LIMIT, false, sequenceIndex)
+
+		fun getClosingTime(cal: OpeningHoursTime, sequenceIndex: Int): String =
+			getTime(cal, WITHOUT_TIME_LIMIT, false, sequenceIndex)
+
+		fun getOpeningTomorrow(calendar: OpeningHoursTime, sequenceIndex: Int): String {
+			val cal = calendar.copy()
+			var openingTime = ""
+			val rules = getRules(sequenceIndex)
+			cal.addDays(1)
+			var openingTimeCal: OpeningHoursTime? = null
+			var openingRule: OpeningHoursRule? = null
+			for (r in rules) {
+				if (r.contains(cal)) {
+					val time = r.getTime(cal, false, WITHOUT_TIME_LIMIT, true)
+					if (KAlgorithms.isEmpty(time) || openingTimeCal == null || cal.isBefore(openingTimeCal)
+						|| r.hasOverlapTimes(cal, openingRule, false)
+					) {
+						openingTime = time
+						openingRule = r
+					}
+					openingTimeCal = cal.copy()
+				}
+			}
+			return openingTime
+		}
+
+		fun getOpeningDay(calendar: OpeningHoursTime, sequenceIndex: Int): String {
+			val cal = calendar.copy()
+			var openingTime = ""
+			val rules = getRules(sequenceIndex)
+			for (i in 0 until 7) {
+				cal.addDays(1)
+				var openingRule: OpeningHoursRule? = null
+				var openingTimeCal: OpeningHoursTime? = null
+				for (r in rules) {
+					if (r.contains(cal)) {
+						val time = r.getTime(cal, false, WITHOUT_TIME_LIMIT, true)
+						if (KAlgorithms.isEmpty(time) || openingTimeCal == null || cal.isBefore(openingTimeCal)
+							|| r.hasOverlapTimes(cal, openingRule, false)
+						) {
+							openingTime = time
+							openingRule = r
+						}
+						openingTimeCal = cal.copy()
+					}
+				}
+				if (!KAlgorithms.isEmpty(openingTime)) {
+					openingTime += " " + localDaysStr[cal.dayOfWeek]
+					break
+				}
+			}
+			return openingTime
+		}
+
+		private fun getTime(cal: OpeningHoursTime, limit: Int, opening: Boolean, sequenceIndex: Int): String {
+			if (!opening) {
+				// an overnight session of the previous day which is still open ends before anything
+				// the rules of the current day contribute (like "Fr 09:00-16:30" while a
+				// "Mo-Th 09:00-00:30" session is running at Friday 00:15)
+				val spillOverClosing = getSpillOverClosing(cal, limit, sequenceIndex)
+				if (!KAlgorithms.isEmpty(spillOverClosing)) {
+					return spillOverClosing
+				}
+			}
+			var time = getTimeDay(cal, limit, opening, sequenceIndex)
+			if (KAlgorithms.isEmpty(time)) {
+				time = getTimeAnotherDay(cal, limit, opening, sequenceIndex)
+			}
+			return time
+		}
+
+		private fun getSpillOverClosing(cal: OpeningHoursTime, limit: Int, sequenceIndex: Int): String {
+			for (r in getRules(sequenceIndex)) {
+				if (r.containsPreviousDay(cal) && r.containsMonth(cal) && r.isOpenedForTime(cal, true)) {
+					return r.getTime(cal, true, limit, false)
+				}
+			}
+			return ""
+		}
+
+		private fun getTimeDay(cal: OpeningHoursTime, limit: Int, opening: Boolean, sequenceIndex: Int): String {
+			var atTime = ""
+			var atTimeMinutes = NO_TIME_MINUTES
+			val rules = getRules(sequenceIndex)
+			var prevRule: OpeningHoursRule? = null
+			for (r in rules) {
+				val appliesToDay = appliesToDay(r, cal)
+				val timeRestrictedOff = isTimeRestrictedOffRule(r)
+				val checkOffRule = timeRestrictedOff && (appliesToDay || (!opening && atTimeMinutes >= 0))
+				if (!appliesToDay && !checkOffRule) {
+					continue
+				}
+				if (appliesToDay && atTime.isNotEmpty() && prevRule != null && !r.hasOverlapTimes(cal, prevRule, true)) {
+					return atTime
+				}
+				if (checkOffRule && r is BasicOpeningHourRule) {
+					// rules like "Jul-Aug 19:00-19:30 off" make only their own time ranges "off",
+					// so they adjust a time found by previous rules instead of discarding it
+					val currentTimeMinutes = cal.hourOfDay * 60 + cal.minute
+					if (opening) {
+						val offLimit = if (limit == CURRENT_DAY_TIME_LIMIT) WITHOUT_TIME_LIMIT else limit
+						val offTimeMinutes = r.getTimeMinutes(cal, false, offLimit, true)
+						val currentlyOff = offTimeMinutes != NO_TIME_MINUTES && r.containsTime(currentTimeMinutes)
+								&& prevRule is BasicOpeningHourRule && prevRule.containsTime(offTimeMinutes)
+						if (offTimeMinutes != NO_TIME_MINUTES &&
+							((atTimeMinutes >= 0 && r.containsTime(atTimeMinutes)) || currentlyOff)
+						) {
+							// the opening time found before is turned off, it moves to the end of the "off" range
+							atTimeMinutes = offTimeMinutes
+							atTime = r.formatResult(offTimeMinutes)
+						}
+					} else {
+						val offTimeAbsolute = getNextTimeRestrictedOffStart(cal, r, limit)
+						val atTimeAbsolute =
+							if (atTimeMinutes < currentTimeMinutes) atTimeMinutes + 24 * 60 else atTimeMinutes
+						if (offTimeAbsolute != NO_TIME_MINUTES && offTimeAbsolute < atTimeAbsolute) {
+							// the "off" range starts before the closing time found before, so it closes earlier
+							atTimeMinutes = offTimeAbsolute % (24 * 60)
+							atTime = r.formatResult(atTimeMinutes)
+						}
+					}
+				} else if (appliesToDay && r is BasicOpeningHourRule) {
+					atTimeMinutes = r.getTimeMinutes(cal, false, limit, opening)
+					val displayTimeMinutes = atTimeMinutes
+					if (!opening && atTimeMinutes == NO_TIME_MINUTES && limit != WITHOUT_TIME_LIMIT) {
+						atTimeMinutes = r.getTimeMinutes(cal, false, WITHOUT_TIME_LIMIT, false)
+					}
+					atTime = r.formatResult(displayTimeMinutes)
+				} else if (appliesToDay) {
+					atTime = r.getTime(cal, false, limit, opening)
+					atTimeMinutes = NO_TIME_MINUTES
+				}
+				if (appliesToDay) {
+					prevRule = r
+				}
+			}
+			return atTime
+		}
+
+		private fun getNextTimeRestrictedOffStart(cal: OpeningHoursTime, offRule: BasicOpeningHourRule, limit: Int): Int {
+			val currentTimeMinutes = cal.hourOfDay * 60 + cal.minute
+			var nextTime = NO_TIME_MINUTES
+			val ruleCal = cal.copy()
+			for (dayOffset in 0..1) {
+				if (appliesToDay(offRule, ruleCal)) {
+					for (i in 0 until offRule.timesSize()) {
+						val timeMinutes = offRule.getStartTime(i)
+						val absoluteMinutes = dayOffset * 24 * 60 + timeMinutes
+						val diff = absoluteMinutes - currentTimeMinutes
+						if (diff >= 0 && (limit == WITHOUT_TIME_LIMIT || diff <= limit)
+							&& (nextTime == NO_TIME_MINUTES || absoluteMinutes < nextTime)
+						) {
+							nextTime = absoluteMinutes
+						}
+					}
+				}
+				ruleCal.addDays(1)
+			}
+			return nextTime
+		}
+
+		/**
+		 * Whether the rule applies to the calendar day of [cal], including rules defined by day-month
+		 * or year ranges (like "Dec 24-Dec 31 off") which set no weekdays.
+		 */
+		private fun appliesToDay(r: OpeningHoursRule, cal: OpeningHoursTime): Boolean {
+			if (r is BasicOpeningHourRule) {
+				return r.appliesToDay(cal)
+			}
+			return r.containsDay(cal) && r.containsMonth(cal)
+		}
+
+		private fun isTimeRestrictedOffRule(r: OpeningHoursRule): Boolean =
+			r is BasicOpeningHourRule && r.isOff() && r.timesSize() > 0
+
+		private fun getTimeAnotherDay(cal: OpeningHoursTime, limit: Int, opening: Boolean, sequenceIndex: Int): String {
+			var atTime = ""
+			for (r in getRules(sequenceIndex)) {
+				if (((opening && r.containsPreviousDay(cal)) || (!opening && r.containsNextDay(cal))) && r.containsMonth(cal)) {
+					atTime = r.getTime(cal, true, limit, opening)
+				}
+			}
+			return atTime
+		}
+
+		fun getCurrentRuleTime(cal: OpeningHoursTime): String? = getCurrentRuleTime(cal, ALL_SEQUENCES)
+
+		fun isFallBackRule(sequenceIndex: Int): Boolean {
+			if (sequenceIndex != ALL_SEQUENCES) {
+				val rules = getRules(sequenceIndex)
+				return rules.isNotEmpty() && rules[0].isFallbackRule()
+			}
+			return false
+		}
+
+		fun getCurrentRuleTime(cal: OpeningHoursTime, sequenceIndex: Int): String? {
+			// see the note in isOpenedForTimeV2 about overlapping times
+			val rules = getRules(sequenceIndex)
+			var ruleClosed: String? = null
+			val overlap = hasRulesOverlapDayBackwardCompatible(rules)
+			for (i in rules.indices.reversed()) {
+				val rule = rules[i]
+				if (rule.contains(cal)) {
+					if (isTimeRestrictedOffRule(rule)) {
+						return rule.toLocalRuleString()
+					}
+					val checkNextNotNeeded = overlap || !isCheckNextNeeded(cal, rules, i, rule)
+					val open = rule.isOpenedForTime(cal)
+					if (open || !checkNextNotNeeded) {
+						return rule.toLocalRuleString()
+					} else {
+						ruleClosed = rule.toLocalRuleString()
+					}
+				}
+			}
+			return ruleClosed
+		}
+
+		private fun isCheckNextNeeded(
+			cal: OpeningHoursTime,
+			rules: MutableList<OpeningHoursRule>,
+			i: Int,
+			rule: OpeningHoursRule
+		): Boolean {
+			var checkNext = true
+			if (i > 0) {
+				for (j in i downTo 1) {
+					checkNext = rule.hasOverlapTimes(cal, rules[j - 1], false)
+					if (checkNext) {
+						break
+					}
+				}
+			}
+			return checkNext
+		}
+
+		private fun hasRulesOverlapDayBackwardCompatible(rules: MutableList<OpeningHoursRule>): Boolean {
+			for (i in rules.indices.reversed()) {
+				if (rules[i].hasOverlapTimesOverDay()) {
+					return true
+				}
+			}
+			return false
+		}
+
+		fun getCurrentRuleTimeV1(cal: OpeningHoursTime): String? {
+			var ruleOpen: String? = null
+			var ruleClosed: String? = null
+			for (r in rules) {
+				if (r.containsPreviousDay(cal) && r.containsMonth(cal)) {
+					if (r.isOpenedForTime(cal, true)) {
+						ruleOpen = r.toLocalRuleString()
+					} else {
+						ruleClosed = r.toLocalRuleString()
+					}
+				}
+			}
+			for (r in rules) {
+				if (r.containsDay(cal) && r.containsMonth(cal)) {
+					if (r.isOpenedForTime(cal, false)) {
+						ruleOpen = r.toLocalRuleString()
+					} else {
+						ruleClosed = r.toLocalRuleString()
+					}
+				}
+			}
+			return ruleOpen ?: ruleClosed
+		}
+
+		override fun toString(): String {
+			if (rules.isEmpty()) {
+				return ""
+			}
+			val s = StringBuilder()
+			for (r in rules) {
+				s.append(r.toString()).append("; ")
+			}
+			return s.substring(0, s.length - 2)
+		}
+
+		fun toLocalString(): String {
+			if (rules.isEmpty()) {
+				return ""
+			}
+			val s = StringBuilder()
+			for (r in rules) {
+				s.append(r.toLocalRuleString()).append("; ")
+			}
+			return s.substring(0, s.length - 2)
+		}
+
+		fun setOriginal(original: String?) {
+			this.original = original
+		}
+
+		fun getOriginal(): String? = original
+
+		companion object {
+			const val ALL_SEQUENCES = -1
+		}
+	}
+
+	/**
+	 * One rule: a collection of days or dates, plus a time range.
+	 */
+	interface OpeningHoursRule : PlatformSerializable {
+
+		/**
+		 * Whether the feature is open at [cal] for this rule. [checkPrevious] selects only the times
+		 * that overflow past midnight from the previous day.
+		 */
+		fun isOpenedForTime(cal: OpeningHoursTime, checkPrevious: Boolean): Boolean
+
+		fun isOpenedForTime(cal: OpeningHoursTime): Boolean
+
+		/** Whether the day before [cal] is part of this rule. */
+		fun containsPreviousDay(cal: OpeningHoursTime): Boolean
+
+		/** Whether the day of [cal] is part of this rule. */
+		fun containsDay(cal: OpeningHoursTime): Boolean
+
+		/** Whether the day after [cal] is part of this rule. */
+		fun containsNextDay(cal: OpeningHoursTime): Boolean
+
+		/** Whether the month of [cal] is part of this rule. */
+		fun containsMonth(cal: OpeningHoursTime): Boolean
+
+		/** Whether the rule overlaps into the next day. */
+		fun hasOverlapTimesOverDay(): Boolean
+
+		/**
+		 * Whether the times of [r] overlap the times of this rule at [cal]. [strictOverlap] also
+		 * counts a touching boundary, where one range ends exactly as the other starts.
+		 */
+		fun hasOverlapTimes(cal: OpeningHoursTime, r: OpeningHoursRule?, strictOverlap: Boolean): Boolean
+
+		/** Whether the rule applies at all at [cal], open or closed. */
+		fun contains(cal: OpeningHoursTime): Boolean
+
+		fun getSequenceIndex(): Int
+
+		fun isFallbackRule(): Boolean
+
+		fun toRuleString(): String
+
+		fun toLocalRuleString(): String
+
+		fun isOpened24_7(): Boolean
+
+		fun getTime(cal: OpeningHoursTime, checkAnotherDay: Boolean, limit: Int, opening: Boolean): String
+	}
+
+	/**
+	 * The basic rule: months, days of the week and numeric times, or the value "off".
+	 */
+	class BasicOpeningHourRule(private val sequenceIndex: Int) : OpeningHoursRule {
+
+		constructor() : this(0)
+
+		/** Open days, index 0 is Monday. */
+		private var days = BooleanArray(7)
+
+		internal var hasDays = false
+
+		/** Per day masks for nth weekday restrictions such as "Su[1]", see parseNthMask. */
+		private val dayNth = IntArray(7)
+
+		/** Open months, index 0 is January. */
+		internal val months = BooleanArray(12)
+
+		/** Holds YEAR for the valid months of the first year: [0, 0, ... YEAR, YEAR, ... 0]. */
+		internal var firstYearMonths: IntArray? = null
+		internal var firstYearDayMonth: Array<BooleanArray>? = null
+		internal var lastYearMonths: IntArray? = null
+		internal var lastYearDayMonth: Array<BooleanArray>? = null
+		internal var year = 0
+
+		internal var fallback = false
+
+		/** Open days per month. */
+		private var dayMonths: Array<BooleanArray>? = null
+
+		/** Equally sized lists of the start and end times. */
+		internal val startTimes = KTIntArrayList()
+		internal val endTimes = KTIntArrayList()
+
+		internal var publicHoliday = false
+		internal var schoolHoliday = false
+		internal var easter = false
+
+		/** Whether the times of this rule mean the feature is closed. */
+		internal var off = false
+
+		/**
+		 * Free text limitation,
+		 * see https://wiki.openstreetmap.org/wiki/Key:opening_hours/specification#explain:comment
+		 */
+		private var comment: String? = null
+
+		override fun getSequenceIndex(): Int = sequenceIndex
+
+		override fun isFallbackRule(): Boolean = fallback
+
+		fun getDays(): BooleanArray = days
+
+		fun getDayMonths(month: Int): BooleanArray {
+			val current = dayMonths ?: Array(12) { BooleanArray(31) }.also { dayMonths = it }
+			return current[month]
+		}
+
+		fun hasDayMonths(): Boolean = dayMonths != null
+
+		fun getMonths(): BooleanArray = months
+
+		fun appliesToPublicHolidays(): Boolean = publicHoliday
+
+		fun appliesEaster(): Boolean = easter
+
+		fun appliesToSchoolHolidays(): Boolean = schoolHoliday
+
+		fun getComment(): String? = comment
+
+		fun setComment(comment: String?) {
+			this.comment = comment
+		}
+
+		/** Sets a single start time, erasing all previously added start times. */
+		fun setStartTime(s: Int) {
+			setSingleValue(startTimes, s)
+			if (endTimes.size != 1) {
+				setSingleValue(endTimes, 0)
+			}
+		}
+
+		/** Sets a single end time, erasing all previously added end times. */
+		fun setEndTime(e: Int) {
+			setSingleValue(endTimes, e)
+			if (startTimes.size != 1) {
+				setSingleValue(startTimes, 0)
+			}
+		}
+
+		/**
+		 * Writes the start time at [position], appending when [position] is one past the last item.
+		 */
+		fun setStartTime(s: Int, position: Int) {
+			if (position == startTimes.size) {
+				startTimes.add(s)
+				endTimes.add(0)
+			} else {
+				startTimes[position] = s
+			}
+		}
+
+		/**
+		 * Writes the end time at [position], appending when [position] is one past the last item.
+		 */
+		fun setEndTime(s: Int, position: Int) {
+			if (position == startTimes.size) {
+				endTimes.add(s)
+				startTimes.add(0)
+			} else {
+				endTimes[position] = s
+			}
+		}
+
+		fun getStartTime(): Int = if (startTimes.size == 0) 0 else startTimes[0]
+
+		fun getStartTime(position: Int): Int = startTimes[position]
+
+		fun getEndTime(): Int = if (endTimes.size == 0) 0 else endTimes[0]
+
+		fun getEndTime(position: Int): Int = endTimes[position]
+
+		/** An independent copy of all start times. */
+		fun getStartTimes(): KTIntArrayList = KTIntArrayList(startTimes.toArray())
+
+		/** An independent copy of all end times. */
+		fun getEndTimes(): KTIntArrayList = KTIntArrayList(endTimes.toArray())
+
+		fun setDays(days: BooleanArray) {
+			if (this.days.size == days.size) {
+				this.days = days
+			}
+		}
+
+		override fun containsDay(cal: OpeningHoursTime): Boolean {
+			val i = cal.dayOfWeek
+			val d = (i + 5) % 7
+			return days[d]
+		}
+
+		override fun containsNextDay(cal: OpeningHoursTime): Boolean {
+			val i = cal.dayOfWeek
+			val p = (i + 6) % 7
+			return days[p]
+		}
+
+		override fun containsPreviousDay(cal: OpeningHoursTime): Boolean {
+			val i = cal.dayOfWeek
+			val p = (i + 4) % 7
+			return days[p]
+		}
+
+		override fun containsMonth(cal: OpeningHoursTime): Boolean {
+			val month = cal.month
+			val year = cal.year
+			if (!hasYears()) {
+				return (this.year == 0 || this.year == year) && months[month]
+			}
+			if (this.year > year) {
+				return false
+			} else if (this.year < year) {
+				val lastYearMonths = this.lastYearMonths ?: return false
+				val lastYear = lastYearMonths[month]
+				return lastYear > 0 && year <= lastYear
+			} else {
+				return firstYearMonths!![month] > 0
+			}
+		}
+
+		override fun isOpenedForTime(cal: OpeningHoursTime, checkPrevious: Boolean): Boolean {
+			val d = getCurrentDay(cal)
+			val p = getPreviousDay(d)
+			val time = getCurrentTimeInMinutes(cal)
+			for (i in 0 until startTimes.size) {
+				val startTime = startTimes[i]
+				val endTime = endTimes[i]
+				if (startTime < endTime || endTime == -1) {
+					// a single day range such as 10:00-20:00, not 20:00-04:00
+					if (days[d] && matchesDayNth(d, cal) && !checkPrevious) {
+						if (time >= startTime && (endTime == -1 || time <= endTime)) {
+							return !off
+						}
+					}
+				} else {
+					// the range wraps past midnight, like "We 20:00-03:00" or "We 07:00-07:00"
+					if (time >= startTime && days[d] && matchesDayNth(d, cal) && !checkPrevious) {
+						return !off
+					} else if (time < endTime && days[p] && matchesPreviousDayNth(p, cal) && checkPrevious) {
+						return !off
+					}
+				}
+			}
+			return false
+		}
+
+		private fun getCurrentDay(cal: OpeningHoursTime): Int = (cal.dayOfWeek + 5) % 7
+
+		private fun getPreviousDay(currentDay: Int): Int {
+			var p = currentDay - 1
+			if (p < 0) {
+				p += 7
+			}
+			return p
+		}
+
+		private fun getNextDay(currentDay: Int): Int {
+			var n = currentDay + 1
+			if (n > 6) {
+				n -= 7
+			}
+			return n
+		}
+
+		private fun getCurrentTimeInMinutes(cal: OpeningHoursTime): Int = cal.hourOfDay * 60 + cal.minute
+
+		override fun toRuleString(): String = toRuleString(false)
+
+		private fun toRuleString(useLocalization: Boolean): String {
+			val dayNames = if (useLocalization) localDaysStr else daysStr
+			val monthNames = if (useLocalization) localMothsStr else monthsStr
+			val offStr = if (useLocalization) (additionalStrings["off"] ?: "off") else "off"
+
+			val b = StringBuilder(25)
+			var allMonths = true
+			for (month in months) {
+				if (!month) {
+					allMonths = false
+					break
+				}
+			}
+			val allDays = !hasDayMonths()
+			if (!allDays) {
+				val dayMonths = this.dayMonths!!
+				var dash = false
+				var first = true
+				var monthAdded = -1
+				var dayAdded = -1
+				var excludedMonthEnd = -1
+				var excludedDayEnd = -1
+				var excludedMonthStart = -1
+				var excludedDayStart = -1
+				if (dayMonths[0][0] && dayMonths[11][30]) {
+					var prevMonth = 0
+					var prevDay = 0
+					for (month in dayMonths.indices) {
+						for (day in dayMonths[month].indices) {
+							if (day == 1) {
+								prevMonth = month
+							}
+							if (!dayMonths[month][day]) {
+								excludedMonthEnd = prevMonth
+								excludedDayEnd = prevDay
+								break
+							}
+							prevDay = day
+						}
+						if (excludedDayEnd != -1) {
+							break
+						}
+					}
+					prevMonth = dayMonths.size - 1
+					prevDay = dayMonths[prevMonth].size - 1
+					for (month in dayMonths.indices.reversed()) {
+						for (day in dayMonths[month].indices.reversed()) {
+							if (day == dayMonths[month].size - 2) {
+								prevMonth = month
+							}
+							if (!dayMonths[month][day]) {
+								excludedMonthStart = prevMonth
+								excludedDayStart = prevDay
+								break
+							}
+							prevDay = day
+						}
+						if (excludedDayStart != -1) {
+							break
+						}
+					}
+				}
+				var yearAdded = false
+				for (month in dayMonths.indices) {
+					for (day in dayMonths[month].indices) {
+						if (excludedDayStart != -1 && excludedDayEnd != -1) {
+							if (month < excludedMonthEnd || (month == excludedMonthEnd && day <= excludedDayEnd)) {
+								continue
+							} else if (month > excludedMonthStart || (month == excludedMonthStart && day >= excludedDayStart)) {
+								continue
+							}
+						}
+						if (dayMonths[month][day]) {
+							if (day == 0 && dash && dayMonths[month][1]) {
+								continue
+							}
+							if (day > 0 && dayMonths[month][day - 1]
+								&& ((day < dayMonths[month].size - 1 && dayMonths[month][day + 1])
+										|| (day == dayMonths[month].size - 1 && month < dayMonths.size - 1 && dayMonths[month + 1][0]))
+							) {
+								if (!dash) {
+									dash = true
+									if (!first) {
+										b.append("-")
+									}
+								}
+								continue
+							}
+							if (first) {
+								first = false
+							} else if (!dash) {
+								b.append(", ")
+								monthAdded = -1
+							}
+							yearAdded = appendYearString(b, if (dash) lastYearMonths else firstYearMonths, month)
+							if (monthAdded != month || yearAdded) {
+								b.append(monthNames[month]).append(" ")
+								monthAdded = month
+							}
+							dayAdded = day + 1
+							b.append(dayAdded)
+							dash = false
+						}
+					}
+				}
+				if (excludedDayStart != -1 && excludedDayEnd != -1) {
+					if (first) {
+						first = false
+					} else if (!dash) {
+						b.append(", ")
+					}
+					appendYearString(b, firstYearMonths, excludedMonthStart)
+					b.append(monthNames[excludedMonthStart]).append(" ").append(excludedDayStart + 1).append("-")
+					appendYearString(b, lastYearMonths, excludedMonthEnd)
+					b.append(monthNames[excludedMonthEnd]).append(" ").append(excludedDayEnd + 1)
+				} else if (yearAdded && !dash && monthAdded != -1 && lastYearMonths != null) {
+					b.append("-")
+					appendYearString(b, lastYearMonths, monthAdded)
+					b.append(monthNames[monthAdded])
+					if (dayAdded != -1) {
+						b.append(" ").append(dayAdded)
+					}
+				}
+				if (!first) {
+					b.append(" ")
+				}
+			} else if (!allMonths) {
+				addArray(months, monthNames, b)
+			}
+
+			appendDaysString(b, dayNames)
+
+			if (startTimes.size == 0) {
+				if (isOpened24_7()) {
+					b.setLength(0)
+					if (!isFallbackRule()) {
+						b.append("24/7 ")
+					}
+				}
+				if (off) {
+					b.append(offStr)
+				}
+			} else {
+				if (isOpened24_7()) {
+					b.setLength(0)
+					b.append("24/7")
+				} else {
+					for (i in 0 until startTimes.size) {
+						if (i > 0) {
+							b.append(", ")
+						}
+						formatTimeRange(startTimes[i], endTimes[i], b)
+					}
+					if (off) {
+						b.append(" ").append(offStr)
+					}
+				}
+			}
+			val comment = this.comment
+			if (!KAlgorithms.isEmpty(comment)) {
+				if (b.isNotEmpty()) {
+					if (b[b.length - 1] != ' ') {
+						b.append(" ")
+					}
+					b.append("- ").append(comment)
+				} else {
+					b.append(comment)
+				}
+			}
+			return b.toString().trim()
+		}
+
+		private fun appendYearString(b: StringBuilder, yearMonths: IntArray?, month: Int): Boolean {
+			if (yearMonths != null && yearMonths[month] > 0) {
+				b.append(yearMonths[month]).append(" ")
+				return true
+			} else if (year > 0) {
+				b.append(year).append(" ")
+				return true
+			}
+			return false
+		}
+
+		private fun addArray(array: BooleanArray, arrayNames: Array<String>?, b: StringBuilder) {
+			var dash = false
+			var first = true
+			for (i in array.indices) {
+				if (array[i]) {
+					if (i > 0 && array[i - 1] && i < array.size - 1 && array[i + 1]) {
+						if (!dash) {
+							dash = true
+							b.append("-")
+						}
+						continue
+					}
+					if (first) {
+						first = false
+					} else if (!dash) {
+						b.append(", ")
+					}
+					b.append(if (arrayNames == null) (i + 1).toString() else arrayNames[i])
+					dash = false
+				}
+			}
+			if (!first) {
+				b.append(" ")
+			}
+		}
+
+		override fun toLocalRuleString(): String = toRuleString(true)
+
+		override fun isOpened24_7(): Boolean {
+			if (isOpenedEveryDay()) {
+				if (startTimes.size > 0) {
+					for (i in 0 until startTimes.size) {
+						if (startTimes[i] == 0 && endTimes[i] / 60 == 24) {
+							return true
+						}
+					}
+				} else {
+					return true
+				}
+			}
+			return false
+		}
+
+		fun isOpenedEveryDay(): Boolean {
+			for (i in 0 until 7) {
+				if (!days[i]) {
+					return false
+				}
+			}
+			return true
+		}
+
+		override fun getTime(cal: OpeningHoursTime, checkAnotherDay: Boolean, limit: Int, opening: Boolean): String =
+			formatResult(getTimeMinutes(cal, checkAnotherDay, limit, opening))
+
+		internal fun getTimeMinutes(cal: OpeningHoursTime, checkAnotherDay: Boolean, limit: Int, opening: Boolean): Int {
+			val d = getCurrentDay(cal)
+			val ad = if (opening) getNextDay(d) else getPreviousDay(d)
+			val time = getCurrentTimeInMinutes(cal)
+			for (i in 0 until startTimes.size) {
+				val startTime = startTimes[i]
+				val endTime = endTimes[i]
+				if (opening != off) {
+					if (startTime < endTime || endTime == -1) {
+						if (days[d] && !checkAnotherDay) {
+							val diff = startTime - time
+							// for "off" rules skip time ranges that are already over
+							if ((limit == WITHOUT_TIME_LIMIT && (!off || diff >= 0))
+								|| (time <= startTime && (diff <= limit || limit == CURRENT_DAY_TIME_LIMIT))
+							) {
+								return startTime
+							}
+						}
+					} else {
+						var diff = -1
+						if (time <= startTime && days[d] && !checkAnotherDay) {
+							diff = startTime - time
+						} else if (time > endTime && days[ad] && checkAnotherDay) {
+							diff = 24 * 60 - endTime + time
+						}
+						// don't accept the time if the day checks above didn't match (diff == -1),
+						// otherwise a "Mo-Th 09:00-00:30" rule reports Friday night as opening at 09:00
+						if (limit == WITHOUT_TIME_LIMIT || (diff != -1 && (diff <= limit || limit == CURRENT_DAY_TIME_LIMIT))) {
+							return startTime
+						}
+					}
+				} else {
+					if (startTime < endTime && endTime != -1) {
+						if (days[d] && !checkAnotherDay) {
+							val diff = endTime - time
+							if ((limit == WITHOUT_TIME_LIMIT && diff >= 0) || (time <= endTime && diff <= limit)) {
+								return endTime
+							}
+						}
+					} else {
+						var diff = -1
+						if ((time >= startTime || time <= endTime) && days[d] && !checkAnotherDay) {
+							// still inside an overnight session of the current day: the closing time is
+							// "endTime" on the next calendar day, so during the evening part
+							// (time >= startTime) the minutes to close must cross midnight
+							diff = 24 * 60 - time + endTime
+						} else if (time < endTime && days[ad] && checkAnotherDay) {
+							diff = endTime - time
+						}
+						if (limit == WITHOUT_TIME_LIMIT || (diff != -1 && diff <= limit)) {
+							return endTime
+						}
+					}
+				}
+			}
+			return NO_TIME_MINUTES
+		}
+
+		internal fun formatResult(timeMinutes: Int): String {
+			if (timeMinutes == NO_TIME_MINUTES) {
+				return ""
+			}
+			val sb = StringBuilder()
+			formatTime(timeMinutes, sb)
+			var res = sb.toString()
+			if (res.isNotEmpty() && !KAlgorithms.isEmpty(comment)) {
+				res += " - " + comment
+			}
+			return res
+		}
+
+		/** Whether [timeMinutes], counted from midnight, falls inside the time ranges of this rule. */
+		internal fun containsTime(timeMinutes: Int): Boolean {
+			for (i in 0 until startTimes.size) {
+				val startTime = startTimes[i]
+				val endTime = endTimes[i]
+				if (endTime == -1 || startTime >= endTime) {
+					// open ended or wrapping past midnight
+					if (timeMinutes >= startTime || (endTime != -1 && timeMinutes < endTime)) {
+						return true
+					}
+				} else if (timeMinutes >= startTime && timeMinutes < endTime) {
+					return true
+				}
+			}
+			return false
+		}
+
+		/**
+		 * Whether the rule applies to the calendar day of [cal], including rules defined by day-month
+		 * or year ranges which set no weekdays.
+		 */
+		fun appliesToDay(cal: OpeningHoursTime): Boolean {
+			if (!containsMonth(cal)) {
+				return false
+			}
+			val month = cal.month
+			val dmonth = cal.dayOfMonth - 1
+			var thisDay = true
+			if (hasYears()) {
+				thisDay = isOpened(cal.year, month, dmonth)
+			} else if (hasDayMonths()) {
+				thisDay = dayMonths!![month][dmonth]
+			}
+			return thisDay && (!hasDays || (containsDay(cal) && matchesDayNth(getCurrentDay(cal), cal)))
+		}
+
+		fun isOff(): Boolean = off
+
+		internal fun setDayNthMask(day: Int, mask: Int) {
+			dayNth[day] = mask
+		}
+
+		/** Whether the day of [cal] matches the nth weekday restriction of [day], such as "Su[1]". */
+		private fun matchesDayNth(day: Int, cal: OpeningHoursTime): Boolean {
+			if (dayNth[day] == NO_NTH_WEEKDAY) {
+				return true
+			}
+			val mask = dayNth[day]
+			val dayOfMonth = cal.dayOfMonth
+			val nthFromStart = (dayOfMonth - 1) / DAYS_IN_WEEK + 1
+			val nthFromEnd = (cal.daysInMonth - dayOfMonth) / DAYS_IN_WEEK + 1
+			return hasNthWeekday(mask, nthFromStart) || hasNthWeekday(mask, -nthFromEnd)
+		}
+
+		private fun matchesPreviousDayNth(previousDay: Int, cal: OpeningHoursTime): Boolean {
+			if (dayNth[previousDay] == NO_NTH_WEEKDAY) {
+				return true
+			}
+			val pcal = cal.copy()
+			pcal.addDays(-1)
+			return matchesDayNth(previousDay, pcal)
+		}
+
+		override fun toString(): String = toRuleString()
+
+		fun appendDaysString(builder: StringBuilder) {
+			appendDaysString(builder, daysStr)
+		}
+
+		fun appendDaysString(builder: StringBuilder, daysNames: Array<String>) {
+			var dash = false
+			var first = true
+			for (i in 0 until 7) {
+				if (days[i]) {
+					if (i > 0 && days[i - 1] && i < 6 && days[i + 1]) {
+						if (!dash) {
+							dash = true
+							builder.append("-")
+						}
+						continue
+					}
+					if (first) {
+						first = false
+					} else if (!dash) {
+						builder.append(", ")
+					}
+					builder.append(daysNames[getDayIndex(i)])
+					if (dayNth[i] != NO_NTH_WEEKDAY) {
+						appendNthString(builder, dayNth[i])
+					}
+					dash = false
+				}
+			}
+			if (publicHoliday) {
+				if (!first) {
+					builder.append(", ")
+				}
+				builder.append("PH")
+				first = false
+			}
+			if (schoolHoliday) {
+				if (!first) {
+					builder.append(", ")
+				}
+				builder.append("SH")
+				first = false
+			}
+			if (easter) {
+				if (!first) {
+					builder.append(", ")
+				}
+				builder.append("Easter")
+				first = false
+			}
+			if (!first) {
+				builder.append(" ")
+			}
+		}
+
+		/** Adds a time range to this rule. */
+		fun addTimeRange(startTime: Int, endTime: Int) {
+			startTimes.add(startTime)
+			endTimes.add(endTime)
+		}
+
+		fun timesSize(): Int = startTimes.size
+
+		fun deleteTimeRange(position: Int) {
+			startTimes.removeAt(position)
+			endTimes.removeAt(position)
+		}
+
+		override fun isOpenedForTime(cal: OpeningHoursTime): Boolean = calculate(cal) > 0
+
+		override fun contains(cal: OpeningHoursTime): Boolean = calculate(cal) != 0
+
+		override fun hasOverlapTimesOverDay(): Boolean {
+			for (i in 0 until startTimes.size) {
+				if (startTimes[i] >= endTimes[i] && endTimes[i] > 0) {
+					return true
+				}
+			}
+			return false
+		}
+
+		override fun hasOverlapTimes(cal: OpeningHoursTime, r: OpeningHoursRule?, strictOverlap: Boolean): Boolean {
+			if (off) {
+				return true
+			}
+			if (r != null && r.contains(cal) && r is BasicOpeningHourRule) {
+				if (startTimes.size > 0 && r.startTimes.size > 0) {
+					for (i in 0 until startTimes.size) {
+						val startTime = startTimes[i]
+						var endTime = endTimes[i]
+						if (endTime == -1) {
+							endTime = 24 * 60
+						} else if (startTime >= endTime) {
+							endTime = 24 * 60 + endTime
+						}
+						for (k in 0 until r.startTimes.size) {
+							val rStartTime = r.startTimes[k]
+							var rEndTime = r.endTimes[k]
+							if (rEndTime == -1) {
+								rEndTime = 24 * 60
+							} else if (rStartTime >= rEndTime) {
+								rEndTime = 24 * 60 + rEndTime
+							}
+							if ((rStartTime >= startTime && (if (strictOverlap) rStartTime <= endTime else rStartTime < endTime))
+								|| (startTime >= rStartTime && (if (strictOverlap) startTime <= rEndTime else startTime < rEndTime))
+							) {
+								return true
+							}
+						}
+					}
+				}
+			}
+			return false
+		}
+
+		private fun calculate(cal: OpeningHoursTime): Int {
+			val year = cal.year
+			val month = cal.month
+			if (!containsMonth(cal)) {
+				return 0
+			}
+			val dmonth = cal.dayOfMonth - 1
+			val i = cal.dayOfWeek
+			val day = (i + 5) % 7
+			val previous = (day + 6) % 7
+			var thisDay = true
+			if (hasYears()) {
+				thisDay = isOpened(year, month, dmonth)
+			} else if (hasDayMonths()) {
+				thisDay = dayMonths!![month][dmonth]
+			}
+			if (thisDay && hasDays) {
+				thisDay = days[day] && matchesDayNth(day, cal)
+			}
+			// potential error for Dec 31 12:00-01:00
+			var previousDay = true
+			if (hasYears()) {
+				if (dmonth > 0) {
+					previousDay = isOpened(year, month, dmonth - 1)
+				}
+			} else if (hasDayMonths() && dmonth > 0) {
+				previousDay = dayMonths!![month][dmonth - 1]
+			}
+			if (previousDay && hasDays) {
+				previousDay = days[previous] && matchesPreviousDayNth(previous, cal)
+			}
+			if (!thisDay && !previousDay) {
+				return 0
+			}
+			val time = cal.hourOfDay * 60 + cal.minute
+			for (k in 0 until startTimes.size) {
+				val startTime = startTimes[k]
+				val endTime = endTimes[k]
+				if (startTime < endTime || endTime == -1) {
+					// a single day range such as 10:00-20:00, not 20:00-04:00
+					if (time >= startTime && (endTime == -1 || time <= endTime) && thisDay) {
+						return if (off) -1 else 1
+					}
+				} else {
+					// the range wraps past midnight, like "We 20:00-03:00" or "We 07:00-07:00"
+					if (time >= startTime && thisDay) {
+						return if (off) -1 else 1
+					} else if (time < endTime && previousDay) {
+						return if (off) -1 else 1
+					}
+				}
+			}
+			if (thisDay && startTimes.isEmpty() && !off) {
+				return 1
+			} else if (thisDay && (startTimes.isEmpty() || !off)) {
+				return -1
+			}
+			return 0
+		}
+
+		private fun isOpened(year: Int, month: Int, dmonth: Int): Boolean {
+			var opened = hasDayMonths() && dayMonths!![month][dmonth]
+			if (hasYears()) {
+				if (year < this.year) {
+					opened = false
+				} else if (year == this.year) {
+					val firstYearDayMonth = this.firstYearDayMonth
+					opened = if (firstYearDayMonth != null) {
+						firstYearDayMonth[month][dmonth]
+					} else {
+						// year-only and year+month rules populate no day-month masks, so the month range decides
+						firstYearMonths!![month] > 0 && (!hasDayMonths() || dayMonths!![month][dmonth])
+					}
+				} else {
+					val lastYear = lastYearMonths!![month]
+					opened = if (year < lastYear) {
+						true
+					} else if (year == lastYear) {
+						val lastYearDayMonth = this.lastYearDayMonth
+						if (lastYearDayMonth != null) {
+							lastYearDayMonth[month][dmonth]
+						} else {
+							// mirror the first-year fallback for the final year of a multi-year range
+							lastYearMonths!![month] > 0 && (!hasDayMonths() || dayMonths!![month][dmonth])
+						}
+					} else {
+						false
+					}
+				}
+			}
+			return opened
+		}
+
+		private fun hasYears(): Boolean = firstYearMonths != null
+
+		companion object {
+
+			private fun setSingleValue(list: KTIntArrayList, s: Int) {
+				list.clear()
+				list.add(s)
+			}
+
+			private fun appendNthString(builder: StringBuilder, mask: Int) {
+				builder.append("[")
+				var first = true
+				for (nth in FIRST_NTH_WEEKDAY..LAST_NTH_WEEKDAY) {
+					first = appendNthValue(builder, mask, nth, first)
+				}
+				for (nth in -FIRST_NTH_WEEKDAY downTo -LAST_NTH_WEEKDAY) {
+					first = appendNthValue(builder, mask, nth, first)
+				}
+				builder.append("]")
+			}
+
+			private fun appendNthValue(builder: StringBuilder, mask: Int, nth: Int, first: Boolean): Boolean {
+				if (!hasNthWeekday(mask, nth)) {
+					return first
+				}
+				if (!first) {
+					builder.append(",")
+				}
+				builder.append(nth)
+				return false
+			}
+		}
+	}
+
+	/** A rule that could not be parsed; it never reports the feature as open. */
+	class UnparseableRule(private val ruleString: String) : OpeningHoursRule {
+
+		override fun isOpenedForTime(cal: OpeningHoursTime, checkPrevious: Boolean): Boolean = false
+
+		override fun isOpenedForTime(cal: OpeningHoursTime): Boolean = false
+
+		override fun containsPreviousDay(cal: OpeningHoursTime): Boolean = false
+
+		override fun containsDay(cal: OpeningHoursTime): Boolean = false
+
+		override fun containsNextDay(cal: OpeningHoursTime): Boolean = false
+
+		override fun containsMonth(cal: OpeningHoursTime): Boolean = false
+
+		override fun hasOverlapTimesOverDay(): Boolean = false
+
+		override fun hasOverlapTimes(cal: OpeningHoursTime, r: OpeningHoursRule?, strictOverlap: Boolean): Boolean = false
+
+		override fun contains(cal: OpeningHoursTime): Boolean = false
+
+		override fun getSequenceIndex(): Int = 0
+
+		override fun isFallbackRule(): Boolean = false
+
+		override fun toRuleString(): String = ruleString
+
+		override fun toLocalRuleString(): String = toRuleString()
+
+		override fun isOpened24_7(): Boolean = false
+
+		override fun getTime(cal: OpeningHoursTime, checkAnotherDay: Boolean, limit: Int, opening: Boolean): String = ""
+
+		override fun toString(): String = toRuleString()
+	}
+
+	private enum class TokenType(val ord: Int) {
+		TOKEN_UNKNOWN(0),
+		TOKEN_COLON(1),
+		TOKEN_COMMA(2),
+		TOKEN_DASH(3),
+
+		// the order matters
+		TOKEN_YEAR(4),
+		TOKEN_MONTH(5),
+		TOKEN_DAY_MONTH(6),
+		TOKEN_HOLIDAY(7),
+		TOKEN_DAY_WEEK(7),
+		TOKEN_HOUR_MINUTES(8),
+		TOKEN_OFF_ON(9),
+		TOKEN_COMMENT(10)
+	}
+
+	private class Token {
+
+		var mainNumber = -1
+		var nthMask = 0
+		var type: TokenType
+		var text: String
+		var parent: Token? = null
+
+		constructor(tokenType: TokenType, string: String) {
+			type = tokenType
+			text = string
+			if (string.isNotEmpty() && string[string.length - 1].isDigit()
+				&& (string[0].isDigit() || string[0] == '-' || string[0] == '+')
+			) {
+				mainNumber = KAlgorithms.parseIntSilently(string, -1)
+			}
+		}
+
+		constructor(tokenType: TokenType, tokenMainNumber: Int) {
+			type = tokenType
+			mainNumber = tokenMainNumber
+			text = mainNumber.toString()
+		}
+
+		override fun toString(): String {
+			val parent = this.parent
+			return if (parent != null) {
+				"${parent.text} [${parent.type}] ($text [$type]) "
+			} else {
+				"$text [$type] "
+			}
+		}
+	}
+
+	@JvmStatic
+	fun parseRuleV2(rule: String, sequenceIndex: Int, rules: MutableList<OpeningHoursRule>) {
+		var r = rule.trim()
+
+		val daysStr = arrayOf("mo", "tu", "we", "th", "fr", "sa", "su")
+		val monthsStr = arrayOf("jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec")
+		val holidayStr = arrayOf("ph", "sh", "easter")
+		val sunrise = "07:00"
+		val sunset = "21:00"
+		val endOfDay = "24:00"
+		r = r.replace('(', ' ') // avoid "(mo-su 17:00-20:00"
+		r = r.replace(')', ' ')
+		val basic = BasicOpeningHourRule(sequenceIndex)
+		if (r.startsWith("|| ")) {
+			r = r.replace("|| ", "")
+			basic.fallback = true
+		}
+		val localRuleString = Regex("sunset", RegexOption.IGNORE_CASE).replace(r, sunset)
+			.let { Regex("sunrise", RegexOption.IGNORE_CASE).replace(it, sunrise) }
+			.replace("+", "-$endOfDay")
+		val days = basic.getDays()
+		val months = basic.getMonths()
+		if ("24/7" == localRuleString) {
+			days.fill(true)
+			basic.hasDays = true
+			months.fill(true)
+			basic.addTimeRange(0, 24 * 60)
+			rules.add(basic)
+			return
+		}
+		val tokens = ArrayList<Token>()
+		var startWord = 0
+		val commentStr = StringBuilder()
+		var comment = false
+		var bracket = false
+		for (i in 0..localRuleString.length) {
+			val ch = if (i == localRuleString.length) ' ' else localRuleString[i]
+			if (i == localRuleString.length) {
+				bracket = false
+			}
+			var delimiter = false
+			var del: Token? = null
+			if (ch == '[' && !comment) {
+				// keep nth weekday brackets like "Su[1]" or "Su[-1]" together as one token
+				bracket = true
+			} else if (ch == ']' && !comment) {
+				bracket = false
+			} else if (ch.isWhitespace()) {
+				delimiter = !bracket
+			} else if (ch == ':') {
+				del = Token(TokenType.TOKEN_COLON, ":")
+			} else if (ch == '-' && !bracket) {
+				del = Token(TokenType.TOKEN_DASH, "-")
+			} else if (ch == ',' && !bracket) {
+				del = Token(TokenType.TOKEN_COMMA, ",")
+			} else if (ch == '"') {
+				if (comment) {
+					if (commentStr.isNotEmpty()) {
+						tokens.add(Token(TokenType.TOKEN_COMMENT, commentStr.toString()))
+					}
+					startWord = i + 1
+					commentStr.setLength(0)
+					comment = false
+				} else {
+					comment = true
+					continue
+				}
+			}
+			if (comment) {
+				commentStr.append(ch)
+			} else if (delimiter || del != null) {
+				val wrd = localRuleString.substring(startWord, i).trim()
+				if (wrd.isNotEmpty()) {
+					tokens.add(Token(TokenType.TOKEN_UNKNOWN, wrd.lowercase()))
+				}
+				startWord = i + 1
+				if (del != null) {
+					tokens.add(del)
+				}
+			}
+		}
+		// recognise days of the week
+		for (t in tokens) {
+			if (t.type == TokenType.TOKEN_UNKNOWN) {
+				findInArray(t, daysStr, TokenType.TOKEN_DAY_WEEK)
+			}
+			if (t.type == TokenType.TOKEN_UNKNOWN) {
+				findNthWeekday(t, daysStr)
+			}
+			if (t.type == TokenType.TOKEN_UNKNOWN) {
+				findInArray(t, monthsStr, TokenType.TOKEN_MONTH)
+			}
+			if (t.type == TokenType.TOKEN_UNKNOWN) {
+				findInArray(t, holidayStr, TokenType.TOKEN_HOLIDAY)
+			}
+			if (t.type == TokenType.TOKEN_UNKNOWN && ("off" == t.text || "closed" == t.text)) {
+				t.type = TokenType.TOKEN_OFF_ON
+				t.mainNumber = 0
+			}
+			if (t.type == TokenType.TOKEN_UNKNOWN && ("24/7" == t.text || "open" == t.text)) {
+				t.type = TokenType.TOKEN_OFF_ON
+				t.mainNumber = 1
+			}
+		}
+		// recognise hours and minutes, as in "Dec 25: 08:30-20:00"
+		for (i in tokens.size - 1 downTo 1) {
+			if (tokens[i].type == TokenType.TOKEN_COLON) {
+				if (i < tokens.size - 1) {
+					if (tokens[i - 1].type == TokenType.TOKEN_UNKNOWN && tokens[i - 1].mainNumber != -1
+						&& tokens[i + 1].type == TokenType.TOKEN_UNKNOWN && tokens[i + 1].mainNumber != -1
+					) {
+						tokens[i].mainNumber = 60 * tokens[i - 1].mainNumber + tokens[i + 1].mainNumber
+						tokens[i].type = TokenType.TOKEN_HOUR_MINUTES
+						tokens.removeAt(i + 1)
+						tokens.removeAt(i - 1)
+					}
+				}
+			} else if (tokens[i].type == TokenType.TOKEN_OFF_ON && tokens[i - 1].type == TokenType.TOKEN_OFF_ON) {
+				tokens.removeAt(i - 1)
+			}
+		}
+		// recognise the remaining numbers
+		var monthSpecified = false
+		for (t in tokens) {
+			if (t.type == TokenType.TOKEN_MONTH) {
+				monthSpecified = true
+				break
+			}
+		}
+		for (t in tokens) {
+			if (t.type == TokenType.TOKEN_UNKNOWN && t.mainNumber >= 0) {
+				if (monthSpecified && t.mainNumber <= 31) {
+					t.type = TokenType.TOKEN_DAY_MONTH
+					t.mainNumber = t.mainNumber - 1
+				} else if (t.mainNumber > 1000) {
+					t.type = TokenType.TOKEN_YEAR
+				}
+			}
+		}
+		buildRule(basic, tokens, rules)
+	}
+
+	private fun buildRule(basic: BasicOpeningHourRule, allTokens: List<Token>, rules: MutableList<OpeningHoursRule>) {
+		// order: MONTH MONTH_DAY DAY_WEEK HOUR_MINUTE OPEN_OFF
+		var tokens = allTokens
+		var currentParse = TokenType.TOKEN_UNKNOWN
+		var currentParseParent = TokenType.TOKEN_UNKNOWN
+		val listOfPairs = ArrayList<Array<Token?>>()
+		val presentTokens = mutableSetOf<TokenType>()
+		var currentPair = arrayOfNulls<Token>(2)
+		listOfPairs.add(currentPair)
+		var prevToken: Token? = null
+		var prevYearToken: Token? = null
+		var indexP = 0
+		var i = 0
+		while (i <= tokens.size) {
+			val t = if (i == tokens.size) null else tokens[i]
+			if (i == 0 && t != null && t.type == TokenType.TOKEN_UNKNOWN) {
+				// skip the rule when the first token is unknown
+				return
+			}
+			if (t == null || t.type.ord > currentParse.ord) {
+				presentTokens.add(currentParse)
+				if (currentParse == TokenType.TOKEN_MONTH || currentParse == TokenType.TOKEN_DAY_MONTH
+					|| currentParse == TokenType.TOKEN_DAY_WEEK || currentParse == TokenType.TOKEN_HOLIDAY
+				) {
+					val tokenDayMonth = currentParse == TokenType.TOKEN_DAY_MONTH
+					var array: BooleanArray? = if (currentParse == TokenType.TOKEN_MONTH) basic.getMonths()
+					else if (tokenDayMonth) null else basic.getDays()
+					for (pair in listOfPairs) {
+						val first = pair[0]
+						val second = pair[1]
+						if (first != null && second != null) {
+							val holidayToken = if (first.type == TokenType.TOKEN_HOLIDAY) first
+							else if (second.type == TokenType.TOKEN_HOLIDAY) second else null
+							if (holidayToken != null
+								&& (first.type == TokenType.TOKEN_DAY_WEEK || second.type == TokenType.TOKEN_DAY_WEEK)
+							) {
+								// "PH Su" means "public holidays falling on Sunday", so the weekday only
+								// restricts the holiday and must not fill the weekday range Mo-Su (#23990)
+								setHolidayFlag(basic, holidayToken.mainNumber)
+								continue
+							}
+							val firstMonthToken =
+								if (first.parent == null && first.type == TokenType.TOKEN_MONTH) first else first.parent
+							val lastMonthToken =
+								if (second.parent == null && second.type == TokenType.TOKEN_MONTH) second else second.parent
+							if (tokenDayMonth && firstMonthToken != null) {
+								if (lastMonthToken != null && lastMonthToken.mainNumber != firstMonthToken.mainNumber) {
+									fillRuleArray(basic.getMonths(), arrayOf<Token?>(firstMonthToken, lastMonthToken))
+
+									var t1 = Token(TokenType.TOKEN_DAY_MONTH, first.mainNumber)
+									var t2 = Token(TokenType.TOKEN_DAY_MONTH, 30)
+									array = basic.getDayMonths(firstMonthToken.mainNumber)
+									fillRuleArray(array, arrayOf<Token?>(t1, t2))
+
+									t1 = Token(TokenType.TOKEN_DAY_MONTH, 0)
+									t2 = Token(TokenType.TOKEN_DAY_MONTH, second.mainNumber)
+									array = basic.getDayMonths(lastMonthToken.mainNumber)
+									fillRuleArray(array, arrayOf<Token?>(t1, t2))
+
+									if (firstMonthToken.mainNumber <= lastMonthToken.mainNumber) {
+										for (month in firstMonthToken.mainNumber + 1 until lastMonthToken.mainNumber) {
+											basic.getDayMonths(month).fill(true)
+										}
+									} else {
+										for (month in firstMonthToken.mainNumber + 1 until 12) {
+											basic.getDayMonths(month).fill(true)
+										}
+										for (month in 0 until lastMonthToken.mainNumber) {
+											basic.getDayMonths(month).fill(true)
+										}
+									}
+								} else {
+									array = basic.getDayMonths(firstMonthToken.mainNumber)
+									fillRuleArray(array, pair)
+								}
+							} else if (array != null) {
+								fillRuleArray(array, pair)
+							}
+							val ruleYear = basic.year
+							if ((ruleYear > 0 || prevYearToken != null) && firstMonthToken != null && lastMonthToken != null) {
+								// support shorthand like "2024-2025 Jan 1-Dec 31" by treating the last seen
+								// year as the range end while keeping the first year already stored
+								val endYear = prevYearToken?.mainNumber ?: ruleYear
+								val startYear = if (ruleYear > 0) ruleYear else endYear
+								if (basic.firstYearMonths == null) {
+									basic.firstYearMonths = IntArray(12)
+								}
+								basic.firstYearMonths!!.fill(startYear, firstMonthToken.mainNumber, 12)
+								if (endYear > startYear) {
+									if (basic.lastYearMonths == null) {
+										basic.lastYearMonths = IntArray(12)
+									}
+									basic.lastYearMonths!!.fill(endYear, 0, lastMonthToken.mainNumber + 1)
+									if (endYear - startYear > 1) {
+										val startInd = lastMonthToken.mainNumber + 1
+										basic.lastYearMonths!!.fill(endYear - 1, startInd, 12)
+									} else {
+										val startInd = maxOf(lastMonthToken.mainNumber + 1, firstMonthToken.mainNumber)
+										basic.lastYearMonths!!.fill(startYear, startInd, 12)
+									}
+									fillFirstLastYearsDayOfMonth(basic, pair)
+									if (firstMonthToken.mainNumber >= lastMonthToken.mainNumber) {
+										basic.months.fill(true)
+									}
+								}
+							}
+						} else if (first != null) {
+							if (first.type == TokenType.TOKEN_HOLIDAY) {
+								setHolidayFlag(basic, first.mainNumber)
+							} else if (first.mainNumber >= 0) {
+								val firstMonthToken = first.parent
+								if (tokenDayMonth && firstMonthToken != null) {
+									array = basic.getDayMonths(firstMonthToken.mainNumber)
+								}
+								val target = array
+								if (target != null) {
+									target[first.mainNumber] = true
+									if (first.type == TokenType.TOKEN_DAY_WEEK && first.nthMask != NO_NTH_WEEKDAY) {
+										basic.setDayNthMask(first.mainNumber, first.nthMask)
+									}
+								}
+							}
+						}
+					}
+				} else if (currentParse == TokenType.TOKEN_HOUR_MINUTES) {
+					for (pair in listOfPairs) {
+						val first = pair[0]
+						val second = pair[1]
+						if (first != null && second != null) {
+							basic.addTimeRange(first.mainNumber, second.mainNumber)
+						}
+					}
+				} else if (currentParse == TokenType.TOKEN_OFF_ON) {
+					val l = listOfPairs[0]
+					if (l[0] != null && l[0]!!.mainNumber == 0) {
+						basic.off = true
+					}
+				} else if (currentParse == TokenType.TOKEN_COMMENT) {
+					val l = listOfPairs[0]
+					val token = l[0]
+					if (token != null && !KAlgorithms.isEmpty(token.text)) {
+						basic.setComment(token.text)
+					}
+				} else if (currentParse == TokenType.TOKEN_YEAR) {
+					if (listOfPairs.size > 1) {
+						// comma separated years have set semantics, so expand each year or year range
+						// into an independent rule that shares the same month and day tail
+						for (pair in listOfPairs) {
+							val newRule = BasicOpeningHourRule(basic.getSequenceIndex())
+							newRule.fallback = basic.fallback
+							newRule.setComment(basic.getComment())
+							val yearTokens = ArrayList<Token>()
+							pair[0]?.let { yearTokens.add(it) }
+							pair[1]?.let { yearTokens.add(it) }
+							if (i < tokens.size) {
+								yearTokens.addAll(tokens.subList(i, tokens.size))
+							}
+							buildRule(newRule, yearTokens, rules)
+						}
+						return
+					}
+					var firstYearToken: Token? = null
+					var lastYearToken: Token? = null
+					for (pair in listOfPairs) {
+						for (yearToken in pair) {
+							if (yearToken != null && yearToken.mainNumber > 1000) {
+								if (firstYearToken == null) {
+									firstYearToken = yearToken
+								}
+								lastYearToken = yearToken
+							}
+						}
+					}
+					if (firstYearToken != null) {
+						if (basic.year == 0) {
+							basic.year = firstYearToken.mainNumber
+						}
+						prevYearToken = lastYearToken
+					}
+				}
+				listOfPairs.clear()
+				currentPair = arrayOfNulls(2)
+				indexP = 0
+				listOfPairs.add(currentPair)
+				currentPair[indexP++] = t
+				if (t != null) {
+					currentParse = t.type
+					currentParseParent = currentParse
+					if (t.type == TokenType.TOKEN_DAY_MONTH && prevToken != null && prevToken.type == TokenType.TOKEN_MONTH) {
+						t.parent = prevToken
+						currentParseParent = prevToken.type
+					} else if (t.type == TokenType.TOKEN_MONTH && prevToken != null && prevToken.type == TokenType.TOKEN_YEAR) {
+						if (basic.year == 0) {
+							// the first year of a range such as "2019 Oct - 2024 dec"
+							basic.year = prevToken.mainNumber
+						}
+					}
+				}
+			} else if (t.type.ord < currentParseParent.ord && indexP == 0 && tokens.size > i) {
+				val newRule = BasicOpeningHourRule(basic.getSequenceIndex())
+				newRule.setComment(basic.getComment())
+				buildRule(newRule, tokens.subList(i, tokens.size), rules)
+				tokens = tokens.subList(0, i + 1)
+			} else if (t.type == TokenType.TOKEN_COMMA) {
+				if (tokens.size > i + 1 && tokens[i + 1].type.ord < currentParseParent.ord) {
+					indexP = 0
+				} else {
+					currentPair = arrayOfNulls(2)
+					indexP = 0
+					listOfPairs.add(currentPair)
+				}
+			} else if (t.type == TokenType.TOKEN_DASH) {
+				// nothing to do, the dash only joins the two ends of a pair
+			} else if (t.type.ord == currentParse.ord) {
+				if (indexP < 2) {
+					currentPair[indexP++] = t
+					if (t.type == TokenType.TOKEN_DAY_MONTH && prevToken != null && prevToken.type == TokenType.TOKEN_MONTH) {
+						t.parent = prevToken
+					} else if (t.type == TokenType.TOKEN_YEAR) {
+						// keep the second year inside the current pair so the month and day range code
+						// can build a proper multi-year span instead of collapsing to the first year
+						prevYearToken = t
+					}
+				}
+			} else if (t.type == TokenType.TOKEN_YEAR) {
+				prevYearToken = t
+			}
+			prevToken = t
+			i++
+		}
+		if (!presentTokens.contains(TokenType.TOKEN_MONTH)) {
+			basic.getMonths().fill(true)
+		}
+		if (!presentTokens.contains(TokenType.TOKEN_DAY_WEEK) && !presentTokens.contains(TokenType.TOKEN_HOLIDAY)
+			&& !presentTokens.contains(TokenType.TOKEN_DAY_MONTH)
+		) {
+			basic.getDays().fill(true)
+			basic.hasDays = true
+		} else if (presentTokens.contains(TokenType.TOKEN_DAY_WEEK) || presentTokens.contains(TokenType.TOKEN_HOLIDAY)) {
+			basic.hasDays = true
+		}
+		rules.add(0, basic)
+	}
+
+	private fun setHolidayFlag(basic: BasicOpeningHourRule, holidayIndex: Int) {
+		when (holidayIndex) {
+			0 -> basic.publicHoliday = true
+			1 -> basic.schoolHoliday = true
+			2 -> basic.easter = true
+		}
+	}
+
+	private fun fillFirstLastYearsDayOfMonth(basic: BasicOpeningHourRule, pair: Array<Token?>) {
+		val first = pair[0]!!
+		val second = pair[1]!!
+		val startMonth = if (first.parent == null) first.mainNumber else first.parent!!.mainNumber
+		val startDayOfMonth = if (first.parent == null) 0 else first.mainNumber
+		val firstYearDayMonth = Array(12) { BooleanArray(31) }
+		basic.firstYearDayMonth = firstYearDayMonth
+		firstYearDayMonth[startMonth].fill(true, startDayOfMonth, 31)
+		for (month in startMonth + 1 until 12) {
+			firstYearDayMonth[month].fill(true)
+		}
+		val endMonth = if (second.parent == null) second.mainNumber else second.parent!!.mainNumber
+		val endDayOfMonth = if (second.parent == null) 30 else second.mainNumber
+		val lastYearDayMonth = Array(12) { BooleanArray(31) }
+		basic.lastYearDayMonth = lastYearDayMonth
+		lastYearDayMonth[endMonth].fill(true, 0, endDayOfMonth + 1)
+		for (month in 0 until endMonth) {
+			lastYearDayMonth[month].fill(true)
+		}
+	}
+
+	private fun fillRuleArray(array: BooleanArray, pair: Array<Token?>) {
+		val from = pair[0]!!.mainNumber
+		val to = pair[1]!!.mainNumber
+		if (from <= to) {
+			var j = from
+			while (j <= to && j >= 0 && j < array.size) {
+				array[j] = true
+				j++
+			}
+		} else {
+			// the range wraps around the end of the year
+			var j = from
+			while (j >= 0 && j < array.size) {
+				array[j] = true
+				j++
+			}
+			j = 0
+			while (j <= to && j < array.size) {
+				array[j] = true
+				j++
+			}
+		}
+	}
+
+	private fun findInArray(t: Token, list: Array<String>, tokenType: TokenType) {
+		for (i in list.indices) {
+			if (list[i] == t.text) {
+				t.type = tokenType
+				t.mainNumber = i
+				break
+			}
+		}
+	}
+
+	/** Recognises nth weekday tokens such as "su[1]", "su[-1]" or "su[1,3]". */
+	private fun findNthWeekday(t: Token, daysStr: Array<String>) {
+		val bracket = t.text.indexOf('[')
+		if (bracket <= 0 || !t.text.endsWith("]")) {
+			return
+		}
+		val day = t.text.substring(0, bracket)
+		for (i in daysStr.indices) {
+			if (daysStr[i] == day) {
+				val mask = parseNthMask(t.text.substring(bracket + 1, t.text.length - 1))
+				if (mask != NO_NTH_WEEKDAY) {
+					t.type = TokenType.TOKEN_DAY_WEEK
+					t.mainNumber = i
+					t.nthMask = mask
+				}
+				return
+			}
+		}
+	}
+
+	/**
+	 * Parses an nth weekday list such as "1", "-1" or "1,3" into a bit mask, where positive values
+	 * count from the start of the month and negative values count from its end.
+	 */
+	private fun parseNthMask(list: String): Int {
+		var mask = NO_NTH_WEEKDAY
+		for (part in list.split(",")) {
+			val n = KAlgorithms.parseIntSilently(part.trim(), 0)
+			val nthMask = getNthWeekdayMask(n)
+			if (nthMask == NO_NTH_WEEKDAY) {
+				return NO_NTH_WEEKDAY
+			}
+			mask = mask or nthMask
+		}
+		return mask
+	}
+
+	private fun hasNthWeekday(mask: Int, nth: Int): Boolean {
+		val nthMask = getNthWeekdayMask(nth)
+		return nthMask != NO_NTH_WEEKDAY && (mask and nthMask) != 0
+	}
+
+	private fun getNthWeekdayMask(nth: Int): Int {
+		if (nth in FIRST_NTH_WEEKDAY..LAST_NTH_WEEKDAY) {
+			return 1 shl (nth - FIRST_NTH_WEEKDAY)
+		}
+		if (nth <= -FIRST_NTH_WEEKDAY && nth >= -LAST_NTH_WEEKDAY) {
+			return 1 shl (NTH_WEEKDAY_FROM_END_OFFSET + (-nth - FIRST_NTH_WEEKDAY))
+		}
+		return NO_NTH_WEEKDAY
+	}
+
+	private fun splitSequences(format: String?): List<List<String>>? {
+		if (format == null) {
+			return null
+		}
+		val res = ArrayList<List<String>>()
+		for (sequence in Regex("(?= \\|\\| )").split(format)) {
+			val seq = sequence.trim()
+			if (seq.isEmpty()) {
+				continue
+			}
+			val rules = ArrayList<String>()
+			var comment = false
+			val sb = StringBuilder()
+			for (c in seq) {
+				if (c == '"') {
+					comment = !comment
+					sb.append(c)
+				} else if (c == ';' && !comment) {
+					if (sb.isNotEmpty()) {
+						val s = sb.toString().trim()
+						if (s.isNotEmpty()) {
+							rules.add(s)
+						}
+						sb.setLength(0)
+					}
+				} else {
+					sb.append(c)
+				}
+			}
+			if (sb.isNotEmpty()) {
+				rules.add(sb.toString())
+				sb.setLength(0)
+			}
+			res.add(rules)
+		}
+		return res
+	}
+
+	@JvmStatic
+	fun parseRules(r: String, sequenceIndex: Int, rules: MutableList<OpeningHoursRule>) {
+		parseRuleV2(r, sequenceIndex, rules)
+	}
+
+	/**
+	 * Parses an OSM `opening_hours` string, returning null when nothing could be parsed.
+	 */
+	@JvmStatic
+	fun parseOpenedHours(format: String?): OpeningHours? {
+		if (format == null) {
+			return null
+		}
+		val rs = OpeningHours()
+		rs.setOriginal(format)
+		val sequences = splitSequences(format)!!
+		for (i in sequences.indices) {
+			val basicRules = ArrayList<BasicOpeningHourRule>()
+			for (r in sequences[i]) {
+				val rList = ArrayList<OpeningHoursRule>()
+				parseRules(r, i, rList)
+				for (rule in rList) {
+					if (rule is BasicOpeningHourRule) {
+						basicRules.add(rule)
+					}
+				}
+			}
+			var basicRuleComment: String? = null
+			if (sequences.size > 1) {
+				for (bRule in basicRules) {
+					if (!KAlgorithms.isEmpty(bRule.getComment())) {
+						basicRuleComment = bRule.getComment()
+						break
+					}
+				}
+			}
+			if (!KAlgorithms.isEmpty(basicRuleComment)) {
+				for (bRule in basicRules) {
+					bRule.setComment(basicRuleComment)
+				}
+			}
+			rs.addRules(basicRules)
+		}
+		rs.setSequenceCount(sequences.size)
+		return if (rs.getRules().size > 0) rs else null
+	}
+
+	/**
+	 * Parses an OSM `opening_hours` string, keeping anything it fails to parse as an
+	 * [UnparseableRule] rather than returning null.
+	 */
+	@JvmStatic
+	fun parseOpenedHoursHandleErrors(format: String?): OpeningHours? {
+		if (format == null) {
+			return null
+		}
+		val rs = OpeningHours()
+		rs.setOriginal(format)
+		val sequences = splitSequences(format)!!
+		for (i in sequences.indices.reversed()) {
+			for (rule in sequences[i]) {
+				val r = rule.trim()
+				if (r.isEmpty()) {
+					continue
+				}
+				val rList = ArrayList<OpeningHoursRule>()
+				parseRules(r, i, rList)
+				rs.addRules(rList)
+			}
+		}
+		rs.setSequenceCount(sequences.size)
+		return rs
+	}
+
+	@JvmStatic
+	fun getInfo(format: String): List<OpeningHours.Info>? = parseOpenedHours(format)?.getInfo()
+
+	private fun formatTimeRange(startMinute: Int, endMinute: Int, stringBuilder: StringBuilder) {
+		val startHour = (startMinute / 60) % 24
+		val endHour = (endMinute / 60) % 24
+		val sameDayPart = maxOf(startHour, endHour) < 12 || minOf(startHour, endHour) >= 12
+		if (twelveHourFormatting && sameDayPart) {
+			val amPmOnLeft = isAmPmOnLeft(startMinute)
+			formatTime(startMinute, stringBuilder, amPmOnLeft)
+			stringBuilder.append("-")
+			formatTime(endMinute, stringBuilder, !amPmOnLeft)
+		} else {
+			formatTime(startMinute, stringBuilder)
+			stringBuilder.append("-")
+			formatTime(endMinute, stringBuilder)
+		}
+	}
+
+	private fun isAmPmOnLeft(startMinute: Int): Boolean {
+		val sb = StringBuilder()
+		formatTime(startMinute, sb)
+		return !sb[0].isDigit()
+	}
+
+	private fun formatTime(minutes: Int, sb: StringBuilder) {
+		formatTime(minutes, sb, true)
+	}
+
+	private fun formatTime(minutes: Int, sb: StringBuilder, appendAmPm: Boolean) {
+		val hour = minutes / 60
+		formatTime(hour, minutes - hour * 60, sb, appendAmPm)
+	}
+
+	private fun formatTime(hours: Int, minutes: Int, b: StringBuilder, appendAmPm: Boolean) {
+		if (twelveHourFormatting) {
+			b.append(PlatformDateNames.formatTwelveHourTime(hours * 60 + minutes, twelveHourLanguageTag, appendAmPm))
+		} else {
+			if (hours < 10) {
+				b.append("0")
+			}
+			b.append(hours).append(":")
+			if (minutes < 10) {
+				b.append("0")
+			}
+			b.append(minutes)
+		}
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/OpeningHoursTime.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/OpeningHoursTime.kt
@@ -1,0 +1,84 @@
+package net.osmand.shared.util
+
+import kotlin.jvm.JvmStatic
+import kotlinx.datetime.Clock
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.isoDayNumber
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
+
+/**
+ * The wall clock reading that [OpeningHoursParser] evaluates rules against.
+ *
+ * Replaces `java.util.Calendar` from the Java original, exposing the same fields with the same
+ * numbering so the rule logic ports across unchanged: [month] counts from zero and [dayOfWeek]
+ * counts Sunday as 1, both as `Calendar` did.
+ *
+ * Mutable and cheap to [copy], because the parser walks forward a day at a time while looking for
+ * the next opening.
+ */
+class OpeningHoursTime(var dateTime: LocalDateTime) {
+
+	/** Four digit year. */
+	val year: Int get() = dateTime.year
+
+	/** Zero based, January is 0, like `Calendar.MONTH`. */
+	val month: Int get() = dateTime.monthNumber - 1
+
+	/** One based day of the month. */
+	val dayOfMonth: Int get() = dateTime.dayOfMonth
+
+	/** Sunday is 1 through Saturday is 7, like `Calendar.DAY_OF_WEEK`. */
+	val dayOfWeek: Int get() = dateTime.dayOfWeek.isoDayNumber % 7 + 1
+
+	/** Hour on a 24 hour clock. */
+	val hourOfDay: Int get() = dateTime.hour
+
+	val minute: Int get() = dateTime.minute
+
+	/** Number of days in the current month, like `Calendar.getActualMaximum(DAY_OF_MONTH)`. */
+	val daysInMonth: Int
+		get() {
+			val firstOfMonth = LocalDate(dateTime.year, dateTime.monthNumber, 1)
+			return firstOfMonth.plus(1, DateTimeUnit.MONTH).minus(1, DateTimeUnit.DAY).dayOfMonth
+		}
+
+	/** Moves this reading by [days], keeping the time of day. */
+	fun addDays(days: Int) {
+		val shifted = dateTime.date.plus(days, DateTimeUnit.DAY)
+		dateTime = LocalDateTime(
+			shifted.year, shifted.monthNumber, shifted.dayOfMonth,
+			dateTime.hour, dateTime.minute, dateTime.second, dateTime.nanosecond
+		)
+	}
+
+	fun copy(): OpeningHoursTime = OpeningHoursTime(dateTime)
+
+	fun isBefore(other: OpeningHoursTime): Boolean = dateTime < other.dateTime
+
+	override fun toString(): String = dateTime.toString()
+
+	companion object {
+
+		/** The current reading in the device time zone. */
+		@JvmStatic
+		fun now(): OpeningHoursTime =
+			OpeningHoursTime(Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()))
+
+		/** [epochMillis] read in the device time zone, the equivalent of `Calendar.setTimeInMillis`. */
+		@JvmStatic
+		fun ofEpochMillis(epochMillis: Long): OpeningHoursTime = OpeningHoursTime(
+			Instant.fromEpochMilliseconds(epochMillis).toLocalDateTime(TimeZone.currentSystemDefault())
+		)
+
+		/** Explicit wall clock reading, mostly useful in tests. */
+		@JvmStatic
+		fun of(year: Int, month: Int, dayOfMonth: Int, hour: Int, minute: Int): OpeningHoursTime =
+			OpeningHoursTime(LocalDateTime(year, month + 1, dayOfMonth, hour, minute))
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/PlatformDateNames.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/PlatformDateNames.kt
@@ -1,0 +1,28 @@
+package net.osmand.shared.util
+
+/**
+ * Locale dependent date names and time formatting, for the parts of [OpeningHoursParser] that render
+ * text for a person to read.
+ *
+ * Only the localized output goes through here. The canonical OSM spelling of days and months is
+ * fixed vocabulary, not locale data, so it lives in [OpeningHoursParser] as constants.
+ */
+expect object PlatformDateNames {
+
+	/**
+	 * Short month names for [languageTag] (null means the device language), index 0 = January.
+	 */
+	fun shortMonths(languageTag: String?): Array<String>
+
+	/**
+	 * Short weekday names for [languageTag] (null means the device language), laid out like
+	 * `java.util.Calendar`: index 1 = Sunday through index 7 = Saturday, index 0 unused. The rest of
+	 * the parser indexes weekdays that way, so the layout is part of the contract.
+	 */
+	fun shortWeekdays(languageTag: String?): Array<String>
+
+	/**
+	 * [minutesOfDay] rendered on a 12 hour clock, with the am/pm marker only when [withAmPm].
+	 */
+	fun formatTwelveHourTime(minutesOfDay: Int, languageTag: String?, withAmPm: Boolean): String
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/PlatformSerializable.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/PlatformSerializable.kt
@@ -1,0 +1,10 @@
+package net.osmand.shared.util
+
+/**
+ * Marks a type the platform may serialize.
+ *
+ * On the JVM this is `java.io.Serializable`, which the Android OSM editor relies on to keep a
+ * partially edited opening hours rule across configuration changes. Elsewhere it carries no
+ * behaviour, it only lets shared classes declare the capability without depending on the JVM.
+ */
+expect interface PlatformSerializable

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/collections/KTIntArrayList.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/collections/KTIntArrayList.kt
@@ -1,5 +1,6 @@
 package net.osmand.shared.util.collections
 
+import net.osmand.shared.util.PlatformSerializable
 import kotlin.jvm.JvmOverloads
 
 /**
@@ -17,7 +18,9 @@ import kotlin.jvm.JvmOverloads
  *
  * Not thread safe.
  */
-class KTIntArrayList @JvmOverloads constructor(initialCapacity: Int = DEFAULT_CAPACITY) {
+class KTIntArrayList @JvmOverloads constructor(
+	initialCapacity: Int = DEFAULT_CAPACITY
+) : PlatformSerializable {
 
 	@PublishedApi
 	internal var data: IntArray = IntArray(if (initialCapacity > 0) initialCapacity else DEFAULT_CAPACITY)

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/OpeningHoursParserTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/OpeningHoursParserTest.kt
@@ -1,0 +1,1103 @@
+package net.osmand.shared.util
+
+import net.osmand.shared.util.OpeningHoursParser.OpeningHours
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Port of `OpeningHoursParserTest` from OsmAnd-java, assertion for assertion.
+ *
+ * The corpus is the point: 541 checks over real world `opening_hours` strings, which is what makes
+ * the Kotlin port of [OpeningHoursParser] trustworthy. Times are written as "dd.MM.yyyy HH:mm" and
+ * read as a local wall clock reading, exactly as the Java version read them into a Calendar.
+ */
+class OpeningHoursParserTest {
+
+	/** Parses "dd.MM.yyyy HH:mm" into the wall clock reading the rules are evaluated against. */
+	private fun timeOf(time: String): OpeningHoursTime {
+		val parts = time.split(" ")
+		val date = parts[0].split(".")
+		val clock = parts[1].split(":")
+		return OpeningHoursTime.of(
+			date[2].toInt(), date[1].toInt() - 1, date[0].toInt(), clock[0].toInt(), clock[1].toInt()
+		)
+	}
+
+	/** Checks the calculated open state against [expected]. */
+	private fun testOpened(time: String, hours: OpeningHours?, expected: Boolean) {
+		val cal = timeOf(time)
+		val calculated = hours!!.isOpenedForTimeV2(cal, OpeningHours.ALL_SEQUENCES)
+		assertEquals(
+			expected, calculated,
+			"Expected $time: $expected but was $calculated (rule ${hours.getCurrentRuleTime(cal, OpeningHours.ALL_SEQUENCES)})"
+		)
+	}
+
+	private fun testInfo(time: String, hours: OpeningHours?, expected: String) {
+		testInfo(time, hours, expected, OpeningHours.ALL_SEQUENCES, false)
+	}
+
+	private fun testInfo(time: String, hours: OpeningHours?, expected: String, sequenceIndex: Int) {
+		testInfo(time, hours, expected, sequenceIndex, false)
+	}
+
+	private fun testShortInfo(time: String, hours: OpeningHours?, expected: String) {
+		testInfo(time, hours, expected, OpeningHours.ALL_SEQUENCES, true)
+	}
+
+	private fun testInfo(
+		time: String, hours: OpeningHours?, expected: String, sequenceIndex: Int, brief: Boolean
+	) {
+		val cal = timeOf(time)
+		val info = if (sequenceIndex == OpeningHours.ALL_SEQUENCES) {
+			hours!!.getCombinedInfo(cal)
+		} else {
+			hours!!.getInfo(cal)!![sequenceIndex]
+		}
+		val description = (if (brief) info.getShortInfo() else info.getInfo()).replace("\u202F", " ")
+		assertTrue(
+			expected.equals(description, ignoreCase = true),
+			"Expected $time: \"$expected\" got \"$description\""
+		)
+	}
+
+	private fun testParsedAndAssembledCorrectly(expected: String, hours: OpeningHours?) {
+		val assembledString = hours.toString().replace("\u202F", " ")
+		assertTrue(
+			assembledString.equals(expected, ignoreCase = true),
+			"Expected: \"$expected\" got: \"$assembledString\""
+		)
+	}
+
+	/**
+	 * Same as [testParsedAndAssembledCorrectly], but tolerates locale data differing between platforms.
+	 *
+	 * Compares with the invisible spacing and bidi marks removed: right to left locales get direction
+	 * marks around the day period, and the two platforms place them differently even when the visible
+	 * text is identical.
+	 */
+	private fun testParsedAndAssembledCorrectlyOneOf(hours: OpeningHours?, vararg expected: String) {
+		val assembledString = hours.toString()
+		val normalized = normalizeForCompare(assembledString)
+		assertTrue(
+			expected.any { normalizeForCompare(it).equals(normalized, ignoreCase = true) },
+			"Expected one of ${expected.joinToString(" | ")} got: \"$assembledString\""
+		)
+	}
+
+	private fun normalizeForCompare(value: String): String = value
+		.replace('\u202F', ' ')
+		.replace('\u00A0', ' ')
+		.filter { it != '\u200E' && it != '\u200F' && it != '\u061C' }
+
+	@Test
+	fun testOpeningHours() {
+		// 0. not properly supported
+		// hours = OpeningHoursParser.parseOpenedHours("Mo-Su (sunrise-00:30)-(sunset+00:30)")
+
+		OpeningHoursParser.initLocalStrings("en-GB")
+		OpeningHoursParser.setTwelveHourFormattingEnabled(false, "en-GB")
+		var hours = OpeningHoursParser.parseOpenedHours("Mo-Fr 11:00-22:00; Sa,Su,PH 12:00-22:00; 2022 jul 31-2022 Aug 31 off \"Betriebsferien\"")
+		println(hours)
+		testOpened("25.08.2022 11:30", hours, false)
+		testOpened("31.08.2022 21:59", hours, false)
+		testOpened("01.09.2022 11:00", hours, true) // Thursday
+		testInfo("25.08.2022 11:30", hours, "Will open on 11:00 Thu.") // (2022 jul 31-2022 Aug 31 off "Betriebsferien")
+
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Fr 10:00-18:30; We 10:00-14:00; Sa 10:00-13:00; Dec-Feb Mo-Fr 11:00-17:00; Dec-Feb We off; Dec-Feb Sa 11:00-13:00; Dec 24-Dec 31 off \"Inventurarbeiten\"; PH off")
+		println(hours)
+		testOpened("05.11.2022 10:30", hours, true) // saturday
+		testOpened("05.12.2022 10:30", hours, false) // Thursday
+		testOpened("05.12.2022 11:30", hours, true)
+		testOpened("30.12.2022 11:00", hours, false)
+		testInfo("29.12.2022 14:00", hours, "Will open on 11:00 Mon.")
+		testInfo("30.12.2022 14:00", hours, "Will open on 11:00 Mon.")
+
+		hours = OpeningHoursParser.parseOpenedHours("2024 Jan 1-Dec 31")
+		println(hours)
+		testOpened("31.12.2023 23:59", hours, false)
+		testOpened("01.01.2024 00:00", hours, true)
+		testOpened("31.12.2024 23:59", hours, true)
+		testOpened("01.01.2025 00:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2024 Jan 01-Dec 31")
+		println(hours)
+		testOpened("31.12.2023 23:59", hours, false)
+		testOpened("01.01.2024 00:00", hours, true)
+		testOpened("31.12.2024 23:59", hours, true)
+		testOpened("01.01.2025 00:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2024 Jan 01-2024 Dec 31")
+		println(hours)
+		testOpened("31.12.2023 23:59", hours, false)
+		testOpened("01.01.2024 00:00", hours, true)
+		testOpened("31.12.2024 23:59", hours, true)
+		testOpened("01.01.2025 00:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2024 Jan 01-2025 Dec 31")
+		println(hours)
+		testOpened("31.12.2023 23:59", hours, false)
+		testOpened("01.01.2024 00:00", hours, true)
+		testOpened("31.12.2024 23:59", hours, true)
+		testOpened("01.01.2025 00:00", hours, true)
+		testOpened("31.12.2025 23:59", hours, true)
+		testOpened("01.01.2026 00:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2022 Oct 24 - 2023 Oct 30")
+		println(hours)
+		testOpened("20.10.2022 10:00", hours, false)
+		testOpened("20.06.2023 10:00", hours, true)
+		testOpened("01.11.2023 10:00", hours, false)
+		testOpened("31.12.2023 10:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2022 Oct 30 - 2023 Oct 24")
+		println(hours)
+		testOpened("25.10.2023 10:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2022 Oct 24 - 2023 Aug 30")
+		println(hours)
+		testOpened("25.10.2022 10:00", hours, true)
+		testOpened("25.09.2023 10:00", hours, false)
+		testOpened("25.09.2022 10:00", hours, false)
+		testOpened("25.08.2022 10:00", hours, false)
+		testOpened("25.08.2023 10:00", hours, true)
+
+//		test for opening_hours not handled correctly #17521
+		hours = OpeningHoursParser.parseOpenedHours("11:00-14:00,17:00-22:00; We off; Fr,Sa 11:00-14:00,17:00-00:00")
+		println(hours)
+		testOpened("28.06.2023 12:00", hours, false) // We 
+
+		hours = OpeningHoursParser.parseOpenedHours("Mo 09:00-12:00; We,Sa 13:30-17:00, Apr 01-Oct 31 We,Sa 17:00-18:30; PH off")
+		println(hours)
+		testInfo("03.10.2020 14:00", hours, "Open until 18:30")
+		hours = OpeningHoursParser.parseOpenedHours("PH,Mo-Su 09:00-22:00")
+		println(hours)
+		testOpened("13.10.2021 11:54", hours, true)
+		hours = OpeningHoursParser.parseOpenedHours("Mo-We 07:00-21:00, Th-Fr 07:00-21:30, PH,Sa-Su 08:00-21:00")
+		println(hours)
+		testOpened("29.08.2021 10:09", hours, true)
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Fr 08:00-12:30, Mo-We 12:30-16:30 \"Sur rendez-vous\", Fr 12:30-15:30 \"Sur rendez-vous\"")
+		println(hours)
+		testInfo("13.10.2019 18:00", hours, "Will open tomorrow at 08:00")
+
+		hours = OpeningHoursParser.parseOpenedHours("2019 Oct 1 - 2024 dec 31 ")
+		println(hours)
+		testOpened("30.09.2019 10:30", hours, false)
+		testOpened("01.10.2019 10:30", hours, true)
+		testOpened("05.02.2023 10:30", hours, true)
+		testOpened("31.08.2024 10:30", hours, true)
+		testOpened("31.12.2024 10:30", hours, true)
+		testOpened("01.01.2025 10:30", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2019 Oct - 2024 dec")
+		println(hours)
+		testOpened("30.09.2019 10:30", hours, false)
+		testOpened("01.10.2019 10:30", hours, true)
+		testOpened("05.02.2023 10:30", hours, true)
+		testOpened("31.12.2024 10:30", hours, true)
+		testOpened("01.01.2025 10:30", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2019 Apr 1 - 2020 Apr 1")
+		println(hours)
+		testOpened("01.04.2018 15:00", hours, false)
+		testOpened("01.04.2019 15:00", hours, true)
+		testOpened("01.04.2020 15:00", hours, true)
+		testOpened("01.08.2019 15:00", hours, true)
+
+		hours = OpeningHoursParser.parseOpenedHours("2019 Apr 15 -  2020 Mar 1")
+		println(hours)
+		testOpened("01.04.2018 15:00", hours, false)
+		testOpened("01.04.2019 15:00", hours, false)
+		testOpened("15.04.2019 15:00", hours, true)
+		testOpened("15.09.2019 15:00", hours, true)
+		testOpened("15.02.2020 15:00", hours, true)
+		testOpened("15.03.2020 15:00", hours, false)
+		testOpened("15.04.2020 15:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2019 Jul 23 05:00-24:00; 2019 Jul 24-2019 Jul 26 00:00-24:00; 2019 Jul 27 00:00-18:00")
+		println(hours)
+		testOpened("23.07.2018 15:00", hours, false)
+		testOpened("23.07.2019 15:00", hours, true)
+		testOpened("23.07.2019 04:00", hours, false)
+		testOpened("23.07.2020 15:00", hours, false)
+		testOpened("25.07.2018 15:00", hours, false)
+		testOpened("24.07.2019 15:00", hours, true)
+		testOpened("25.07.2019 04:00", hours, true)
+		testOpened("26.07.2019 15:00", hours, true)
+		testOpened("25.07.2020 15:00", hours, false)
+		testOpened("27.07.2018 15:00", hours, false)
+		testOpened("27.07.2019 15:00", hours, true)
+		testOpened("27.07.2019 19:00", hours, false)
+		testOpened("27.07.2020 15:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2019 Sep 1 - 2022 Apr 1")
+		println(hours)
+		testOpened("01.02.2018 15:00", hours, false)
+		testOpened("29.05.2019 15:00", hours, false)
+		testOpened("05.09.2019 11:00", hours, true)
+		testOpened("05.02.2020 11:00", hours, true)
+		testOpened("03.06.2020 11:00", hours, true)
+		testOpened("05.02.2021 11:00", hours, true)
+		testOpened("05.02.2022 11:00", hours, true)
+		testOpened("05.02.2023 11:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2019 Apr 15 - 2019 Sep 1: Mo-Fr 00:00-24:00")
+		println(hours)
+		testOpened("06.04.2019 15:00", hours, false)
+		testOpened("29.05.2019 15:00", hours, true)
+		testOpened("25.07.2019 11:00", hours, true)
+		testOpened("12.07.2018 11:00", hours, false)
+		testOpened("18.07.2020 11:00", hours, false)
+		testOpened("28.07.2021 11:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2019 Sep 1 - 2020 Apr 1")
+		println(hours)
+		testOpened("01.04.2019 15:00", hours, false)
+		testOpened("29.05.2019 15:00", hours, false)
+		testOpened("05.09.2019 11:00", hours, true)
+		testOpened("05.02.2020 11:00", hours, true)
+		testOpened("05.06.2020 11:00", hours, false)
+		testOpened("05.02.2021 11:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2019 Apr 15 - 2019 Sep 1")
+		println(hours)
+		testOpened("01.04.2019 15:00", hours, false)
+		testOpened("29.05.2019 15:00", hours, true)
+		testOpened("27.07.2019 15:00", hours, true)
+		testOpened("05.09.2019 11:00", hours, false)
+		testOpened("05.06.2018 11:00", hours, false)
+		testOpened("05.06.2020 11:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("Apr 15 - Sep 1")
+		println(hours)
+		testOpened("01.04.2019 15:00", hours, false)
+		testOpened("29.05.2019 15:00", hours, true)
+		testOpened("27.07.2019 15:00", hours, true)
+		testOpened("05.09.2019 11:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("Apr 15 - Sep 1: Mo-Fr 00:00-24:00")
+		println(hours)
+		testOpened("01.04.2019 15:00", hours, false)
+		testOpened("29.05.2019 15:00", hours, true)
+		testOpened("24.07.2019 15:00", hours, true)
+		testOpened("27.07.2019 15:00", hours, false)
+		testOpened("05.09.2019 11:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("Apr 05-Oct 24: Fr 08:00-16:00")
+		println(hours)
+		testOpened("26.08.2018 15:00", hours, false)
+		testOpened("29.03.2019 15:00", hours, false)
+		testOpened("05.04.2019 11:00", hours, true)
+
+		hours = OpeningHoursParser.parseOpenedHours("Oct 24-Apr 05: Fr 08:00-16:00")
+		println(hours)
+		testOpened("26.08.2018 15:00", hours, false)
+		testOpened("29.03.2019 15:00", hours, true)
+		testOpened("26.04.2019 11:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("Oct 24-Apr 05, Jun 10-Jun 20, Jul 6-12: Fr 08:00-16:00")
+		println(hours)
+		testOpened("26.08.2018 15:00", hours, false)
+		testOpened("02.01.2019 15:00", hours, false)
+		testOpened("29.03.2019 15:00", hours, true)
+		testOpened("26.04.2019 11:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("Apr 05-24: Fr 08:00-16:00")
+		println(hours)
+		testOpened("12.10.2018 11:00", hours, false)
+		testOpened("12.04.2019 15:00", hours, true)
+		testOpened("27.04.2019 15:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("Apr 5: Fr 08:00-16:00")
+		println(hours)
+		testOpened("05.04.2019 15:00", hours, true)
+		testOpened("06.04.2019 15:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("Apr 24-05: Fr 08:00-16:00")
+		println(hours)
+		testOpened("12.10.2018 11:00", hours, false)
+		testOpened("12.04.2018 15:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("Apr: Fr 08:00-16:00")
+		println(hours)
+		testOpened("12.10.2018 11:00", hours, false)
+		testOpened("12.04.2019 15:00", hours, true)
+
+		hours = OpeningHoursParser.parseOpenedHours("Apr-Oct: Fr 08:00-16:00")
+		println(hours)
+		testOpened("09.11.2018 11:00", hours, false)
+		testOpened("12.10.2018 11:00", hours, true)
+		testOpened("24.08.2018 15:00", hours, true)
+		testOpened("09.03.2018 15:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("Apr, Oct: Fr 08:00-16:00")
+		println(hours)
+		testOpened("09.11.2018 11:00", hours, false)
+		testOpened("12.10.2018 11:00", hours, true)
+		testOpened("24.08.2018 15:00", hours, false)
+		testOpened("12.04.2019 15:00", hours, true)
+
+		// test basic case
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Fr 08:30-14:40") //$NON-NLS-1$
+		println(hours)
+		testOpened("09.08.2012 11:00", hours, true)
+		testOpened("09.08.2012 16:00", hours, false)
+		//hours = OpeningHoursParser.parseOpenedHours("mo-fr 07:00-19:00; sa 12:00-18:00")
+
+		val string = "Mo-Fr 11:30-15:00, 17:30-23:00; Sa, Su, PH 11:30-23:00"
+		hours = OpeningHoursParser.parseOpenedHours(string)
+		testParsedAndAssembledCorrectly("Mo-Fr 11:30-15:00, 17:30-23:00; Sa, Su, PH 11:30-23:00", hours)
+		println(hours)
+		testOpened("7.09.2015 14:54", hours, true) // monday
+		testOpened("7.09.2015 15:05", hours, false)
+		testOpened("6.09.2015 16:05", hours, true)
+
+		// two time and date ranges
+		hours = OpeningHoursParser.parseOpenedHours("Mo-We, Fr 08:30-14:40,15:00-19:00") //$NON-NLS-1$
+		println(hours)
+		testOpened("08.08.2012 14:00", hours, true)
+		testOpened("08.08.2012 14:50", hours, false)
+		testOpened("10.08.2012 15:00", hours, true)
+
+		// test exception on general schema
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Sa 08:30-14:40; Tu 08:00 - 14:00") //$NON-NLS-1$
+		println(hours)
+		testOpened("07.08.2012 14:20", hours, false)
+		testOpened("07.08.2012 08:15", hours, true) // Tuesday
+
+		// test off value
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Sa 09:00-18:25; Th off") //$NON-NLS-1$
+		println(hours)
+		testOpened("08.08.2012 12:00", hours, true)
+		testOpened("09.08.2012 12:00", hours, false)
+
+		// test 24/7
+		hours = OpeningHoursParser.parseOpenedHours("24/7") //$NON-NLS-1$
+		println(hours)
+		testOpened("08.08.2012 23:59", hours, true)
+		testOpened("08.08.2012 12:23", hours, true)
+		testOpened("08.08.2012 06:23", hours, true)
+		hours = OpeningHoursParser.parseOpenedHours("24/7 closed \"Temporarily, for major repairs\"")
+		println(hours)
+		testOpened("13.10.2019 18:00", hours, false)
+		testInfo("13.10.2019 18:00", hours, "24/7 off - Temporarily, for major repairs")
+
+		// some people seem to use the following syntax:
+		hours = OpeningHoursParser.parseOpenedHours("Sa-Su 24/7")
+		println(hours)
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Fr 9-19")
+		println(hours)
+		hours = OpeningHoursParser.parseOpenedHours("09:00-17:00")
+		println(hours)
+		hours = OpeningHoursParser.parseOpenedHours("sunrise-sunset")
+		println(hours)
+		hours = OpeningHoursParser.parseOpenedHours("10:00+")
+		println(hours)
+		hours = OpeningHoursParser.parseOpenedHours("Su-Th sunset-24:00, 04:00-sunrise; Fr-Sa sunset-sunrise")
+		println(hours)
+		testOpened("12.08.2012 04:00", hours, true)
+		testOpened("12.08.2012 23:00", hours, true)
+		testOpened("08.08.2012 12:00", hours, false)
+		testOpened("08.08.2012 05:00", hours, true)
+
+		// test simple day wrap
+		hours = OpeningHoursParser.parseOpenedHours("Mo 20:00-02:00")
+		println(hours)
+		testOpened("05.05.2013 10:30", hours, false)
+		testOpened("05.05.2013 23:59", hours, false)
+		testOpened("06.05.2013 10:30", hours, false)
+		testOpened("06.05.2013 20:30", hours, true)
+		testOpened("06.05.2013 23:59", hours, true)
+		testOpened("07.05.2013 00:00", hours, true)
+		testOpened("07.05.2013 00:30", hours, true)
+		testOpened("07.05.2013 01:59", hours, true)
+		testOpened("07.05.2013 20:30", hours, false)
+
+		// test maximum day wrap
+		hours = OpeningHoursParser.parseOpenedHours("Su 10:00-10:00")
+		println(hours)
+		testOpened("05.05.2013 09:59", hours, false)
+		testOpened("05.05.2013 10:00", hours, true)
+		testOpened("05.05.2013 23:59", hours, true)
+		testOpened("06.05.2013 00:00", hours, true)
+		testOpened("06.05.2013 09:59", hours, true)
+		testOpened("06.05.2013 10:00", hours, false)
+
+		// test day wrap as seen on OSM
+		hours = OpeningHoursParser.parseOpenedHours("Tu-Th 07:00-2:00; Fr 17:00-4:00; Sa 18:00-05:00; Su,Mo off")
+		println(hours)
+		testOpened("05.05.2013 04:59", hours, true) // sunday 05.05.2013
+		testOpened("05.05.2013 05:00", hours, false)
+		testOpened("05.05.2013 12:30", hours, false)
+		testOpened("06.05.2013 10:30", hours, false)
+		testOpened("07.05.2013 01:00", hours, false)
+		testOpened("07.05.2013 20:25", hours, true)
+		testOpened("07.05.2013 23:59", hours, true)
+		testOpened("08.05.2013 00:00", hours, true)
+		testOpened("08.05.2013 02:00", hours, false)
+
+		// test day wrap as seen on OSM
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Th 09:00-03:00; Fr-Sa 09:00-04:00; Su off")
+		testOpened("11.05.2015 08:59", hours, false)
+		testOpened("11.05.2015 09:01", hours, true)
+		testOpened("12.05.2015 02:59", hours, true)
+		testOpened("12.05.2015 03:00", hours, false)
+		testOpened("16.05.2015 03:59", hours, true)
+		testOpened("16.05.2015 04:01", hours, false)
+		testOpened("17.05.2015 01:00", hours, true)
+		testOpened("17.05.2015 04:01", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("Tu-Th 07:00-2:00; Fr 17:00-4:00; Sa 18:00-05:00; Su,Mo off")
+		testOpened("11.05.2015 08:59", hours, false)
+		testOpened("11.05.2015 09:01", hours, false)
+		testOpened("12.05.2015 01:59", hours, false)
+		testOpened("12.05.2015 02:59", hours, false)
+		testOpened("12.05.2015 03:00", hours, false)
+		testOpened("13.05.2015 01:59", hours, true)
+		testOpened("13.05.2015 02:59", hours, false)
+		testOpened("16.05.2015 03:59", hours, true)
+		testOpened("16.05.2015 04:01", hours, false)
+		testOpened("17.05.2015 01:00", hours, true)
+		testOpened("17.05.2015 05:01", hours, false)
+
+		// tests single month value
+		hours = OpeningHoursParser.parseOpenedHours("May: 07:00-19:00")
+		println(hours)
+		testOpened("05.05.2013 12:00", hours, true)
+		testOpened("05.05.2013 05:00", hours, false)
+		testOpened("05.05.2013 21:00", hours, false)
+		testOpened("05.01.2013 12:00", hours, false)
+		testOpened("05.01.2013 05:00", hours, false)
+
+		// tests multi month value
+		hours = OpeningHoursParser.parseOpenedHours("Apr-Sep 8:00-22:00; Oct-Mar 10:00-18:00")
+		println(hours)
+		testOpened("05.03.2013 15:00", hours, true)
+		testOpened("05.03.2013 20:00", hours, false)
+
+		testOpened("05.05.2013 20:00", hours, true)
+		testOpened("05.05.2013 23:00", hours, false)
+
+		testOpened("05.10.2013 15:00", hours, true)
+		testOpened("05.10.2013 20:00", hours, false)
+
+		// Test time with breaks
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Fr: 9:00-13:00, 14:00-18:00")
+		println(hours)
+		testOpened("02.12.2015 12:00", hours, true)
+		testOpened("02.12.2015 13:30", hours, false)
+		testOpened("02.12.2015 16:00", hours, true)
+
+		testOpened("05.12.2015 16:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Su 07:00-23:00; Dec 25 08:00-20:00")
+		println(hours)
+		testOpened("25.12.2015 07:00", hours, false)
+		testOpened("24.12.2015 07:00", hours, true)
+		testOpened("24.12.2015 22:00", hours, true)
+		testOpened("25.12.2015 08:00", hours, true)
+		testOpened("25.12.2015 22:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Su 07:00-23:00; Dec 25 off")
+		println(hours)
+		testOpened("25.12.2015 14:00", hours, false)
+		testOpened("24.12.2015 08:00", hours, true)
+
+		// easter itself as public holiday is not supported
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Su 07:00-23:00; Easter off; Dec 25 off")
+		println(hours)
+		testOpened("25.12.2015 14:00", hours, false)
+		testOpened("24.12.2015 08:00", hours, true)
+
+		// test time off (not days
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Fr 08:30-17:00; 12:00-12:40 off;")
+		println(hours)
+		testOpened("07.05.2017 14:00", hours, false) // Sunday
+		testOpened("06.05.2017 12:15", hours, false) // Saturday
+		testOpened("05.05.2017 14:00", hours, true) // Friday
+		testOpened("05.05.2017 12:15", hours, false)
+		testOpened("05.05.2017 12:00", hours, false)
+		testOpened("05.05.2017 11:45", hours, true)
+
+		// Test holidays
+		val hoursString = "mo-fr 11:00-21:00; PH off"
+		hours = OpeningHoursParser.parseOpenedHoursHandleErrors(hoursString)
+		testParsedAndAssembledCorrectly("mo-fr 11:00-21:00; PH off", hours)
+
+		// test open from/until
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Fr 08:30-17:00; 12:00-12:40 off;")
+		println(hours)
+		testInfo("15.01.2018 09:00", hours, "Open until 12:00")
+		testInfo("15.01.2018 11:00", hours, "Will close at 12:00")
+		testInfo("15.01.2018 12:00", hours, "Will open at 12:40")
+
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Fr: 9:00-13:00, 14:00-18:00")
+		println(hours)
+		testInfo("15.01.2018 08:00", hours, "Will open at 09:00")
+		testInfo("15.01.2018 09:00", hours, "Open until 13:00")
+		testInfo("15.01.2018 12:00", hours, "Will close at 13:00")
+		testInfo("15.01.2018 13:10", hours, "Will open at 14:00")
+		testInfo("15.01.2018 14:00", hours, "Open until 18:00")
+		testInfo("15.01.2018 16:00", hours, "Will close at 18:00")
+		testInfo("15.01.2018 18:10", hours, "Will open tomorrow at 09:00")
+
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Sa 02:00-10:00; Th off")
+		println(hours)
+		testInfo("15.01.2018 23:00", hours, "Will open tomorrow at 02:00")
+
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Sa 23:00-02:00; Th off")
+		println(hours)
+		testInfo("15.01.2018 22:00", hours, "Will open at 23:00")
+		testInfo("15.01.2018 23:00", hours, "Open until 02:00")
+		testInfo("16.01.2018 00:30", hours, "Will close at 02:00")
+		testInfo("16.01.2018 02:00", hours, "Open from 23:00")
+
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Sa 08:30-17:00; Th off")
+		println(hours)
+		testInfo("17.01.2018 20:00", hours, "Will open on 08:30 Fri.")
+		testInfo("18.01.2018 05:00", hours, "Will open tomorrow at 08:30")
+		testInfo("20.01.2018 05:00", hours, "Open from 08:30")
+		testInfo("21.01.2018 05:00", hours, "Will open tomorrow at 08:30")
+		testInfo("22.01.2018 02:00", hours, "Open from 08:30")
+		testInfo("22.01.2018 04:00", hours, "Open from 08:30")
+		testInfo("22.01.2018 07:00", hours, "Will open at 08:30")
+		testInfo("23.01.2018 10:00", hours, "Open until 17:00")
+		testInfo("23.01.2018 16:00", hours, "Will close at 17:00")
+
+		hours = OpeningHoursParser.parseOpenedHours("24/7")
+		println(hours)
+		testInfo("24.01.2018 02:00", hours, "Open 24/7")
+
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Su 07:00-23:00, Fr 08:00-20:00")
+		println(hours)
+		testOpened("15.01.2018 06:45", hours, false)
+		testOpened("15.01.2018 07:45", hours, true)
+		testOpened("15.01.2018 23:45", hours, false)
+		testOpened("19.01.2018 07:45", hours, false)
+		testOpened("19.01.2018 08:45", hours, true)
+		testOpened("19.01.2018 20:45", hours, false)
+
+		// test fallback case
+		hours = OpeningHoursParser.parseOpenedHours(
+				"07:00-01:00 open \"Restaurant\" || Mo 00:00-04:00,07:00-04:00; Tu-Th 07:00-04:00; Fr 07:00-24:00; Sa,Su 00:00-24:00 open \"McDrive\"")
+		println(hours)
+		testOpened("22.01.2018 00:30", hours, true)
+		testOpened("22.01.2018 08:00", hours, true)
+		testOpened("22.01.2018 03:30", hours, true)
+		testOpened("22.01.2018 05:00", hours, false)
+		testOpened("23.01.2018 05:00", hours, false)
+		testOpened("27.01.2018 05:00", hours, true)
+		testOpened("28.01.2018 05:00", hours, true)
+
+		testInfo("22.01.2018 05:00", hours, "Will open at 07:00 - Restaurant", 0)
+		testInfo("26.01.2018 00:00", hours, "Will close at 01:00 - Restaurant", 0)
+		testInfo("22.01.2018 05:00", hours, "Will open at 07:00 - McDrive", 1)
+		testInfo("22.01.2018 00:00", hours, "Open until 04:00 - McDrive", 1)
+		testInfo("22.01.2018 02:00", hours, "Will close at 04:00 - McDrive", 1)
+		testInfo("27.01.2018 02:00", hours, "Open until 24:00 - McDrive", 1)
+
+		hours = OpeningHoursParser.parseOpenedHours("07:00-03:00 open \"Restaurant\" || 24/7 open \"McDrive\"")
+		println(hours)
+		testOpened("22.01.2018 02:00", hours, true)
+		testOpened("22.01.2018 17:00", hours, true)
+		testInfo("22.01.2018 05:00", hours, "Will open at 07:00 - Restaurant", 0)
+		testInfo("22.01.2018 04:00", hours, "McDrive", 1)
+
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Fr 12:00-15:00, Tu-Fr 17:00-23:00, Sa 12:00-23:00, Su 14:00-23:00")
+		println(hours)
+		testOpened("16.02.2018 14:00", hours, true)
+		testOpened("16.02.2018 16:00", hours, false)
+		testOpened("16.02.2018 17:00", hours, true)
+		testInfo("16.02.2018 9:45", hours, "Open from 12:00")
+		testInfo("16.02.2018 12:00", hours, "Open until 15:00")
+		testInfo("16.02.2018 14:00", hours, "Will close at 15:00")
+		testInfo("16.02.2018 16:00", hours, "Will open at 17:00")
+		testInfo("16.02.2018 18:00", hours, "Open until 23:00")
+
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Fr 08:00-12:00, Mo,Tu,Th 15:00-17:00; PH off")
+		println(hours)
+		testOpened("09.08.2019 15:00", hours, false)
+		testInfo("09.08.2019 15:00", hours, "Will open on 08:00 Mon.")
+
+		hours = OpeningHoursParser.parseOpenedHours(
+				"Mo-Fr 10:00-21:00; Sa 12:00-23:00; PH \"Wird auf der Homepage bekannt gegeben.\"")
+		testParsedAndAssembledCorrectly(
+				"Mo-Fr 10:00-21:00; Sa 12:00-23:00; PH - Wird auf der Homepage bekannt gegeben.", hours)
+		println(hours)
+
+		testAmPm()
+		testComma()
+		testYearFormats()
+		testGetShortInfo()
+		testTimeRestrictedOffRules()
+		testMonthRuleOverride()
+		testHolidayWithWeekday()
+		testNthWeekdayOfMonth()
+		testOvernightNextOpening()
+		testRealWorldSchedules()
+	}
+
+	private fun testOvernightNextOpening() {
+		// overnight rules of other days must not report an opening time for today,
+		// and a still running overnight session determines the closing time
+		OpeningHoursParser.initLocalStrings("en-GB")
+		OpeningHoursParser.setTwelveHourFormattingEnabled(false, "en-GB")
+		var hours = OpeningHoursParser.parseOpenedHours("Mo-Th,Su 09:00-00:30; Fr 09:00-16:30")
+		println(hours)
+		// Friday evening: Saturday is closed, so the next opening is on Sunday
+		// (was "Open from 09:00", which means "opens today")
+		testOpened("06.02.2026 21:00", hours, false)
+		testInfo("06.02.2026 21:00", hours, "Will open on 09:00 Sun.")
+		testInfo("06.02.2026 19:00", hours, "Will open on 09:00 Sun.")
+		// Friday 00:15 is inside the Thursday session which ends 00:30
+		// (was "Open until 16:30" from the Friday rule)
+		testOpened("06.02.2026 00:15", hours, true)
+		testInfo("06.02.2026 00:15", hours, "Will close at 00:30")
+		// unchanged behavior around it
+		testInfo("06.02.2026 12:00", hours, "Open until 16:30")
+		testInfo("06.02.2026 15:00", hours, "Will close at 16:30")
+		testOpened("07.02.2026 12:00", hours, false)
+		testInfo("07.02.2026 12:00", hours, "Will open tomorrow at 09:00")
+		// Sunday evening: the overnight session closes at 00:30 the next day, so the
+		// "closing soon" warning must also trigger before midnight (was "Open until 00:30")
+		testOpened("08.02.2026 23:00", hours, true)
+		testInfo("08.02.2026 22:00", hours, "Open until 00:30") // 2.5 h to closing
+		testInfo("08.02.2026 23:00", hours, "Will close at 00:30") // 1.5 h to closing
+		testInfo("08.02.2026 23:50", hours, "Will close at 00:30") // 40 min to closing
+		testInfo("09.02.2026 07:00", hours, "Will open at 09:00")
+	}
+
+	// Real-world schedules (the kind actually tagged on OSM shops, bars, markets, museums)
+	// exercising the fixes of this PR end to end: time-restricted "off", seasonal month
+	// overrides, nth weekday of month and overnight next-open/close.
+	private fun testRealWorldSchedules() {
+		OpeningHoursParser.initLocalStrings("en-GB")
+		OpeningHoursParser.setTwelveHourFormattingEnabled(false, "en-GB")
+
+		// weekend-only nightclub, overnight into the next morning; next opening after the
+		// last overnight day (Sat) skips the whole week to the following Friday
+		var hours = OpeningHoursParser.parseOpenedHours("Fr,Sa 20:00-04:00")
+		println(hours)
+		testParsedAndAssembledCorrectly("Fr, Sa 20:00-04:00", hours)
+		testInfo("03.01.2025 19:00", hours, "Will open at 20:00") // Fri, opens in 1 h
+		testInfo("03.01.2025 23:30", hours, "Open until 04:00") // Fri night, closes 04:00
+		testInfo("04.01.2025 02:00", hours, "Will close at 04:00") // Sat 02:00, Fri session
+		testInfo("05.01.2025 01:00", hours, "Open until 04:00") // Sun 01:00, Sat session
+		testOpened("05.01.2025 05:00", hours, false)
+		testInfo("05.01.2025 05:00", hours, "Will open on 20:00 Fri.") // closed until next Fri
+		testInfo("06.01.2025 12:00", hours, "Will open on 20:00 Fri.")
+
+		// neighbourhood bar, mix of overnight and non-overnight days; the "closing soon"
+		// warning must trigger before midnight for the overnight days too
+		hours = OpeningHoursParser.parseOpenedHours("We-Th 18:00-01:00; Fr-Sa 18:00-03:00; Su 16:00-23:00")
+		println(hours)
+		testParsedAndAssembledCorrectly("We, Th 18:00-01:00; Fr, Sa 18:00-03:00; Su 16:00-23:00", hours)
+		testInfo("04.06.2025 23:30", hours, "Will close at 01:00") // Wed 23:30 -> 90 min to close
+		testInfo("05.06.2025 00:30", hours, "Will close at 01:00") // Thu 00:30, Wed session
+		testInfo("07.06.2025 02:00", hours, "Will close at 03:00") // Sat 02:00, Fri session
+		testInfo("08.06.2025 22:00", hours, "Will close at 23:00") // Sun evening
+		testOpened("08.06.2025 03:00", hours, false)
+		testInfo("08.06.2025 03:00", hours, "Open from 16:00") // Sun early morning, opens 16:00
+		testInfo("10.06.2025 20:00", hours, "Will open tomorrow at 18:00") // Tue closed
+
+		// ice-cream parlour with a reduced winter schedule that wraps the year end (Dec-Feb)
+		// the winter rule must win inside the summer time window too (#23457 family)
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Su 12:00-22:00; Dec-Feb Mo-Su 13:00-18:00")
+		println(hours)
+		testInfo("15.01.2026 14:00", hours, "Open until 18:00") // winter override
+		testOpened("07.02.2026 12:30", hours, false)
+		testInfo("07.02.2026 12:30", hours, "Will open at 13:00") // 12:30 winter-closed
+		testInfo("10.12.2025 20:00", hours, "Will open tomorrow at 13:00")
+		testInfo("20.06.2025 21:00", hours, "Will close at 22:00") // summer
+		testInfo("30.11.2025 19:00", hours, "Open until 22:00") // Nov still summer
+
+		// museum with a Monday closing day and a wrap-around winter season (Nov-Mar)
+		hours = OpeningHoursParser.parseOpenedHours("Tu-Su 10:00-18:00; Nov-Mar Tu-Su 10:00-16:00")
+		println(hours)
+		testInfo("14.02.2026 15:00", hours, "Will close at 16:00") // winter
+		testInfo("15.05.2025 17:00", hours, "Will close at 18:00") // summer
+		testOpened("08.06.2025 19:00", hours, false)
+		testInfo("08.06.2025 19:00", hours, "Will open on 10:00 Tue.") // Sun evening, Mon closed
+		testInfo("20.01.2026 17:00", hours, "Will open tomorrow at 10:00")
+		testInfo("20.12.2025 07:30", hours, "Open from 10:00")
+
+		// pharmacy with a lunch closure; a passed lunch break must not shorten the afternoon
+		// closing time (#22931) and the reopening is the end of the "off" range
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Fr 08:30-18:30; Sa 09:00-13:00; Mo-Fr 13:00-14:00 off")
+		println(hours)
+		testParsedAndAssembledCorrectly("Mo-Fr 08:30-18:30; Sa 09:00-13:00; Mo-Fr 13:00-14:00 off", hours)
+		testInfo("02.06.2025 10:30", hours, "Open until 13:00") // closes for lunch
+		testOpened("02.06.2025 13:20", hours, false)
+		testInfo("02.06.2025 13:20", hours, "Will open at 14:00") // lunch break
+		testInfo("02.06.2025 15:00", hours, "Open until 18:30") // afternoon, full closing time
+		testInfo("02.06.2025 17:00", hours, "Will close at 18:30")
+		testInfo("07.06.2025 11:00", hours, "Will close at 13:00") // Saturday
+		testInfo("08.06.2025 12:00", hours, "Will open tomorrow at 08:30")
+
+		// weekly farmers market plus a "first Sunday of the month" special during the season
+		hours = OpeningHoursParser.parseOpenedHours("We,Sa 07:00-13:00; Apr-Oct Su[1] 08:00-16:00")
+		println(hours)
+		testParsedAndAssembledCorrectly("We, Sa 07:00-13:00; Apr-Oct Su[1] 08:00-16:00", hours)
+		testOpened("06.07.2025 07:30", hours, false)
+		testInfo("06.07.2025 07:30", hours, "Will open at 08:00") // 1st Sunday of July
+		testInfo("06.07.2025 09:00", hours, "Open until 16:00")
+		testInfo("06.07.2025 15:00", hours, "Will close at 16:00")
+		testOpened("13.07.2025 10:00", hours, false) // 2nd Sunday, no market
+		testInfo("13.07.2025 10:00", hours, "Will open on 07:00 Wed.")
+		testInfo("04.10.2025 12:00", hours, "Will close at 13:00") // Saturday market
+		testOpened("07.01.2025 08:00", hours, false) // January, out of season
+
+		// rural church sharing a priest: mass on 1st/3rd/5th Sundays in the morning,
+		// on 2nd/4th Sundays in the evening; the tricky 5th-Sunday occurrence must count
+		hours = OpeningHoursParser.parseOpenedHours("Su[1,3,5] 09:00-10:00; Su[2,4] 18:00-19:00")
+		println(hours)
+		testParsedAndAssembledCorrectly("Su[1,3,5] 09:00-10:00; Su[2,4] 18:00-19:00", hours)
+		testOpened("03.08.2025 09:30", hours, true) // 1st Sunday morning
+		testInfo("03.08.2025 09:30", hours, "Will close at 10:00")
+		testOpened("10.08.2025 09:30", hours, false) // 2nd Sunday, no morning mass
+		testInfo("10.08.2025 09:30", hours, "Open from 18:00")
+		testInfo("10.08.2025 18:30", hours, "Will close at 19:00") // 2nd Sunday evening
+		testOpened("31.08.2025 09:45", hours, true) // 5th Sunday counts
+		testInfo("31.08.2025 09:45", hours, "Will close at 10:00")
+		testInfo("06.08.2025 12:00", hours, "Will open on 18:00 Sun.") // next is 2nd Sunday
+
+		// bakery open every day including Sunday morning, closed on public holidays; the
+		// trailing "PH off" must not disturb the regular Sunday hours
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Fr 06:00-18:30; Sa 06:30-13:00; Su 07:30-11:00; PH off")
+		println(hours)
+		testParsedAndAssembledCorrectly("Mo-Fr 06:00-18:30; Sa 06:30-13:00; Su 07:30-11:00; PH off", hours)
+		testInfo("12.10.2025 08:00", hours, "Open until 11:00") // Sunday morning
+		testInfo("12.10.2025 09:30", hours, "Will close at 11:00")
+		testOpened("12.10.2025 12:00", hours, false)
+		testInfo("12.10.2025 12:00", hours, "Will open tomorrow at 06:00")
+		testInfo("11.10.2025 13:30", hours, "Will open tomorrow at 07:30") // Sat -> Sun
+		testInfo("10.10.2025 18:00", hours, "Will close at 18:30") // Friday
+		testInfo("06.10.2025 03:00", hours, "Open from 06:00")
+
+		// self-service car wash with a reduced-noise winter evening off window; the seasonal
+		// "off" must only shorten its own window and only in its months
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Sa 07:00-21:00; Nov-Feb 19:00-21:00 off")
+		println(hours)
+		testInfo("15.01.2025 18:30", hours, "Will close at 19:00") // winter, off shortens evening
+		testInfo("16.07.2025 18:30", hours, "Open until 21:00") // summer, no off
+		testInfo("16.07.2025 19:30", hours, "Will close at 21:00")
+		testInfo("16.07.2025 04:30", hours, "Open from 07:00")
+		testInfo("15.01.2025 06:00", hours, "Will open at 07:00")
+	}
+
+	private fun testHolidayWithWeekday() {
+		// "PH Su" means "public holidays falling on Sunday" and must not fill
+		// the weekday range Mo-Su (#23990)
+		OpeningHoursParser.initLocalStrings("en-GB")
+		OpeningHoursParser.setTwelveHourFormattingEnabled(false, "en-GB")
+		var hours = OpeningHoursParser.parseOpenedHours("Tu-Sa,PH 10:00-12:00,14:00-19:00; PH Su off")
+		println(hours)
+		testParsedAndAssembledCorrectly("Tu-Sa, PH 10:00-12:00, 14:00-19:00; PH off", hours)
+		testOpened("07.10.2025 11:00", hours, true) // regular Tuesday must stay open
+		testOpened("05.10.2025 11:00", hours, false) // regular Sunday
+		testOpened("06.10.2025 11:00", hours, false) // Monday
+		testInfo("07.10.2025 11:00", hours, "Will close at 12:00")
+
+		// without holiday info the rule can not be applied to regular weekdays
+		hours = OpeningHoursParser.parseOpenedHours("PH Su 08:30-12:30")
+		println(hours)
+		testParsedAndAssembledCorrectly("PH 08:30-12:30", hours)
+		testOpened("06.10.2025 09:00", hours, false) // Monday
+		testOpened("05.10.2025 09:00", hours, false) // regular Sunday
+
+		hours = OpeningHoursParser.parseOpenedHours("SH Mo-Fr 10:00-14:00")
+		println(hours)
+		testOpened("06.10.2025 11:00", hours, false) // regular Monday
+	}
+
+	private fun testNthWeekdayOfMonth() {
+		// nth weekday of the month like "Su[1]", "Su[-1]" or "Su[1,3]" (#23990)
+		OpeningHoursParser.initLocalStrings("en-GB")
+		OpeningHoursParser.setTwelveHourFormattingEnabled(false, "en-GB")
+		var hours = OpeningHoursParser.parseOpenedHours("Jul Su[1] 08:00-18:00")
+		println(hours)
+		testParsedAndAssembledCorrectly("Jul Su[1] 08:00-18:00", hours)
+		testOpened("06.07.2025 10:00", hours, true) // 1st Sunday of July
+		testOpened("13.07.2025 10:00", hours, false) // 2nd Sunday
+		testOpened("07.07.2025 10:00", hours, false) // Monday
+		testOpened("01.06.2025 10:00", hours, false) // Sunday outside July
+
+		hours = OpeningHoursParser.parseOpenedHours("Nov Su[-1] 08:00-18:00")
+		println(hours)
+		testParsedAndAssembledCorrectly("Nov Su[-1] 08:00-18:00", hours)
+		testOpened("30.11.2025 10:00", hours, true) // last Sunday of November
+		testOpened("23.11.2025 10:00", hours, false) // 4th but not last Sunday
+
+		hours = OpeningHoursParser.parseOpenedHours("Su[1,3] 08:00-12:00")
+		println(hours)
+		testOpened("05.10.2025 09:00", hours, true) // 1st Sunday
+		testOpened("12.10.2025 09:00", hours, false) // 2nd Sunday
+		testOpened("19.10.2025 09:00", hours, true) // 3rd Sunday
+
+		// full rule from #23990
+		hours = OpeningHoursParser.parseOpenedHours("Tu-Sa,PH 10:00-12:00,14:00-19:00; PH Su off; May 01,Dec 25 off; Jul Su[1] 08:00-18:00; Nov Su[4] 08:00-18:00")
+		println(hours)
+		testOpened("07.10.2025 11:00", hours, true) // regular Tuesday
+		testOpened("01.05.2025 11:00", hours, false) // May 1st
+		testOpened("06.07.2025 09:00", hours, true) // 1st Sunday of July
+		testOpened("23.11.2025 09:00", hours, true) // 4th Sunday of November
+		testOpened("05.10.2025 11:00", hours, false) // regular Sunday
+
+		// library from #7857, the "Sa[1,3]" rule was parsed as "24/7" before
+		hours = OpeningHoursParser.parseOpenedHours("Jul-Aug Mo,Tu 13:00-19:00; Jul-Aug We-Fr 08:00-14:00; Jul-Aug Sa off; "
+				+ "Jan-Jun,Sep-Dec Mo,Tu 13:00-19:00; Jan-Jun,Sep-Dec We-Fr 08:00-16:00; Jan-Jun,Sep-Dec Sa[1,3] 09:00-13:00; PH off")
+		println(hours)
+		testOpened("05.11.2019 05:00", hours, false) // issue scenario: Tuesday 5 AM, was "open 24/7"
+		testOpened("05.11.2019 14:00", hours, true)
+		testOpened("01.11.2025 10:00", hours, true) // 1st Saturday of November
+		testOpened("08.11.2025 10:00", hours, false) // 2nd Saturday
+		testOpened("15.11.2025 10:00", hours, true) // 3rd Saturday
+		testOpened("05.07.2025 10:00", hours, false) // Saturday in July is off
+		testOpened("09.07.2025 09:00", hours, true) // Wednesday in July
+	}
+
+	private fun testTimeRestrictedOffRules() {
+		// "off" rules with time ranges must only turn off their own time windows
+		// and must not discard opening/closing times found by other rules (#22907)
+		OpeningHoursParser.initLocalStrings("en-GB")
+		OpeningHoursParser.setTwelveHourFormattingEnabled(false, "en-GB")
+		var hours = OpeningHoursParser.parseOpenedHours("Mo-Fr 08:30-12:30,14:00-19:30; Sa 09:00-12:30; Jul-Aug 19:00-19:30 off; PH off")
+		println(hours)
+		// Wednesday inside the Jul-Aug period
+		testOpened("02.07.2025 13:50", hours, false)
+		testInfo("02.07.2025 13:50", hours, "Will open at 14:00")
+		testInfo("02.07.2025 05:00", hours, "Open from 08:30")
+		testInfo("02.07.2025 10:00", hours, "Open until 12:30")
+		testInfo("02.07.2025 12:20", hours, "Will close at 12:30")
+		// the "off" range shortens the evening interval
+		testOpened("02.07.2025 14:05", hours, true)
+		testInfo("02.07.2025 14:05", hours, "Open until 19:00")
+		testOpened("02.07.2025 19:10", hours, false)
+		testInfo("02.07.2025 21:00", hours, "Will open tomorrow at 08:30")
+		// outside the Jul-Aug period the "off" rule has no effect
+		testInfo("03.09.2025 13:50", hours, "Will open at 14:00")
+		testInfo("03.09.2025 14:05", hours, "Open until 19:30")
+
+		// lunch break: reopening time is the end of the "off" range
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Fr 08:00-18:00; Mo-Fr 12:00-13:00 off")
+		println(hours)
+		testOpened("06.10.2025 12:30", hours, false)
+		testInfo("06.10.2025 12:30", hours, "Will open at 13:00")
+		testInfo("06.10.2025 10:30", hours, "Will close at 12:00")
+		testInfo("06.10.2025 14:00", hours, "Open until 18:00")
+
+		// a passed "off" range must not affect the closing time anymore (#22931)
+		hours = OpeningHoursParser.parseOpenedHours("Tu-Fr 08:00-17:00; Mo-Fr 12:00-13:00 off \"Lunch\"")
+		println(hours)
+		testInfo("07.10.2025 09:00", hours, "Open until 12:00 - Lunch")
+		testInfo("07.10.2025 12:30", hours, "Will open at 13:00 - Lunch")
+		testInfo("07.10.2025 15:00", hours, "Will close at 17:00")
+
+		// multiple "off" time ranges in one rule
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Fr 08:00-20:00; Mo-Fr 10:00-10:30,15:00-15:30 off")
+		println(hours)
+		testInfo("06.10.2025 09:00", hours, "Will close at 10:00")
+		testInfo("06.10.2025 10:15", hours, "Will open at 10:30")
+		testInfo("06.10.2025 12:00", hours, "Open until 15:00")
+		testInfo("06.10.2025 16:00", hours, "Open until 20:00")
+
+		// overnight opening with an "off" window after midnight: the off start is 00:00
+		// in the next calendar day, so it must still shorten the closing time before midnight
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Su 20:00-02:00; Mo-Su 00:00-01:00 off")
+		println(hours)
+		testOpened("06.10.2025 23:00", hours, true)
+		testInfo("06.10.2025 23:00", hours, "Will close at 00:00")
+		testOpened("07.10.2025 00:30", hours, false)
+		testInfo("07.10.2025 00:30", hours, "Will open at 01:00")
+		testOpened("07.10.2025 01:30", hours, true)
+		testInfo("07.10.2025 01:30", hours, "Will close at 02:00")
+
+		// whole-day "off" rules by year/day-month ranges must discard the opening time of that day (#21780)
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Fr 09:00-20:00; Sa 09:00-18:00; 2025 Jan 07 - 2025 Feb 26 closed")
+		println(hours)
+		testOpened("23.01.2025 07:40", hours, false)
+		testInfo("23.01.2025 07:40", hours, "2025 Jan 7-2025 Feb 26 off")
+		testOpened("23.01.2025 12:00", hours, false)
+		testInfo("27.02.2025 09:30", hours, "Open until 20:00")
+		testInfo("06.01.2025 12:00", hours, "Open until 20:00")
+	}
+
+	private fun testMonthRuleOverride() {
+		// later month rules override the default rule also inside the default time window (#23457)
+		OpeningHoursParser.initLocalStrings("en-GB")
+		OpeningHoursParser.setTwelveHourFormattingEnabled(false, "en-GB")
+		var hours = OpeningHoursParser.parseOpenedHours("07:00-17:00; Mar 07:00-19:00; Apr 07:00-21:00; May-Aug 07:00-22:00; Sep 07:00-21:00; Oct 07:00-19:00")
+		println(hours)
+		testOpened("12.09.2025 14:09", hours, true)
+		testInfo("12.09.2025 14:09", hours, "Open until 21:00")
+		testInfo("12.09.2025 18:00", hours, "Open until 21:00")
+		testInfo("12.09.2025 20:00", hours, "Will close at 21:00")
+		testOpened("12.09.2025 21:30", hours, false)
+		testInfo("12.09.2025 21:30", hours, "Will open tomorrow at 07:00")
+		testInfo("12.01.2025 14:09", hours, "Open until 17:00")
+		testInfo("12.06.2025 21:30", hours, "Will close at 22:00")
+		testInfo("12.03.2025 18:30", hours, "Will close at 19:00")
+	}
+
+	private fun testGetShortInfo() {
+		OpeningHoursParser.initLocalStrings("en-GB")
+		OpeningHoursParser.setTwelveHourFormattingEnabled(false, "en-GB")
+		var hours = OpeningHoursParser.parseOpenedHours("24/7")
+		testShortInfo("16.02.2018 12:00", hours, "24/7")
+
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Fr 12:00-15:00, Tu-Fr 17:00-23:00, Sa 12:00-23:00, Su 14:00-23:00")
+		testShortInfo("16.02.2018 09:45", hours, "From 12:00")
+		testShortInfo("16.02.2018 12:00", hours, "Until 15:00")
+		testShortInfo("16.02.2018 14:00", hours, "Until 15:00")
+		testShortInfo("16.02.2018 16:00", hours, "From 17:00")
+
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Fr 09:00-18:00")
+		testShortInfo("18.02.2018 12:00", hours, "Tomorrow 09:00")
+
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Fr 08:00-12:00, Mo,Tu,Th 15:00-17:00; PH off")
+		testShortInfo("09.08.2019 15:00", hours, "From 08:00 Mon")
+
+		hours = OpeningHoursParser.parseOpenedHours("Mo-Fr; PH off")
+		testShortInfo("09.08.2019 15:00", hours, "Mon-Fri")
+	}
+
+	private fun testYearFormats() {
+		var hours = OpeningHoursParser.parseOpenedHours("2024 Jan-Dec")
+		testOpened("31.12.2023 23:59", hours, false)
+		testOpened("01.01.2024 00:00", hours, true)
+		testOpened("31.12.2024 23:59", hours, true)
+		testOpened("01.01.2025 00:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2024-2025 Jan 1-Dec 31")
+		testOpened("31.12.2023 23:59", hours, false)
+		testOpened("01.01.2024 00:00", hours, true)
+		testOpened("31.12.2024 23:59", hours, true)
+		testOpened("31.12.2025 23:59", hours, true)
+		testOpened("01.01.2026 00:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2024,2025 Jan 1-Dec 31")
+		testOpened("31.12.2023 23:59", hours, false)
+		testOpened("01.01.2024 00:00", hours, true)
+		testOpened("31.12.2024 23:59", hours, true)
+		testOpened("31.12.2025 23:59", hours, true)
+		testOpened("01.01.2026 00:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2024")
+		testOpened("31.12.2023 23:59", hours, false)
+		testOpened("01.01.2024 00:00", hours, true)
+		testOpened("31.12.2024 23:59", hours, true)
+		testOpened("01.01.2025 00:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2024,2026")
+		testOpened("31.12.2023 23:59", hours, false)
+		testOpened("01.01.2024 00:00", hours, true)
+		testOpened("31.12.2024 23:59", hours, true)
+		testOpened("15.06.2025 12:00", hours, false)
+		testOpened("01.01.2026 00:00", hours, true)
+		testOpened("31.12.2026 23:59", hours, true)
+		testOpened("01.01.2027 00:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2024,2026 Jan 1-Dec 31")
+		testOpened("31.12.2023 23:59", hours, false)
+		testOpened("01.01.2024 00:00", hours, true)
+		testOpened("31.12.2024 23:59", hours, true)
+		testOpened("15.06.2025 12:00", hours, false)
+		testOpened("01.01.2026 00:00", hours, true)
+		testOpened("31.12.2026 23:59", hours, true)
+		testOpened("01.01.2027 00:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2024,2026-2027 Jan 1-Dec 31")
+		testOpened("31.12.2023 23:59", hours, false)
+		testOpened("01.01.2024 00:00", hours, true)
+		testOpened("15.06.2025 12:00", hours, false)
+		testOpened("01.01.2026 00:00", hours, true)
+		testOpened("31.12.2027 23:59", hours, true)
+		testOpened("01.01.2028 00:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2024-2025,2027-2028 Jan 1-Dec 31")
+		testOpened("31.12.2023 23:59", hours, false)
+		testOpened("01.01.2024 00:00", hours, true)
+		testOpened("31.12.2025 23:59", hours, true)
+		testOpened("15.06.2026 12:00", hours, false)
+		testOpened("01.01.2027 00:00", hours, true)
+		testOpened("31.12.2028 23:59", hours, true)
+		testOpened("01.01.2029 00:00", hours, false)
+
+		hours = OpeningHoursParser.parseOpenedHours("2024,2026,2028 Jan 1-Dec 31")
+		testOpened("31.12.2023 23:59", hours, false)
+		testOpened("01.01.2024 00:00", hours, true)
+		testOpened("15.06.2025 12:00", hours, false)
+		testOpened("01.01.2026 00:00", hours, true)
+		testOpened("15.06.2027 12:00", hours, false)
+		testOpened("01.01.2028 00:00", hours, true)
+		testOpened("01.01.2029 00:00", hours, false)
+	}
+	
+	private fun testComma() {
+		OpeningHoursParser.setTwelveHourFormattingEnabled(true, "en-US")
+
+		var hours = OpeningHoursParser.parseOpenedHours("Mo-Fr 09:00-13:00,Tu 14:00-18:00, Th 14:00-17:00; We \"Nach Vereinbarung\"; Sa,Su,PH closed")
+		println(hours)
+		testOpened("24.03.2025 10:00", hours, true) // Mo
+		testOpened("24.03.2025 13:30", hours, false)
+		testOpened("24.03.2025 17:50", hours, false)
+		testOpened("25.03.2025 10:00", hours, true) // Tu
+		testOpened("25.03.2025 13:30", hours, false)
+		testOpened("25.03.2025 17:50", hours, true)
+		testInfo("24.03.2025 16:00", hours, "Will open tomorrow at 9:00 AM") // Mo
+		testInfo("25.03.2025 10:00", hours, "Open until 1:00 PM") // Tu
+		testInfo("25.03.2025 13:30", hours, "Will open at 2:00 PM")
+		testInfo("25.03.2025 17:50", hours, "Will close at 6:00 PM")
+		testInfo("25.03.2025 18:50", hours, "Will open on 9:00 AM Thu.") // not ok
+	}
+
+
+	private fun testAmPm() {
+		OpeningHoursParser.setTwelveHourFormattingEnabled(true, "en-US")
+
+		var hours = OpeningHoursParser.parseOpenedHours("Mo-Fr: 9:00-13:00, 14:00-18:00")
+		println(hours)
+		testInfo("15.01.2018 08:00", hours, "Will open at 9:00 AM")
+		testInfo("15.01.2018 09:00", hours, "Open until 1:00 PM")
+		testInfo("15.01.2018 12:00", hours, "Will close at 1:00 PM")
+		testInfo("15.01.2018 13:10", hours, "Will open at 2:00 PM")
+		testInfo("15.01.2018 14:00", hours, "Open until 6:00 PM")
+		testInfo("15.01.2018 16:00", hours, "Will close at 6:00 PM")
+		testInfo("15.01.2018 18:10", hours, "Will open tomorrow at 9:00 AM")
+
+		// Don't write AM or PM twice for range
+		var string = "Mo-Fr 04:30-10:00, 07:30-23:00; Sa, Su, PH 13:30-23:00"
+		hours = OpeningHoursParser.parseOpenedHours(string)
+		testParsedAndAssembledCorrectly("Mo-Fr 4:30-10:00 AM, 7:30 AM-11:00 PM; Sa, Su, PH 1:30-11:00 PM", hours)
+
+		string = "Mo-Fr 00:00-12:00, 12:00-24:00;"
+		hours = OpeningHoursParser.parseOpenedHours(string)
+		testParsedAndAssembledCorrectly("Mo-Fr 12:00 AM-12:00 PM, 12:00 PM-12:00 AM", hours)
+
+		OpeningHoursParser.setTwelveHourFormattingEnabled(true, "zh-TW")
+		string = "Mo-Fr 04:30-10:00, 07:30-23:00; Sa, Su, PH 13:30-23:00"
+		hours = OpeningHoursParser.parseOpenedHours(string)
+		// java.text renders the Traditional Chinese day period as 上午 / 下午, while Foundation follows
+		// newer CLDR data and picks finer periods such as 凌晨, 清晨 and 晚上. Both spellings are correct,
+		// so accept either rather than pin the assertion to one platform's locale data.
+		testParsedAndAssembledCorrectlyOneOf(
+			hours,
+			"Mo-Fr 上午4:30-10:00, 上午7:30-下午11:00; Sa, Su, PH 下午1:30-11:00",
+			"Mo-Fr 凌晨4:30-10:00, 清晨7:30-晚上11:00; Sa, Su, PH 下午1:30-11:00"
+		)
+
+		OpeningHoursParser.setTwelveHourFormattingEnabled(true, "ar")
+		string = "Mo-Fr 04:30-10:00, 07:30-23:00; Sa, Su, PH 13:30-23:00"
+		hours = OpeningHoursParser.parseOpenedHours(string)
+		// java.text defaults Arabic to Arabic-Indic digits, Foundation follows newer CLDR and keeps
+		// Western digits with the Arabic day period markers. Both are valid renderings of "ar".
+		testParsedAndAssembledCorrectlyOneOf(
+			hours,
+			"Mo-Fr ٤:٣٠-١٠:٠٠ ص, ٧:٣٠ ص-١١:٠٠ م; Sa, Su, PH ١:٣٠-١١:٠٠ م",
+			"Mo-Fr 4:30-10:00 ص, 7:30 ص-11:00 م; Sa, Su, PH 1:30-11:00 م"
+		)
+	}
+
+}

--- a/OsmAnd-shared/src/iosMain/kotlin/net/osmand/shared/util/PlatformDateNames.kt
+++ b/OsmAnd-shared/src/iosMain/kotlin/net/osmand/shared/util/PlatformDateNames.kt
@@ -1,0 +1,51 @@
+package net.osmand.shared.util
+
+import platform.Foundation.NSDate
+import platform.Foundation.NSDateFormatter
+import platform.Foundation.NSDateFormatterShortStyle
+import platform.Foundation.NSLocale
+import platform.Foundation.NSTimeZone
+import platform.Foundation.currentLocale
+import platform.Foundation.dateWithTimeIntervalSince1970
+import platform.Foundation.localeWithLocaleIdentifier
+import platform.Foundation.timeZoneWithAbbreviation
+
+actual object PlatformDateNames {
+
+	private fun locale(languageTag: String?): NSLocale =
+		if (languageTag == null) NSLocale.currentLocale
+		// NSLocale identifiers use an underscore, BCP 47 tags a hyphen
+		else NSLocale.localeWithLocaleIdentifier(languageTag.replace('-', '_'))
+
+	private fun formatter(languageTag: String?): NSDateFormatter {
+		val formatter = NSDateFormatter()
+		formatter.locale = locale(languageTag)
+		return formatter
+	}
+
+	actual fun shortMonths(languageTag: String?): Array<String> {
+		val symbols = formatter(languageTag).shortMonthSymbols
+		return Array(12) { index -> symbols.getOrNull(index)?.toString() ?: "" }
+	}
+
+	actual fun shortWeekdays(languageTag: String?): Array<String> {
+		// NSDateFormatter starts at Sunday with index 0, java.util.Calendar leaves index 0 unused
+		// and starts at Sunday with index 1, and the parser indexes the Calendar way
+		val symbols = formatter(languageTag).shortWeekdaySymbols
+		return Array(8) { index ->
+			if (index == 0) "" else symbols.getOrNull(index - 1)?.toString() ?: ""
+		}
+	}
+
+	actual fun formatTwelveHourTime(minutesOfDay: Int, languageTag: String?, withAmPm: Boolean): String {
+		val formatter = formatter(languageTag)
+		if (withAmPm) {
+			formatter.timeStyle = NSDateFormatterShortStyle
+		} else {
+			formatter.dateFormat = "h:mm"
+		}
+		// the value is minutes of a day, not an instant, so read it back in UTC
+		NSTimeZone.timeZoneWithAbbreviation("UTC")?.let { formatter.timeZone = it }
+		return formatter.stringFromDate(NSDate.dateWithTimeIntervalSince1970(minutesOfDay * 60.0))
+	}
+}

--- a/OsmAnd-shared/src/iosMain/kotlin/net/osmand/shared/util/PlatformSerializable.kt
+++ b/OsmAnd-shared/src/iosMain/kotlin/net/osmand/shared/util/PlatformSerializable.kt
@@ -1,0 +1,3 @@
+package net.osmand.shared.util
+
+actual interface PlatformSerializable

--- a/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/util/PlatformDateNames.kt
+++ b/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/util/PlatformDateNames.kt
@@ -1,0 +1,36 @@
+package net.osmand.shared.util
+
+import java.text.DateFormat
+import java.text.DateFormatSymbols
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+actual object PlatformDateNames {
+
+	private fun symbols(languageTag: String?): DateFormatSymbols =
+		if (languageTag == null) DateFormatSymbols.getInstance()
+		else DateFormatSymbols.getInstance(Locale.forLanguageTag(languageTag))
+
+	private fun locale(languageTag: String?): Locale =
+		if (languageTag == null) Locale.getDefault() else Locale.forLanguageTag(languageTag)
+
+	actual fun shortMonths(languageTag: String?): Array<String> =
+		symbols(languageTag).shortMonths.map { it ?: "" }.toTypedArray()
+
+	actual fun shortWeekdays(languageTag: String?): Array<String> =
+		symbols(languageTag).shortWeekdays.map { it ?: "" }.toTypedArray()
+
+	actual fun formatTwelveHourTime(minutesOfDay: Int, languageTag: String?, withAmPm: Boolean): String {
+		val locale = locale(languageTag)
+		val format: DateFormat = if (withAmPm) {
+			DateFormat.getTimeInstance(DateFormat.SHORT, locale)
+		} else {
+			SimpleDateFormat("h:mm", locale)
+		}
+		// the value is minutes of a day, not an instant, so read it back in UTC
+		format.timeZone = TimeZone.getTimeZone("UTC")
+		return format.format(Date(minutesOfDay * 60L * 1000L))
+	}
+}

--- a/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/util/PlatformSerializable.kt
+++ b/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/util/PlatformSerializable.kt
@@ -1,0 +1,3 @@
+package net.osmand.shared.util
+
+actual typealias PlatformSerializable = java.io.Serializable


### PR DESCRIPTION
Part of the routing-to-OsmAnd-shared series: the java classes stay in `OsmAnd-java` and android, tools and the C++ core keep using them; each step adds a copy to `OsmAnd-shared` and a test that the copy behaves like the original. The copies are for iOS, which will call them instead of its own C++ turn preparation.

`OpeningHoursParser`, with the platform names and 12-hour formatting behind `PlatformDateNames`. `OpeningHoursCompatTest` parses the 102 rules the java tests have collected with both parsers and asks both `isOpenedForTime`, `getInfo` and `getCurrentRuleTime` at 3 650 moments over three years.

Supersedes #25903.
