### PR TITLE
Copy RouteCalculationProgress to OsmAnd-shared

### DIFF
--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/FastRoutingState.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/FastRoutingState.kt
@@ -1,0 +1,98 @@
+package net.osmand.shared.routing
+
+import kotlin.jvm.JvmStatic
+import kotlin.math.max
+
+/**
+ * How far the fast (hierarchical) routing attempt got, and why it stopped.
+ *
+ * The state is a single ordinal, as in java, where the C++ core reads and raises it through one int field on
+ * [RouteCalculationProgress]; the transitions live here rather than on the progress itself because
+ * they only ever move forward, and [raise] is what enforces that.
+ */
+object FastRoutingState {
+
+	enum class Status {
+		READY,
+
+		// MissingMapsCalculator
+		MIXED_MAPS_INTERMEDIATES,
+		MIXED_MAPS_AT_START_OR_END,
+		MISSING_MAPS_INTERMEDIATES,
+		MISSING_MAPS_AT_START_OR_END,
+
+		// HHRoutePlanner
+		FAILED_WITH_MIXED_MAPS,
+		FAILED_WITH_MISSING_MAPS,
+		FAILED_NO_HH_ROUTING_DATA, // pedestrian profile, ancient maps, etc
+		FAILED_NEED_MORE_LAND_MAPS, // unusual geometry, e.g. Istanbul to Chișinău without the Bulgaria map
+		FAILED_UNSUPPORTED_PARAMETERS, // highly likely unsupported routing parameters (too many recalculations)
+
+		CANCELLED,
+		SUCCESS
+	}
+
+	@JvmStatic
+	fun isSuccessStatus(status: Status): Boolean {
+		return status == Status.SUCCESS
+	}
+
+	@JvmStatic
+	fun isCancelledStatus(status: Status): Boolean {
+		return status == Status.CANCELLED
+	}
+
+	@JvmStatic
+	fun isFailedStatus(status: Status): Boolean {
+		return status == Status.FAILED_WITH_MIXED_MAPS
+				|| status == Status.FAILED_WITH_MISSING_MAPS
+				|| status == Status.FAILED_NO_HH_ROUTING_DATA
+				|| status == Status.FAILED_NEED_MORE_LAND_MAPS
+				|| status == Status.FAILED_UNSUPPORTED_PARAMETERS
+	}
+
+	internal fun get(ordinal: Int): Status {
+		return Status.entries[ordinal]
+	}
+
+	internal fun reset(): Int {
+		return Status.READY.ordinal
+	}
+
+	internal fun raise(old: Int, status: Status): Int {
+		return max(status.ordinal, old)
+	}
+
+	internal fun fail(old: Int, hasUnsupportedParameters: Boolean): Int {
+		return if (isMixedMaps(old)) {
+			raise(old, Status.FAILED_WITH_MIXED_MAPS)
+		} else if (isMissingMaps(old)) {
+			raise(old, Status.FAILED_WITH_MISSING_MAPS)
+		} else {
+			raise(
+				old, if (hasUnsupportedParameters) Status.FAILED_UNSUPPORTED_PARAMETERS
+				else Status.FAILED_NEED_MORE_LAND_MAPS
+			)
+		}
+	}
+
+	internal fun isMixedOrMissingMaps(ordinal: Int): Boolean {
+		return isMixedMaps(ordinal) || isMissingMaps(ordinal)
+	}
+
+	internal fun isSlowRoutingActive(ordinal: Int): Boolean {
+		return isFailedStatus(get(ordinal))
+	}
+
+	internal fun isMixedMaps(ordinal: Int): Boolean {
+		return ordinal == Status.FAILED_WITH_MIXED_MAPS.ordinal
+				|| ordinal == Status.MIXED_MAPS_INTERMEDIATES.ordinal
+				|| ordinal == Status.MIXED_MAPS_AT_START_OR_END.ordinal
+	}
+
+	internal fun isMissingMaps(ordinal: Int): Boolean {
+		return ordinal == Status.FAILED_WITH_MISSING_MAPS.ordinal
+				|| ordinal == Status.MISSING_MAPS_INTERMEDIATES.ordinal
+				|| ordinal == Status.MISSING_MAPS_AT_START_OR_END.ordinal
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/MissingMapsResult.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/MissingMapsResult.kt
@@ -1,0 +1,14 @@
+package net.osmand.shared.routing
+
+/**
+ * The outcome of the missing maps check, as far as [RouteCalculationProgress] is concerned.
+ *
+ * Working the outcome out needs the region index and a whole routing context, neither of which is
+ * here yet, so the calculation stays in OsmAnd-java and only its answer crosses over. The progress
+ * itself just carries the reference; the one thing it is asked for is the message below.
+ */
+interface MissingMapsResult {
+
+	/** Why the route cannot be calculated, for the routing log and for the failed result. */
+	fun getErrorMessage(): String
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteCalculationProgress.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteCalculationProgress.kt
@@ -1,0 +1,338 @@
+package net.osmand.shared.routing
+
+import kotlin.jvm.JvmField
+import kotlin.jvm.JvmStatic
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Live state of one route calculation: how far it has got, what it has loaded, and how long that
+ * took.
+ *
+ * A copy of `net.osmand.router.RouteCalculationProgress`, which stays in OsmAnd-java: android, tools and the C++ core keep using
+ * the original, and this copy is for iOS. Keep the two identical, field names included.
+ */
+class RouteCalculationProgress {
+
+	@JvmField
+	var segmentNotFound: Int = -1
+
+	@JvmField
+	var distanceFromBegin: Float = 0f
+
+	@JvmField
+	var directDistance: Float = 0f
+
+	@JvmField
+	var directSegmentQueueSize: Int = 0
+
+	@JvmField
+	var distanceFromEnd: Float = 0f
+
+	@JvmField
+	var reverseSegmentQueueSize: Int = 0
+
+	@JvmField
+	var reverseDistance: Float = 0f
+
+	@JvmField
+	var totalEstimatedDistance: Float = 0f
+
+	@JvmField
+	var totalApproximateDistance: Float = 0f
+
+	@JvmField
+	var approximatedDistance: Float = 0f
+
+	@JvmField
+	var routingCalculatedTime: Float = 0f
+
+	@JvmField
+	var visitedSegments: Int = 0
+
+	@JvmField
+	var visitedDirectSegments: Int = 0
+
+	@JvmField
+	var visitedOppositeSegments: Int = 0
+
+	@JvmField
+	var directQueueSize: Int = 0
+
+	@JvmField
+	var oppositeQueueSize: Int = 0
+
+	@JvmField
+	var finalSegmentsFound: Int = 0
+
+	@JvmField
+	var totalIterations: Int = 1
+
+	@JvmField
+	var iteration: Int = -1
+
+	@JvmField
+	var timeNanoToCalcDeviation: Long = 0
+
+	@JvmField
+	var timeToLoad: Long = 0
+
+	@JvmField
+	var timeToLoadHeaders: Long = 0
+
+	@JvmField
+	var timeToFindInitialSegments: Long = 0
+
+	@JvmField
+	var timeToCalculate: Long = 0
+
+	@JvmField
+	var distinctLoadedTiles: Int = 0
+
+	@JvmField
+	var maxLoadedTiles: Int = 0
+
+	@JvmField
+	var loadedPrevUnloadedTiles: Int = 0
+
+	@JvmField
+	var unloadedTiles: Int = 0
+
+	@JvmField
+	var loadedTiles: Int = 0
+
+	@JvmField
+	var isCancelled: Boolean = false
+
+	@JvmField
+	var requestPrivateAccessRouting: Boolean = false
+
+	@JvmField
+	var routeCalculationStartTime: Long = 0
+
+	@JvmField
+	var missingMapsCalculationResult: MissingMapsResult? = null
+
+	// An int rather than the enum, as in java, where the C++ core reads and writes it
+	private var fastRoutingStatusOrdinal: Int = FastRoutingState.Status.READY.ordinal
+
+	private var hhIterationStep: Int = HHIteration.HH_NOT_STARTED.ordinal
+	private var hhTargetsDone: Int = 0
+	private var hhTargetsTotal: Int = 0
+	private var hhCurrentStepProgress: Double = 0.0
+	private var hhCalcCounter: Int = 0
+
+	fun getInfo(firstPhase: RouteCalculationProgress?): MutableMap<String, Any> {
+		val first = firstPhase ?: RouteCalculationProgress()
+		val tiles = LinkedHashMap<String, Any>()
+		tiles["loadedTiles"] = this.loadedTiles - first.loadedTiles
+		tiles["loadedTilesDistinct"] = this.distinctLoadedTiles - first.distinctLoadedTiles
+		tiles["loadedTilesPrevUnloaded"] = this.loadedPrevUnloadedTiles - first.loadedPrevUnloadedTiles
+		tiles["loadedTilesMax"] = max(this.maxLoadedTiles, this.distinctLoadedTiles)
+		tiles["unloadedTiles"] = this.unloadedTiles - first.unloadedTiles
+		val segms = LinkedHashMap<String, Any>()
+		segms["visited"] = this.visitedSegments - first.visitedSegments
+		segms["queueDirectSize"] = this.directQueueSize - first.directQueueSize
+		segms["queueOppositeSize"] = this.reverseSegmentQueueSize - first.reverseSegmentQueueSize
+		segms["visitedDirectPoints"] = this.visitedDirectSegments - first.visitedDirectSegments
+		segms["visitedOppositePoints"] = this.visitedOppositeSegments - first.visitedOppositeSegments
+		segms["finalSegmentsFound"] = this.finalSegmentsFound - first.finalSegmentsFound
+		val time = LinkedHashMap<String, Any>()
+		val timeToCalc = ((this.timeToCalculate - first.timeToCalculate) / 1.0e9).toFloat()
+		time["timeToCalculate"] = timeToCalc
+		val timeToLoad = ((this.timeToLoad - first.timeToLoad) / 1.0e9).toFloat()
+		time["timeToLoad"] = timeToLoad
+		val timeToLoadHeaders = ((this.timeToLoadHeaders - first.timeToLoadHeaders) / 1.0e9).toFloat()
+		time["timeToLoadHeaders"] = timeToLoadHeaders
+		val timeToFindInitialSegments =
+			((this.timeToFindInitialSegments - first.timeToFindInitialSegments) / 1.0e9).toFloat()
+		time["timeToFindInitialSegments"] = timeToFindInitialSegments
+		val timeExtra = ((this.timeNanoToCalcDeviation - first.timeNanoToCalcDeviation) / 1.0e9).toFloat()
+		time["timeExtra"] = timeExtra
+		val metrics = LinkedHashMap<String, Any>()
+		if (timeToLoad + timeToLoadHeaders > 0) {
+			metrics["tilesPerSec"] = (this.loadedTiles - first.loadedTiles) / (timeToLoad + timeToLoadHeaders)
+		}
+		val pureTime = timeToCalc - (timeToLoad + timeToLoadHeaders + timeToFindInitialSegments)
+		if (pureTime > 0) {
+			metrics["segmentsPerSec"] = (this.visitedSegments - first.visitedSegments) / pureTime
+		} else {
+			metrics["segmentsPerSec"] = 0f
+		}
+		val map = LinkedHashMap<String, Any>()
+		map["tiles"] = sortedByKey(tiles)
+		map["segments"] = segms
+		map["time"] = time
+		map["metrics"] = metrics
+		return sortedByKey(map)
+	}
+
+	private fun getLinearProgressHH(): Float {
+		var progress = 0f
+		for (i in HHIteration.entries) {
+			if (i.ordinal == hhIterationStep) {
+				// the multiply runs in double, the way it did in java, and narrows on the way back
+				progress = (progress + hhCurrentStepProgress * i.approxStepPercent.toFloat()).toFloat() // current step
+				break
+			} else {
+				progress += i.approxStepPercent.toFloat() // passed step
+			}
+		}
+
+		// 1. implement 2-3 reiterations progress
+
+		if (hhTargetsTotal > 0) {
+			progress = (100f * hhTargetsDone + progress) / hhTargetsTotal // intermediate points
+		}
+
+		return min(progress, 99f)
+	}
+
+	fun getLinearProgress(): Float {
+		if (hhIterationStep != HHIteration.HH_NOT_STARTED.ordinal) {
+			return getLinearProgressHH()
+		}
+		val p = max(distanceFromBegin, distanceFromEnd)
+		val all = totalEstimatedDistance * 1.35f
+		var pr = 0f
+		if (all > 0) {
+			pr = min(p * p / (all * all), 1f)
+		}
+		val progress: Float
+		if (totalIterations <= 1) {
+			progress = INITIAL_PROGRESS + pr * (1f - INITIAL_PROGRESS)
+		} else if (totalIterations <= 2) {
+			progress = if (iteration < 1) {
+				pr * FIRST_ITERATION + INITIAL_PROGRESS
+			} else {
+				(INITIAL_PROGRESS + FIRST_ITERATION) + pr * (1f - FIRST_ITERATION - INITIAL_PROGRESS)
+			}
+		} else {
+			progress = ((iteration + min(pr.toDouble(), 0.7)) / totalIterations).toFloat()
+		}
+		return min(progress * 100f, 99f)
+	}
+
+	fun getApproximationProgress(): Float {
+		var progress = 0f
+		if (totalApproximateDistance > 0) {
+			progress = approximatedDistance / totalApproximateDistance
+		}
+		progress = INITIAL_PROGRESS + progress * (1f - INITIAL_PROGRESS)
+		return min(progress * 100f, 99f)
+	}
+
+	fun nextIteration() {
+		iteration++
+		totalEstimatedDistance = 0f
+	}
+
+	enum class HHIteration(@JvmField val approxStepPercent: Int) {
+		HH_NOT_STARTED(0), // hhIteration is not filled
+		SELECT_REGIONS(5),
+		LOAD_POINTS(5),
+		START_END_POINT(15),
+		ROUTING(15),
+		DETAILED(50),
+		RECALCULATION(10),
+		ALTERNATIVES(0), // disabled
+		DONE(0); // success
+	}
+
+	fun hhIteration(step: HHIteration) {
+		this.hhIterationStep = step.ordinal
+		this.hhCurrentStepProgress = 0.0
+	}
+
+	fun hhIterationProgress(k: Double) {
+		// validate 0-100% and disallow to progress back
+		if (k >= 0 && k <= 1.0 && k > this.hhCurrentStepProgress) {
+			this.hhCurrentStepProgress = k
+		}
+	}
+
+	fun hhTargetsProgress(done: Int, total: Int) {
+		this.hhTargetsDone = done
+		this.hhTargetsTotal = total
+	}
+
+	fun hhUpdateCalcCounter(counter: Int) {
+		this.hhCalcCounter = counter
+	}
+
+	fun hhGetCalcCounter(): Int {
+		return this.hhCalcCounter
+	}
+
+	fun isSlowRoutingActive(): Boolean {
+		return FastRoutingState.isSlowRoutingActive(fastRoutingStatusOrdinal)
+	}
+
+	fun hasMixedOrMissingMaps(): Boolean {
+		return FastRoutingState.isMixedOrMissingMaps(fastRoutingStatusOrdinal)
+	}
+
+	fun hasAnyMissingMaps(): Boolean {
+		return FastRoutingState.isMissingMaps(fastRoutingStatusOrdinal)
+	}
+
+	fun getFastRoutingStatus(): FastRoutingState.Status {
+		return FastRoutingState.get(fastRoutingStatusOrdinal)
+	}
+
+	fun resetFastRoutingStatus() {
+		fastRoutingStatusOrdinal = FastRoutingState.reset()
+	}
+
+	fun failFastRoutingStatus(hasUnsupportedParameters: Boolean) {
+		fastRoutingStatusOrdinal = FastRoutingState.fail(fastRoutingStatusOrdinal, hasUnsupportedParameters)
+	}
+
+	fun raiseFastRoutingStatus(status: FastRoutingState.Status) {
+		fastRoutingStatusOrdinal = FastRoutingState.raise(fastRoutingStatusOrdinal, status)
+	}
+
+	companion object {
+
+		private const val INITIAL_PROGRESS = 0.01f
+		private const val FIRST_ITERATION = 0.72f
+
+		@JvmStatic
+		fun capture(cp: RouteCalculationProgress): RouteCalculationProgress {
+			val p = RouteCalculationProgress()
+			p.timeNanoToCalcDeviation = cp.timeNanoToCalcDeviation
+			p.timeToCalculate = cp.timeToCalculate
+			p.timeToLoadHeaders = cp.timeToLoadHeaders
+			p.timeToFindInitialSegments = cp.timeToFindInitialSegments
+			p.timeToLoad = cp.timeToLoad
+
+			p.visitedSegments = cp.visitedSegments
+			p.directQueueSize = cp.directQueueSize
+			p.reverseSegmentQueueSize = cp.reverseSegmentQueueSize
+			p.visitedDirectSegments = cp.visitedDirectSegments
+			p.visitedOppositeSegments = cp.visitedOppositeSegments
+			p.finalSegmentsFound = cp.finalSegmentsFound
+
+			p.loadedTiles = cp.loadedTiles
+			p.distinctLoadedTiles = cp.distinctLoadedTiles
+			p.maxLoadedTiles = cp.maxLoadedTiles
+			p.loadedPrevUnloadedTiles = cp.loadedPrevUnloadedTiles
+
+			cp.maxLoadedTiles = 0
+			return p
+		}
+
+		/**
+		 * Java built the maps [getInfo] returns with a `TreeMap`, and their order is user visible:
+		 * the routing log prints the entries as they iterate. There is no sorted map in common
+		 * code, so the keys are put in order once, here.
+		 */
+		private fun sortedByKey(values: Map<String, Any>): MutableMap<String, Any> {
+			val sorted = LinkedHashMap<String, Any>()
+			for (key in values.keys.sorted()) {
+				sorted[key] = values.getValue(key)
+			}
+			return sorted
+		}
+	}
+}

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/routing/RouteCalculationProgressTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/routing/RouteCalculationProgressTest.kt
@@ -1,0 +1,303 @@
+package net.osmand.shared.routing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RouteCalculationProgressTest {
+
+	@Suppress("UNCHECKED_CAST")
+	private fun section(info: Map<String, Any>, name: String): Map<String, Any> =
+		info[name] as Map<String, Any>
+
+	@Test
+	fun testInfoKeysComeOutInTheOrderTheLogPrintsThem() {
+		val info = RouteCalculationProgress().getInfo(null)
+		// java built the outer map and the tiles map with a TreeMap, so both are sorted
+		assertEquals(listOf("metrics", "segments", "tiles", "time"), info.keys.toList())
+		assertEquals(
+			listOf(
+				"loadedTiles", "loadedTilesDistinct", "loadedTilesMax",
+				"loadedTilesPrevUnloaded", "unloadedTiles"
+			),
+			section(info, "tiles").keys.toList()
+		)
+		// the other three keep insertion order
+		assertEquals(
+			listOf(
+				"visited", "queueDirectSize", "queueOppositeSize",
+				"visitedDirectPoints", "visitedOppositePoints", "finalSegmentsFound"
+			),
+			section(info, "segments").keys.toList()
+		)
+		assertEquals(
+			listOf(
+				"timeToCalculate", "timeToLoad", "timeToLoadHeaders",
+				"timeToFindInitialSegments", "timeExtra"
+			),
+			section(info, "time").keys.toList()
+		)
+	}
+
+	@Test
+	fun testInfoKeepsCountsIntAndSecondsFloat() {
+		// the routing log formats a Float with one decimal and everything else with toString,
+		// so the boxed types are part of the output
+		val info = RouteCalculationProgress().getInfo(null)
+		assertIs<Int>(section(info, "tiles")["loadedTiles"])
+		assertIs<Int>(section(info, "segments")["visited"])
+		assertIs<Float>(section(info, "time")["timeToCalculate"])
+		assertIs<Float>(section(info, "metrics")["segmentsPerSec"])
+	}
+
+	@Test
+	fun testInfoConvertsNanosToSecondsAndDerivesRates() {
+		val progress = RouteCalculationProgress()
+		progress.timeToCalculate = 5_000_000_000L
+		progress.timeToLoad = 1_000_000_000L
+		progress.timeToLoadHeaders = 1_000_000_000L
+		progress.timeToFindInitialSegments = 500_000_000L
+		progress.timeNanoToCalcDeviation = 250_000_000L
+		progress.loadedTiles = 300
+		progress.visitedSegments = 1000
+
+		val info = progress.getInfo(null)
+		val time = section(info, "time")
+		assertEquals(5f, time["timeToCalculate"])
+		assertEquals(1f, time["timeToLoad"])
+		assertEquals(1f, time["timeToLoadHeaders"])
+		assertEquals(0.5f, time["timeToFindInitialSegments"])
+		assertEquals(0.25f, time["timeExtra"])
+
+		val metrics = section(info, "metrics")
+		assertEquals(150f, metrics["tilesPerSec"])
+		// 5s total less the 2.5s spent loading and finding the first segments
+		assertEquals(400f, metrics["segmentsPerSec"])
+	}
+
+	@Test
+	fun testInfoReportsTheSecondPhaseOnItsOwn() {
+		val first = RouteCalculationProgress()
+		first.loadedTiles = 100
+		first.visitedSegments = 700
+		first.timeToCalculate = 2_000_000_000L
+
+		val progress = RouteCalculationProgress()
+		progress.loadedTiles = 250
+		progress.visitedSegments = 1000
+		progress.timeToCalculate = 5_000_000_000L
+
+		val info = progress.getInfo(first)
+		assertEquals(150, section(info, "tiles")["loadedTiles"])
+		assertEquals(300, section(info, "segments")["visited"])
+		assertEquals(3f, section(info, "time")["timeToCalculate"])
+	}
+
+	@Test
+	fun testInfoDropsTilesPerSecWhenNothingWasLoaded() {
+		val info = RouteCalculationProgress().getInfo(null)
+		val metrics = section(info, "metrics")
+		assertNull(metrics["tilesPerSec"])
+		assertEquals(0f, metrics["segmentsPerSec"])
+	}
+
+	@Test
+	fun testInfoReportsTheLargerOfMaxAndDistinctTiles() {
+		val progress = RouteCalculationProgress()
+		progress.maxLoadedTiles = 40
+		progress.distinctLoadedTiles = 90
+		assertEquals(90, section(progress.getInfo(null), "tiles")["loadedTilesMax"])
+		progress.maxLoadedTiles = 120
+		assertEquals(120, section(progress.getInfo(null), "tiles")["loadedTilesMax"])
+	}
+
+	@Test
+	fun testLinearProgressStartsAtOneAndStopsBelowHundred() {
+		val progress = RouteCalculationProgress()
+		assertEquals(1f, progress.getLinearProgress())
+
+		progress.totalEstimatedDistance = 1000f
+		progress.distanceFromBegin = 1350f
+		assertEquals(99f, progress.getLinearProgress())
+	}
+
+	@Test
+	fun testLinearProgressSplitsTwoIterations() {
+		val progress = RouteCalculationProgress()
+		progress.totalIterations = 2
+		progress.totalEstimatedDistance = 1000f
+		progress.distanceFromBegin = 1350f // pr saturates at 1
+
+		progress.iteration = 0
+		assertEquals(73f, progress.getLinearProgress())
+		progress.iteration = 1
+		assertEquals(99f, progress.getLinearProgress())
+	}
+
+	@Test
+	fun testLinearProgressSpreadsThreeIterationsEvenly() {
+		val progress = RouteCalculationProgress()
+		progress.totalIterations = 3
+		progress.iteration = 1
+		progress.totalEstimatedDistance = 1000f
+		progress.distanceFromBegin = 1350f // pr saturates at 1, and is then capped at 0.7
+		assertEquals(((1 + 0.7) / 3 * 100).toFloat(), progress.getLinearProgress())
+	}
+
+	@Test
+	fun testHhProgressAddsUpThePassedSteps() {
+		val progress = RouteCalculationProgress()
+		progress.hhIteration(RouteCalculationProgress.HHIteration.START_END_POINT)
+		// SELECT_REGIONS and LOAD_POINTS are worth 5 each, the current step counts as nothing yet
+		assertEquals(10f, progress.getLinearProgress())
+
+		progress.hhIterationProgress(0.5)
+		assertEquals(17.5f, progress.getLinearProgress())
+	}
+
+	@Test
+	fun testHhProgressNeverGoesBack() {
+		val progress = RouteCalculationProgress()
+		progress.hhIteration(RouteCalculationProgress.HHIteration.START_END_POINT)
+		progress.hhIterationProgress(0.5)
+		progress.hhIterationProgress(0.2)
+		progress.hhIterationProgress(-1.0)
+		progress.hhIterationProgress(2.0)
+		assertEquals(17.5f, progress.getLinearProgress())
+	}
+
+	@Test
+	fun testHhProgressIsSharedBetweenTargets() {
+		val progress = RouteCalculationProgress()
+		progress.hhIteration(RouteCalculationProgress.HHIteration.START_END_POINT)
+		progress.hhIterationProgress(0.5)
+		progress.hhTargetsProgress(1, 2)
+		// one target done out of two, plus what the second target has covered so far
+		assertEquals(58.75f, progress.getLinearProgress())
+	}
+
+	@Test
+	fun testHhNotStartedFallsBackToTheDistanceProgress() {
+		val progress = RouteCalculationProgress()
+		progress.hhIteration(RouteCalculationProgress.HHIteration.DETAILED)
+		progress.hhIteration(RouteCalculationProgress.HHIteration.HH_NOT_STARTED)
+		assertEquals(1f, progress.getLinearProgress())
+	}
+
+	@Test
+	fun testApproximationProgress() {
+		val progress = RouteCalculationProgress()
+		assertEquals(1f, progress.getApproximationProgress())
+
+		progress.totalApproximateDistance = 100f
+		progress.approximatedDistance = 50f
+		assertEquals(50.5f, progress.getApproximationProgress())
+
+		progress.approximatedDistance = 100f
+		assertEquals(99f, progress.getApproximationProgress())
+	}
+
+	@Test
+	fun testNextIterationDropsTheEstimate() {
+		val progress = RouteCalculationProgress()
+		progress.totalEstimatedDistance = 5000f
+		progress.nextIteration()
+		assertEquals(0, progress.iteration)
+		assertEquals(0f, progress.totalEstimatedDistance)
+	}
+
+	@Test
+	fun testCaptureCopiesCountersAndResetsMaxLoadedTiles() {
+		val progress = RouteCalculationProgress()
+		progress.timeToCalculate = 7L
+		progress.visitedSegments = 11
+		progress.finalSegmentsFound = 2
+		progress.loadedTiles = 13
+		progress.maxLoadedTiles = 17
+
+		val captured = RouteCalculationProgress.capture(progress)
+		assertEquals(7L, captured.timeToCalculate)
+		assertEquals(11, captured.visitedSegments)
+		assertEquals(2, captured.finalSegmentsFound)
+		assertEquals(13, captured.loadedTiles)
+		assertEquals(17, captured.maxLoadedTiles)
+		// the second phase counts its own peak from zero
+		assertEquals(0, progress.maxLoadedTiles)
+	}
+
+	@Test
+	fun testFastRoutingStatusOnlyMovesForward() {
+		val progress = RouteCalculationProgress()
+		assertEquals(FastRoutingState.Status.READY, progress.getFastRoutingStatus())
+
+		progress.raiseFastRoutingStatus(FastRoutingState.Status.MISSING_MAPS_INTERMEDIATES)
+		progress.raiseFastRoutingStatus(FastRoutingState.Status.MIXED_MAPS_INTERMEDIATES)
+		assertEquals(FastRoutingState.Status.MISSING_MAPS_INTERMEDIATES, progress.getFastRoutingStatus())
+
+		progress.resetFastRoutingStatus()
+		assertEquals(FastRoutingState.Status.READY, progress.getFastRoutingStatus())
+	}
+
+	@Test
+	fun testFailureKeepsTheReasonTheMapsGaveIt() {
+		val missing = RouteCalculationProgress()
+		missing.raiseFastRoutingStatus(FastRoutingState.Status.MISSING_MAPS_AT_START_OR_END)
+		missing.failFastRoutingStatus(false)
+		assertEquals(FastRoutingState.Status.FAILED_WITH_MISSING_MAPS, missing.getFastRoutingStatus())
+
+		val mixed = RouteCalculationProgress()
+		mixed.raiseFastRoutingStatus(FastRoutingState.Status.MIXED_MAPS_INTERMEDIATES)
+		mixed.failFastRoutingStatus(false)
+		assertEquals(FastRoutingState.Status.FAILED_WITH_MIXED_MAPS, mixed.getFastRoutingStatus())
+
+		val plain = RouteCalculationProgress()
+		plain.failFastRoutingStatus(false)
+		assertEquals(FastRoutingState.Status.FAILED_NEED_MORE_LAND_MAPS, plain.getFastRoutingStatus())
+
+		val unsupported = RouteCalculationProgress()
+		unsupported.failFastRoutingStatus(true)
+		assertEquals(FastRoutingState.Status.FAILED_UNSUPPORTED_PARAMETERS, unsupported.getFastRoutingStatus())
+	}
+
+	@Test
+	fun testSlowRoutingIsActiveOnlyAfterAFailure() {
+		val progress = RouteCalculationProgress()
+		assertFalse(progress.isSlowRoutingActive())
+
+		progress.raiseFastRoutingStatus(FastRoutingState.Status.MISSING_MAPS_INTERMEDIATES)
+		assertFalse(progress.isSlowRoutingActive())
+		assertTrue(progress.hasAnyMissingMaps())
+		assertTrue(progress.hasMixedOrMissingMaps())
+
+		progress.failFastRoutingStatus(false)
+		assertTrue(progress.isSlowRoutingActive())
+	}
+
+	@Test
+	fun testMixedMapsAreNotReportedAsMissing() {
+		val progress = RouteCalculationProgress()
+		progress.raiseFastRoutingStatus(FastRoutingState.Status.MIXED_MAPS_AT_START_OR_END)
+		assertFalse(progress.hasAnyMissingMaps())
+		assertTrue(progress.hasMixedOrMissingMaps())
+	}
+
+	@Test
+	fun testSuccessAndCancellationAreNotFailures() {
+		assertTrue(FastRoutingState.isSuccessStatus(FastRoutingState.Status.SUCCESS))
+		assertFalse(FastRoutingState.isFailedStatus(FastRoutingState.Status.SUCCESS))
+		assertTrue(FastRoutingState.isCancelledStatus(FastRoutingState.Status.CANCELLED))
+		assertFalse(FastRoutingState.isFailedStatus(FastRoutingState.Status.CANCELLED))
+		assertTrue(FastRoutingState.isFailedStatus(FastRoutingState.Status.FAILED_NO_HH_ROUTING_DATA))
+	}
+
+	@Test
+	fun testCalcCounterRoundTrips() {
+		val progress = RouteCalculationProgress()
+		assertEquals(0, progress.hhGetCalcCounter())
+		progress.hhUpdateCalcCounter(4)
+		assertEquals(4, progress.hhGetCalcCounter())
+	}
+}

--- a/OsmAnd-shared/src/jvmTest/kotlin/net/osmand/shared/routing/RouteCalculationProgressOrderJvmTest.kt
+++ b/OsmAnd-shared/src/jvmTest/kotlin/net/osmand/shared/routing/RouteCalculationProgressOrderJvmTest.kt
@@ -1,0 +1,29 @@
+package net.osmand.shared.routing
+
+import java.util.TreeMap
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The java original built the maps [RouteCalculationProgress.getInfo] returns with a `TreeMap`, and
+ * their iteration order reaches the user in the routing log. Common code has no sorted map, so the
+ * shared version sorts the keys itself; this checks that the two agree.
+ */
+class RouteCalculationProgressOrderJvmTest {
+
+	@Test
+	fun testInfoMatchesTreeMapOrder() {
+		val progress = RouteCalculationProgress()
+		progress.timeToCalculate = 5_000_000_000L
+		progress.timeToLoad = 1_000_000_000L
+		progress.loadedTiles = 300
+		progress.visitedSegments = 1000
+
+		val info = progress.getInfo(null)
+		assertEquals(TreeMap(info).keys.toList(), info.keys.toList())
+
+		@Suppress("UNCHECKED_CAST")
+		val tiles = info["tiles"] as Map<String, Any>
+		assertEquals(TreeMap(tiles).keys.toList(), tiles.keys.toList())
+	}
+}


### PR DESCRIPTION
Part of the routing-to-OsmAnd-shared series: the java classes stay in `OsmAnd-java` and android, tools and the C++ core keep using them; each step adds a copy to `OsmAnd-shared` and a test that the copy behaves like the original. The copies are for iOS, which will call them instead of its own C++ turn preparation.

`RouteCalculationProgress`, `FastRoutingState` and `MissingMapsResult`. Data the routers write and the UI reads; no behaviour worth a comparison beyond `RouteCalculationProgressOrderJvmTest`.

Supersedes #25917.
