### PR TITLE
Copy RouteDataObject and the route regions to OsmAnd-shared

### DIFF
--- a/OsmAnd-java/src/test/java/net/osmand/shared/compat/JavaToShared.java
+++ b/OsmAnd-java/src/test/java/net/osmand/shared/compat/JavaToShared.java
@@ -1,0 +1,103 @@
+package net.osmand.shared.compat;
+
+import net.osmand.binary.BinaryMapRouteReaderAdapter;
+import net.osmand.shared.routing.RouteDataObject;
+import net.osmand.shared.routing.RouteRegion;
+import net.osmand.shared.util.collections.KTIntObjectMap;
+
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds the OsmAnd-shared copy of a java routing object, field for field, so the two can be given
+ * the same input. Test scaffolding only: it copies and never corrects, so a difference it introduces
+ * shows up as a failed comparison rather than hiding one.
+ *
+ * Regions and roads are converted once per java instance, because the java code compares roads by
+ * identity in places and the copies have to agree on what is the same road.
+ */
+public final class JavaToShared {
+
+	private final Map<BinaryMapRouteReaderAdapter.RouteRegion, RouteRegion> regions = new IdentityHashMap<>();
+	private final Map<net.osmand.binary.RouteDataObject, RouteDataObject> roads = new IdentityHashMap<>();
+
+	public RouteRegion region(BinaryMapRouteReaderAdapter.RouteRegion j) {
+		RouteRegion k = regions.get(j);
+		if (k == null) {
+			k = new RouteRegion();
+			k.setName(j.getName());
+			k.setFilePointer(j.getFilePointer());
+			k.setLength(j.getLength());
+			List<BinaryMapRouteReaderAdapter.RouteTypeRule> rules = j.routeEncodingRules;
+			for (int i = 0; i < rules.size(); i++) {
+				BinaryMapRouteReaderAdapter.RouteTypeRule rule = rules.get(i);
+				if (rule != null) {
+					k.initRouteEncodingRule(i, rule.getTag(), rule.getValue());
+				}
+			}
+			// what the reader does once the rules are in: give every condition the id of its value's rule
+			k.completeRouteEncodingRules();
+			regions.put(j, k);
+		}
+		return k;
+	}
+
+	public RouteDataObject road(net.osmand.binary.RouteDataObject j) {
+		RouteDataObject k = roads.get(j);
+		if (k == null) {
+			k = new RouteDataObject(region(j.region));
+			k.id = j.id;
+			k.pointsX = copy(j.pointsX);
+			k.pointsY = copy(j.pointsY);
+			k.types = copy(j.types);
+			k.restrictions = copy(j.restrictions);
+			k.restrictionsVia = copy(j.restrictionsVia);
+			k.pointTypes = copy(j.pointTypes);
+			k.pointNameTypes = copy(j.pointNameTypes);
+			k.pointNames = copy(j.pointNames);
+			k.nameIds = copy(j.nameIds);
+			if (j.names != null) {
+				KTIntObjectMap<String> names = new KTIntObjectMap<>();
+				for (int key : j.names.keys()) {
+					names.put(key, j.names.get(key));
+				}
+				k.names = names;
+			}
+			k.heightDistanceArray = j.heightDistanceArray == null ? null : j.heightDistanceArray.clone();
+			k.heightByCurrentLocation = j.heightByCurrentLocation;
+			roads.put(j, k);
+		}
+		return k;
+	}
+
+	private static int[] copy(int[] a) {
+		return a == null ? null : a.clone();
+	}
+
+	private static long[] copy(long[] a) {
+		return a == null ? null : a.clone();
+	}
+
+	private static int[][] copy(int[][] a) {
+		if (a == null) {
+			return null;
+		}
+		int[][] r = new int[a.length][];
+		for (int i = 0; i < a.length; i++) {
+			r[i] = copy(a[i]);
+		}
+		return r;
+	}
+
+	private static String[][] copy(String[][] a) {
+		if (a == null) {
+			return null;
+		}
+		String[][] r = new String[a.length][];
+		for (int i = 0; i < a.length; i++) {
+			r[i] = a[i] == null ? null : a[i].clone();
+		}
+		return r;
+	}
+}

--- a/OsmAnd-java/src/test/java/net/osmand/shared/compat/RouteDataObjectCompatTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/shared/compat/RouteDataObjectCompatTest.java
@@ -1,0 +1,159 @@
+package net.osmand.shared.compat;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import net.osmand.shared.routing.GeneralRouterProfile;
+import net.osmand.shared.routing.RouteDataObject;
+import net.osmand.shared.routing.RouteTypeRule;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * {@link RouteDataObject} is a copy of {@link net.osmand.binary.RouteDataObject}; this hands both the
+ * same roads out of the test obf files and compares everything the router and the turn preparation
+ * read off a road - tags, names, geometry, restrictions, direction and distance.
+ */
+public class RouteDataObjectCompatTest {
+
+	private static final String[] LANGS = {null, "", "en", "ru", "de", "ja"};
+	private static final String[] TAGS = {"maxspeed", "lanes", "oneway", "highway", "name", "surface", "access",
+			"junction", "turn:lanes", "turn:lanes:forward", "turn:lanes:backward", "railway", "tunnel", "layer",
+			"junction:ref", "junction:name", "destination", "traffic_signals:direction", "nonexistent"};
+
+	@Test
+	public void testEveryRoadReadsTheSame() throws IOException {
+		List<net.osmand.binary.RouteDataObject> roads = TestObf.roads(6000);
+		assertEquals(true, roads.size() > 10000);
+		JavaToShared convert = new JavaToShared();
+		Random random = new Random(20260913);
+		for (net.osmand.binary.RouteDataObject j : roads) {
+			RouteDataObject k = convert.road(j);
+			String m = "road " + j.id;
+			assertEquals(m, j.getId(), k.getId());
+			assertEquals(m, j.getPointsLength(), k.getPointsLength());
+			assertEquals(m, j.getHighway(), k.getHighway());
+			assertEquals(m, j.getRoute(), k.getRoute());
+			assertEquals(m, j.getOneway(), k.getOneway());
+			assertEquals(m, j.getLanes(), k.getLanes());
+			assertEquals(m, j.platform(), k.platform());
+			assertEquals(m, j.roundabout(), k.roundabout());
+			assertEquals(m, j.tunnel(), k.tunnel());
+			assertEquals(m, j.isRoadDeleted(), k.isRoadDeleted());
+			assertEquals(m, j.hasMotorwayJunctionNode(), k.hasMotorwayJunctionNode());
+			assertEquals(m, j.getJunctionRef(), k.getJunctionRef());
+			assertEquals(m, j.getJunctionName(), k.getJunctionName());
+			assertEquals(m, j.getNodeRef(), k.getNodeRef());
+			assertEquals(m, j.getNodeName(), k.getNodeName());
+			assertEquals(m, j.getExitRef(), k.getExitRef());
+			assertEquals(m, j.getExitName(), k.getExitName());
+			assertEquals(m, j.hasPointTypes(), k.hasPointTypes());
+			assertEquals(m, j.hasPointNames(), k.hasPointNames());
+			assertEquals(m, j.getName(), k.getName());
+			assertEquals(m, j.coordinates(), k.coordinates());
+			assertEquals(m, j.toString(), k.toString());
+			assertEquals(m, j.hasNameTagStartsWith("name:"), k.hasNameTagStartsWith("name:"));
+			assertEquals(m, j.hasNameTagStartsWith("junk"), k.hasNameTagStartsWith("junk"));
+			assertArrayEquals(m, j.getTypes(), k.getTypes());
+			assertArrayEquals(m, j.getNameIds(), k.getNameIds());
+			assertArrayEquals(m, j.calculateHeightArray(), k.calculateHeightArray(null), 0f);
+			for (boolean dir : new boolean[] {false, true}) {
+				assertEquals(m, j.getMaximumSpeed(dir), k.getMaximumSpeed(dir), 0f);
+				assertEquals(m, j.getMaximumSpeed(dir, RouteTypeRule.PROFILE_CAR), k.getMaximumSpeed(dir, RouteTypeRule.PROFILE_CAR), 0f);
+				assertEquals(m, j.getMaximumSpeed(dir, RouteTypeRule.PROFILE_TRUCK), k.getMaximumSpeed(dir, RouteTypeRule.PROFILE_TRUCK), 0f);
+				assertEquals(m, j.isClockwise(dir), k.isClockwise(dir));
+				for (String lang : LANGS) {
+					assertEquals(m + " " + lang, j.getName(lang, false), k.getName(lang, false));
+					assertEquals(m + " " + lang, j.getRef(lang, false, dir), k.getRef(lang, false, dir));
+					assertEquals(m + " " + lang, j.getDestinationRef(lang, false, dir), k.getDestinationRef(lang, false, dir));
+					assertEquals(m + " " + lang, j.getDestinationName(lang, false, dir), k.getDestinationName(lang, false, dir));
+				}
+			}
+			for (String tag : TAGS) {
+				assertEquals(m + " " + tag, j.getValue(tag), k.getValue(tag));
+			}
+			for (GeneralRouterProfile profile : GeneralRouterProfile.values()) {
+				assertEquals(m + " " + profile, j.hasPrivateAccess(profile), k.hasPrivateAccess(profile));
+			}
+			if (j.getTypes() != null) {
+				for (int t : j.getTypes()) {
+					assertEquals(m + " type " + t, j.containsType(t), k.containsType(t));
+				}
+				assertEquals(m, j.containsType(-1), k.containsType(-1));
+			}
+			assertEquals(m, j.getRestrictionLength(), k.getRestrictionLength());
+			for (int r = 0; r < j.getRestrictionLength(); r++) {
+				assertEquals(m + " restriction " + r, j.getRestrictionType(r), k.getRestrictionType(r));
+				assertEquals(m + " restriction " + r, j.getRestrictionId(r), k.getRestrictionId(r));
+				assertEquals(m + " restriction " + r, j.getRestrictionVia(r), k.getRestrictionVia(r));
+			}
+			int n = j.getPointsLength();
+			for (int i = 0; i < n; i++) {
+				String p = m + " point " + i;
+				assertEquals(p, j.getPoint31XTile(i), k.getPoint31XTile(i));
+				assertEquals(p, j.getPoint31YTile(i), k.getPoint31YTile(i));
+				assertArrayEquals(p, j.getPointTypes(i), k.getPointTypes(i));
+				assertArrayEquals(p, j.getPointNames(i), k.getPointNames(i));
+				assertArrayEquals(p, j.getPointNameTypes(i), k.getPointNameTypes(i));
+				assertEquals(p, j.hasTrafficLightAt(i), k.hasTrafficLightAt(i));
+				for (String tag : TAGS) {
+					assertEquals(p + " " + tag, j.getValue(i, tag), k.getValue(i, tag));
+				}
+				for (boolean plus : new boolean[] {false, true}) {
+					Same.close(p, j.directionRoute(i, plus), k.directionRoute(i, plus));
+					for (float dist : new float[] {5, 15, 50}) {
+						Same.close(p + " dist " + dist, j.directionRoute(i, plus, dist), k.directionRoute(i, plus, dist));
+					}
+					final int ii = i;
+					final boolean pp = plus;
+					Same.outcome(p, () -> j.isDirectionApplicable(pp, ii, 0, n - 1), () -> k.isDirectionApplicable(pp, ii, 0, n - 1));
+					Same.outcome(p, () -> j.isDirectionApplicable(pp, ii, n - 1, 0), () -> k.isDirectionApplicable(pp, ii, n - 1, 0));
+				}
+				if (i + 1 < n) {
+					assertEquals(p, j.getPoint31XTile(i, i + 1), k.getPoint31XTile(i, i + 1));
+					assertEquals(p, j.getPoint31YTile(i, i + 1), k.getPoint31YTile(i, i + 1));
+					Same.close(p, j.distance(i, i + 1), k.distance(i, i + 1));
+					Same.close(p, j.distance(i + 1, i), k.distance(i + 1, i));
+				}
+			}
+			if (n > 1) {
+				Same.close(m, j.distance(0, n - 1), k.distance(0, n - 1));
+			}
+			assertEquals(m, j.compareRoute(j), k.compareRoute(k));
+
+			// what the direction points do to a road: splice a point in, on a copy
+			if (n > 1 && random.nextInt(20) == 0) {
+				net.osmand.binary.RouteDataObject jc = new net.osmand.binary.RouteDataObject(j);
+				RouteDataObject kc = new RouteDataObject(k);
+				int pos = 1 + random.nextInt(n - 1);
+				int x = jc.getPoint31XTile(pos - 1) + 100;
+				int y = jc.getPoint31YTile(pos - 1) - 100;
+				jc.insert(pos, x, y);
+				kc.insert(pos, x, y);
+				assertEquals(m + " after insert", jc.getPointsLength(), kc.getPointsLength());
+				for (int i = 0; i < jc.getPointsLength(); i++) {
+					assertEquals(m + " after insert " + i, jc.getPoint31XTile(i), kc.getPoint31XTile(i));
+					assertEquals(m + " after insert " + i, jc.getPoint31YTile(i), kc.getPoint31YTile(i));
+					assertArrayEquals(m + " after insert " + i, jc.getPointTypes(i), kc.getPointTypes(i));
+					assertArrayEquals(m + " after insert " + i, jc.getPointNames(i), kc.getPointNames(i));
+				}
+				assertEquals(m + " after insert", jc.compareRoute(j), kc.compareRoute(k));
+			}
+			if (j.names != null) {
+				int[] keys = j.names.keys();
+				Arrays.sort(keys);
+				int[] kkeys = k.getNames().keys();
+				Arrays.sort(kkeys);
+				assertArrayEquals(m, keys, kkeys);
+				for (int key : keys) {
+					assertEquals(m + " name " + key, j.names.get(key), k.getNames().get(key));
+				}
+			}
+		}
+	}
+}

