### PR TITLE
KTIntObjectMap for OsmAnd-shared

### DIFF
--- a/OsmAnd-java/src/test/java/net/osmand/shared/util/collections/CollectionsTroveBenchmarkTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/shared/util/collections/CollectionsTroveBenchmarkTest.java
@@ -14,6 +14,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import gnu.trove.list.array.TIntArrayList;
+import gnu.trove.map.hash.TIntObjectHashMap;
 import gnu.trove.map.hash.TLongObjectHashMap;
 import gnu.trove.set.hash.TLongHashSet;
 
@@ -117,6 +118,78 @@ public class CollectionsTroveBenchmarkTest {
 			assertEquals(checksums[1], checksums[0]);
 			assertEquals(checksums[1], checksums[2]);
 			printRow(distribution.label, "KTLongObjectMap", shared, "TLongObjectHashMap", trove, "HashMap", boxed);
+		}
+	}
+
+	@Test
+	public void benchmarkIntObjectMap() {
+		System.out.println();
+		System.out.printf("### int -> object map, %d entries, %d lookups%n", ENTRIES, LOOKUPS);
+		printHeader();
+
+		for (IntKeyDistribution distribution : IntKeyDistribution.values()) {
+			int[] keys = distribution.keys(ENTRIES);
+			int[] probes = intProbeKeys(keys, LOOKUPS);
+			Object value = new Object();
+			long[] checksums = new long[3];
+
+			double shared = measure(() -> {
+				KTIntObjectMap<Object> map = new KTIntObjectMap<>(ENTRIES);
+				for (int key : keys) {
+					map.put(key, value);
+				}
+				long hits = 0;
+				for (int probe : probes) {
+					if (map.get(probe) != null) {
+						hits++;
+					}
+				}
+				long iterated = 0;
+				for (int key : map.keys()) {
+					iterated += key;
+				}
+				checksums[0] = hits * 31 + iterated;
+			});
+
+			double trove = measure(() -> {
+				TIntObjectHashMap<Object> map = new TIntObjectHashMap<>(ENTRIES);
+				for (int key : keys) {
+					map.put(key, value);
+				}
+				long hits = 0;
+				for (int probe : probes) {
+					if (map.get(probe) != null) {
+						hits++;
+					}
+				}
+				long iterated = 0;
+				for (int key : map.keys()) {
+					iterated += key;
+				}
+				checksums[1] = hits * 31 + iterated;
+			});
+
+			double boxed = measure(() -> {
+				HashMap<Integer, Object> map = new HashMap<>(ENTRIES * 2);
+				for (int key : keys) {
+					map.put(key, value);
+				}
+				long hits = 0;
+				for (int probe : probes) {
+					if (map.get(probe) != null) {
+						hits++;
+					}
+				}
+				long iterated = 0;
+				for (int key : map.keySet()) {
+					iterated += key;
+				}
+				checksums[2] = hits * 31 + iterated;
+			});
+
+			assertEquals(checksums[1], checksums[0]);
+			assertEquals(checksums[1], checksums[2]);
+			printRow(distribution.label, "KTIntObjectMap", shared, "TIntObjectHashMap", trove, "HashMap", boxed);
 		}
 	}
 
@@ -317,6 +390,42 @@ public class CollectionsTroveBenchmarkTest {
 			}
 			return keys;
 		}
+	}
+
+	private enum IntKeyDistribution {
+
+		/** Dense ids counted from zero, the shape of encoding rule and string table keys. */
+		DENSE_IDS("encoding rules"),
+
+		/** Uniformly spread keys, the friendly case for any hash function. */
+		RANDOM("random     ");
+
+		final String label;
+
+		IntKeyDistribution(String label) {
+			this.label = label;
+		}
+
+		int[] keys(int count) {
+			int[] keys = new int[count];
+			Random random = new Random(20260908L);
+			for (int i = 0; i < count; i++) {
+				keys[i] = this == DENSE_IDS ? i : random.nextInt();
+			}
+			return keys;
+		}
+	}
+
+	/** Half of the probes hit an existing key, half miss. */
+	private static int[] intProbeKeys(int[] keys, int count) {
+		int[] probes = new int[count];
+		Random random = new Random(1234L);
+		for (int i = 0; i < count; i++) {
+			probes[i] = (i & 1) == 0
+					? keys[random.nextInt(keys.length)]
+					: random.nextInt() | (1 << 30);
+		}
+		return probes;
 	}
 
 	/** Half of the probes hit an existing key, half miss. */

