### PR TITLE
Copy the direction points to OsmAnd-shared

### DIFF
--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/DirectionPoint.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/DirectionPoint.kt
@@ -1,0 +1,77 @@
+package net.osmand.shared.routing
+
+import net.osmand.shared.util.collections.KTIntArrayList
+import kotlin.jvm.JvmField
+
+/**
+ * A point that forces the router to treat one spot on a road differently - the "avoid road" markers
+ * the app drops, and the direction points OsmAndMapCreator loads from GeoJSON.
+ *
+ * The point is not part of any map. While a tile is being loaded the router looks for the road it
+ * belongs to, splices an extra point into that road's geometry and gives it [types], so the routing
+ * rules see the tags below as if the map had carried them. [connected], [connectedx], [connectedy]
+ * and [distance] are that bookkeeping: a road closer to the point takes it over from the one that
+ * held it before, and the point it left behind is retyped as deleted.
+ *
+ * That state belongs to one calculation, which is why [RoutingConfiguration.Builder] copies every
+ * point it was given rather than handing the same objects to two routes.
+ */
+class DirectionPoint(private val lat: Double, private val lon: Double) {
+
+	private val tags = LinkedHashMap<String, String>()
+
+	/** How far the point sits from [connected]; only a closer road may take it over. */
+	@JvmField
+	var distance: Double = Double.MAX_VALUE
+
+	/** The road the point is currently spliced into. */
+	@JvmField
+	var connected: RouteDataObject? = null
+
+	/** Route types the spliced point carries, the tags below resolved against the road's region. */
+	@JvmField
+	val types = KTIntArrayList()
+
+	@JvmField
+	var connectedx: Int = 0
+
+	@JvmField
+	var connectedy: Int = 0
+
+	/** The same place and tags, with the routing bookkeeping back at its starting state. */
+	constructor(other: DirectionPoint) : this(other.lat, other.lon) {
+		tags.putAll(other.tags)
+	}
+
+	fun getLatitude(): Double = lat
+
+	fun getLongitude(): Double = lon
+
+	fun getTags(): MutableMap<String, String> = tags
+
+	fun getTag(key: String): String? = tags[key]
+
+	/**
+	 * Keys are lower cased, as they were when these points were OSM nodes and went through
+	 * `Entity.putTag`: the router looks the tags up in the routing rules, which are lower case.
+	 */
+	fun putTag(key: String, value: String): String? = tags.put(key.lowercase(), value)
+
+	/** The heading the point applies to, or NaN when it applies whichever way the road runs. */
+	fun getAngle(): Double {
+		val angle = getTag(ANGLE_TAG) ?: return Double.NaN
+		try {
+			return angle.toDouble()
+		} catch (e: NumberFormatException) {
+			throw RuntimeException(e)
+		}
+	}
+
+	companion object {
+		const val TAG = "osmand_dp"
+		const val DELETE_TYPE = "osmand_delete_point"
+		const val CREATE_TYPE = "osmand_add_point"
+		const val ANGLE_TAG = "apply_direction_angle"
+		const val MAX_ANGLE_DIFF = 45.0 // in degrees
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/NativeDirectionPoint.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/NativeDirectionPoint.kt
@@ -1,0 +1,23 @@
+package net.osmand.shared.routing
+
+import net.osmand.shared.util.KMapUtils
+import kotlin.jvm.JvmField
+
+/**
+ * A [DirectionPoint] flattened for the C++ core, which does its own splicing.
+ *
+ * A copy of `RoutingConfiguration.NativeDirectionPoint`, which stays in OsmAnd-java where
+ * `java_wrap.cpp` reads these three fields off it; this copy is for iOS. Nothing writes them after
+ * construction.
+ */
+class NativeDirectionPoint(latitude: Double, longitude: Double, tags: Map<String, String>) {
+
+	@JvmField
+	val x31: Int = KMapUtils.get31TileNumberX(longitude)
+
+	@JvmField
+	val y31: Int = KMapUtils.get31TileNumberY(latitude)
+
+	@JvmField
+	val tags: Array<Array<String>> = tags.entries.map { arrayOf(it.key, it.value) }.toTypedArray()
+}

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/routing/DirectionPointTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/routing/DirectionPointTest.kt
@@ -1,0 +1,124 @@
+package net.osmand.shared.routing
+
+import net.osmand.shared.util.KMapUtils
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DirectionPointTest {
+
+	@Test
+	fun testTagKeysAreLowerCased() {
+		// the router looks these up in the routing rules, which are lower case
+		val point = DirectionPoint(50.0, 10.0)
+		point.putTag("Apply_Direction_Angle", "90")
+		assertEquals("90", point.getTag("apply_direction_angle"))
+		assertNull(point.getTag("Apply_Direction_Angle"))
+		assertEquals(mapOf("apply_direction_angle" to "90"), point.getTags())
+	}
+
+	@Test
+	fun testPutTagAnswersTheValueItReplaced() {
+		val point = DirectionPoint(50.0, 10.0)
+		assertNull(point.putTag("osmand_dp", "yes"))
+		assertEquals("yes", point.putTag("osmand_dp", "no"))
+		assertEquals("no", point.getTag("osmand_dp"))
+	}
+
+	@Test
+	fun testAngleIsNaNWhenTheTagIsMissing() {
+		assertTrue(DirectionPoint(50.0, 10.0).getAngle().isNaN())
+	}
+
+	@Test
+	fun testAngleIsRead() {
+		val point = DirectionPoint(50.0, 10.0)
+		point.putTag(DirectionPoint.ANGLE_TAG, "137.5")
+		assertEquals(137.5, point.getAngle())
+
+		point.putTag(DirectionPoint.ANGLE_TAG, "-45")
+		assertEquals(-45.0, point.getAngle())
+	}
+
+	@Test
+	fun testUnreadableAngleThrows() {
+		val point = DirectionPoint(50.0, 10.0)
+		point.putTag(DirectionPoint.ANGLE_TAG, "north")
+		assertFailsWith<RuntimeException> { point.getAngle() }
+	}
+
+	@Test
+	fun testCopyKeepsThePlaceAndTagsAndNothingElse() {
+		val source = DirectionPoint(50.0, 10.0)
+		source.putTag("osmand_dp", "yes")
+		source.putTag(DirectionPoint.ANGLE_TAG, "90")
+		// state a previous calculation left on it
+		source.distance = 12.0
+		source.connected = RouteDataObject(RouteRegion())
+		source.connectedx = 5
+		source.connectedy = 7
+		source.types.add(3)
+
+		val copy = DirectionPoint(source)
+		assertEquals(50.0, copy.getLatitude())
+		assertEquals(10.0, copy.getLongitude())
+		assertEquals(source.getTags(), copy.getTags())
+		assertNotSame(source.getTags(), copy.getTags())
+
+		assertEquals(Double.MAX_VALUE, copy.distance)
+		assertNull(copy.connected)
+		assertEquals(0, copy.connectedx)
+		assertEquals(0, copy.connectedy)
+		assertEquals(0, copy.types.size())
+	}
+
+	@Test
+	fun testCopiedTagsAreIndependent() {
+		val source = DirectionPoint(50.0, 10.0)
+		source.putTag("osmand_dp", "yes")
+		val copy = DirectionPoint(source)
+		copy.putTag("osmand_dp", "no")
+		assertEquals("yes", source.getTag("osmand_dp"))
+		assertEquals("no", copy.getTag("osmand_dp"))
+	}
+
+	@Test
+	fun testTheTagsThatNameTheRouteTypes() {
+		// the router splices a point carrying DirectionPoint.TAG into the road, and retypes the one
+		// it left behind; the strings reach the map data, so they are fixed
+		assertEquals("osmand_dp", DirectionPoint.TAG)
+		assertEquals("osmand_add_point", DirectionPoint.CREATE_TYPE)
+		assertEquals("osmand_delete_point", DirectionPoint.DELETE_TYPE)
+		assertEquals("apply_direction_angle", DirectionPoint.ANGLE_TAG)
+		assertEquals(45.0, DirectionPoint.MAX_ANGLE_DIFF)
+	}
+
+	@Test
+	fun testNativePointTakesXFromLongitudeAndYFromLatitude() {
+		val point = DirectionPoint(50.0, 10.0)
+		val native = NativeDirectionPoint(point.getLatitude(), point.getLongitude(), point.getTags())
+		assertEquals(10.0, KMapUtils.get31LongitudeX(native.x31), 1e-5)
+		assertEquals(50.0, KMapUtils.get31LatitudeY(native.y31), 1e-5)
+	}
+
+	@Test
+	fun testNativePointFlattensTagsInOrder() {
+		val point = DirectionPoint(50.0, 10.0)
+		point.putTag("osmand_dp", "yes")
+		point.putTag(DirectionPoint.ANGLE_TAG, "90")
+
+		val native = NativeDirectionPoint(point.getLatitude(), point.getLongitude(), point.getTags())
+		assertEquals(2, native.tags.size)
+		assertEquals(listOf("osmand_dp", "yes"), native.tags[0].toList())
+		assertEquals(listOf("apply_direction_angle", "90"), native.tags[1].toList())
+	}
+
+	@Test
+	fun testNativePointWithoutTags() {
+		val native = NativeDirectionPoint(50.0, 10.0, emptyMap())
+		assertEquals(0, native.tags.size)
+	}
+}


### PR DESCRIPTION
Part of the routing-to-OsmAnd-shared series: the java classes stay in `OsmAnd-java` and android, tools and the C++ core keep using them; each step adds a copy to `OsmAnd-shared` and a test that the copy behaves like the original. The copies are for iOS, which will call them instead of its own C++ turn preparation.

`DirectionPoint` and `NativeDirectionPoint`. Java's point is an OSM node; the copy carries the place and the tags itself, keys lower-cased as `Entity.putTag` did. Compared with java's in `DirectionPointsCompatTest`, which needs the configuration and so comes with the next step.

Supersedes #25919.
