### PR TITLE
Copy RouteTypeRule to OsmAnd-shared

### DIFF
--- a/OsmAnd-java/src/test/java/net/osmand/shared/compat/RouteTypeRuleCompatTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/shared/compat/RouteTypeRuleCompatTest.java
@@ -1,0 +1,102 @@
+package net.osmand.shared.compat;
+
+import static org.junit.Assert.assertEquals;
+
+import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteRegion;
+import net.osmand.shared.routing.RouteTypeRule;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+
+/**
+ * {@link RouteTypeRule} is a copy of {@link net.osmand.binary.BinaryMapRouteReaderAdapter.RouteTypeRule};
+ * this builds both from the same tag and value and compares everything a rule tells the router.
+ *
+ * The tags and values are every encoding rule of every routing region in the test obf files - the
+ * real vocabulary, conditionals and all - plus a handful of shapes that are legal but rare.
+ */
+public class RouteTypeRuleCompatTest {
+
+	private static final String[][] RARE = {
+			{"maxspeed", "50"}, {"maxspeed", "RO:urban"}, {"maxspeed", "none"}, {"maxspeed", "30 mph"},
+			{"maxspeed", "junk"}, {"maxspeed", ""},
+			{"maxspeed:conditional", "50 @ (22:00-06:00)"},
+			{"maxspeed:conditional", "30 @ (Mo-Fr 07:00-09:00); 50 @ (Sa,Su)"},
+			{"maxspeed:conditional", "junk @ ()"},
+			{"maxspeed:hgv", "60"}, {"maxspeed:forward", "70"}, {"maxspeed:backward", "40"},
+			{"maxspeed:hgv:forward", "60"},
+			{"lanes", "2"}, {"lanes", "2;3"}, {"lanes", "junk"}, {"lanes", ""},
+			{"oneway", "yes"}, {"oneway", "-1"}, {"oneway", "no"}, {"oneway", "reversible"}, {"oneway", null},
+			{"junction", "roundabout"}, {"roundabout", "yes"},
+			{"highway", "motorway"}, {"highway", "junk"}, {"highway", null},
+			{"access:conditional", "no @ (Mo-Fr 07:00-09:00)"},
+			{"hgv:conditional", "no @ (22:00-06:00)"},
+			{"traffic_signals", "signal"}, {"name", "Main street"}, {"tunnel", "yes"},
+			{"layer", "-1"}, {"maxheight", "3.5"}, {"maxweight", "7.5 t"}, {"width", "2.5 m"},
+			{"area", null}, {"", ""},
+	};
+
+	private static List<String[]> corpus() throws IOException {
+		List<String[]> pairs = new ArrayList<>();
+		for (RouteRegion region : TestObf.regions()) {
+			for (net.osmand.binary.BinaryMapRouteReaderAdapter.RouteTypeRule rule : region.routeEncodingRules) {
+				if (rule != null) {
+					pairs.add(new String[] {rule.getTag(), rule.getValue()});
+				}
+			}
+		}
+		for (String[] rare : RARE) {
+			pairs.add(rare);
+		}
+		return pairs;
+	}
+
+	private static long[] moments() {
+		long[] times = new long[6];
+		Calendar cal = Calendar.getInstance();
+		int[][] when = {{2024, Calendar.JANUARY, 15, 8, 30}, {2024, Calendar.JUNE, 15, 23, 30},
+				{2024, Calendar.DECEMBER, 25, 12, 0}, {2024, Calendar.MARCH, 3, 0, 0},
+				{2025, Calendar.JULY, 4, 7, 59}, {2022, Calendar.SEPTEMBER, 30, 18, 1}};
+		for (int i = 0; i < when.length; i++) {
+			cal.clear();
+			cal.set(when[i][0], when[i][1], when[i][2], when[i][3], when[i][4], 0);
+			times[i] = cal.getTimeInMillis();
+		}
+		return times;
+	}
+
+	@Test
+	public void testEveryRuleAgrees() throws IOException {
+		List<String[]> corpus = corpus();
+		assertEquals(true, corpus.size() > 1000);
+		long[] moments = moments();
+		for (String[] pair : corpus) {
+			String m = pair[0] + "=" + pair[1];
+			net.osmand.binary.BinaryMapRouteReaderAdapter.RouteTypeRule j =
+					new net.osmand.binary.BinaryMapRouteReaderAdapter.RouteTypeRule(pair[0], pair[1]);
+			RouteTypeRule k = new RouteTypeRule(pair[0], pair[1]);
+			assertEquals(m, j.getTag(), k.getTag());
+			assertEquals(m, j.getValue(), k.getValue());
+			assertEquals(m, j.getType(), k.getType());
+			assertEquals(m, j.isForward(), k.isForward());
+			assertEquals(m, j.roundabout(), k.roundabout());
+			assertEquals(m, j.conditional(), k.conditional());
+			assertEquals(m, j.getNonConditionalTag(), k.getNonConditionalTag());
+			assertEquals(m, j.onewayDirection(), k.onewayDirection());
+			assertEquals(m, j.getMaxIntegerConditionalValue(), k.getMaxIntegerConditionalValue());
+			assertEquals(m, j.lanes(), k.lanes());
+			assertEquals(m, j.highwayRoad(), k.highwayRoad());
+			assertEquals(m, j.toString(), k.toString());
+			for (int profile : new int[] {RouteTypeRule.PROFILE_NONE, RouteTypeRule.PROFILE_CAR, RouteTypeRule.PROFILE_TRUCK}) {
+				assertEquals(m + " profile " + profile, j.maxSpeed(profile), k.maxSpeed(profile), 0f);
+			}
+			for (long t : moments) {
+				assertEquals(m + " at " + t, j.conditionalValue(t), k.conditionalValue(t));
+			}
+		}
+	}
+}