--- a/OsmAnd-java/src/test/java/net/osmand/shared/util/collections/TroveComparisonTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/shared/util/collections/TroveComparisonTest.java
@@ -11,6 +11,7 @@ import java.util.Random;
 import org.junit.Test;
 
 import gnu.trove.list.array.TIntArrayList;
+import gnu.trove.map.hash.TIntObjectHashMap;
 import gnu.trove.map.hash.TLongObjectHashMap;
 import gnu.trove.set.hash.TLongHashSet;
 
@@ -56,6 +57,37 @@ public class TroveComparisonTest {
 		Arrays.sort(sharedKeys);
 		assertArrayEquals(troveKeys, sharedKeys);
 		for (long key : troveKeys) {
+			assertEquals(trove.get(key), shared.get(key));
+		}
+	}
+
+	@Test
+	public void testIntObjectMapMatchesTrove() {
+		KTIntObjectMap<Integer> shared = new KTIntObjectMap<>();
+		TIntObjectHashMap<Integer> trove = new TIntObjectHashMap<>();
+		Random random = new Random(20260908L);
+
+		for (int step = 0; step < OPERATIONS; step++) {
+			int key = random.nextInt(4000) - 2000;
+			int op = random.nextInt(10);
+			if (op <= 5) {
+				assertEquals("put(" + key + ")", trove.put(key, step), shared.put(key, step));
+			} else if (op <= 7) {
+				assertEquals("remove(" + key + ")", trove.remove(key), shared.remove(key));
+			} else if (op == 8) {
+				assertEquals("get(" + key + ")", trove.get(key), shared.get(key));
+			} else {
+				assertEquals("containsKey(" + key + ")", trove.containsKey(key), shared.containsKey(key));
+			}
+			assertEquals(trove.size(), shared.getSize());
+		}
+
+		int[] troveKeys = trove.keys();
+		int[] sharedKeys = shared.keys();
+		Arrays.sort(troveKeys);
+		Arrays.sort(sharedKeys);
+		assertArrayEquals(troveKeys, sharedKeys);
+		for (int key : troveKeys) {
 			assertEquals(trove.get(key), shared.get(key));
 		}
 	}