--- a/OsmAnd-shared/build.gradle.kts
+++ b/OsmAnd-shared/build.gradle.kts
@@ -62,6 +62,7 @@ kotlin {
 	val statelyVersion = "2.1.0"
 	val coilVersion = "3.1.0"
     val ktorVersion = "3.1.3"
+	val junidecodeVersion = "0.1.1"
 
 	sourceSets {
 		commonMain.dependencies {
@@ -82,6 +83,7 @@ kotlin {
 			implementation("net.sf.kxml:kxml2:$kxml2Version")
 			implementation("org.xerial:sqlite-jdbc:$sqliteJDBCVersion")
 			implementation("commons-logging:commons-logging:$commonLoggingVersion")
+			implementation("com.moparisthebest:junidecode:$junidecodeVersion")
             implementation("io.ktor:ktor-client-okhttp:$ktorVersion")
 		}
 		androidMain.dependencies {
@@ -90,6 +92,7 @@ kotlin {
 			implementation("net.sf.kxml:kxml2:$kxml2Version")
 			implementation("io.coil-kt.coil3:coil-core:$coilVersion")
 			implementation("io.coil-kt.coil3:coil-network-okhttp:$coilVersion")
+			implementation("com.moparisthebest:junidecode:$junidecodeVersion")
             implementation("io.ktor:ktor-client-okhttp:$ktorVersion")
 		}
 		iosMain.dependencies {

--- a/OsmAnd-shared/jvm.build.gradle
+++ b/OsmAnd-shared/jvm.build.gradle
@@ -24,6 +24,7 @@ kotlin {
     def commonLoggingVersion = "1.2"
     def statelyVersion = "2.1.0"
     def ktorVersion = "3.1.3"
+    def junidecodeVersion = "0.1.1"
 
     sourceSets {
         commonMain {
@@ -45,6 +46,7 @@ kotlin {
                 implementation "net.sf.kxml:kxml2:$kxml2Version"
                 implementation "org.xerial:sqlite-jdbc:$sqliteJDBCVersion"
                 implementation "commons-logging:commons-logging:$commonLoggingVersion"
+                implementation "com.moparisthebest:junidecode:$junidecodeVersion"
                 implementation "io.ktor:ktor-client-okhttp:$ktorVersion"
             }
         }

--- a/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/util/KTransliterationHelper.kt
+++ b/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/util/KTransliterationHelper.kt
@@ -1,0 +1,5 @@
+package net.osmand.shared.util
+
+import net.sf.junidecode.Junidecode
+
+internal actual fun toLatin(text: String): String = Junidecode.unidecode(text)

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/binary/BinaryIndexPart.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/binary/BinaryIndexPart.kt
@@ -1,0 +1,47 @@
+package net.osmand.shared.binary
+
+import kotlin.jvm.JvmField
+
+/**
+ * One top level section of an obf file: its name and where its bytes are.
+ *
+ * The fields stay public so the readers can fill them in while parsing, and so the C++ core can
+ * read `length` and `filePointer` off a route region through JNI.
+ */
+abstract class BinaryIndexPart {
+
+	@JvmField
+	var name: String? = null
+
+	@JvmField
+	var length: Long = 0
+
+	@JvmField
+	var filePointer: Long = 0
+
+	/** Human readable section name, used when inspecting and merging obf files. */
+	abstract fun getPartName(): String
+
+	/** Number of the field this section occupies in the obf root message. */
+	abstract fun getFieldNumber(): Int
+
+	fun getLength(): Long = length
+
+	fun setLength(length: Long) {
+		this.length = length
+	}
+
+	fun getFilePointer(): Long = filePointer
+
+	fun setFilePointer(filePointer: Long) {
+		this.filePointer = filePointer
+	}
+
+	open fun getName(): String? = name
+
+	fun setName(name: String?) {
+		this.name = name
+	}
+
+	fun isBasemap(): Boolean = name?.startsWith("basemap") == true
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteDataObject.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteDataObject.kt
@@ -1,0 +1,1099 @@
+package net.osmand.shared.routing
+
+import net.osmand.shared.data.KLatLon
+import net.osmand.shared.util.KAlgorithms
+import net.osmand.shared.util.KMapUtils
+import net.osmand.shared.util.KTransliterationHelper
+import net.osmand.shared.util.collections.KTIntObjectMap
+import kotlin.jvm.JvmField
+import kotlin.jvm.JvmOverloads
+import kotlin.jvm.JvmStatic
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.atan2
+
+/**
+ * One road as it is stored in an obf file: its geometry, its tag indices into the encoding rules of
+ * the [region] it was read from, and the turn restrictions attached to it.
+ *
+ * The arrays are shared between copies of the same road and are meant to be read only.
+ *
+ * A copy of `net.osmand.binary.RouteDataObject`, which stays in OsmAnd-java: android, tools and the C++ core keep using
+ * the original, and this copy is for iOS. Keep the two identical, field names included; `RouteDataObjectCompatTest` checks that they behave
+ * the same.
+ */
+class RouteDataObject {
+
+	@JvmField
+	val region: RouteRegion
+
+	// all these arrays supposed to be immutable!
+	// These fields accessible from C++
+	@JvmField
+	var types: IntArray? = null
+
+	@JvmField
+	var pointsX: IntArray? = null
+
+	@JvmField
+	var pointsY: IntArray? = null
+
+	@JvmField
+	var restrictions: LongArray? = null
+
+	@JvmField
+	var restrictionsVia: LongArray? = null
+
+	@JvmField
+	var pointTypes: Array<IntArray?>? = null
+
+	@JvmField
+	var pointNames: Array<Array<String>?>? = null
+
+	@JvmField
+	var pointNameTypes: Array<IntArray?>? = null
+
+	@JvmField
+	var id: Long = 0
+
+	@JvmField
+	var names: KTIntObjectMap<String>? = null
+
+	@JvmField
+	var nameIds: IntArray? = null
+
+	/** Mixed array [0, height, distance, height, ...], twice the length of the geometry. */
+	@JvmField
+	var heightDistanceArray: FloatArray? = null
+
+	@JvmField
+	var heightByCurrentLocation: Float = Float.NaN
+
+	constructor(region: RouteRegion) {
+		this.region = region
+	}
+
+	constructor(region: RouteRegion, nameIds: IntArray, nameValues: Array<String>) {
+		this.region = region
+		this.nameIds = nameIds
+		if (nameIds.isNotEmpty()) {
+			names = KTIntObjectMap()
+		}
+		for (i in nameIds.indices) {
+			names!!.put(nameIds[i], nameValues[i])
+		}
+	}
+
+	constructor(copy: RouteDataObject) {
+		this.region = copy.region
+		this.pointsX = copy.pointsX
+		this.pointsY = copy.pointsY
+		this.types = copy.types
+		this.names = copy.names
+		this.nameIds = copy.nameIds
+		this.restrictions = copy.restrictions
+		this.restrictionsVia = copy.restrictionsVia
+		this.pointTypes = copy.pointTypes
+		this.pointNames = copy.pointNames
+		this.pointNameTypes = copy.pointNameTypes
+		this.id = copy.id
+	}
+
+	/** The rule [id] stands for. Roads only carry ids their own region defines. */
+	private fun rule(id: Int): RouteTypeRule = region.quickGetEncodingRule(id)!!
+
+	/** True when the two roads carry the same geometry, tags and restrictions. */
+	fun compareRoute(thatObj: RouteDataObject): Boolean {
+		if (id != thatObj.id ||
+			!pointsX.contentEquals(thatObj.pointsX) ||
+			!pointsY.contentEquals(thatObj.pointsY)
+		) {
+			return false
+		}
+		var equals = restrictions.contentEquals(thatObj.restrictions) &&
+				restrictionsVia.contentEquals(thatObj.restrictionsVia)
+
+		val types = this.types
+		val thatTypes = thatObj.types
+		if (equals) {
+			if (types == null || thatTypes == null) {
+				equals = types === thatTypes
+			} else if (types.size != thatTypes.size) {
+				equals = false
+			} else {
+				var i = 0
+				while (i < types.size && equals) {
+					val thisRule = rule(types[i])
+					val thatRule = thatObj.rule(thatTypes[i])
+					equals = thisRule.getTag() == thatRule.getTag() &&
+							thisRule.getValue() == thatRule.getValue()
+					i++
+				}
+			}
+		}
+
+		val nameIds = this.nameIds
+		val thatNameIds = thatObj.nameIds
+		if (equals) {
+			if (nameIds == null || thatNameIds == null) {
+				equals = nameIds === thatNameIds
+			} else if (nameIds.size != thatNameIds.size) {
+				equals = false
+			} else {
+				var i = 0
+				while (i < nameIds.size && equals) {
+					equals = KAlgorithms.stringsEqual(rule(nameIds[i]).getTag(), thatObj.rule(thatNameIds[i]).getTag()) &&
+							KAlgorithms.stringsEqual(names?.get(nameIds[i]), thatObj.names?.get(thatNameIds[i]))
+					i++
+				}
+			}
+		}
+
+		val pointTypes = this.pointTypes
+		val thatPointTypes = thatObj.pointTypes
+		if (equals) {
+			if (pointTypes == null || thatPointTypes == null) {
+				equals = pointTypes === thatPointTypes
+			} else if (pointTypes.size != thatPointTypes.size) {
+				equals = false
+			} else {
+				var i = 0
+				while (i < pointTypes.size && equals) {
+					val point = pointTypes[i]
+					val thatPoint = thatPointTypes[i]
+					if (point == null || thatPoint == null) {
+						equals = point === thatPoint
+					} else if (point.size != thatPoint.size) {
+						equals = false
+					} else {
+						var j = 0
+						while (j < point.size && equals) {
+							val thisRule = rule(point[j])
+							val thatRule = thatObj.rule(thatPoint[j])
+							equals = KAlgorithms.stringsEqual(thisRule.getTag(), thatRule.getTag()) &&
+									KAlgorithms.stringsEqual(thisRule.getValue(), thatRule.getValue())
+							j++
+						}
+					}
+					i++
+				}
+			}
+		}
+
+		val pointNameTypes = this.pointNameTypes
+		val thatPointNameTypes = thatObj.pointNameTypes
+		if (equals) {
+			if (pointNameTypes == null || thatPointNameTypes == null) {
+				equals = pointNameTypes === thatPointNameTypes
+			} else if (pointNameTypes.size != thatPointNameTypes.size) {
+				equals = false
+			} else {
+				var i = 0
+				while (i < pointNameTypes.size && equals) {
+					val point = pointNameTypes[i]
+					val thatPoint = thatPointNameTypes[i]
+					if (point == null || thatPoint == null) {
+						equals = point === thatPoint
+					} else if (point.size != thatPoint.size) {
+						equals = false
+					} else {
+						var j = 0
+						while (j < point.size && equals) {
+							equals = KAlgorithms.stringsEqual(rule(point[j]).getTag(), thatObj.rule(thatPoint[j]).getTag()) &&
+									KAlgorithms.stringsEqual(pointNames?.get(i)?.get(j), thatObj.pointNames?.get(i)?.get(j))
+							j++
+						}
+					}
+					i++
+				}
+			}
+		}
+		return equals
+	}
+
+	/**
+	 * Heights along the road, as [distance from the previous point, height] pairs, interpolated
+	 * over the points that carry no height of their own. Empty when the road has no heights.
+	 *
+	 * When [currentLocation] is given, [heightByCurrentLocation] is left holding the height of the
+	 * point nearest to it.
+	 */
+	@JvmOverloads
+	fun calculateHeightArray(currentLocation: KLatLon? = null): FloatArray {
+		heightDistanceArray?.let { return it }
+
+		val startHeight = KAlgorithms.parseIntSilently(getValue("osmand_ele_start"), HEIGHT_UNDEFINED)
+		val endHeight = KAlgorithms.parseIntSilently(getValue("osmand_ele_end"), startHeight)
+		if (startHeight == HEIGHT_UNDEFINED) {
+			val empty = FloatArray(0)
+			heightDistanceArray = empty
+			return empty
+		}
+
+		val heights = FloatArray(2 * getPointsLength())
+		heightDistanceArray = heights
+		var plon = 0.0
+		var plat = 0.0
+		var prevHeight = startHeight.toFloat()
+		heightByCurrentLocation = Float.NaN
+		var prevDistance = 0.0
+		for (k in 0 until getPointsLength()) {
+			val lon = KMapUtils.get31LongitudeX(getPoint31XTile(k))
+			val lat = KMapUtils.get31LatitudeY(getPoint31YTile(k))
+			if (k > 0) {
+				val dd = KMapUtils.getDistance(plat, plon, lat, lon)
+				var height = HEIGHT_UNDEFINED.toFloat()
+				if (k == getPointsLength() - 1) {
+					height = endHeight.toFloat()
+				} else {
+					val asc = getValue(k, "osmand_ele_asc")
+					if (!asc.isNullOrEmpty()) {
+						height = prevHeight + asc.toFloat()
+					} else {
+						val desc = getValue(k, "osmand_ele_desc")
+						if (!desc.isNullOrEmpty()) {
+							height = prevHeight - desc.toFloat()
+						}
+					}
+				}
+				heights[2 * k] = dd.toFloat()
+				heights[2 * k + 1] = height
+
+				if (currentLocation != null) {
+					val distance = KMapUtils.getDistance(currentLocation, lat, lon)
+					if (height != HEIGHT_UNDEFINED.toFloat() && distance < prevDistance) {
+						prevDistance = distance
+						heightByCurrentLocation = height
+					}
+				}
+
+				if (height != HEIGHT_UNDEFINED.toFloat()) {
+					// interpolate undefined
+					var totalDistance = dd
+					var startUndefined = k
+					while (startUndefined - 1 >= 0 && heights[2 * (startUndefined - 1) + 1] == HEIGHT_UNDEFINED.toFloat()) {
+						startUndefined--
+						totalDistance += heights[2 * startUndefined]
+					}
+					if (totalDistance > 0) {
+						val angle = (height - prevHeight) / totalDistance
+						for (j in startUndefined until k) {
+							heights[2 * j + 1] = ((heights[2 * j] * angle) + heights[2 * j - 1]).toFloat()
+						}
+					}
+					prevHeight = height
+				}
+			} else {
+				heights[0] = 0f
+				heights[1] = startHeight.toFloat()
+			}
+			plat = lat
+			plon = lon
+			if (currentLocation != null) {
+				prevDistance = KMapUtils.getDistance(currentLocation, plat, plon)
+			}
+		}
+		return heights
+	}
+
+	fun getId(): Long = id
+
+	fun getName(): String? = names?.get(region.nameTypeRule)
+
+	@JvmOverloads
+	fun getName(lang: String?, transliterate: Boolean = false): String? {
+		val names = this.names ?: return null
+		if (KAlgorithms.isEmpty(lang)) {
+			return names[region.nameTypeRule]
+		}
+		for (k in names.keys()) {
+			if (region.routeEncodingRules.size > k && "name:$lang" == region.routeEncodingRules[k]?.getTag()) {
+				return names[k]
+			}
+		}
+		val nmDef = names[region.nameTypeRule]
+		if (transliterate && !nmDef.isNullOrEmpty()) {
+			return KTransliterationHelper.transliterate(nmDef)
+		}
+		return nmDef
+	}
+
+	fun getNameIds(): IntArray? = nameIds
+
+	fun getNames(): KTIntObjectMap<String>? = names
+
+	fun getRef(lang: String?, transliterate: Boolean, direction: Boolean): String? {
+		val names = this.names ?: return null
+		if (KAlgorithms.isEmpty(lang)) {
+			return names[region.refTypeRule]
+		}
+		for (k in names.keys()) {
+			if (region.routeEncodingRules.size > k && "ref:$lang" == region.routeEncodingRules[k]?.getTag()) {
+				return names[k]
+			}
+		}
+		val refDefault = names[region.refTypeRule]
+		if (transliterate && !refDefault.isNullOrEmpty()) {
+			return KTransliterationHelper.transliterate(refDefault)
+		}
+		return refDefault
+	}
+
+	fun getDestinationRef(lang: String?, transliterate: Boolean, direction: Boolean): String? {
+		val names = this.names ?: return null
+		val refTag = if (direction) "destination:ref:forward" else "destination:ref:backward"
+		val refTagDefault = "destination:ref"
+		var refDefault: String? = null
+
+		for (k in names.keys()) {
+			if (region.routeEncodingRules.size > k) {
+				val tag = region.routeEncodingRules[k]?.getTag()
+				if (refTag == tag) {
+					return names[k]?.let { KAlgorithms.splitAndClearRepeats(it, ";") }
+				}
+				if (refTagDefault == tag) {
+					refDefault = names[k]
+				}
+			}
+		}
+		if (refDefault != null) {
+			return KAlgorithms.splitAndClearRepeats(refDefault, ";")
+		}
+		return null
+	}
+
+	fun getDestinationName(lang: String?, transliterate: Boolean, direction: Boolean): String {
+		val names = this.names ?: return ""
+		val tagPriorities = HashMap<String, Int>()
+		var tagPriority = 1
+		if (!KAlgorithms.isEmpty(lang)) {
+			tagPriorities["destination:lang:$lang" + (if (direction) ":forward" else ":backward")] = tagPriority++
+		}
+		tagPriorities["destination:" + (if (direction) "forward" else "backward")] = tagPriority++
+		if (!KAlgorithms.isEmpty(lang)) {
+			tagPriorities["destination:lang:$lang"] = tagPriority++
+		}
+		tagPriorities["destination"] = tagPriority
+
+		var highestPriorityNameKey = -1
+		var highestPriority = Int.MAX_VALUE
+		for (nameKey in names.keys()) {
+			if (region.routeEncodingRules.size > nameKey) {
+				val tag = region.routeEncodingRules[nameKey]?.getTag()
+				val priority = tagPriorities[tag]
+				if (priority != null && priority < highestPriority) {
+					highestPriority = priority
+					highestPriorityNameKey = nameKey
+				}
+			}
+		}
+		if (highestPriorityNameKey > 0) {
+			val name = names[highestPriorityNameKey] ?: return ""
+			return if (transliterate) KTransliterationHelper.transliterate(name) else name
+		}
+		return ""
+	}
+
+	fun getPoint31XTile(i: Int): Int = pointsX!![i]
+
+	/** Midpoint of the two points, kept in 31 tile units to avoid an overflow of their sum. */
+	fun getPoint31XTile(s: Int, e: Int): Int = pointsX!![s] / 2 + pointsX!![e] / 2
+
+	fun getPoint31YTile(i: Int): Int = pointsY!![i]
+
+	fun getPoint31YTile(s: Int, e: Int): Int = pointsY!![s] / 2 + pointsY!![e] / 2
+
+	fun getPointsLength(): Int = pointsX!!.size
+
+	fun getRestrictionLength(): Int = restrictions?.size ?: 0
+
+	fun getRestrictionType(i: Int): Int = (restrictions!![i] and RESTRICTION_MASK.toLong()).toInt()
+
+	fun getRestrictionInfo(k: Int): RestrictionInfo {
+		val ri = RestrictionInfo()
+		ri.toWay = getRestrictionId(k)
+		ri.type = getRestrictionType(k)
+		val via = restrictionsVia
+		if (via != null && k < via.size) {
+			ri.viaWay = via[k]
+		}
+		return ri
+	}
+
+	fun getRestrictionVia(i: Int): Long {
+		val via = restrictionsVia
+		if (via != null && via.size > i) {
+			return via[i]
+		}
+		return 0
+	}
+
+	fun getRestrictionId(i: Int): Long = restrictions!![i] shr RESTRICTION_SHIFT
+
+	fun hasPointTypes(): Boolean = pointTypes != null
+
+	fun hasPointNames(): Boolean = pointNames != null
+
+	/** Adds a point at [pos], shifting everything after it one place along. */
+	fun insert(pos: Int, x31: Int, y31: Int) {
+		val opointsX = pointsX!!
+		val opointsY = pointsY!!
+		val opointTypes = pointTypes
+		val opointNames = pointNames
+		val opointNameTypes = pointNameTypes
+		val npointsX = IntArray(opointsX.size + 1)
+		val npointsY = IntArray(opointsY.size + 1)
+		pointsX = npointsX
+		pointsY = npointsY
+		val insTypes = opointTypes != null && opointTypes.size > pos
+		val insNames = opointNames != null && opointNames.size > pos
+		var npointTypes: Array<IntArray?>? = null
+		var npointNames: Array<Array<String>?>? = null
+		var npointNameTypes: Array<IntArray?>? = null
+		if (insTypes) {
+			npointTypes = arrayOfNulls(opointTypes!!.size + 1)
+			pointTypes = npointTypes
+		}
+		if (insNames) {
+			npointNames = arrayOfNulls(opointNames!!.size + 1)
+			npointNameTypes = arrayOfNulls(opointNameTypes!!.size + 1)
+			pointNames = npointNames
+			pointNameTypes = npointNameTypes
+		}
+		var i = 0
+		while (i < pos) {
+			npointsX[i] = opointsX[i]
+			npointsY[i] = opointsY[i]
+			if (insTypes) {
+				npointTypes!![i] = opointTypes!![i]
+			}
+			if (insNames) {
+				npointNames!![i] = opointNames!![i]
+				npointNameTypes!![i] = opointNameTypes!![i]
+			}
+			i++
+		}
+		npointsX[i] = x31
+		npointsY[i] = y31
+		if (insTypes) {
+			npointTypes!![i] = null
+		}
+		if (insNames) {
+			npointNames!![i] = null
+			npointNameTypes!![i] = null
+		}
+		i++
+		while (i < npointsX.size) {
+			npointsX[i] = opointsX[i - 1]
+			npointsY[i] = opointsY[i - 1]
+			if (insTypes && i < npointTypes!!.size) {
+				npointTypes[i] = opointTypes!![i - 1]
+			}
+			if (insNames && i < npointNames!!.size) {
+				npointNames[i] = opointNames!![i - 1]
+			}
+			if (insNames && i < npointNameTypes!!.size) {
+				npointNameTypes[i] = opointNameTypes!![i - 1]
+			}
+			i++
+		}
+	}
+
+	fun getPointNames(ind: Int): Array<String>? {
+		val pointNames = this.pointNames
+		if (pointNames == null || ind >= pointNames.size) {
+			return null
+		}
+		return pointNames[ind]
+	}
+
+	fun getPointNameTypes(ind: Int): IntArray? {
+		val pointNameTypes = this.pointNameTypes
+		if (pointNameTypes == null || ind >= pointNameTypes.size) {
+			return null
+		}
+		return pointNameTypes[ind]
+	}
+
+	fun getPointTypes(ind: Int): IntArray? {
+		val pointTypes = this.pointTypes
+		if (pointTypes == null || ind >= pointTypes.size) {
+			return null
+		}
+		return pointTypes[ind]
+	}
+
+	fun removePointType(ind: Int, type: Int) {
+		val pointTypes = this.pointTypes ?: return
+		val typesArr = pointTypes[ind] ?: return
+		for (i in typesArr.indices) {
+			if (typesArr[i] == type) {
+				val result = IntArray(typesArr.size - 1)
+				typesArr.copyInto(result, 0, 0, i)
+				if (typesArr.size != i) {
+					typesArr.copyInto(result, i, i + 1, typesArr.size)
+					pointTypes[ind] = result
+					break
+				}
+			}
+		}
+	}
+
+	fun getTypes(): IntArray? = types
+
+	@JvmOverloads
+	fun getMaximumSpeed(direction: Boolean, profile: Int = RouteTypeRule.PROFILE_NONE): Float {
+		var maxSpeed = 0f
+		var maxProfileSpeed = 0f
+		for (type in types!!) {
+			val r = rule(type)
+			val forwardDirection = r.isForward() > 0
+			if (forwardDirection == direction || r.isForward() == 0) {
+				// priority over default
+				val plain = r.maxSpeed(RouteTypeRule.PROFILE_NONE)
+				if (plain > 0) {
+					maxSpeed = plain
+				}
+				val forProfile = r.maxSpeed(profile)
+				if (forProfile > 0) {
+					maxProfileSpeed = forProfile
+				}
+			}
+		}
+		return if (maxProfileSpeed > 0) maxProfileSpeed else maxSpeed
+	}
+
+	fun platform(): Boolean {
+		for (type in types!!) {
+			val r = rule(type)
+			if (r.getTag() == "railway" && r.getValue() == "platform") {
+				return true
+			}
+			if (r.getTag() == "public_transport" && r.getValue() == "platform") {
+				return true
+			}
+		}
+		return false
+	}
+
+	fun roundabout(): Boolean {
+		for (type in types!!) {
+			if (rule(type).roundabout()) {
+				return true
+			}
+		}
+		return false
+	}
+
+	fun isClockwise(leftSide: Boolean): Boolean {
+		val pointTypes = this.pointTypes
+		if (pointTypes != null) {
+			for (tt in pointTypes) {
+				if (tt == null) {
+					continue
+				}
+				for (t in tt) {
+					val r = rule(t)
+					if (r.getTag() == "direction") {
+						if (r.getValue() == "clockwise") {
+							return true
+						}
+						if (r.getValue() == "anticlockwise") {
+							return false
+						}
+					}
+				}
+			}
+		}
+		return leftSide
+	}
+
+	fun tunnel(): Boolean {
+		for (type in types!!) {
+			val r = rule(type)
+			if (r.getTag() == "tunnel" && r.getValue() == "yes") {
+				return true
+			}
+			if (r.getTag() == "layer" && r.getValue() == "-1") {
+				return true
+			}
+		}
+		return false
+	}
+
+	fun hasMotorwayJunctionNode(): Boolean {
+		val pointTypes = this.pointTypes ?: return false
+		for (point in pointTypes) {
+			if (point != null) {
+				for (t in point) {
+					if (region.routeEncodingRules[t]?.getValue() == "motorway_junction") {
+						return true
+					}
+				}
+			}
+		}
+		return false
+	}
+
+	fun getJunctionRef(): String? = getValue(JUNCTION_REF)
+
+	fun getJunctionName(): String? = getValue(JUNCTION_NAME)
+
+	fun getNodeRef(): String? = getPointNameByTypeRule(region.refTypeRule)
+
+	fun getNodeName(): String? = getPointNameByTypeRule(region.nameTypeRule)
+
+	fun getExitRef(): String? = getJunctionRef() ?: getNodeRef()
+
+	fun getExitName(): String? = getJunctionName() ?: getNodeName()
+
+	fun hasTrafficLightAt(i: Int): Boolean {
+		val pointTypes = getPointTypes(i) ?: return false
+		for (pointType in pointTypes) {
+			if (region.routeEncodingRules[pointType]?.getValue()?.startsWith("traffic_signals") == true) {
+				return true
+			}
+		}
+		return false
+	}
+
+	fun getOneway(): Int {
+		for (type in types!!) {
+			val r = rule(type)
+			if (r.onewayDirection() != 0) {
+				return r.onewayDirection()
+			} else if (r.roundabout()) {
+				return 1
+			}
+		}
+		return 0
+	}
+
+	fun getRoute(): String? {
+		for (type in types!!) {
+			val r = rule(type)
+			if ("route" == r.getTag()) {
+				return r.getValue()
+			}
+		}
+		return null
+	}
+
+	fun getHighway(): String? = getHighway(types!!, region)
+
+	fun hasPrivateAccess(profile: GeneralRouterProfile): Boolean {
+		for (type in types!!) {
+			val rule = rule(type)
+			val tag = rule.getTag()
+			if (rule.getValue() == "private") {
+				if ("vehicle" == tag || "access" == tag) {
+					return true
+				} else if (profile == GeneralRouterProfile.CAR) {
+					return "motorcar" == tag || "motor_vehicle" == tag
+				} else if (profile == GeneralRouterProfile.BICYCLE) {
+					return "bicycle" == tag
+				}
+			}
+		}
+		return false
+	}
+
+	/** Value of [tag] on the road itself, looked up in its types and then in its names. */
+	fun getValue(tag: String): String? {
+		for (type in types!!) {
+			val r = rule(type)
+			if (r.getTag() == tag) {
+				return r.getValue()
+			}
+		}
+		val nameIds = this.nameIds
+		if (nameIds != null) {
+			for (nameId in nameIds) {
+				if (rule(nameId).getTag() == tag) {
+					return names?.get(nameId)
+				}
+			}
+		}
+		return null
+	}
+
+	/** Value of [tag] on point [pnt] of the road. */
+	fun getValue(pnt: Int, tag: String): String? {
+		val pointTypes = this.pointTypes
+		if (pointTypes != null && pnt < pointTypes.size) {
+			val point = pointTypes[pnt]
+			if (point != null) {
+				for (type in point) {
+					val r = rule(type)
+					if (r.getTag() == tag) {
+						return r.getValue()
+					}
+				}
+			}
+		}
+		val pointNameTypes = this.pointNameTypes
+		if (pointNameTypes != null && pnt < pointNameTypes.size) {
+			val point = pointNameTypes[pnt]
+			if (point != null) {
+				for (i in point.indices) {
+					if (rule(point[i]).getTag() == tag) {
+						return pointNames?.get(pnt)?.get(i)
+					}
+				}
+			}
+		}
+		return null
+	}
+
+	fun getLanes(): Int {
+		for (type in types!!) {
+			val ln = rule(type).lanes()
+			if (ln > 0) {
+				return ln
+			}
+		}
+		return -1
+	}
+
+	fun directionRoute(startPoint: Int, plus: Boolean): Double {
+		// same goes to C++
+		// Victor : the problem to put more than 5 meters that BinaryRoutePlanner will treat
+		// 2 consequent Turn Right as UT and here 2 points will have same turn angle
+		// So it should be fix in both places
+		return directionRoute(startPoint, plus, 5f)
+	}
+
+	/**
+	 * True when a heading of [bearing] degrees points along the road rather than against it.
+	 * A fix that carries no bearing, passed as null, reads as the forward direction.
+	 */
+	fun bearingVsRouteDirection(bearing: Float?): Boolean {
+		if (bearing == null) {
+			return true
+		}
+		val diff = KMapUtils.alignAngleDifference(directionRoute(0, true) - bearing / 180f * PI)
+		return abs(diff) < PI / 2f
+	}
+
+	fun isRoadDeleted(): Boolean {
+		for (type in types!!) {
+			val r = rule(type)
+			if ("osmand_change" == r.getTag() && "delete" == r.getValue()) {
+				return true
+			}
+		}
+		return false
+	}
+
+	fun isDirectionApplicable(direction: Boolean, ind: Int, startPointInd: Int, endPointInd: Int): Boolean {
+		val pt = getPointTypes(ind)!!
+		for (type in pt) {
+			val r = rule(type)
+			// Evaluate direction tag if present
+			if (r.getTag() == "direction") {
+				val dv = r.getValue()
+				if ((dv == "forward" && direction) || (dv == "backward" && !direction)) {
+					return true
+				} else if ((dv == "forward" && !direction) || (dv == "backward" && direction)) {
+					return false
+				}
+			}
+		}
+		if (startPointInd >= 0) {
+			// Heuristic fallback: Distance analysis for STOP with no recognized directional tagging:
+			// Mask STOPs closer to the start than to the end of the routing segment if it is within 50m of start,
+			// but do not mask STOPs mapped directly on start/end (likely intersection node)
+			val d2Start = distance(startPointInd, ind)
+			val d2End = distance(ind, endPointInd)
+			if (d2Start < d2End && d2Start != 0.0 && d2End != 0.0 && d2Start < 50) {
+				return false
+			}
+		}
+		// No directional info detected
+		return true
+	}
+
+	fun distance(startPoint: Int, endPoint: Int): Double {
+		var start = startPoint
+		var end = endPoint
+		if (start > end) {
+			val k = end
+			end = start
+			start = k
+		}
+		var d = 0.0
+		var k = start
+		while (k < end && k < getPointsLength() - 1) {
+			val x = getPoint31XTile(k)
+			val y = getPoint31YTile(k)
+			val kx = getPoint31XTile(k + 1)
+			val ky = getPoint31YTile(k + 1)
+			d += KMapUtils.squareRootDist31(kx, ky, x, y)
+			k++
+		}
+		return d
+	}
+
+	/** Route direction of EAST degrees from NORTH ]-PI, PI]. */
+	fun directionRoute(startPoint: Int, plus: Boolean, dist: Float): Double {
+		val x = getPoint31XTile(startPoint)
+		val y = getPoint31YTile(startPoint)
+		var nx = startPoint
+		var px = x
+		var py = y
+		var total = 0.0
+		do {
+			if (plus) {
+				nx++
+				if (nx >= getPointsLength()) {
+					break
+				}
+			} else {
+				nx--
+				if (nx < 0) {
+					break
+				}
+			}
+			px = getPoint31XTile(nx)
+			py = getPoint31YTile(nx)
+			// translate into meters
+			total += KMapUtils.squareRootDist31(x, y, px, py)
+		} while (total < dist)
+		return -atan2((x - px).toDouble(), (y - py).toDouble())
+	}
+
+	fun coordinates(): String {
+		val b = StringBuilder()
+		b.append(" lat/lon : ")
+		for (i in 0 until getPointsLength()) {
+			val x = KMapUtils.get31LongitudeX(getPoint31XTile(i)).toFloat()
+			val y = KMapUtils.get31LatitudeY(getPoint31YTile(i)).toFloat()
+			b.append(y).append(" / ").append(x).append(" , ")
+		}
+		return b.toString()
+	}
+
+	override fun toString(): String {
+		var str = "Road (${id / 64})"
+		val rf = getRef("", false, true)
+		if (!KAlgorithms.isEmpty(rf)) {
+			str += ", ref ('$rf')"
+		}
+		val name = getName()
+		if (!KAlgorithms.isEmpty(name)) {
+			str += ", name ('$name')"
+		}
+		return str
+	}
+
+	fun hasNameTagStartsWith(tagStartsWith: String): Boolean {
+		val nameIds = this.nameIds ?: return false
+		for (nameId in nameIds) {
+			val rtr = region.quickGetEncodingRule(nameId)
+			if (rtr != null && rtr.getTag().startsWith(tagStartsWith)) {
+				return true
+			}
+		}
+		return false
+	}
+
+	class RestrictionInfo {
+		@JvmField
+		var type: Int = 0
+
+		@JvmField
+		var toWay: Long = 0
+
+		@JvmField
+		var viaWay: Long = 0
+
+		/** Optional, to simulate a linked list. */
+		@JvmField
+		var next: RestrictionInfo? = null
+
+		fun length(): Int {
+			val next = this.next ?: return 1
+			return next.length() + 1
+		}
+	}
+
+	fun setRestriction(k: Int, to: Long, type: Int, viaWay: Long) {
+		var restrictions = this.restrictions
+		if (restrictions == null) {
+			restrictions = LongArray(k + 1)
+			this.restrictions = restrictions
+		}
+		if (restrictions.size <= k) {
+			restrictions = restrictions.copyOf(k + 1)
+			this.restrictions = restrictions
+		}
+		restrictions[k] = (to shl RESTRICTION_SHIFT) or (type.toLong() and RESTRICTION_MASK.toLong())
+		if (viaWay != 0L) {
+			setRestrictionVia(k, viaWay)
+		}
+	}
+
+	fun setRestrictionVia(k: Int, viaWay: Long) {
+		// note: the copy below reads `restrictions`, not `restrictionsVia`. That looks wrong, but it
+		// is what the java original did and changing it would change which turns get restricted.
+		val via = restrictionsVia
+		val target: LongArray
+		if (via != null) {
+			val restrictions = this.restrictions!!
+			target = LongArray(maxOf(k + 1, restrictions.size))
+			restrictions.copyInto(target, 0, 0, restrictions.size)
+		} else {
+			target = LongArray(k + 1)
+		}
+		restrictionsVia = target
+		target[k] = viaWay
+	}
+
+	fun setPointNames(pntInd: Int, array: IntArray, nms: Array<String>) {
+		val pointNameTypes = this.pointNameTypes
+		if (pointNameTypes == null || pointNameTypes.size <= pntInd) {
+			val npointTypes = arrayOfNulls<IntArray>(pntInd + 1)
+			val npointNames = arrayOfNulls<Array<String>>(pntInd + 1)
+			val pointNames = this.pointNames
+			var k = 0
+			while (pointNameTypes != null && k < pointNameTypes.size) {
+				npointTypes[k] = pointNameTypes[k]
+				npointNames[k] = pointNames!![k]
+				k++
+			}
+			this.pointNameTypes = npointTypes
+			this.pointNames = npointNames
+		}
+		this.pointNameTypes!![pntInd] = array
+		this.pointNames!![pntInd] = nms
+	}
+
+	fun setPointTypes(pntInd: Int, array: IntArray) {
+		val pointTypes = this.pointTypes
+		if (pointTypes == null || pointTypes.size <= pntInd) {
+			val npointTypes = arrayOfNulls<IntArray>(pntInd + 1)
+			var k = 0
+			while (pointTypes != null && k < pointTypes.size) {
+				npointTypes[k] = pointTypes[k]
+				k++
+			}
+			this.pointTypes = npointTypes
+		}
+		this.pointTypes!![pntInd] = array
+	}
+
+	fun hasPointType(pntId: Int, type: Int): Boolean {
+		val point = (pointTypes ?: return false)[pntId] ?: return false
+		for (t in point) {
+			if (t == type) {
+				return true
+			}
+		}
+		return false
+	}
+
+	fun containsType(cachedType: Int): Boolean {
+		if (cachedType != -1) {
+			for (type in types!!) {
+				if (type == cachedType) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	private fun getPointNameByTypeRule(typeRule: Int): String? {
+		val pointNames = this.pointNames
+		val pointNameTypes = this.pointNameTypes
+		if (typeRule != -1 && pointNames != null && pointNameTypes != null) {
+			for (i in pointNames.indices) {
+				val point = pointNames[i] ?: continue
+				for (j in point.indices) {
+					if (pointNameTypes[i]!![j] == typeRule) {
+						return point[j]
+					}
+				}
+			}
+		}
+		return null
+	}
+
+	companion object {
+		private const val RESTRICTION_SHIFT = 3
+		private const val RESTRICTION_MASK = 7
+
+		const val HEIGHT_UNDEFINED = -80000
+
+		const val NONE_MAX_SPEED = RouteDataUtils.NONE_MAX_SPEED
+
+		const val JUNCTION_REF = "junction:ref"
+		const val JUNCTION_NAME = "junction:name"
+
+		@JvmStatic
+		fun parseSpeed(v: String, def: Float): Float = RouteDataUtils.parseSpeed(v, def)
+
+		/** Parses an osm length, which may be metric, or feet and inches like `14'10"`. */
+		@JvmStatic
+		fun parseLength(v: String, def: Float): Float {
+			var f = 0f
+			// 14'10" 14 - inches, 10 feet
+			val i = KAlgorithms.findFirstNumberEndIndex(v)
+			if (i > 0) {
+				f += v.substring(0, i).toFloat()
+				var pref = v.substring(i).trim()
+				var add = 0f
+				for (ik in pref.indices) {
+					if (KAlgorithms.isDigit(pref[ik]) || pref[ik] == '.' || pref[ik] == '-') {
+						val first = KAlgorithms.findFirstNumberEndIndex(pref.substring(ik))
+						if (first != -1) {
+							add = parseLength(pref.substring(ik), 0f)
+							pref = pref.substring(0, ik)
+						}
+						break
+					}
+				}
+				if (pref.contains("km")) {
+					f *= 1000f
+				}
+				if (pref.contains("\"") || pref.contains("in")) {
+					f = (f * 0.0254).toFloat()
+				} else if (pref.contains("'") || pref.contains("ft") || pref.contains("feet")) {
+					// foot to meters
+					f = (f * 0.3048).toFloat()
+				} else if (pref.contains("cm")) {
+					f = (f * 0.01).toFloat()
+				} else if (pref.contains("mile")) {
+					f *= 1609.34f
+				}
+				return f + add
+			}
+			return def
+		}
+
+		@JvmStatic
+		fun parseWeightInTon(v: String, def: Float): Float {
+			val i = KAlgorithms.findFirstNumberEndIndex(v)
+			if (i > 0) {
+				var f = v.substring(0, i).toFloat()
+				if (v.contains("\"") || v.contains("lbs")) {
+					// lbs -> kg -> ton
+					f = (f * 0.4535f) / 1000f
+				}
+				return f
+			}
+			return def
+		}
+
+		@JvmStatic
+		fun getHighway(types: IntArray, region: RouteRegion): String? {
+			for (type in types) {
+				val highway = region.quickGetEncodingRule(type)!!.highwayRoad()
+				if (highway != null) {
+					return highway
+				}
+			}
+			return null
+		}
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteRegion.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteRegion.kt
@@ -1,0 +1,317 @@
+package net.osmand.shared.routing
+
+import net.osmand.shared.binary.BinaryIndexPart
+import net.osmand.shared.util.KMapUtils
+import net.osmand.shared.util.collections.KTIntObjectMap
+import kotlin.jvm.JvmField
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * The routing section of one obf file: its encoding rules and the r-tree over its roads.
+ *
+ * Roads are stored with their tags replaced by indices into [routeEncodingRules], so a road can
+ * only be read through the region it came from.
+ *
+ * A copy of `BinaryMapRouteReaderAdapter.RouteRegion`, which stays in OsmAnd-java: android, tools and the C++ core keep using
+ * the original, and this copy is for iOS. Keep the two identical.
+ */
+class RouteRegion : BinaryIndexPart() {
+
+	@JvmField
+	var regionsRead: Int = 0
+
+	@JvmField
+	var routeEncodingRules: MutableList<RouteTypeRule?> = ArrayList()
+
+	@JvmField
+	var routeEncodingRulesBytes: Int = 0
+
+	private var decodingRules: MutableMap<String, Int>? = null
+
+	@JvmField
+	var subregions: MutableList<RouteSubregion> = ArrayList()
+
+	@JvmField
+	var basesubregions: MutableList<RouteSubregion> = ArrayList()
+
+	@JvmField
+	var directionForward: Int = -1
+
+	@JvmField
+	var directionBackward: Int = -1
+
+	@JvmField
+	var maxheightForward: Int = -1
+
+	@JvmField
+	var maxheightBackward: Int = -1
+
+	@JvmField
+	var directionTrafficSignalsForward: Int = -1
+
+	@JvmField
+	var directionTrafficSignalsBackward: Int = -1
+
+	@JvmField
+	var trafficSignals: Int = -1
+
+	@JvmField
+	var stopSign: Int = -1
+
+	@JvmField
+	var stopMinor: Int = -1
+
+	@JvmField
+	var giveWaySign: Int = -1
+
+	@JvmField
+	var nameTypeRule: Int = -1
+
+	@JvmField
+	var refTypeRule: Int = -1
+
+	@JvmField
+	var destinationTypeRule: Int = -1
+
+	@JvmField
+	var destinationRefTypeRule: Int = -1
+
+	/** The region whose rules this one borrowed in [adopt], so its roads need no re-encoding. */
+	private var referenceRouteRegion: RouteRegion? = null
+
+	override fun getPartName(): String = "Routing"
+
+	override fun getFieldNumber(): Int = ROUTING_INDEX_FIELD_NUMBER
+
+	/** Index of the rule for [tag]/[value], or -1. */
+	fun searchRouteEncodingRule(tag: String, value: String?): Int {
+		var rules = decodingRules
+		if (rules == null) {
+			rules = LinkedHashMap()
+			for (i in 1 until routeEncodingRules.size) {
+				val rt = routeEncodingRules[i] ?: continue
+				rules[rt.getTag() + "#" + (rt.getValue() ?: "")] = i
+			}
+			decodingRules = rules
+		}
+		return rules[tag + "#" + (value ?: "")] ?: -1
+	}
+
+	fun getNameTypeRule(): Int = nameTypeRule
+
+	fun getRefTypeRule(): Int = refTypeRule
+
+	/** The rule at [id]. Null only where the rule table has a gap. */
+	fun quickGetEncodingRule(id: Int): RouteTypeRule? = routeEncodingRules[id]
+
+	fun quickGetEncodingRulesSize(): Int = routeEncodingRules.size
+
+	fun initRouteEncodingRule(id: Int, tags: String, `val`: String?) {
+		val append = id >= routeEncodingRules.size
+		if (!append) {
+			decodingRules = null
+		}
+		while (routeEncodingRules.size <= id) {
+			routeEncodingRules.add(null)
+		}
+		val rt = RouteTypeRule(tags, `val`)
+		routeEncodingRules[id] = rt
+		if (append && id > 0) {
+			decodingRules?.put(rt.getTag() + "#" + (rt.getValue() ?: ""), id)
+		}
+		if (tags == "name") {
+			nameTypeRule = id
+		} else if (tags == "ref") {
+			refTypeRule = id
+		} else if (tags == "destination" || tags == "destination:forward" || tags == "destination:backward" || tags.startsWith("destination:lang:")) {
+			destinationTypeRule = id
+		} else if (tags == "destination:ref" || tags == "destination:ref:forward" || tags == "destination:ref:backward") {
+			destinationRefTypeRule = id
+		} else if (tags == "highway" && `val` == "traffic_signals") {
+			trafficSignals = id
+		} else if (tags == "stop" && `val` == "minor") {
+			stopMinor = id
+		} else if (tags == "highway" && `val` == "stop") {
+			stopSign = id
+		} else if (tags == "highway" && `val` == "give_way") {
+			giveWaySign = id
+		} else if (tags == "traffic_signals:direction" && `val` != null) {
+			if (`val` == "forward") {
+				directionTrafficSignalsForward = id
+			} else if (`val` == "backward") {
+				directionTrafficSignalsBackward = id
+			}
+		} else if (tags == "direction" && `val` != null) {
+			if (`val` == "forward") {
+				directionForward = id
+			} else if (`val` == "backward") {
+				directionBackward = id
+			}
+			// could be generic
+		} else if (tags == "maxheight:forward" && `val` != null) {
+			maxheightForward = id
+		} else if (tags == "maxheight:backward" && `val` != null) {
+			maxheightBackward = id
+		}
+	}
+
+	/** Resolves every conditional rule to the plain rule it stands for while the condition holds. */
+	fun completeRouteEncodingRules() {
+		for (i in routeEncodingRules.indices) {
+			val rtr = routeEncodingRules[i]
+			if (rtr != null && rtr.conditional()) {
+				val tag = rtr.getNonConditionalTag()
+				for (c in rtr.getConditions()!!) {
+					if (c.value != null) {
+						c.ruleId = findOrCreateRouteType(tag, c.value)
+					}
+				}
+			}
+		}
+	}
+
+	fun getSubregions(): MutableList<RouteSubregion> = subregions
+
+	fun getBaseSubregions(): MutableList<RouteSubregion> = basesubregions
+
+	fun getLeftLongitude(): Double {
+		var l = 180.0
+		for (s in subregions) {
+			l = min(l, KMapUtils.get31LongitudeX(s.left))
+		}
+		return l
+	}
+
+	fun getRightLongitude(): Double {
+		var l = -180.0
+		for (s in subregions) {
+			l = max(l, KMapUtils.get31LongitudeX(s.right))
+		}
+		return l
+	}
+
+	fun getBottomLatitude(): Double {
+		var l = 90.0
+		for (s in subregions) {
+			l = min(l, KMapUtils.get31LatitudeY(s.bottom))
+		}
+		return l
+	}
+
+	fun getTopLatitude(): Double {
+		var l = -90.0
+		for (s in subregions) {
+			l = max(l, KMapUtils.get31LatitudeY(s.top))
+		}
+		return l
+	}
+
+	fun contains(x31: Int, y31: Int): Boolean {
+		for (s in subregions) {
+			if (s.left <= x31 && s.right >= x31 && s.top <= y31 && s.bottom >= y31) {
+				return true
+			}
+		}
+		return false
+	}
+
+	/**
+	 * Returns [o] re-encoded against this region's rules, or [o] itself when it needs no change.
+	 *
+	 * Used when roads from several files are merged into one: their type indices point into
+	 * different rule tables and have to be made to agree.
+	 */
+	fun adopt(o: RouteDataObject): RouteDataObject {
+		if (o.region === this || o.region === referenceRouteRegion) {
+			return o
+		}
+
+		if (routeEncodingRules.isEmpty()) {
+			routeEncodingRules.addAll(o.region.routeEncodingRules)
+			referenceRouteRegion = o.region
+			return o
+		}
+		val rdo = RouteDataObject(this)
+		rdo.pointsX = o.pointsX
+		rdo.pointsY = o.pointsY
+		rdo.id = o.id
+		rdo.restrictions = o.restrictions
+		rdo.restrictionsVia = o.restrictionsVia
+
+		val types = o.types
+		if (types != null) {
+			rdo.types = IntArray(types.size) { i ->
+				val tp = o.region.routeEncodingRules[types[i]]!!
+				findOrCreateRouteType(tp.getTag(), tp.getValue())
+			}
+		}
+		val pointTypes = o.pointTypes
+		if (pointTypes != null) {
+			val adopted = arrayOfNulls<IntArray>(pointTypes.size)
+			for (i in pointTypes.indices) {
+				val point = pointTypes[i] ?: continue
+				adopted[i] = IntArray(point.size) { j ->
+					val tp = o.region.routeEncodingRules[point[j]]!!
+					var ruleId = searchRouteEncodingRule(tp.getTag(), tp.getValue())
+					if (ruleId == -1) {
+						ruleId = routeEncodingRules.size
+						initRouteEncodingRule(ruleId, tp.getTag(), tp.getValue())
+					}
+					ruleId
+				}
+			}
+			rdo.pointTypes = adopted
+		}
+		val nameIds = o.nameIds
+		if (nameIds != null) {
+			val adopted = IntArray(nameIds.size)
+			val names = KTIntObjectMap<String>()
+			for (i in nameIds.indices) {
+				val tp = o.region.routeEncodingRules[nameIds[i]]!!
+				var ruleId = searchRouteEncodingRule(tp.getTag(), null)
+				if (ruleId == -1) {
+					ruleId = routeEncodingRules.size
+					initRouteEncodingRule(ruleId, tp.getTag(), null)
+				}
+				adopted[i] = ruleId
+				o.names?.get(nameIds[i])?.let { names.put(ruleId, it) }
+			}
+			rdo.nameIds = adopted
+			rdo.names = names
+		}
+		rdo.pointNames = o.pointNames
+		val pointNameTypes = o.pointNameTypes
+		if (pointNameTypes != null) {
+			val adopted = arrayOfNulls<IntArray>(pointNameTypes.size)
+			for (i in pointNameTypes.indices) {
+				val point = pointNameTypes[i] ?: continue
+				adopted[i] = IntArray(point.size) { j ->
+					val tp = o.region.routeEncodingRules[point[j]]!!
+					var ruleId = searchRouteEncodingRule(tp.getTag(), null)
+					if (ruleId == -1) {
+						ruleId = routeEncodingRules.size
+						initRouteEncodingRule(ruleId, tp.getTag(), tp.getValue())
+					}
+					ruleId
+				}
+			}
+			rdo.pointNameTypes = adopted
+		}
+		return rdo
+	}
+
+	fun findOrCreateRouteType(tag: String, value: String?): Int {
+		var ruleId = searchRouteEncodingRule(tag, value)
+		if (ruleId == -1) {
+			ruleId = routeEncodingRules.size
+			initRouteEncodingRule(ruleId, tag, value)
+		}
+		return ruleId
+	}
+
+	companion object {
+		/** `OsmAndStructure.routingIndex` in osmand_odb.proto, frozen by the obf format. */
+		private const val ROUTING_INDEX_FIELD_NUMBER = 9
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteSubregion.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteSubregion.kt
@@ -1,0 +1,85 @@
+package net.osmand.shared.routing
+
+import kotlin.jvm.JvmField
+
+/**
+ * One node of the routing r-tree of a [RouteRegion]: a bounding box and where its bytes are.
+ *
+ * A copy of `BinaryMapRouteReaderAdapter.RouteSubregion`, which stays in OsmAnd-java: android, tools and the C++ core keep using
+ * the original, and this copy is for iOS. Keep the two identical.
+ */
+class RouteSubregion {
+
+	@JvmField
+	val routeReg: RouteRegion
+
+	@JvmField
+	var length: Long = 0
+
+	@JvmField
+	var filePointer: Long = 0
+
+	@JvmField
+	var left: Int = 0
+
+	@JvmField
+	var right: Int = 0
+
+	@JvmField
+	var top: Int = 0
+
+	@JvmField
+	var bottom: Int = 0
+
+	@JvmField
+	var shiftToData: Long = 0
+
+	@JvmField
+	var subregions: MutableList<RouteSubregion>? = null
+
+	/** Objects of this node once it has been read, cleared as soon as they are handed out. */
+	@JvmField
+	var dataObjects: MutableList<RouteDataObject?>? = null
+
+	constructor(routeReg: RouteRegion) {
+		this.routeReg = routeReg
+	}
+
+	/** Copies the box and the file position, but not the loaded objects. */
+	constructor(copy: RouteSubregion) {
+		this.routeReg = copy.routeReg
+		this.left = copy.left
+		this.right = copy.right
+		this.top = copy.top
+		this.bottom = copy.bottom
+		this.filePointer = copy.filePointer
+		this.length = copy.length
+	}
+
+	fun getEstimatedSize(): Int {
+		var shallow = 7 * INT_SIZE + 4 * 3
+		val subregions = this.subregions
+		if (subregions != null) {
+			shallow += 8
+			for (s in subregions) {
+				shallow += s.getEstimatedSize()
+			}
+		}
+		return shallow
+	}
+
+	fun countSubregions(): Int {
+		var cnt = 1
+		val subregions = this.subregions
+		if (subregions != null) {
+			for (s in subregions) {
+				cnt += s.countSubregions()
+			}
+		}
+		return cnt
+	}
+
+	companion object {
+		private const val INT_SIZE = 4
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/KAlgorithms.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/KAlgorithms.kt
@@ -93,6 +93,26 @@ object KAlgorithms {
 		}
 	}
 
+	/**
+	 * Joins the [symbol] separated parts of [ref] back together, dropping empty parts and any part
+	 * that repeats the one before it. Road refs are often tagged as "A1;A1;A2".
+	 */
+	fun splitAndClearRepeats(ref: String, symbol: String): String {
+		val res = StringBuilder()
+		var prev = ""
+		for (s in ref.split(symbol)) {
+			if (isEmpty(s) || prev == s) {
+				continue
+			}
+			if (res.isNotEmpty()) {
+				res.append(symbol)
+			}
+			res.append(s)
+			prev = s
+		}
+		return res.toString()
+	}
+
 	fun isDigit(c: Char): Boolean {
 		return c in '0'..'9'
 	}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/KTransliterationHelper.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/KTransliterationHelper.kt
@@ -1,0 +1,30 @@
+package net.osmand.shared.util
+
+import kotlin.jvm.JvmStatic
+
+/**
+ * Romanisation of map names, used wherever a latin rendering of a local name is asked for.
+ */
+object KTransliterationHelper {
+
+	private var japanese = false
+
+	@JvmStatic
+	fun isJapanese(): Boolean = japanese
+
+	/** Set once per loaded map set, from whether any of the maps covers Japan. */
+	@JvmStatic
+	fun setJapanese(japanese: Boolean) {
+		KTransliterationHelper.japanese = japanese
+	}
+
+	@JvmStatic
+	fun transliterate(text: String): String {
+		// japanese is left as it is: romanising it properly needs a tokenizer, and a character by
+		// character transliteration reads worse than the original
+		return if (japanese) text else toLatin(text)
+	}
+}
+
+/** Character by character romanisation, whatever the platform offers for it. */
+internal expect fun toLatin(text: String): String

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/routing/RouteDataObjectTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/routing/RouteDataObjectTest.kt
@@ -1,0 +1,260 @@
+package net.osmand.shared.routing
+
+import net.osmand.shared.util.KMapUtils
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RouteDataObjectTest {
+
+	/** A region with the rules a small test road needs, in a fixed order. */
+	private fun region(vararg tags: Pair<String, String?>): RouteRegion {
+		val region = RouteRegion()
+		// id 0 is never a real rule, the readers count rules from 1
+		region.initRouteEncodingRule(0, "", "")
+		for ((i, tag) in tags.withIndex()) {
+			region.initRouteEncodingRule(i + 1, tag.first, tag.second)
+		}
+		return region
+	}
+
+	private fun road(region: RouteRegion, vararg types: Int): RouteDataObject {
+		val road = RouteDataObject(region)
+		road.id = 64
+		road.types = types.toList().toIntArray()
+		// a short segment near the equator, roughly 1.5 km long
+		road.pointsX = intArrayOf(KMapUtils.get31TileNumberX(30.0), KMapUtils.get31TileNumberX(30.01))
+		road.pointsY = intArrayOf(KMapUtils.get31TileNumberY(50.0), KMapUtils.get31TileNumberY(50.0))
+		return road
+	}
+
+	@Test
+	fun testEncodingRulesAreFoundByTagAndValue() {
+		val region = region("highway" to "primary", "oneway" to "yes")
+		assertEquals(1, region.searchRouteEncodingRule("highway", "primary"))
+		assertEquals(2, region.searchRouteEncodingRule("oneway", "yes"))
+		assertEquals(-1, region.searchRouteEncodingRule("highway", "service"))
+		assertEquals("primary", region.quickGetEncodingRule(1)?.getValue())
+		assertEquals(3, region.quickGetEncodingRulesSize())
+	}
+
+	@Test
+	fun testFindOrCreateRouteTypeAppends() {
+		val region = region("highway" to "primary")
+		assertEquals(1, region.findOrCreateRouteType("highway", "primary"))
+		val created = region.findOrCreateRouteType("bridge", "yes")
+		assertEquals(2, created)
+		assertEquals(3, region.quickGetEncodingRulesSize())
+		// the lookup cache is rebuilt after a rule is added
+		assertEquals(2, region.searchRouteEncodingRule("bridge", "yes"))
+	}
+
+	@Test
+	fun testSpecialRuleIdsAreRemembered() {
+		val region = region("name" to null, "ref" to null, "highway" to "traffic_signals")
+		assertEquals(1, region.getNameTypeRule())
+		assertEquals(2, region.getRefTypeRule())
+		assertEquals(3, region.trafficSignals)
+	}
+
+	@Test
+	fun testHighwayAndOneway() {
+		val region = region("highway" to "primary", "oneway" to "-1")
+		val road = road(region, 1, 2)
+		assertEquals("primary", road.getHighway())
+		assertEquals(-1, road.getOneway())
+		assertFalse(road.roundabout())
+		assertFalse(road.tunnel())
+	}
+
+	@Test
+	fun testRoundaboutImpliesOneway() {
+		val region = region("junction" to "roundabout")
+		val road = road(region, 1)
+		assertTrue(road.roundabout())
+		assertEquals(1, road.getOneway())
+	}
+
+	@Test
+	fun testTunnel() {
+		assertTrue(road(region("tunnel" to "yes"), 1).tunnel())
+		assertTrue(road(region("layer" to "-1"), 1).tunnel())
+		assertFalse(road(region("layer" to "1"), 1).tunnel())
+	}
+
+	@Test
+	fun testMaximumSpeedFollowsDirection() {
+		val region = region("highway" to "primary", "maxspeed:forward" to "50", "maxspeed:backward" to "30")
+		val road = road(region, 1, 2, 3)
+		assertTrue(abs(50 / 3.6f - road.getMaximumSpeed(true)) < 1e-4f)
+		assertTrue(abs(30 / 3.6f - road.getMaximumSpeed(false)) < 1e-4f)
+	}
+
+	@Test
+	fun testMaximumSpeedProfileWins() {
+		val region = region("maxspeed" to "90", "maxspeed:hgv" to "60")
+		val road = road(region, 1, 2)
+		assertTrue(abs(90 / 3.6f - road.getMaximumSpeed(true)) < 1e-4f)
+		assertTrue(abs(60 / 3.6f - road.getMaximumSpeed(true, RouteTypeRule.PROFILE_TRUCK)) < 1e-4f)
+	}
+
+	@Test
+	fun testValueLookup() {
+		val region = region("highway" to "primary", "surface" to "asphalt")
+		val road = road(region, 1, 2)
+		assertEquals("asphalt", road.getValue("surface"))
+		assertNull(road.getValue("bridge"))
+	}
+
+	@Test
+	fun testNames() {
+		val region = region("name" to null, "ref" to null, "name:de" to null)
+		val road = RouteDataObject(region, intArrayOf(1, 2, 3), arrayOf("Main street", "A1", "Hauptstrasse"))
+		assertEquals("Main street", road.getName())
+		assertEquals("Main street", road.getName(""))
+		assertEquals("Hauptstrasse", road.getName("de"))
+		// an unknown language falls back to the plain name
+		assertEquals("Main street", road.getName("fr"))
+		assertEquals("A1", road.getRef("", false, true))
+		assertEquals(3, road.getNames()?.size)
+	}
+
+	@Test
+	fun testPrivateAccess() {
+		assertTrue(road(region("access" to "private"), 1).hasPrivateAccess(GeneralRouterProfile.CAR))
+		assertTrue(road(region("motorcar" to "private"), 1).hasPrivateAccess(GeneralRouterProfile.CAR))
+		assertFalse(road(region("motorcar" to "private"), 1).hasPrivateAccess(GeneralRouterProfile.BICYCLE))
+		assertFalse(road(region("highway" to "primary"), 1).hasPrivateAccess(GeneralRouterProfile.CAR))
+	}
+
+	@Test
+	fun testGeometry() {
+		val road = road(region("highway" to "primary"), 1)
+		assertEquals(2, road.getPointsLength())
+		val d = road.distance(0, 1)
+		// 0.01 degrees of longitude at 50N is about 715 m
+		assertTrue(d > 600 && d < 800, "unexpected distance $d")
+		// the road runs east, which is a quarter turn clockwise from north
+		assertTrue(abs(road.directionRoute(0, true) - kotlin.math.PI / 2) < 0.05)
+	}
+
+	@Test
+	fun testBearingVsRouteDirection() {
+		val road = road(region("highway" to "primary"), 1)
+		assertTrue(road.bearingVsRouteDirection(90f))
+		assertFalse(road.bearingVsRouteDirection(270f))
+		// a fix with no bearing reads as the forward direction
+		assertTrue(road.bearingVsRouteDirection(null))
+	}
+
+	@Test
+	fun testInsertPoint() {
+		val road = road(region("highway" to "primary"), 1)
+		val x = road.getPoint31XTile(0)
+		val y = road.getPoint31YTile(0)
+		road.insert(1, x + 10, y + 10)
+		assertEquals(3, road.getPointsLength())
+		assertEquals(x + 10, road.getPoint31XTile(1))
+		assertEquals(y + 10, road.getPoint31YTile(1))
+	}
+
+	@Test
+	fun testRestrictions() {
+		val road = road(region("highway" to "primary"), 1)
+		road.setRestriction(0, 512, 3, 0)
+		road.setRestriction(1, 1024, 5, 77)
+		assertEquals(2, road.getRestrictionLength())
+		assertEquals(512, road.getRestrictionId(0))
+		assertEquals(3, road.getRestrictionType(0))
+		val info = road.getRestrictionInfo(1)
+		assertEquals(1024, info.toWay)
+		assertEquals(5, info.type)
+	}
+
+	@Test
+	fun testPointTypesAndTrafficLights() {
+		val region = region("highway" to "primary", "highway" to "traffic_signals")
+		val road = road(region, 1)
+		road.setPointTypes(1, intArrayOf(2))
+		assertTrue(road.hasPointTypes())
+		assertTrue(road.hasPointType(1, 2))
+		assertTrue(road.hasTrafficLightAt(1))
+		assertFalse(road.hasTrafficLightAt(0))
+		road.removePointType(1, 2)
+		assertFalse(road.hasPointType(1, 2))
+	}
+
+	@Test
+	fun testCompareRoute() {
+		val region = region("highway" to "primary")
+		val a = road(region, 1)
+		val b = road(region, 1)
+		assertTrue(a.compareRoute(b))
+
+		val c = road(region, 1)
+		c.id = 128
+		assertFalse(a.compareRoute(c))
+
+		val d = RouteDataObject(a)
+		assertTrue(a.compareRoute(d))
+	}
+
+	@Test
+	fun testAdoptReencodesTypesAgainstAnotherRegion() {
+		val source = region("highway" to "primary", "surface" to "asphalt")
+		val road = road(source, 1, 2)
+
+		// a target that already knows one of the tags under a different id
+		val target = region("bridge" to "yes", "surface" to "asphalt")
+		val adopted = target.adopt(road)
+
+		assertTrue(adopted !== road)
+		assertEquals("primary", adopted.getHighway())
+		assertEquals("asphalt", adopted.getValue("surface"))
+		// the tag it already had keeps its id, the new one is appended
+		assertEquals(2, adopted.types!![1])
+		assertEquals(road.id, adopted.id)
+
+		// a road of the region itself is handed back untouched
+		assertTrue(target.adopt(adopted) === adopted)
+	}
+
+	@Test
+	fun testAdoptBorrowsRulesOfAnEmptyRegion() {
+		val source = region("highway" to "primary")
+		val road = road(source, 1)
+		val empty = RouteRegion()
+		assertTrue(empty.adopt(road) === road)
+		assertEquals(source.quickGetEncodingRulesSize(), empty.quickGetEncodingRulesSize())
+	}
+
+	@Test
+	fun testParseLength() {
+		assertTrue(abs(3.5f - RouteDataObject.parseLength("3.5", 0f)) < 1e-4f)
+		assertTrue(abs(3.5f - RouteDataObject.parseLength("3.5 m", 0f)) < 1e-4f)
+		assertTrue(abs(3500f - RouteDataObject.parseLength("3.5 km", 0f)) < 1e-2f)
+		// 14 feet 10 inches
+		val feetAndInches = RouteDataObject.parseLength("14'10\"", 0f)
+		assertTrue(abs(14 * 0.3048f + 10 * 0.0254f - feetAndInches) < 1e-3f, "was $feetAndInches")
+		assertTrue(abs(7f - RouteDataObject.parseLength("no number", 7f)) < 1e-4f)
+	}
+
+	@Test
+	fun testParseWeightInTon() {
+		assertTrue(abs(7.5f - RouteDataObject.parseWeightInTon("7.5", 0f)) < 1e-4f)
+		assertTrue(abs(7.5f - RouteDataObject.parseWeightInTon("7.5 t", 0f)) < 1e-4f)
+		val lbs = RouteDataObject.parseWeightInTon("1000 lbs", 0f)
+		assertTrue(abs(0.4535f - lbs) < 1e-3f, "was $lbs")
+		assertTrue(abs(2f - RouteDataObject.parseWeightInTon("none", 2f)) < 1e-4f)
+	}
+
+	@Test
+	fun testGetHighwayStatic() {
+		val region = region("surface" to "asphalt", "highway" to "secondary")
+		assertEquals("secondary", RouteDataObject.getHighway(intArrayOf(1, 2), region))
+		assertNull(RouteDataObject.getHighway(intArrayOf(1), region))
+	}
+}

--- a/OsmAnd-shared/src/iosMain/kotlin/net/osmand/shared/util/KTransliterationHelper.kt
+++ b/OsmAnd-shared/src/iosMain/kotlin/net/osmand/shared/util/KTransliterationHelper.kt
@@ -1,0 +1,74 @@
+package net.osmand.shared.util
+
+import platform.Foundation.NSString
+import platform.Foundation.NSStringTransformToLatin
+import platform.Foundation.decomposedStringWithCanonicalMapping
+import platform.Foundation.precomposedStringWithCanonicalMapping
+import platform.Foundation.stringByApplyingTransform
+
+/**
+ * Foundation's ICU transliteration, which is not the same engine as junidecode on the jvm: the two
+ * agree on plain cyrillic and greek but not everywhere, so a name romanised here can differ from the
+ * one android produces for the same map.
+ *
+ * The diacritics are stripped by decomposing rather than by a second
+ * `NSStringTransformStripDiacritics` pass. That transform is the rule set `NFD; [:Mn:] Remove; NFC`,
+ * and Foundation takes a transform identifier rather than a handle, so it rebuilds the rule based
+ * transliterator on **every call** - on a simulator about 160 us per name, against 1.7 us for the
+ * Any-Latin pass in front of it. Search calls this once per candidate without a `name:en`, tens of
+ * thousands of times per query.
+ *
+ * The two spell the same result: checked over 22121 amenity names off three regional maps.
+ */
+internal actual fun toLatin(text: String): String {
+	val latin = (text as NSString).stringByApplyingTransform(NSStringTransformToLatin, false)
+		?: return text
+	return stripDiacritics(latin)
+}
+
+/**
+ * Decompose, drop the marks sitting on latin letters, compose again.
+ *
+ * Only latin ones: the point of this pass is that what Any-Latin could not romanise should not be
+ * left with combining accents, and in scripts it did not touch a non spacing mark is not a
+ * decoration - lao U+0EB1 and U+0EB5 are vowels, and removing them turns a word into a different
+ * one. `NSStringTransformStripDiacritics` leaves them alone as well.
+ */
+private fun stripDiacritics(text: String): String {
+	if (isAscii(text)) {
+		return text
+	}
+	val decomposed = (text as NSString).decomposedStringWithCanonicalMapping
+	var filtered: StringBuilder? = null
+	var latinBase = false
+	for (i in decomposed.indices) {
+		val c = decomposed[i]
+		val mark = c.category == CharCategory.NON_SPACING_MARK
+		if (mark && latinBase) {
+			if (filtered == null) {
+				filtered = StringBuilder(decomposed.length).append(decomposed, 0, i)
+			}
+		} else {
+			if (!mark) {
+				// everything Any-Latin emits, up to and including the spacing modifier letters it
+				// uses for the cyrillic soft and hard signs
+				latinBase = c.code <= 0x2ff
+			}
+			filtered?.append(c)
+		}
+	}
+	if (filtered == null) {
+		return text
+	}
+	return (filtered.toString() as NSString).precomposedStringWithCanonicalMapping
+}
+
+/** Any-Latin leaves most names pure ascii, and ascii can carry no combining mark. */
+private fun isAscii(text: String): Boolean {
+	for (c in text) {
+		if (c.code > 0x7f) {
+			return false
+		}
+	}
+	return true
+}

--- a/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/util/KTransliterationHelper.kt
+++ b/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/util/KTransliterationHelper.kt
@@ -1,0 +1,5 @@
+package net.osmand.shared.util
+
+import net.sf.junidecode.Junidecode
+
+internal actual fun toLatin(text: String): String = Junidecode.unidecode(text)


### PR DESCRIPTION
Part of the routing-to-OsmAnd-shared series: the java classes stay in `OsmAnd-java` and android, tools and the C++ core keep using them; each step adds a copy to `OsmAnd-shared` and a test that the copy behaves like the original. The copies are for iOS, which will call them instead of its own C++ turn preparation.

`RouteDataObject`, `RouteRegion`, `RouteSubregion` and `BinaryIndexPart`, with `KTransliterationHelper` for the names. `JavaToShared` (test code) builds the copy of a java road field for field; `RouteDataObjectCompatTest` does that for every road in the test obf files and compares everything the router and the turn preparation read off a road - tags, names in six languages, geometry, restrictions, direction and distance at every point. Distances and directions are compared to a few ulps: the shared distance helpers predate the copies and associate their arithmetic differently, and the last bit is not what a route turns on.

`RouteRegion.initRouteEncodingRule` carries the fix master got after the copy was taken (an appended rule keeps the decoding map), which the region test would otherwise have caught.

Supersedes #25906.