--- a/OsmAnd-java/src/test/java/net/osmand/shared/compat/TestObf.java
+++ b/OsmAnd-java/src/test/java/net/osmand/shared/compat/TestObf.java
@@ -1,0 +1,84 @@
+package net.osmand.shared.compat;
+
+import net.osmand.binary.BinaryMapDataObject;
+import net.osmand.binary.BinaryMapIndexReader;
+import net.osmand.binary.BinaryMapIndexReader.SearchRequest;
+import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteRegion;
+import net.osmand.binary.BinaryMapRouteReaderAdapter.RouteSubregion;
+import net.osmand.binary.RouteDataObject;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * The obf files the routing tests ship with, opened once, and the roads in them - real input for the
+ * java-versus-copy tests, which otherwise would have to invent roads and would invent the easy ones.
+ */
+public final class TestObf {
+
+	private static List<BinaryMapIndexReader> readers;
+
+	private TestObf() {
+	}
+
+	public static synchronized List<BinaryMapIndexReader> readers() throws IOException {
+		if (readers == null) {
+			List<File> files = new ArrayList<>();
+			File resources = new File("src/test/resources");
+			files.add(new File(resources, "Turn_lanes_test.obf"));
+			File[] routing = new File(resources, "routing").listFiles((dir, name) -> name.endsWith(".obf"));
+			if (routing != null) {
+				Arrays.sort(routing);
+				files.addAll(Arrays.asList(routing));
+			}
+			List<BinaryMapIndexReader> opened = new ArrayList<>();
+			for (File f : files) {
+				if (f.exists()) {
+					opened.add(new BinaryMapIndexReader(new RandomAccessFile(f, "r"), f));
+				}
+			}
+			readers = opened;
+		}
+		return readers;
+	}
+
+	/** Every routing region of every file, in file order. */
+	public static List<RouteRegion> regions() throws IOException {
+		List<RouteRegion> regions = new ArrayList<>();
+		for (BinaryMapIndexReader reader : readers()) {
+			regions.addAll(reader.getRoutingIndexes());
+		}
+		return regions;
+	}
+
+	/** Up to {@code perFile} roads out of each file, whole regions at a time, in file order. */
+	public static List<RouteDataObject> roads(int perFile) throws IOException {
+		List<RouteDataObject> roads = new ArrayList<>();
+		for (BinaryMapIndexReader reader : readers()) {
+			int fromThisFile = 0;
+			SearchRequest<BinaryMapDataObject> req = BinaryMapIndexReader.buildSearchRequest(
+					0, Integer.MAX_VALUE, 0, Integer.MAX_VALUE, 16, null);
+			for (RouteRegion region : reader.getRoutingIndexes()) {
+				for (RouteSubregion subregion : reader.searchRouteIndexTree(req, region.getSubregions())) {
+					for (RouteDataObject road : reader.loadRouteIndexData(subregion)) {
+						if (road != null && fromThisFile < perFile) {
+							roads.add(road);
+							fromThisFile++;
+						}
+					}
+					if (fromThisFile >= perFile) {
+						break;
+					}
+				}
+				if (fromThisFile >= perFile) {
+					break;
+				}
+			}
+		}
+		return roads;
+	}
+}