@@ -182,6 +214,7 @@ public class TroveComparisonTest {
 	public void testConstructorsAreUsableFromJava() {
 		// @JvmOverloads must keep the no-arg form available for the Java routing code
 		assertEquals(0, new KTLongObjectMap<String>().getSize());
+		assertEquals(0, new KTIntObjectMap<String>().getSize());
 		assertEquals(0, new KTLongHashSet().getSize());
 		assertEquals(0, new KTIntArrayList().getSize());
 		assertFalse(new KBitSet().get(0));

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/collections/KTIntObjectMap.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/collections/KTIntObjectMap.kt
@@ -1,0 +1,379 @@
+package net.osmand.shared.util.collections
+
+import kotlin.jvm.JvmOverloads
+
+/**
+ * Primitive `int` -> object map without boxing of keys.
+ *
+ * Minimal replacement for `gnu.trove.map.hash.TIntObjectHashMap`, covering the API actually used by
+ * the routing code: [get], [put], [containsKey], [remove], [size], [clear], [keys], [values] and
+ * iteration. The `long` keyed twin is [KTLongObjectMap] and the two behave identically.
+ *
+ * Implementation notes:
+ * - open addressing with linear probing over power-of-two tables (cache friendly, no per-entry
+ *   allocation, unlike a bucket-per-entry hash map);
+ * - keys are mixed by Fibonacci hashing rather than the MurmurHash3 finalizer that [KTLongObjectMap]
+ *   uses. Keys here are mostly small dense integers, encoding rule ids and string table indices,
+ *   and a full mixer only adds work without spreading them any better;
+ * - deletions leave tombstones, which are purged on the next rehash. Routing removes entries very
+ *   rarely, so this keeps [remove] simple and iteration-safe.
+ *
+ * Values may not be null: a null result from [get] always means "no such key".
+ * The map is not thread safe.
+ */
+class KTIntObjectMap<V : Any> @JvmOverloads constructor(
+	initialCapacity: Int = DEFAULT_CAPACITY
+) {
+
+	@PublishedApi
+	internal var keysArr: IntArray
+
+	@PublishedApi
+	internal var valuesArr: Array<Any?>
+
+	/** Per slot state, one of [FREE], [FULL], [REMOVED]. */
+	@PublishedApi
+	internal var statesArr: ByteArray
+
+	private var mask: Int
+
+	/** How far to shift the hash product down to land in the table, see [hashIndex]. */
+	private var shift: Int
+	private var threshold: Int
+
+	/** Number of slots that are not [FREE], i.e. live entries plus tombstones. */
+	private var occupied: Int = 0
+
+	/** Bumped on every structural change, used to detect modification during iteration. */
+	@PublishedApi
+	internal var modCount: Int = 0
+
+	var size: Int = 0
+		private set
+
+	init {
+		val capacity = tableSizeFor(initialCapacity)
+		keysArr = IntArray(capacity)
+		valuesArr = arrayOfNulls(capacity)
+		statesArr = ByteArray(capacity)
+		mask = capacity - 1
+		shift = Int.SIZE_BITS - capacity.countTrailingZeroBits()
+		threshold = capacity / 2
+	}
+
+	/**
+	 * Trove compatible alias of [size].
+	 *
+	 * Kotlin callers read the [size] property; this exists so Java code migrating off
+	 * `TIntObjectHashMap` keeps calling `size()` rather than the property accessor `getSize()`.
+	 */
+	fun size(): Int = size
+
+	fun isEmpty(): Boolean = size == 0
+
+	fun isNotEmpty(): Boolean = size != 0
+
+	@Suppress("UNCHECKED_CAST")
+	operator fun get(key: Int): V? {
+		val index = indexOf(key)
+		return if (index < 0) null else valuesArr[index] as V
+	}
+
+	fun containsKey(key: Int): Boolean = indexOf(key) >= 0
+
+	/** Returns the value previously stored under [key], or null. */
+	@Suppress("UNCHECKED_CAST")
+	fun put(key: Int, value: V): V? {
+		val index = insertionIndex(key)
+		if (index < 0) {
+			val existing = -index - 1
+			val previous = valuesArr[existing]
+			valuesArr[existing] = value
+			return previous as V
+		}
+		insertAt(index, key, value)
+		return null
+	}
+
+	/** Stores [value] only when [key] is absent. Returns the value that is in the map afterwards. */
+	@Suppress("UNCHECKED_CAST")
+	fun putIfAbsent(key: Int, value: V): V {
+		val index = insertionIndex(key)
+		if (index < 0) {
+			return valuesArr[-index - 1] as V
+		}
+		insertAt(index, key, value)
+		return value
+	}
+
+	/**
+	 * Returns the value stored under [key], inserting the result of [defaultValue] when absent.
+	 * Saves the second lookup of the `containsKey` / `put` / `get` sequence.
+	 */
+	@Suppress("UNCHECKED_CAST")
+	fun getOrPut(key: Int, defaultValue: () -> V): V {
+		val index = insertionIndex(key)
+		if (index < 0) {
+			return valuesArr[-index - 1] as V
+		}
+		val expected = modCount
+		val value = defaultValue()
+		if (modCount != expected) {
+			// defaultValue() touched this map, the resolved slot is stale
+			val slot = insertionIndex(key)
+			if (slot < 0) {
+				return valuesArr[-slot - 1] as V
+			}
+			insertAt(slot, key, value)
+			return value
+		}
+		insertAt(index, key, value)
+		return value
+	}
+
+	@Suppress("UNCHECKED_CAST")
+	fun remove(key: Int): V? {
+		val index = indexOf(key)
+		if (index < 0) {
+			return null
+		}
+		val previous = valuesArr[index]
+		valuesArr[index] = null
+		statesArr[index] = REMOVED
+		size--
+		modCount++
+		return previous as V
+	}
+
+	fun clear() {
+		if (occupied == 0) {
+			return
+		}
+		statesArr.fill(FREE)
+		valuesArr.fill(null)
+		size = 0
+		occupied = 0
+		modCount++
+	}
+
+	/** Grows the table so that [entries] entries fit without a rehash. */
+	fun ensureCapacity(entries: Int) {
+		if (entries > threshold) {
+			rehash(tableSizeFor(entries))
+		}
+	}
+
+	/** Keys of all live entries, in unspecified order. */
+	fun keys(): IntArray {
+		val result = IntArray(size)
+		var at = 0
+		for (i in statesArr.indices) {
+			if (statesArr[i] == FULL) {
+				result[at++] = keysArr[i]
+			}
+		}
+		return result
+	}
+
+	/** Values of all live entries, in unspecified order. */
+	@Suppress("UNCHECKED_CAST")
+	fun values(): List<V> {
+		val result = ArrayList<V>(size)
+		for (i in statesArr.indices) {
+			if (statesArr[i] == FULL) {
+				result.add(valuesArr[i] as V)
+			}
+		}
+		return result
+	}
+
+	/** Trove compatible alias of [values]. */
+	fun valueCollection(): List<V> = values()
+
+	fun iterator(): KTIntObjectIterator<V> = KTIntObjectIterator(this)
+
+	/** Allocation free iteration over live entries. */
+	@Suppress("UNCHECKED_CAST")
+	inline fun forEach(action: (key: Int, value: V) -> Unit) {
+		val expected = modCount
+		val states = statesArr
+		for (i in states.indices) {
+			if (states[i] == FULL) {
+				action(keysArr[i], valuesArr[i] as V)
+				check(modCount == expected) { "Map was modified during iteration" }
+			}
+		}
+	}
+
+	/** Allocation free iteration over live values. */
+	@Suppress("UNCHECKED_CAST")
+	inline fun forEachValue(action: (value: V) -> Unit) {
+		val expected = modCount
+		val states = statesArr
+		for (i in states.indices) {
+			if (states[i] == FULL) {
+				action(valuesArr[i] as V)
+				check(modCount == expected) { "Map was modified during iteration" }
+			}
+		}
+	}
+
+	override fun toString(): String {
+		val builder = StringBuilder("{")
+		var first = true
+		forEach { key, value ->
+			if (!first) {
+				builder.append(", ")
+			}
+			first = false
+			builder.append(key).append('=').append(value)
+		}
+		return builder.append('}').toString()
+	}
+
+	private fun insertAt(index: Int, key: Int, value: V) {
+		val wasFree = statesArr[index] == FREE
+		keysArr[index] = key
+		valuesArr[index] = value
+		statesArr[index] = FULL
+		size++
+		modCount++
+		if (wasFree) {
+			occupied++
+			if (occupied > threshold) {
+				rehash(tableSizeFor(size + 1))
+			}
+		}
+	}
+
+	/** Index of the slot holding [key], or -1. */
+	private fun indexOf(key: Int): Int {
+		var index = hashIndex(key)
+		while (true) {
+			val state = statesArr[index]
+			if (state == FREE) {
+				return -1
+			}
+			if (state == FULL && keysArr[index] == key) {
+				return index
+			}
+			index = (index + 1) and mask
+		}
+	}
+
+	/**
+	 * Index of the slot to write [key] into, or `-existingIndex - 1` when the key is already there.
+	 * Reuses the first tombstone of the probe chain, but only after proving the key is absent.
+	 */
+	private fun insertionIndex(key: Int): Int {
+		var index = hashIndex(key)
+		var firstRemoved = -1
+		while (true) {
+			val state = statesArr[index]
+			if (state == FREE) {
+				return if (firstRemoved >= 0) firstRemoved else index
+			}
+			if (state == FULL) {
+				if (keysArr[index] == key) {
+					return -index - 1
+				}
+			} else if (firstRemoved < 0) {
+				firstRemoved = index
+			}
+			index = (index + 1) and mask
+		}
+	}
+
+	/**
+	 * Fibonacci hashing: multiply by the 32-bit golden ratio and keep the high bits.
+	 *
+	 * One multiply and one shift, and consecutive keys land in distinct, well spread slots, which
+	 * matters because most keys here are dense ids. A stronger mixer such as the MurmurHash3
+	 * finalizer used by [KTLongObjectMap] costs more and buys nothing on this key shape.
+	 */
+	private fun hashIndex(key: Int): Int = (key * GOLDEN_RATIO) ushr shift
+
+	private fun rehash(newCapacity: Int) {
+		val oldKeys = keysArr
+		val oldValues = valuesArr
+		val oldStates = statesArr
+
+		keysArr = IntArray(newCapacity)
+		valuesArr = arrayOfNulls(newCapacity)
+		statesArr = ByteArray(newCapacity)
+		mask = newCapacity - 1
+		shift = Int.SIZE_BITS - newCapacity.countTrailingZeroBits()
+		threshold = newCapacity / 2
+		occupied = 0
+		modCount++
+
+		for (i in oldStates.indices) {
+			if (oldStates[i] == FULL) {
+				val key = oldKeys[i]
+				var index = hashIndex(key)
+				while (statesArr[index] == FULL) {
+					index = (index + 1) and mask
+				}
+				keysArr[index] = key
+				valuesArr[index] = oldValues[i]
+				statesArr[index] = FULL
+				occupied++
+			}
+		}
+	}
+
+	companion object {
+		const val DEFAULT_CAPACITY = 16
+
+		@PublishedApi
+		internal const val FREE: Byte = 0
+
+		@PublishedApi
+		internal const val FULL: Byte = 1
+
+		@PublishedApi
+		internal const val REMOVED: Byte = 2
+
+		/** 2^32 / phi, rounded to an odd integer. */
+		private const val GOLDEN_RATIO = -0x61c88647
+	}
+}
+
+/**
+ * Trove style iterator: `while (it.hasNext()) { it.advance(); it.key(); it.value() }`.
+ * Fails fast when the map is structurally modified while iterating.
+ */
+class KTIntObjectIterator<V : Any> internal constructor(private val map: KTIntObjectMap<V>) {
+
+	private val expectedModCount = map.modCount
+	private var cursor = 0
+	private var current = -1
+
+	fun hasNext(): Boolean {
+		val states = map.statesArr
+		while (cursor < states.size && states[cursor] != KTIntObjectMap.FULL) {
+			cursor++
+		}
+		return cursor < states.size
+	}
+
+	fun advance() {
+		check(map.modCount == expectedModCount) { "Map was modified during iteration" }
+		if (!hasNext()) {
+			throw NoSuchElementException()
+		}
+		current = cursor
+		cursor++
+	}
+
+	fun key(): Int {
+		check(current >= 0) { "advance() must be called first" }
+		return map.keysArr[current]
+	}
+
+	@Suppress("UNCHECKED_CAST")
+	fun value(): V {
+		check(current >= 0) { "advance() must be called first" }
+		return map.valuesArr[current] as V
+	}
+}

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/collections/CollectionsBenchmarkTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/collections/CollectionsBenchmarkTest.kt
@@ -14,7 +14,7 @@ import kotlin.time.TimeSource
  * **Disabled on purpose.** Measuring takes seconds and the timings are noise in a normal test run,
  * so this class is not part of the suite. It is a tool you reach for when you change a collection
  * or want platform numbers, not a regression gate — correctness is covered by [KTLongObjectMapTest],
- * [KTLongHashSetTest], [KTIntArrayListTest] and [KBitSetTest], which do run.
+ * [KTIntObjectMapTest], [KTLongHashSetTest], [KTIntArrayListTest] and [KBitSetTest], which do run.
  *
  * To measure, remove the `@Ignore` below and put it back afterwards.
  *
@@ -90,6 +90,58 @@ class CollectionsBenchmarkTest {
 
 			assertEquals(refChecksum, ktChecksum, "checksum mismatch for $distribution")
 			report.add(distribution.label, "KTLongObjectMap", ktTime, "HashMap<Long,V>", refTime)
+		}
+
+		report.print()
+	}
+
+	@Test
+	fun benchmarkIntObjectMap() {
+		val report = BenchmarkReport("int -> object map, ${ENTRIES} entries, ${LOOKUPS} lookups")
+
+		for (distribution in IntKeyDistribution.entries) {
+			val keys = distribution.keys(ENTRIES)
+			val probes = intProbeKeys(keys, LOOKUPS)
+			val value = Any()
+
+			var ktChecksum = 0L
+			val ktTime = measure {
+				val map = KTIntObjectMap<Any>(ENTRIES)
+				for (key in keys) {
+					map.put(key, value)
+				}
+				var hits = 0L
+				for (probe in probes) {
+					if (map[probe] != null) {
+						hits++
+					}
+				}
+				var iterated = 0L
+				map.forEach { key, _ -> iterated += key }
+				ktChecksum = hits * 31 + iterated
+			}
+
+			var refChecksum = 0L
+			val refTime = measure {
+				val map = HashMap<Int, Any>(ENTRIES * 2)
+				for (key in keys) {
+					map[key] = value
+				}
+				var hits = 0L
+				for (probe in probes) {
+					if (map[probe] != null) {
+						hits++
+					}
+				}
+				var iterated = 0L
+				for (key in map.keys) {
+					iterated += key
+				}
+				refChecksum = hits * 31 + iterated
+			}
+
+			assertEquals(refChecksum, ktChecksum, "checksum mismatch for $distribution")
+			report.add(distribution.label, "KTIntObjectMap", ktTime, "HashMap<Int,V>", refTime)
 		}
 
 		report.print()
@@ -254,6 +306,31 @@ class CollectionsBenchmarkTest {
 				}
 				RANDOM -> LongArray(count) { random.nextLong() }
 			}
+		}
+	}
+
+	private enum class IntKeyDistribution(val label: String) {
+
+		/** Dense ids counted from zero, the shape of encoding rule and string table keys. */
+		DENSE_IDS("encoding rules"),
+
+		/** Uniformly spread keys, the friendly case for any hash function. */
+		RANDOM("random     ");
+
+		fun keys(count: Int): IntArray {
+			val random = XorShiftRandom(20260908L)
+			return when (this) {
+				DENSE_IDS -> IntArray(count) { i -> i }
+				RANDOM -> IntArray(count) { random.nextLong().toInt() }
+			}
+		}
+	}
+
+	/** Half of the probes hit an existing key, half miss. */
+	private fun intProbeKeys(keys: IntArray, count: Int): IntArray {
+		val random = XorShiftRandom(1234L)
+		return IntArray(count) { i ->
+			if (i and 1 == 0) keys[random.nextInt(keys.size)] else (random.nextLong().toInt() or (1 shl 30))
 		}
 	}
 

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/collections/KTIntObjectMapTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/util/collections/KTIntObjectMapTest.kt
@@ -1,0 +1,223 @@
+package net.osmand.shared.util.collections
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class KTIntObjectMapTest {
+
+	@Test
+	fun testSizeIsReachableBothWays() {
+		// Java code migrating off trove keeps calling size()
+		val collection = KTIntObjectMap<Int>()
+		assertEquals(0, collection.size())
+		assertEquals(collection.size, collection.size())
+	}
+
+	@Test
+	fun testPutGetRemove() {
+		val map = KTIntObjectMap<String>()
+		assertTrue(map.isEmpty())
+		assertNull(map[1])
+
+		assertNull(map.put(1, "one"))
+		assertEquals("one", map.put(1, "ONE"))
+		assertEquals("ONE", map[1])
+		assertEquals(1, map.size)
+		assertTrue(map.containsKey(1))
+
+		assertNull(map.remove(2))
+		assertEquals("ONE", map.remove(1))
+		assertEquals(0, map.size)
+		assertFalse(map.containsKey(1))
+		assertNull(map[1])
+	}
+
+	@Test
+	fun testNegativeAndExtremeKeys() {
+		val map = KTIntObjectMap<String>()
+		val keys = intArrayOf(0, -1, Int.MIN_VALUE, Int.MAX_VALUE, -42, 42)
+		for (key in keys) {
+			map.put(key, "v$key")
+		}
+		assertEquals(keys.size, map.size)
+		for (key in keys) {
+			assertEquals("v$key", map[key])
+		}
+	}
+
+	@Test
+	fun testGrowthKeepsEveryEntry() {
+		val map = KTIntObjectMap<Int>(4)
+		val count = 5000
+		for (i in 0 until count) {
+			map.put(i * 31, i)
+		}
+		assertEquals(count, map.size)
+		for (i in 0 until count) {
+			assertEquals(i, map[i * 31])
+		}
+		assertNull(map[1])
+	}
+
+	@Test
+	fun testTombstonesAreReused() {
+		val map = KTIntObjectMap<Int>(8)
+		// churn far beyond the table size, tombstones must not fill the table up
+		for (round in 0 until 200) {
+			for (i in 0 until 50) {
+				map.put(round * 50 + i, i)
+			}
+			for (i in 0 until 50) {
+				map.remove(round * 50 + i)
+			}
+		}
+		assertEquals(0, map.size)
+		map.put(7, 7)
+		assertEquals(7, map[7])
+		assertEquals(1, map.size)
+	}
+
+	@Test
+	fun testRemovedKeyDoesNotBreakProbeChain() {
+		// keys chosen to be inserted, then removed from the middle of a chain
+		val map = KTIntObjectMap<Int>(8)
+		for (i in 0 until 12) {
+			map.put(i, i)
+		}
+		map.remove(5)
+		map.remove(6)
+		for (i in 0 until 12) {
+			if (i == 5 || i == 6) {
+				assertNull(map[i], "key $i must be gone")
+			} else {
+				assertEquals(i, map[i], "key $i must still resolve")
+			}
+		}
+	}
+
+	@Test
+	fun testClear() {
+		val map = KTIntObjectMap<Int>()
+		for (i in 0 until 100) {
+			map.put(i, i)
+		}
+		map.clear()
+		assertEquals(0, map.size)
+		assertTrue(map.isEmpty())
+		assertTrue(map.keys().isEmpty())
+		assertTrue(map.values().isEmpty())
+		map.put(1, 1)
+		assertEquals(1, map[1])
+	}
+
+	@Test
+	fun testPutIfAbsentAndGetOrPut() {
+		val map = KTIntObjectMap<String>()
+		assertEquals("a", map.putIfAbsent(1, "a"))
+		assertEquals("a", map.putIfAbsent(1, "b"))
+		assertEquals("a", map[1])
+
+		var created = 0
+		assertEquals("a", map.getOrPut(1) { created++; "z" })
+		assertEquals(0, created)
+		assertEquals("c", map.getOrPut(2) { created++; "c" })
+		assertEquals(1, created)
+		assertEquals("c", map[2])
+		assertEquals(2, map.size)
+	}
+
+	@Test
+	fun testKeysAndValues() {
+		val map = KTIntObjectMap<Int>()
+		for (i in 0 until 64) {
+			map.put(i, i * 2)
+		}
+		map.remove(10)
+		assertEquals(63, map.keys().size)
+		assertEquals(63, map.values().size)
+		assertEquals(map.values().sorted(), (0 until 64).filter { it != 10 }.map { it * 2 })
+		assertEquals(map.keys().sorted(), (0 until 64).filter { it != 10 })
+		assertEquals(map.values(), map.valueCollection())
+	}
+
+	@Test
+	fun testIteration() {
+		val map = KTIntObjectMap<Int>()
+		for (i in 0 until 100) {
+			map.put(i, i)
+		}
+		val seenByForEach = HashMap<Int, Int>()
+		map.forEach { key, value -> seenByForEach[key] = value }
+		assertEquals(100, seenByForEach.size)
+
+		val seenByIterator = HashMap<Int, Int>()
+		val it = map.iterator()
+		while (it.hasNext()) {
+			it.advance()
+			seenByIterator[it.key()] = it.value()
+		}
+		assertEquals(seenByForEach, seenByIterator)
+
+		var sum = 0
+		map.forEachValue { sum += it }
+		assertEquals((0 until 100).sum(), sum)
+	}
+
+	@Test
+	fun testIterationFailsFastOnModification() {
+		val map = KTIntObjectMap<Int>()
+		for (i in 0 until 10) {
+			map.put(i, i)
+		}
+		assertFailsWith<IllegalStateException> {
+			map.forEach { key, _ -> map.put(key + 1000, 0) }
+		}
+		val map2 = KTIntObjectMap<Int>()
+		for (i in 0 until 10) {
+			map2.put(i, i)
+		}
+		assertFailsWith<IllegalStateException> {
+			val it = map2.iterator()
+			it.advance()
+			map2.remove(9)
+			it.advance()
+		}
+	}
+
+	@Test
+	fun testMatchesReferenceModelUnderRandomOps() {
+		val map = KTIntObjectMap<Int>(4)
+		val model = HashMap<Int, Int>()
+		val random = XorShiftRandom(20260908L)
+		repeat(60_000) { step ->
+			// small key space, so collisions, overwrites and re-inserts all get exercised
+			val key = random.nextInt(2000) - 1000
+			when (random.nextInt(10)) {
+				in 0..5 -> {
+					assertEquals(model.put(key, step), map.put(key, step), "put($key)")
+				}
+				in 6..7 -> {
+					assertEquals(model.remove(key), map.remove(key), "remove($key)")
+				}
+				8 -> {
+					assertEquals(model[key], map[key], "get($key)")
+				}
+				else -> {
+					assertEquals(model.containsKey(key), map.containsKey(key), "containsKey($key)")
+				}
+			}
+			assertEquals(model.size, map.size)
+		}
+		assertEquals(model.size, map.size)
+		for ((key, value) in model) {
+			assertEquals(value, map[key])
+		}
+		val fromMap = HashMap<Int, Int>()
+		map.forEach { key, value -> fromMap[key] = value }
+		assertEquals(model, fromMap)
+	}
+}


### PR DESCRIPTION
Part of the routing-to-OsmAnd-shared series: the java classes stay in `OsmAnd-java` and android, tools and the C++ core keep using them; each step adds a copy to `OsmAnd-shared` and a test that the copy behaves like the original. The copies are for iOS, which will call them instead of its own C++ turn preparation.

`KTIntObjectMap`, the last primitive map the road copy needs. Pure addition, with its own tests and the trove comparison.

Supersedes #25905.

One more commit since the review started: `KTIntObjectIterator.key()` is exported to Objective-C as `intKey`. The app calls `-key` on untyped receivers (`[v key]`, `[item key]`) and expects a string back; with the iterator's primitive `- (int32_t)key` in the framework header the selector has two result types and clang refuses those calls under ARC. Only the Objective-C selector changes; the Kotlin name stays `key`.