--- a/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/util/PlatformStrings.kt
+++ b/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/util/PlatformStrings.kt
@@ -1,0 +1,3 @@
+package net.osmand.shared.util
+
+actual fun internString(value: String): String = value.intern()

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteDataUtils.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteDataUtils.kt
@@ -1,0 +1,33 @@
+package net.osmand.shared.routing
+
+import net.osmand.shared.util.KAlgorithms
+import kotlin.jvm.JvmStatic
+
+/** Helpers shared by the routing data model. */
+object RouteDataUtils {
+
+	/** Speed reported for roads tagged `maxspeed=none`, in m/s. */
+	const val NONE_MAX_SPEED = 40f
+
+	/**
+	 * Converts an osm `maxspeed` value to m/s, [def] if the value carries no number.
+	 */
+	@JvmStatic
+	fun parseSpeed(v: String, def: Float): Float {
+		if (v == "none") {
+			return NONE_MAX_SPEED
+		}
+		val i = KAlgorithms.findFirstNumberEndIndex(v)
+		if (i > 0) {
+			// the arithmetic runs in double and narrows once, the way the java original did, so the
+			// speeds that reach the router are bit for bit the ones it saw before
+			var f = v.substring(0, i).toFloat()
+			f = (f / 3.6).toFloat() // km/h -> m/s
+			if (v.contains("mph")) {
+				f = (f * 1.6).toFloat()
+			}
+			return f
+		}
+		return def
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteTypeRule.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteTypeRule.kt
@@ -1,0 +1,232 @@
+package net.osmand.shared.routing
+
+import net.osmand.shared.util.KAlgorithms
+import net.osmand.shared.util.LoggerFactory
+import net.osmand.shared.util.OpeningHoursParser
+import net.osmand.shared.util.internString
+
+/**
+ * One tag/value pair of the routing section of an obf file.
+ *
+ * Rules are read once per region and then looked up by index for every road of that region,
+ * so everything the router asks for later is precomputed in [analyze].
+ */
+class RouteTypeRule(t: String, v: String?) {
+
+	private val t: String
+	private val v: String?
+	private var intValue = 0
+	private var floatValue = 0f
+	private var type = 0
+	private var conditions: MutableList<RouteTypeCondition>? = null
+	private var forward = 0
+
+	init {
+		this.t = internString(t)
+		var value = v
+		if ("true" == value) {
+			value = "yes"
+		}
+		if ("false" == value) {
+			value = "no"
+		}
+		this.v = if (value == null) null else internString(value)
+		try {
+			analyze()
+		} catch (e: RuntimeException) {
+			LOG.error("Error analyzing tag/value = ${this.t}/${this.v}")
+			throw e
+		}
+	}
+
+	/** A single `value @ (opening hours)` alternative of a `*:conditional` tag. */
+	class RouteTypeCondition internal constructor(val value: String?, val condition: String) {
+
+		internal val hours: OpeningHoursParser.OpeningHours? =
+			OpeningHoursParser.parseOpenedHours(condition)
+
+		/** Index of the rule this condition resolves to, assigned by the owning route region. */
+		var ruleId: Int = 0
+	}
+
+	override fun hashCode(): Int {
+		val prime = 31
+		var result = 1
+		result = prime * result + (t.hashCode())
+		result = prime * result + (v?.hashCode() ?: 0)
+		return result
+	}
+
+	override fun equals(other: Any?): Boolean {
+		if (this === other) {
+			return true
+		}
+		if (other == null || other !is RouteTypeRule) {
+			return false
+		}
+		return KAlgorithms.stringsEqual(other.t, t) && KAlgorithms.stringsEqual(other.v, v)
+	}
+
+	override fun toString(): String = "$t=$v"
+
+	fun isForward(): Int = forward
+
+	fun getTag(): String = t
+
+	fun getValue(): String? = v
+
+	fun roundabout(): Boolean = type == ROUNDABOUT
+
+	fun getType(): Int = type
+
+	fun conditional(): Boolean = conditions != null
+
+	fun getConditions(): List<RouteTypeCondition>? = conditions
+
+	fun getNonConditionalTag(): String {
+		var tag = getTag()
+		if (tag.endsWith(":conditional")) {
+			tag = tag.substring(0, tag.length - ":conditional".length)
+		}
+		return tag
+	}
+
+	fun onewayDirection(): Int {
+		if (type == ONEWAY) {
+			return intValue
+		}
+		return 0
+	}
+
+	fun conditionalValue(time: Long): Int {
+		conditions?.let {
+			for (c in it) {
+				if (c.hours != null && c.hours.isOpenedForTime(time)) {
+					return c.ruleId
+				}
+			}
+		}
+		return 0
+	}
+
+	fun getMaxIntegerConditionalValue(): Int? {
+		val conditions = this.conditions ?: return null
+		var maxValue = Int.MIN_VALUE
+		for (c in conditions) {
+			val value = c.value?.toIntOrNull() ?: continue
+			if (value > maxValue) {
+				maxValue = value
+			}
+		}
+		return if (maxValue > Int.MIN_VALUE) maxValue else null
+	}
+
+	fun maxSpeed(profile: Int): Float {
+		if (type == MAXSPEED + profile) {
+			return floatValue
+		}
+		return -1f
+	}
+
+	fun lanes(): Int {
+		if (type == LANES) {
+			return intValue
+		}
+		return -1
+	}
+
+	fun highwayRoad(): String? {
+		if (type == HIGHWAY_TYPE) {
+			return v
+		}
+		return null
+	}
+
+	private fun analyze() {
+		if (t.equals("oneway", ignoreCase = true)) {
+			type = ONEWAY
+			intValue = if ("-1" == v || "reverse" == v) {
+				-1
+			} else if ("1" == v || "yes" == v) {
+				1
+			} else {
+				0
+			}
+		} else if (t.equals("highway", ignoreCase = true) && "traffic_signals" == v) {
+			type = TRAFFIC_SIGNALS
+		} else if (t.equals("railway", ignoreCase = true) && ("crossing" == v || "level_crossing" == v)) {
+			type = RAILWAY_CROSSING
+		} else if (t.equals("roundabout", ignoreCase = true) && v != null) {
+			type = ROUNDABOUT
+		} else if (t.equals("junction", ignoreCase = true) && "roundabout".equals(v, ignoreCase = true)) {
+			type = ROUNDABOUT
+		} else if (t.equals("highway", ignoreCase = true) && v != null) {
+			type = HIGHWAY_TYPE
+		} else if (t.endsWith(":conditional") && v != null) {
+			val parsed = ArrayList<RouteTypeCondition>()
+			for (c in v.split(");")) {
+				val ch = c.indexOf('@')
+				if (ch > 0) {
+					var condition = c.substring(ch + 1).trim()
+					if (condition.startsWith("(")) {
+						condition = condition.substring(1).trim()
+					}
+					if (condition.endsWith(")")) {
+						condition = condition.substring(0, condition.length - 1).trim()
+					}
+					parsed.add(RouteTypeCondition(c.substring(0, ch).trim(), condition))
+				}
+			}
+			conditions = parsed
+			// we don't set type for conditional so they are not used directly
+		} else if (t.startsWith("access") && v != null) {
+			type = ACCESS
+		} else if (t.startsWith("maxspeed") && v != null) {
+			var tg = t
+			if (t.endsWith(":forward")) {
+				tg = t.substring(0, t.length - ":forward".length)
+				forward = 1
+			} else if (t.endsWith(":backward")) {
+				tg = t.substring(0, t.length - ":backward".length)
+				forward = -1
+			} else {
+				forward = 0
+			}
+			floatValue = RouteDataUtils.parseSpeed(v, 0f)
+			if (tg.equals("maxspeed", ignoreCase = true)) {
+				type = MAXSPEED
+			} else if (tg.equals("maxspeed:hgv", ignoreCase = true)) {
+				type = MAXSPEED + PROFILE_TRUCK
+			} else if (tg.equals("maxspeed:motorcar", ignoreCase = true)) {
+				type = MAXSPEED + PROFILE_CAR
+			}
+		} else if (t.equals("lanes", ignoreCase = true) && v != null) {
+			intValue = -1
+			var i = 0
+			type = LANES
+			while (i < v.length && KAlgorithms.isDigit(v[i])) {
+				i++
+			}
+			if (i > 0) {
+				intValue = v.substring(0, i).toInt()
+			}
+		}
+	}
+
+	companion object {
+		private val LOG = LoggerFactory.getLogger("RouteTypeRule")
+
+		private const val ACCESS = 1
+		private const val ONEWAY = 2
+		private const val HIGHWAY_TYPE = 3
+		private const val MAXSPEED = 4
+		private const val ROUNDABOUT = 5
+		const val TRAFFIC_SIGNALS = 6
+		const val RAILWAY_CROSSING = 7
+		private const val LANES = 8
+
+		const val PROFILE_NONE = 0
+		const val PROFILE_TRUCK = 1000
+		const val PROFILE_CAR = 1001
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/KAlgorithms.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/KAlgorithms.kt
@@ -93,6 +93,50 @@ object KAlgorithms {
 		}
 	}
 
+	fun isDigit(c: Char): Boolean {
+		return c in '0'..'9'
+	}
+
+	/**
+	 * Index right after the leading decimal number of [value], -1 when it does not start with one.
+	 * A trailing dot is not part of the number, so "40." reports 2.
+	 */
+	fun findFirstNumberEndIndex(value: String): Int {
+		var i = 0
+		if (value.isNotEmpty() && value[0] == '-') {
+			i++
+		}
+		var state = 0 // 0 - no number, 1 - 1st digits, 2 - dot, 3 - last digits
+		while (i < value.length && (isDigit(value[i]) || value[i] == '.')) {
+			if (value[i] == '.') {
+				if (state == 2) {
+					return i - 1
+				}
+				if (state != 1) {
+					return -1
+				}
+				state = 2
+			} else {
+				if (state == 2) {
+					// last digits
+					state = 3
+				} else if (state == 0) {
+					// first digits started
+					state = 1
+				}
+			}
+			i++
+		}
+		if (state == 2) {
+			// invalid number like 40. correct to -> '40'
+			return i - 1
+		}
+		if (state == 0) {
+			return -1
+		}
+		return i
+	}
+
 	fun colorToString(color: Int): String {
 		return if ((0xFF000000.toInt() and color) == 0xFF000000.toInt()) {
 			"#%06X".format(color and 0x00FFFFFF)

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/OpeningHoursTime.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/OpeningHoursTime.kt
@@ -3,6 +3,7 @@ package net.osmand.shared.util
 import kotlin.jvm.JvmStatic
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.IllegalTimeZoneException
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
@@ -75,6 +76,20 @@ class OpeningHoursTime(var dateTime: LocalDateTime) {
 		fun ofEpochMillis(epochMillis: Long): OpeningHoursTime = OpeningHoursTime(
 			Instant.fromEpochMilliseconds(epochMillis).toLocalDateTime(TimeZone.currentSystemDefault())
 		)
+
+		/**
+		 * [epochMillis] read in [timeZoneId], the equivalent of `Calendar.getInstance(TimeZone)`.
+		 * An unknown zone falls back to UTC, the way `TimeZone.getTimeZone` falls back to GMT.
+		 */
+		@JvmStatic
+		fun ofEpochMillis(epochMillis: Long, timeZoneId: String): OpeningHoursTime {
+			val zone = try {
+				TimeZone.of(timeZoneId)
+			} catch (e: IllegalTimeZoneException) {
+				TimeZone.UTC
+			}
+			return OpeningHoursTime(Instant.fromEpochMilliseconds(epochMillis).toLocalDateTime(zone))
+		}
 
 		/** Explicit wall clock reading, mostly useful in tests. */
 		@JvmStatic

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/PlatformStrings.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/PlatformStrings.kt
@@ -1,0 +1,9 @@
+package net.osmand.shared.util
+
+/**
+ * Returns a shared instance of [value] where the platform keeps a string pool.
+ *
+ * Every loaded region repeats the same routing tags and values, so pooling them keeps
+ * one copy per tag instead of one per region.
+ */
+expect fun internString(value: String): String

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/routing/RouteTypeRuleTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/routing/RouteTypeRuleTest.kt
@@ -1,0 +1,177 @@
+package net.osmand.shared.routing
+
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RouteTypeRuleTest {
+
+	private fun assertSpeed(expected: Float, actual: Float) {
+		assertTrue(abs(expected - actual) < 1e-4f, "expected $expected but was $actual")
+	}
+
+	@Test
+	fun testOneway() {
+		assertEquals(1, RouteTypeRule("oneway", "yes").onewayDirection())
+		assertEquals(1, RouteTypeRule("oneway", "1").onewayDirection())
+		assertEquals(-1, RouteTypeRule("oneway", "-1").onewayDirection())
+		assertEquals(-1, RouteTypeRule("oneway", "reverse").onewayDirection())
+		assertEquals(0, RouteTypeRule("oneway", "no").onewayDirection())
+		// the tag is matched case insensitively
+		assertEquals(1, RouteTypeRule("OneWay", "yes").onewayDirection())
+		// a rule of another type never reports a direction
+		assertEquals(0, RouteTypeRule("highway", "primary").onewayDirection())
+	}
+
+	@Test
+	fun testBooleanValuesAreNormalized() {
+		// "true"/"false" come from a few third party sources, osm itself uses yes/no
+		assertEquals("yes", RouteTypeRule("oneway", "true").getValue())
+		assertEquals("no", RouteTypeRule("oneway", "false").getValue())
+		assertEquals(1, RouteTypeRule("oneway", "true").onewayDirection())
+		assertEquals(0, RouteTypeRule("oneway", "false").onewayDirection())
+	}
+
+	@Test
+	fun testHighwayAndRoundabout() {
+		val primary = RouteTypeRule("highway", "primary")
+		assertEquals("primary", primary.highwayRoad())
+		assertFalse(primary.roundabout())
+
+		assertTrue(RouteTypeRule("junction", "roundabout").roundabout())
+		assertTrue(RouteTypeRule("roundabout", "any").roundabout())
+		assertNull(RouteTypeRule("junction", "roundabout").highwayRoad())
+		// a highway without a value is not a highway type rule
+		assertNull(RouteTypeRule("highway", null).highwayRoad())
+	}
+
+	@Test
+	fun testTrafficSignalsAndRailwayCrossing() {
+		assertEquals(RouteTypeRule.TRAFFIC_SIGNALS, RouteTypeRule("highway", "traffic_signals").getType())
+		assertEquals(RouteTypeRule.RAILWAY_CROSSING, RouteTypeRule("railway", "crossing").getType())
+		assertEquals(RouteTypeRule.RAILWAY_CROSSING, RouteTypeRule("railway", "level_crossing").getType())
+		assertNotEquals(RouteTypeRule.RAILWAY_CROSSING, RouteTypeRule("railway", "rail").getType())
+	}
+
+	@Test
+	fun testMaxSpeed() {
+		// values are stored in m/s
+		assertSpeed(50 / 3.6f, RouteTypeRule("maxspeed", "50").maxSpeed(RouteTypeRule.PROFILE_NONE))
+		assertSpeed(30 / 3.6f * 1.6f, RouteTypeRule("maxspeed", "30 mph").maxSpeed(RouteTypeRule.PROFILE_NONE))
+		assertSpeed(RouteDataUtils.NONE_MAX_SPEED, RouteTypeRule("maxspeed", "none").maxSpeed(RouteTypeRule.PROFILE_NONE))
+		// an unparseable value keeps the default passed to parseSpeed, which is 0
+		assertSpeed(0f, RouteTypeRule("maxspeed", "walk").maxSpeed(RouteTypeRule.PROFILE_NONE))
+		// asking for the wrong profile reports no limit
+		assertSpeed(-1f, RouteTypeRule("maxspeed", "50").maxSpeed(RouteTypeRule.PROFILE_TRUCK))
+	}
+
+	@Test
+	fun testMaxSpeedProfiles() {
+		val hgv = RouteTypeRule("maxspeed:hgv", "60")
+		assertSpeed(60 / 3.6f, hgv.maxSpeed(RouteTypeRule.PROFILE_TRUCK))
+		assertSpeed(-1f, hgv.maxSpeed(RouteTypeRule.PROFILE_NONE))
+
+		val motorcar = RouteTypeRule("maxspeed:motorcar", "90")
+		assertSpeed(90 / 3.6f, motorcar.maxSpeed(RouteTypeRule.PROFILE_CAR))
+		assertSpeed(-1f, motorcar.maxSpeed(RouteTypeRule.PROFILE_NONE))
+	}
+
+	@Test
+	fun testMaxSpeedDirection() {
+		val forward = RouteTypeRule("maxspeed:forward", "70")
+		assertEquals(1, forward.isForward())
+		assertSpeed(70 / 3.6f, forward.maxSpeed(RouteTypeRule.PROFILE_NONE))
+
+		val backward = RouteTypeRule("maxspeed:backward", "70")
+		assertEquals(-1, backward.isForward())
+		assertSpeed(70 / 3.6f, backward.maxSpeed(RouteTypeRule.PROFILE_NONE))
+
+		assertEquals(0, RouteTypeRule("maxspeed", "70").isForward())
+	}
+
+	@Test
+	fun testLanes() {
+		assertEquals(3, RouteTypeRule("lanes", "3").lanes())
+		// osm sometimes carries a suffix, the leading digits still count
+		assertEquals(2, RouteTypeRule("lanes", "2 lanes").lanes())
+		assertEquals(-1, RouteTypeRule("lanes", "unknown").lanes())
+		assertEquals(-1, RouteTypeRule("highway", "primary").lanes())
+	}
+
+	@Test
+	fun testConditional() {
+		val rule = RouteTypeRule("maxspeed:conditional", "30 @ (Mo-Fr 07:00-19:00); 50 @ (Sa-Su)")
+		assertTrue(rule.conditional())
+		assertEquals("maxspeed", rule.getNonConditionalTag())
+		// a conditional rule is never used directly, so it stays untyped
+		assertEquals(0, rule.getType())
+
+		val conditions = rule.getConditions()
+		assertEquals(2, conditions?.size)
+		assertEquals("30", conditions?.get(0)?.value)
+		assertEquals("50", conditions?.get(1)?.value)
+	}
+
+	@Test
+	fun testConditionalValueResolvesToRuleId() {
+		val rule = RouteTypeRule("access:conditional", "no @ (24/7)")
+		rule.getConditions()!![0].ruleId = 42
+		assertEquals(42, rule.conditionalValue(0L))
+
+		// an unconditional rule has nothing to resolve
+		assertFalse(RouteTypeRule("access", "no").conditional())
+		assertEquals(0, RouteTypeRule("access", "no").conditionalValue(0L))
+	}
+
+	@Test
+	fun testMaxIntegerConditionalValue() {
+		val rule = RouteTypeRule("maxspeed:conditional", "30 @ (Mo-Fr 07:00-19:00); 50 @ (Sa-Su)")
+		assertEquals(50, rule.getMaxIntegerConditionalValue())
+
+		// non numeric values are skipped, and a rule with none at all reports nothing
+		val weight = RouteTypeRule("maxweight:conditional", "delivery @ (Mo-Fr 07:00-19:00)")
+		assertNull(weight.getMaxIntegerConditionalValue())
+		assertNull(RouteTypeRule("highway", "primary").getMaxIntegerConditionalValue())
+	}
+
+	@Test
+	fun testNonConditionalTagOfPlainTag() {
+		assertEquals("maxspeed", RouteTypeRule("maxspeed", "50").getNonConditionalTag())
+	}
+
+	@Test
+	fun testEqualsAndHashCode() {
+		// rules are used as map keys when a route is exported
+		val a = RouteTypeRule("highway", "primary")
+		val b = RouteTypeRule("highway", "primary")
+		assertEquals(a, b)
+		assertEquals(a.hashCode(), b.hashCode())
+
+		assertNotEquals(a, RouteTypeRule("highway", "secondary"))
+		assertNotEquals(a, RouteTypeRule("route", "primary"))
+		assertNotEquals<Any?>(a, "highway=primary")
+
+		val noValue = RouteTypeRule("name", null)
+		assertEquals(noValue, RouteTypeRule("name", null))
+		assertNotEquals(noValue, RouteTypeRule("name", "Main street"))
+	}
+
+	@Test
+	fun testToString() {
+		assertEquals("highway=primary", RouteTypeRule("highway", "primary").toString())
+		assertEquals("name=null", RouteTypeRule("name", null).toString())
+	}
+
+	@Test
+	fun testParseSpeed() {
+		assertSpeed(RouteDataUtils.NONE_MAX_SPEED, RouteDataUtils.parseSpeed("none", 1f))
+		assertSpeed(50 / 3.6f, RouteDataUtils.parseSpeed("50", 1f))
+		assertSpeed(50 / 3.6f, RouteDataUtils.parseSpeed("50 km/h", 1f))
+		assertSpeed(50 / 3.6f * 1.6f, RouteDataUtils.parseSpeed("50mph", 1f))
+		assertSpeed(7.5f, RouteDataUtils.parseSpeed("no number", 7.5f))
+	}
+}

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/KAlgorithmsTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/KAlgorithmsTest.kt
@@ -1,0 +1,46 @@
+package net.osmand.shared.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class KAlgorithmsTest {
+
+	@Test
+	fun testIsDigit() {
+		assertTrue(KAlgorithms.isDigit('0'))
+		assertTrue(KAlgorithms.isDigit('9'))
+		assertFalse(KAlgorithms.isDigit('.'))
+		assertFalse(KAlgorithms.isDigit('a'))
+		// only ascii digits count, the same as the java original
+		assertFalse(KAlgorithms.isDigit('٣'))
+	}
+
+	@Test
+	fun testFindFirstNumberEndIndex() {
+		assertEquals(2, KAlgorithms.findFirstNumberEndIndex("50"))
+		assertEquals(2, KAlgorithms.findFirstNumberEndIndex("50 km/h"))
+		assertEquals(4, KAlgorithms.findFirstNumberEndIndex("12.5 t"))
+		assertEquals(2, KAlgorithms.findFirstNumberEndIndex("-5"))
+		assertEquals(4, KAlgorithms.findFirstNumberEndIndex("-3.5m"))
+	}
+
+	@Test
+	fun testFindFirstNumberEndIndexWithoutNumber() {
+		assertEquals(-1, KAlgorithms.findFirstNumberEndIndex(""))
+		assertEquals(-1, KAlgorithms.findFirstNumberEndIndex("none"))
+		assertEquals(-1, KAlgorithms.findFirstNumberEndIndex("-"))
+		// a value that opens with a dot carries no number
+		assertEquals(-1, KAlgorithms.findFirstNumberEndIndex(".5"))
+	}
+
+	@Test
+	fun testFindFirstNumberEndIndexDropsTrailingDot() {
+		// "40." is corrected to "40"
+		assertEquals(2, KAlgorithms.findFirstNumberEndIndex("40."))
+		assertEquals(2, KAlgorithms.findFirstNumberEndIndex("40. t"))
+		// a second dot makes the whole value unusable
+		assertEquals(-1, KAlgorithms.findFirstNumberEndIndex("40.5.1"))
+	}
+}

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/OpeningHoursTimeTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/OpeningHoursTimeTest.kt
@@ -1,0 +1,31 @@
+package net.osmand.shared.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OpeningHoursTimeTest {
+
+	// 2024-06-01T12:00:00Z
+	private val instant = 1717243200000L
+
+	@Test
+	fun testOfEpochMillisInZone() {
+		val utc = OpeningHoursTime.ofEpochMillis(instant, "UTC")
+		assertEquals(2024, utc.year)
+		assertEquals(5, utc.month) // zero based, June
+		assertEquals(1, utc.dayOfMonth)
+		assertEquals(12, utc.hourOfDay)
+
+		assertEquals(15, OpeningHoursTime.ofEpochMillis(instant, "Europe/Moscow").hourOfDay)
+		// summer time is applied, New York is at UTC-4 in June
+		assertEquals(8, OpeningHoursTime.ofEpochMillis(instant, "America/New_York").hourOfDay)
+	}
+
+	@Test
+	fun testOfEpochMillisFallsBackToUtc() {
+		// TimeZone.getTimeZone answers GMT for an unknown id, this keeps that behaviour
+		val unknown = OpeningHoursTime.ofEpochMillis(instant, "Not/AZone")
+		assertEquals(12, unknown.hourOfDay)
+		assertEquals(1, unknown.dayOfMonth)
+	}
+}

--- a/OsmAnd-shared/src/iosMain/kotlin/net/osmand/shared/util/PlatformStrings.kt
+++ b/OsmAnd-shared/src/iosMain/kotlin/net/osmand/shared/util/PlatformStrings.kt
@@ -1,0 +1,4 @@
+package net.osmand.shared.util
+
+// Kotlin/Native has no string pool, strings stay as they were read.
+actual fun internString(value: String): String = value

--- a/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/util/PlatformStrings.kt
+++ b/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/util/PlatformStrings.kt
@@ -1,0 +1,3 @@
+package net.osmand.shared.util
+
+actual fun internString(value: String): String = value.intern()


### PR DESCRIPTION
Part of the routing-to-OsmAnd-shared series: the java classes stay in `OsmAnd-java` and android, tools and the C++ core keep using them; each step adds a copy to `OsmAnd-shared` and a test that the copy behaves like the original. The copies are for iOS, which will call them instead of its own C++ turn preparation.

`RouteTypeRule`, the decoded form of one encoding rule of a routing region. `RouteTypeRuleCompatTest` builds both from every encoding rule of every routing region in the test obf files, plus the rare shapes, and compares type, direction, speed per profile, lanes and the conditional values at six moments. `TestObf`, which opens the routing test obf files once, arrives here for the tests that follow.

Supersedes #25904.
