### PR TITLE
Copy PrecalculatedRouteDirection and RouteConditionalHelper to OsmAnd-shared

### DIFF
--- a/OsmAnd-java/src/test/java/net/osmand/shared/compat/PrecalculatedRouteCompatTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/shared/compat/PrecalculatedRouteCompatTest.java
@@ -1,0 +1,211 @@
+package net.osmand.shared.compat;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import net.osmand.data.LatLon;
+import net.osmand.shared.data.KLatLon;
+import net.osmand.shared.routing.PrecalculatedRouteDirection;
+import net.osmand.shared.routing.RouteConditionalHelper;
+import net.osmand.shared.routing.RouteDataObject;
+import net.osmand.shared.routing.RouteSegmentResult;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * {@link PrecalculatedRouteDirection} and {@link RouteConditionalHelper} are copies of the java
+ * classes of the same names; this feeds both sides the same roads and compares what they compute.
+ *
+ * The precalculated direction is built from chains of real road segments and asked for its time
+ * estimate, deviation and index at the points of those roads and around them. The conditional helper
+ * is run over every road with the moments the routing tests use, and the road's types afterwards
+ * are compared - that is what the router sees of a conditional tag.
+ */
+public class PrecalculatedRouteCompatTest {
+
+	@Test
+	public void testDirectionsEstimateTheSame() throws IOException {
+		List<net.osmand.binary.RouteDataObject> roads = new ArrayList<>();
+		for (net.osmand.binary.RouteDataObject road : TestObf.roads(400)) {
+			if (road.getPointsLength() > 2) {
+				roads.add(road);
+			}
+		}
+		assertEquals(true, roads.size() > 1000);
+		JavaToShared convert = new JavaToShared();
+		Random random = new Random(20260913);
+		net.osmand.router.RoutingConfiguration.RoutingMemoryLimits jlimits = new net.osmand.router.RoutingConfiguration.RoutingMemoryLimits(30, 256);
+		net.osmand.router.RoutingContext ctx = new net.osmand.router.RoutePlannerFrontEnd().buildRoutingContext(
+				net.osmand.router.RoutingConfiguration.getDefault().build("car", jlimits),
+				null, TestObf.readers().toArray(new net.osmand.binary.BinaryMapIndexReader[0]));
+		net.osmand.shared.routing.VehicleRouter router = net.osmand.shared.routing.RoutingConfiguration.getDefault()
+				.build("car", new net.osmand.shared.routing.RoutingConfiguration.RoutingMemoryLimits(30, 256)).router;
+		for (int chain = 0; chain < 300; chain++) {
+			List<net.osmand.router.RouteSegmentResult> js = new ArrayList<>();
+			List<RouteSegmentResult> ks = new ArrayList<>();
+			int start = random.nextInt(roads.size() - 6);
+			for (int i = 0; i < 1 + random.nextInt(5); i++) {
+				net.osmand.binary.RouteDataObject road = roads.get(start + i);
+				int n = road.getPointsLength();
+				int a = random.nextInt(n);
+				int b = random.nextInt(n);
+				if (a == b) {
+					b = (a + 1) % n;
+				}
+				net.osmand.router.RouteSegmentResult j = new net.osmand.router.RouteSegmentResult(road, a, b);
+				RouteSegmentResult k = new RouteSegmentResult(convert.road(road), a, b);
+				float speed = 5 + random.nextInt(30);
+				j.setSegmentSpeed(speed);
+				k.setSegmentSpeed(speed);
+				js.add(j);
+				ks.add(k);
+			}
+			for (float cutoff : new float[] {0, 500, 5000}) {
+				for (float maxSpeed : new float[] {15, 40}) {
+					String m = "chain " + chain + " cutoff " + cutoff + " maxSpeed " + maxSpeed;
+					net.osmand.router.PrecalculatedRouteDirection j = net.osmand.router.PrecalculatedRouteDirection.build(js, cutoff, maxSpeed);
+					PrecalculatedRouteDirection k = PrecalculatedRouteDirection.build(ks, cutoff, maxSpeed);
+					assertEquals(m, j == null, k == null);
+					if (j == null) {
+						continue;
+					}
+					assertSame(m, j, k, js, random, ctx, router);
+				}
+			}
+			LatLon[] jl = new LatLon[js.size() * 2];
+			KLatLon[] kl = new KLatLon[js.size() * 2];
+			for (int i = 0; i < js.size(); i++) {
+				jl[2 * i] = js.get(i).getStartPoint();
+				jl[2 * i + 1] = js.get(i).getEndPoint();
+				kl[2 * i] = new KLatLon(jl[2 * i].getLatitude(), jl[2 * i].getLongitude());
+				kl[2 * i + 1] = new KLatLon(jl[2 * i + 1].getLatitude(), jl[2 * i + 1].getLongitude());
+			}
+			net.osmand.router.PrecalculatedRouteDirection j = net.osmand.router.PrecalculatedRouteDirection.build(jl, 25);
+			PrecalculatedRouteDirection k = PrecalculatedRouteDirection.build(kl, 25);
+			assertSame("chain " + chain + " from points", j, k, js, random, ctx, router);
+		}
+	}
+
+	/**
+	 * What a calculation does with a direction: adopts it for its start and target, which also sets the
+	 * speeds it estimates with, and then asks how long from a point to the end or from the start to a point.
+	 * The deviation truncates a projection to a tile unit, so a last-bit difference in the projection is
+	 * one unit - two centimetres - of deviation, and that much over the default speed of time.
+	 */
+	private static void assertSame(String m, net.osmand.router.PrecalculatedRouteDirection j, PrecalculatedRouteDirection k,
+	                               List<net.osmand.router.RouteSegmentResult> segments, Random random,
+	                               net.osmand.router.RoutingContext ctx, net.osmand.shared.routing.VehicleRouter router) {
+		assertEquals(m, j.isFollowNext(), k.isFollowNext());
+		List<int[]> points = new ArrayList<>();
+		for (net.osmand.router.RouteSegmentResult s : segments) {
+			points.add(new int[] {s.getStartPointX(), s.getStartPointY()});
+			points.add(new int[] {s.getEndPointX(), s.getEndPointY()});
+			points.add(new int[] {s.getStartPointX() + random.nextInt(20000) - 10000, s.getStartPointY() + random.nextInt(20000) - 10000});
+		}
+		for (int[] p : points) {
+			String pm = m + " at " + p[0] + "," + p[1];
+			assertEquals(pm, j.getIndex(p[0], p[1]), k.getIndex(p[0], p[1]));
+			assertEquals(pm, j.getDeviationDistance(p[0], p[1]), k.getDeviationDistance(p[0], p[1]), 0.05f);
+		}
+		int[] start = points.get(0);
+		int[] target = points.get(points.size() - 2);
+		ctx.startX = start[0];
+		ctx.startY = start[1];
+		ctx.targetX = target[0];
+		ctx.targetY = target[1];
+		net.osmand.router.PrecalculatedRouteDirection ja = j.adopt(ctx);
+		PrecalculatedRouteDirection ka = k.adopt(start[0], start[1], target[0], target[1], router);
+		assertEquals(m + " adopted", ja == null, ka == null);
+		if (ja == null) {
+			return;
+		}
+		for (int[] p : points) {
+			String pm = m + " adopted, at " + p[0] + "," + p[1];
+			assertEquals(pm, ja.getIndex(p[0], p[1]), ka.getIndex(p[0], p[1]));
+			assertEquals(pm + " to target", ja.timeEstimate(p[0], p[1], target[0], target[1]), ka.timeEstimate(p[0], p[1], target[0], target[1]), 0.05f);
+			assertEquals(pm + " from start", ja.timeEstimate(start[0], start[1], p[0], p[1]), ka.timeEstimate(start[0], start[1], p[0], p[1]), 0.05f);
+		}
+		int[] a = points.get(1);
+		int[] b = points.get(points.size() - 1);
+		ja.updatePreciseStartEnd(a[0], a[1], b[0], b[1]);
+		ka.updatePreciseStartEnd(a[0], a[1], b[0], b[1]);
+		assertEquals(m + " after precise ends", ja.timeEstimate(a[0], a[1], b[0], b[1]), ka.timeEstimate(a[0], a[1], b[0], b[1]), 0.05f);
+		ja.setFollowNext(true);
+		ka.setFollowNext(true);
+		assertEquals(m + " following", ja.timeEstimate(a[0], a[1], b[0], b[1]), ka.timeEstimate(a[0], a[1], b[0], b[1]), 0.05f);
+	}
+
+	private static String decode(net.osmand.binary.RouteDataObject road) {
+		StringBuilder sb = new StringBuilder();
+		for (int t : road.getTypes()) {
+			sb.append(t).append(':').append(road.region.quickGetEncodingRule(t)).append(' ');
+		}
+		return sb.toString().trim();
+	}
+
+	private static String decode(RouteDataObject road) {
+		StringBuilder sb = new StringBuilder();
+		for (int t : road.getTypes()) {
+			sb.append(t).append(':').append(road.region.quickGetEncodingRule(t)).append(' ');
+		}
+		return sb.toString().trim();
+	}
+
+	@Test
+	public void testConditionalTagsResolveTheSame() throws IOException {
+		List<net.osmand.binary.RouteDataObject> roads = TestObf.roads(3000);
+		assertEquals(true, roads.size() > 5000);
+		// what the app passes: which conditional tags may override their plain tag, and how
+		Map<String, String> ambiguous = new HashMap<>();
+		ambiguous.put("maxspeed:conditional", net.osmand.router.RouteConditionalHelper.RULE_INT_MAX);
+		ambiguous.put("access:conditional", "yes");
+		ambiguous.put("oneway:conditional", "no");
+		Calendar cal = Calendar.getInstance();
+		long[] moments = new long[4];
+		int[][] when = {{2024, Calendar.JANUARY, 15, 8, 30}, {2024, Calendar.JUNE, 15, 23, 30},
+				{2024, Calendar.DECEMBER, 25, 12, 0}, {2025, Calendar.JULY, 4, 7, 59}};
+		for (int i = 0; i < when.length; i++) {
+			cal.clear();
+			cal.set(when[i][0], when[i][1], when[i][2], when[i][3], when[i][4], 0);
+			moments[i] = cal.getTimeInMillis();
+		}
+		JavaToShared convert = new JavaToShared();
+		net.osmand.router.RouteConditionalHelper jh = new net.osmand.router.RouteConditionalHelper();
+		RouteConditionalHelper kh = new RouteConditionalHelper();
+		int conditional = 0;
+		for (net.osmand.binary.RouteDataObject road : roads) {
+			boolean hasConditional = false;
+			if (road.getTypes() != null) {
+				for (int t : road.getTypes()) {
+					if (road.region.quickGetEncodingRule(t).conditional()) {
+						hasConditional = true;
+					}
+				}
+			}
+			for (long time : moments) {
+				net.osmand.binary.RouteDataObject j = new net.osmand.binary.RouteDataObject(road);
+				RouteDataObject k = new RouteDataObject(convert.road(road));
+				jh.resolveAmbiguousConditionalTags(j, ambiguous);
+				kh.resolveAmbiguousConditionalTags(k, ambiguous);
+				jh.processConditionalTags(j, time);
+				kh.processConditionalTags(k, time);
+				String m = "road " + road.id + " at " + time;
+				assertEquals(m + " types", decode(j), decode(k));
+				assertEquals(m, j.getMaximumSpeed(true), k.getMaximumSpeed(true), 0f);
+				assertEquals(m, j.getValue("access"), k.getValue("access"));
+				if (hasConditional) {
+					conditional++;
+				}
+			}
+		}
+		assertEquals("the fixtures carry conditional tags", true, conditional > 0);
+	}
+}

--- a/OsmAnd-java/src/test/java/net/osmand/util/KMapUtilsProjectionCompatTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/util/KMapUtilsProjectionCompatTest.java
@@ -1,0 +1,59 @@
+package net.osmand.util;
+
+import static org.junit.Assert.assertEquals;
+
+import net.osmand.data.QuadPointDouble;
+import net.osmand.shared.data.KQuadPointDouble;
+import net.osmand.shared.util.KMapUtils;
+
+import org.junit.Test;
+
+import java.util.Random;
+
+/**
+ * {@link KMapUtils#getProjectionPoint31} is a port of {@link MapUtils#getProjectionPoint31}, added
+ * for the shared {@link net.osmand.shared.routing.PrecalculatedRouteDirection}. The java one stays -
+ * {@code RoutingContext} attaches direction points with it - so the two have to agree, and this
+ * module is the only one where both are on the classpath.
+ *
+ * The projection is a routing cost, so a difference here moves routes.
+ */
+public class KMapUtilsProjectionCompatTest {
+
+	private void assertSame(int px, int py, int stx, int sty, int endx, int endy) {
+		QuadPointDouble expected = MapUtils.getProjectionPoint31(px, py, stx, sty, endx, endy);
+		KQuadPointDouble actual = KMapUtils.INSTANCE.getProjectionPoint31(px, py, stx, sty, endx, endy);
+		String where = px + "," + py + " onto " + stx + "," + sty + " - " + endx + "," + endy;
+		assertEquals(where, expected.x, actual.getX(), 0);
+		assertEquals(where, expected.y, actual.getY(), 0);
+	}
+
+	@Test
+	public void testProjectionMatchesTheJavaOne() {
+		// a point beside a segment, and both ends of the clamp
+		assertSame(1000, 1000, 0, 0, 2000, 0);
+		assertSame(-500, 1000, 0, 0, 2000, 0);
+		assertSame(5000, 1000, 0, 0, 2000, 0);
+		// a degenerate segment
+		assertSame(1000, 1000, 700, 700, 700, 700);
+	}
+
+	@Test
+	public void testProjectionMatchesTheJavaOneOnRandomInput() {
+		Random random = new Random(20260908L);
+		for (int i = 0; i < 100000; i++) {
+			int stx = random.nextInt(Integer.MAX_VALUE);
+			int sty = random.nextInt(Integer.MAX_VALUE);
+			// segments a road could actually have, and a point somewhere near them
+			int endx = clamp(stx + random.nextInt(20000) - 10000);
+			int endy = clamp(sty + random.nextInt(20000) - 10000);
+			int px = clamp(stx + random.nextInt(40000) - 20000);
+			int py = clamp(sty + random.nextInt(40000) - 20000);
+			assertSame(px, py, stx, sty, endx, endy);
+		}
+	}
+
+	private static int clamp(int v) {
+		return Math.max(0, Math.min(Integer.MAX_VALUE, v));
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/PrecalculatedRouteDirection.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/PrecalculatedRouteDirection.kt
@@ -1,0 +1,333 @@
+package net.osmand.shared.routing
+
+import net.osmand.shared.data.KLatLon
+import net.osmand.shared.data.KQuadRect
+import net.osmand.shared.data.KQuadTree
+import net.osmand.shared.util.KMapUtils
+import net.osmand.shared.util.collections.KTIntArrayList
+import kotlin.jvm.JvmStatic
+
+/**
+ * A route that has already been found, kept so the next search can lean on it.
+ *
+ * The points are indexed by place and carry the time still left to the end, so the A* heuristic can
+ * ask "how long from here, if I follow the route I already have" instead of guessing from straight
+ * line distance. That is what makes recalculating a long route cheap: the search stays in a corridor
+ * around the old one, and only the ends are worked out again.
+ *
+ * The C++ core reads the same eight fields off the java original and runs the same estimate itself.
+ *
+ * A copy of `net.osmand.router.PrecalculatedRouteDirection`, which stays in OsmAnd-java: android, tools and the C++ core keep using
+ * the original, and this copy is for iOS. Keep the two identical.
+ */
+class PrecalculatedRouteDirection {
+
+	private lateinit var pointsX: IntArray
+	private lateinit var pointsY: IntArray
+	private var minSpeed: Float = 0f
+	private var maxSpeed: Float = 0f
+	private lateinit var tms: FloatArray
+	private var followNext: Boolean = false
+
+	private val cachedS: MutableList<Int> = ArrayList()
+
+	private var startPoint: Long = 0
+	private var endPoint: Long = 0
+	private val quadTree = KQuadTree<Int>(
+		KQuadRect(0.0, 0.0, Int.MAX_VALUE.toDouble(), Int.MAX_VALUE.toDouble()), 8, 0.55f
+	)
+	private var startFinishTime: Float = 0f
+	private var endFinishTime: Float = 0f
+
+	constructor(px: KTIntArrayList, py: KTIntArrayList, speedSegments: List<Float>, maxSpeed: Float) {
+		this.maxSpeed = maxSpeed
+		initPoints(px, py, speedSegments)
+	}
+
+	private constructor(ls: List<RouteSegmentResult>, maxSpeed: Float) {
+		this.maxSpeed = maxSpeed
+		initFromRoute(ls)
+	}
+
+	private constructor(ls: Array<KLatLon>, maxSpeed: Float) {
+		this.maxSpeed = maxSpeed
+		initFromLatLon(ls)
+	}
+
+	private constructor(parent: PrecalculatedRouteDirection, start: Int, end: Int) {
+		this.minSpeed = parent.minSpeed
+		this.maxSpeed = parent.maxSpeed
+		var s1 = start
+		var s2 = end
+		var inverse = false
+		if (s1 > s2) {
+			val tmp = s1
+			s1 = s2
+			s2 = tmp
+			inverse = true
+		}
+		tms = FloatArray(s2 - s1 + 1)
+		pointsX = IntArray(s2 - s1 + 1)
+		pointsY = IntArray(s2 - s1 + 1)
+		for (i in s1..s2) {
+			val shiftInd = i - s1
+			pointsX[shiftInd] = parent.pointsX[i]
+			pointsY[shiftInd] = parent.pointsY[i]
+			quadTree.insert(shiftInd, parent.pointsX[i].toFloat(), parent.pointsY[i].toFloat())
+			tms[shiftInd] = parent.tms[i] - parent.tms[if (inverse) s1 else s2]
+		}
+	}
+
+	private fun initFromRoute(ls: List<RouteSegmentResult>) {
+		val px = KTIntArrayList()
+		val py = KTIntArrayList()
+		val speedSegments = ArrayList<Float>()
+		for (s in ls) {
+			val plus = s.getStartPointIndex() < s.getEndPointIndex()
+			var i = s.getStartPointIndex()
+			val obj = s.getObject()
+			val routeSpd = if (s.getRoutingTime() == 0f || s.getDistance() == 0f) maxSpeed
+			else (s.getDistance() / s.getRoutingTime())
+			while (true) {
+				i = if (plus) i + 1 else i - 1
+				px.add(obj.getPoint31XTile(i))
+				py.add(obj.getPoint31YTile(i))
+				speedSegments.add(routeSpd)
+				if (i == s.getEndPointIndex()) {
+					break
+				}
+			}
+		}
+		initPoints(px, py, speedSegments)
+	}
+
+	private fun initFromLatLon(ls: Array<KLatLon>) {
+		val px = KTIntArrayList()
+		val py = KTIntArrayList()
+		val speedSegments = ArrayList<Float>()
+		for (s in ls) {
+			val routeSpd = maxSpeed // (s.getDistance() / s.getRoutingTime())
+			px.add(KMapUtils.get31TileNumberX(s.longitude))
+			py.add(KMapUtils.get31TileNumberY(s.latitude))
+			speedSegments.add(routeSpd)
+		}
+		initPoints(px, py, speedSegments)
+	}
+
+	private fun initPoints(px: KTIntArrayList, py: KTIntArrayList, speedSegments: List<Float>) {
+		var totaltm = 0f
+		val times = ArrayList<Float>()
+		for (i in 0 until px.size()) {
+			// KMapUtils.measuredDist31 vs BinaryRoutePlanner.squareRootDist
+			// use measuredDist31 because we use precise s.getDistance() to calculate routeSpd
+			val ip = if (i == 0) 0 else i - 1
+			val dist = KMapUtils.measuredDist31(px[ip], py[ip], px[i], py[i]).toFloat()
+			val tm = dist / speedSegments[i] // routeSpd
+			times.add(tm)
+			quadTree.insert(i, px[i].toFloat(), py[i].toFloat())
+			totaltm += tm
+		}
+		pointsX = px.toArray()
+		pointsY = py.toArray()
+		tms = FloatArray(times.size)
+		var totDec = totaltm
+		for (i in times.indices) {
+			totDec -= times[i]
+			tms[i] = totDec
+		}
+	}
+
+	fun timeEstimate(sx31: Int, sy31: Int, ex31: Int, ey31: Int): Float {
+		val l1 = calc(sx31, sy31)
+		val l2 = calc(ex31, ey31)
+		val x31: Int
+		val y31: Int
+		val start: Boolean
+		if (l1 == startPoint || l1 == endPoint) {
+			start = l1 == startPoint
+			x31 = ex31
+			y31 = ey31
+		} else if (l2 == startPoint || l2 == endPoint) {
+			start = l2 == startPoint
+			x31 = sx31
+			y31 = sy31
+		} else {
+			val sInd = getIndex(sx31, sy31)
+			val eInd = getIndex(ex31, ey31)
+			val err = "startPoint:$startPoint, endPoint:$endPoint, l1:$l1, l2:$l2, sx31:$sx31," +
+					" sy31:$sy31, ex31:$ex31, ey31:$ey31, startIndex: $sInd, endIndex:$eInd"
+			throw UnsupportedOperationException(err)
+		}
+		val ind = getIndex(x31, y31)
+		if (ind == -1) {
+			return -1f
+		}
+		if ((ind == 0 && start) || (ind == pointsX.size - 1 && !start)) {
+			return -1f
+		}
+		val distToPoint = getDeviationDistance(x31, y31, ind)
+		val deviationPenalty = distToPoint / minSpeed
+		val finishTime = if (start) startFinishTime else endFinishTime
+		return if (start) {
+			(tms[0] - tms[ind]) + deviationPenalty + finishTime
+		} else {
+			tms[ind] + deviationPenalty + finishTime
+		}
+	}
+
+	fun getDeviationDistance(x31: Int, y31: Int): Float {
+		val ind = getIndex(x31, y31)
+		if (ind == -1) {
+			return 0f
+		}
+		return getDeviationDistance(x31, y31, ind)
+	}
+
+	fun getDeviationDistance(x31: Int, y31: Int, ind: Int): Float {
+		var distToPoint = 0f
+		if (ind < pointsX.size - 1 && ind != 0) {
+			val nx = KMapUtils.squareRootDist31(x31, y31, pointsX[ind + 1], pointsY[ind + 1])
+			val pr = KMapUtils.squareRootDist31(x31, y31, pointsX[ind - 1], pointsY[ind - 1])
+			val nind = if (nx > pr) ind - 1 else ind + 1
+			// pointsX twice is how java had it; the projection is only a penalty, and changing it
+			// would move every route that leans on a precalculated one
+			val proj = KMapUtils.getProjectionPoint31(
+				x31, y31, pointsX[ind], pointsY[ind], pointsX[nind], pointsX[nind]
+			)
+			distToPoint = KMapUtils.squareRootDist31(x31, y31, proj.x.toInt(), proj.y.toInt()).toFloat()
+		}
+		return distToPoint
+	}
+
+	fun getIndex(x31: Int, y31: Int): Int {
+		var ind = -1
+		cachedS.clear()
+		quadTree.queryInBox(
+			KQuadRect(
+				(x31 - SHIFT).toDouble(), (y31 - SHIFT).toDouble(),
+				(x31 + SHIFT).toDouble(), (y31 + SHIFT).toDouble()
+			), cachedS
+		)
+		if (cachedS.size == 0) {
+			for (k in SHIFTS.indices) {
+				quadTree.queryInBox(
+					KQuadRect(
+						(x31 - SHIFTS[k]).toDouble(), (y31 - SHIFTS[k]).toDouble(),
+						(x31 + SHIFTS[k]).toDouble(), (y31 + SHIFTS[k]).toDouble()
+					), cachedS
+				)
+				if (cachedS.size != 0) {
+					break
+				}
+			}
+			if (cachedS.size == 0) {
+				return -1
+			}
+		}
+		var minDist = 0.0
+		for (i in cachedS.indices) {
+			val n = cachedS[i]
+			val ds = KMapUtils.squareRootDist31(x31, y31, pointsX[n], pointsY[n])
+			if (ds < minDist || i == 0) {
+				ind = n
+				minDist = ds
+			}
+		}
+		return ind
+	}
+
+	private fun calc(x31: Int, y31: Int): Long {
+		return (x31.toLong() shl 32) + y31.toLong()
+	}
+
+	fun setFollowNext(followNext: Boolean) {
+		this.followNext = followNext
+	}
+
+	fun isFollowNext(): Boolean = followNext
+
+	/**
+	 * Cuts the part of this route between the two points out, and measures how far the real start
+	 * and target sit from it.
+	 *
+	 * Takes the points and the router rather than a routing context: the context holds an open obf
+	 * reader and stays in OsmAnd-java, and this is all of it that was ever read here.
+	 */
+	fun adopt(startX: Int, startY: Int, targetX: Int, targetY: Int, router: VehicleRouter): PrecalculatedRouteDirection? {
+		val ind1 = getIndex(startX, startY)
+		val ind2 = getIndex(targetX, targetY)
+		minSpeed = router.getDefaultSpeed()
+		maxSpeed = router.getMaxSpeed()
+		if (ind1 == -1) {
+			return null
+		}
+		if (ind2 == -1) {
+			return null
+		}
+		val routeDirection = PrecalculatedRouteDirection(this, ind1, ind2)
+		routeDirection.startPoint = calc(startX, startY)
+		routeDirection.startFinishTime =
+			(KMapUtils.squareRootDist31(pointsX[ind1], pointsY[ind1], startX, startY) / maxSpeed).toFloat()
+		routeDirection.endPoint = calc(targetX, targetY)
+		routeDirection.endFinishTime =
+			(KMapUtils.squareRootDist31(pointsX[ind2], pointsY[ind2], targetX, targetY) / maxSpeed).toFloat()
+		routeDirection.followNext = followNext
+		return routeDirection
+	}
+
+	fun updatePreciseStartEnd(sx: Int, sy: Int, ex: Int, ey: Int) {
+		if (sx > 0 && sy > 0) {
+			val ind = getIndex(sx, sy)
+			if (ind != -1) {
+				startPoint = calc(sx, sy)
+				startFinishTime = (KMapUtils.squareRootDist31(pointsX[ind], pointsY[ind], sx, sy) / maxSpeed).toFloat()
+			}
+		}
+		if (ex > 0 && ey > 0) {
+			val ind = getIndex(ex, ey)
+			if (ind != -1) {
+				endPoint = calc(ex, ey)
+				endFinishTime = (KMapUtils.squareRootDist31(pointsX[ind], pointsY[ind], ex, ey) / maxSpeed).toFloat()
+			}
+		}
+	}
+
+	companion object {
+
+		private const val SHIFT = 1 shl (31 - 17)
+		private val SHIFTS = intArrayOf(
+			1 shl (31 - 15), 1 shl (31 - 13), 1 shl (31 - 12),
+			1 shl (31 - 11), 1 shl (31 - 7)
+		)
+
+		@JvmStatic
+		fun build(ls: List<RouteSegmentResult>, cutoffDistance: Float, maxSpeed: Float): PrecalculatedRouteDirection? {
+			var begi = 0
+			var d = cutoffDistance
+			while (begi < ls.size) {
+				d -= ls[begi].getDistance()
+				if (d < 0) {
+					break
+				}
+				begi++
+			}
+			var endi = ls.size
+			d = cutoffDistance
+			while (endi > 0) {
+				d -= ls[endi - 1].getDistance()
+				if (d < 0) {
+					break
+				}
+				endi--
+			}
+			if (begi < endi) {
+				return PrecalculatedRouteDirection(ls.subList(begi, endi), maxSpeed)
+			}
+			return null
+		}
+
+		@JvmStatic
+		fun build(ls: Array<KLatLon>, maxSpeed: Float): PrecalculatedRouteDirection =
+			PrecalculatedRouteDirection(ls, maxSpeed)
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteConditionalHelper.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteConditionalHelper.kt
@@ -1,0 +1,143 @@
+package net.osmand.shared.routing
+
+import net.osmand.shared.util.LoggerFactory
+
+/**
+ * Applies `:conditional` tags to a road before the router sees it.
+ *
+ * Two things happen here. [processConditionalTags] resolves a condition against a moment in time -
+ * `maxspeed:conditional` that only holds at night, an `access:conditional` that only holds in
+ * summer - and writes the value it produced onto the road as if the map had carried it plainly.
+ * [resolveAmbiguousConditionalTags] does the same for the conditions the caller decided to treat as
+ * always true, which is how HHRoutingShortcutCreator builds a graph that no clock can invalidate.
+ */
+class RouteConditionalHelper {
+
+	fun resolveAmbiguousConditionalTags(rdo: RouteDataObject, ambiguousConditionalTags: Map<String, String>) {
+		val existingIntValues = HashMap<String, Int>()
+
+		// Find corresponding non-conditional tags and save their existing int-values.
+		// Example: maxspeed:conditional (RULE_INT_MAX) will save the value of maxspeed.
+		for (type in rdo.types!!) {
+			val r = rdo.region!!.quickGetEncodingRule(type)
+			if (r != null && !r.conditional()) {
+				val key = r.getTag() + ":conditional"
+				val rule = ambiguousConditionalTags[key]
+				if (rule != null && RULE_INT_MAX == rule) {
+					val newValue = r.getValue()?.toIntOrNull() ?: continue
+					val oldValue = existingIntValues[key]
+					if (oldValue == null || newValue > oldValue) {
+						existingIntValues[key] = newValue
+					}
+				}
+			}
+		}
+
+		// Find conditionals and update their non-conditionals by the rules.
+		// Example: access:conditional ("yes") will always set "access" = "yes"
+		// Example: maxspeed:conditional (RULE_INT_MAX) might set maxspeed = max(existing, conditional)
+		for (type in rdo.types!!) {
+			val r = rdo.region!!.quickGetEncodingRule(type)
+			if (r != null && r.conditional()) {
+				val key = r.getTag()
+				val rule = ambiguousConditionalTags[key]
+				if (rule != null && RULE_INT_MAX == rule) {
+					val existingValue = existingIntValues[key]
+					val newValue = r.getMaxIntegerConditionalValue()
+					if (newValue != null && (existingValue == null || newValue > existingValue)) {
+						updateTypesByTagValue(rdo, r.getNonConditionalTag(), newValue.toString()) // max value
+					}
+				} else if (rule != null) {
+					updateTypesByTagValue(rdo, r.getNonConditionalTag(), rule) // Default rule: set the string value
+				}
+			}
+		}
+	}
+
+	fun processConditionalTags(rdo: RouteDataObject, conditionalTime: Long) {
+		val sz = rdo.types!!.size
+		for (i in 0 until sz) {
+			val r = rdo.region!!.quickGetEncodingRule(rdo.types!![i])
+			if (r != null && r.conditional()) {
+				val vl = r.conditionalValue(conditionalTime)
+				if (vl != 0) {
+					val nonCondTag = rdo.region!!.quickGetEncodingRule(vl)!!.getTag()
+					updateTypesByTagRuleId(rdo, nonCondTag, vl)
+				}
+			}
+		}
+
+		val pointTypes = rdo.pointTypes
+		if (pointTypes != null) {
+			for (i in pointTypes.indices) {
+				if (pointTypes[i] != null) {
+					var pTypes = pointTypes[i]!!
+					val pSz = pTypes.size
+					if (pSz > 0) {
+						for (j in 0 until pSz) {
+							val r = rdo.region!!.quickGetEncodingRule(pTypes[j])
+							if (r != null && r.conditional()) {
+								val vl = r.conditionalValue(conditionalTime)
+								if (vl != 0) {
+									val rtr = rdo.region!!.quickGetEncodingRule(vl)!!
+									val nonCondTag = rtr.getTag()
+									var ks = 0
+									while (ks < pointTypes[i]!!.size) {
+										val toReplace = rdo.region!!.quickGetEncodingRule(pointTypes[i]!![ks])
+										if (toReplace != null && toReplace.getTag() == nonCondTag) {
+											break
+										}
+										ks++
+									}
+									if (ks == pTypes.size) {
+										val ntypes = IntArray(pTypes.size + 1)
+										pTypes.copyInto(ntypes, 0, 0, pTypes.size)
+										pTypes = ntypes
+									}
+									pTypes[ks] = vl
+								}
+							}
+						}
+					}
+					pointTypes[i] = pTypes
+				}
+			}
+		}
+	}
+
+	fun updateTypesByTagValue(rdo: RouteDataObject, tag: String, value: String) {
+		val ruleId = rdo.region!!.searchRouteEncodingRule(tag, value)
+		if (ruleId > 0) {
+			updateTypesByTagRuleId(rdo, tag, ruleId)
+		} else {
+			LOG.error("updateTypesByTagValue($tag,$value): searchRouteEncodingRule failed")
+		}
+	}
+
+	fun updateTypesByTagRuleId(rdo: RouteDataObject, tag: String, ruleId: Int) {
+		if (ruleId > 0) {
+			var types = rdo.types!!
+			var ks = 0
+			while (ks < types.size) {
+				val toReplace = rdo.region!!.quickGetEncodingRule(types[ks])
+				if (toReplace != null && toReplace.getTag() == tag) {
+					break
+				}
+				ks++
+			}
+			if (ks == types.size) {
+				val ntypes = IntArray(types.size + 1)
+				types.copyInto(ntypes, 0, 0, types.size)
+				rdo.types = ntypes
+				types = ntypes
+			}
+			types[ks] = ruleId
+		}
+	}
+
+	companion object {
+		const val RULE_INT_MAX = "RULE_INT_MAX"
+
+		private val LOG = LoggerFactory.getLogger("RouteConditionalHelper")
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/KMapUtils.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/KMapUtils.kt
@@ -2,6 +2,7 @@ package net.osmand.shared.util
 
 import co.touchlab.stately.collections.ConcurrentMutableMap
 import net.osmand.shared.data.KLatLon
+import net.osmand.shared.data.KQuadPointDouble
 import net.osmand.shared.data.KQuadRect
 import net.osmand.shared.extensions.toDegrees
 import net.osmand.shared.extensions.toRadians
@@ -487,6 +488,31 @@ object KMapUtils {
 			diff += 360
 		}
 		return diff
+	}
+
+	/**
+	 * Where a point projects onto the segment between two others, clamped to its ends, in 31 coords.
+	 */
+	fun getProjectionPoint31(px: Int, py: Int, st31x: Int, st31y: Int, end31x: Int, end31y: Int): KQuadPointDouble {
+		// st31x, st31y - A, end31x, end31y - B, px, py - C
+		val tWidth = getTileWidth(py)
+		// Scalar multiplication between (AB, AC)
+		val projection = (end31x - st31x) * tWidth * (px - st31x) * tWidth +
+				(end31y - st31y) * tWidth * (py - st31y) * tWidth
+		val mDist = squareRootDist31(end31x, end31y, st31x, st31y)
+		var pry = end31y.toDouble()
+		var prx = end31x.toDouble()
+		if (projection < 0) {
+			prx = st31x.toDouble()
+			pry = st31y.toDouble()
+		} else if (projection >= mDist * mDist) {
+			prx = end31x.toDouble()
+			pry = end31y.toDouble()
+		} else {
+			prx = st31x + (end31x - st31x) * (projection / (mDist * mDist))
+			pry = st31y + (end31y - st31y) * (projection / (mDist * mDist))
+		}
+		return KQuadPointDouble(prx, pry)
 	}
 
 	fun squareRootDist31(x1: Int, y1: Int, x2: Int, y2: Int): Double {

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/routing/PrecalculatedRouteDirectionTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/routing/PrecalculatedRouteDirectionTest.kt
@@ -1,0 +1,174 @@
+package net.osmand.shared.routing
+
+import net.osmand.shared.data.KLatLon
+import net.osmand.shared.util.KMapUtils
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PrecalculatedRouteDirectionTest {
+
+	/** Six points a hundredth of a degree apart, west to east along the same parallel. */
+	private val line = Array(6) { KLatLon(50.0, 30.0 + it * 0.01) }
+
+	private fun x(i: Int) = KMapUtils.get31TileNumberX(line[i].longitude)
+	private fun y(i: Int) = KMapUtils.get31TileNumberY(line[i].latitude)
+
+	private fun direction() = PrecalculatedRouteDirection.build(line, 20f)
+
+	private fun router(): GeneralRouter = GeneralRouter(GeneralRouterProfile.CAR, LinkedHashMap())
+
+	@Test
+	fun testEveryPointOfTheRouteFindsItself() {
+		val direction = direction()
+		for (i in line.indices) {
+			assertEquals(i, direction.getIndex(x(i), y(i)), "point $i")
+		}
+	}
+
+	@Test
+	fun testAPointBesideTheRouteFindsTheNearestOne() {
+		val direction = direction()
+		// a little north of the third point, well inside the search box
+		val aside = KMapUtils.get31TileNumberY(50.0005)
+		assertEquals(2, direction.getIndex(x(2), aside))
+	}
+
+	@Test
+	fun testAPointFarFromTheRouteIsNotFound() {
+		assertEquals(-1, direction().getIndex(KMapUtils.get31TileNumberX(10.0), KMapUtils.get31TileNumberY(10.0)))
+	}
+
+	@Test
+	fun testDeviationDistanceGrowsWithTheDistanceFromTheRoute() {
+		val direction = direction()
+		val onRoute = direction.getDeviationDistance(x(2), y(2))
+		val aside = direction.getDeviationDistance(x(2), KMapUtils.get31TileNumberY(50.0005))
+		assertTrue(aside > onRoute, "expected $aside to be more than $onRoute")
+		// the ends have no segment to project onto
+		assertEquals(0f, direction.getDeviationDistance(x(0), y(0)))
+		assertEquals(0f, direction.getDeviationDistance(x(5), y(5)))
+	}
+
+	@Test
+	fun testAdoptCutsTheRouteBetweenTheTwoPoints() {
+		val adopted = direction().adopt(x(1), y(1), x(4), y(4), router())
+		assertNotNull(adopted)
+		// the adopted copy is indexed from its own start, and holds only the four points it kept
+		assertEquals(0, adopted.getIndex(x(1), y(1)))
+		assertEquals(3, adopted.getIndex(x(4), y(4)))
+		// a point outside the cut falls back to the nearest one that is still there
+		assertEquals(0, adopted.getIndex(x(0), y(0)))
+		assertEquals(3, adopted.getIndex(x(5), y(5)))
+	}
+
+	@Test
+	fun testAdoptWorksBackwards() {
+		val adopted = direction().adopt(x(4), y(4), x(1), y(1), router())
+		assertNotNull(adopted)
+		assertEquals(0, adopted.getIndex(x(1), y(1)))
+		assertEquals(3, adopted.getIndex(x(4), y(4)))
+	}
+
+	@Test
+	fun testAdoptGivesUpWhenAPointIsNotOnTheRoute() {
+		val far = KMapUtils.get31TileNumberX(10.0)
+		assertNull(direction().adopt(far, far, x(4), y(4), router()))
+		assertNull(direction().adopt(x(1), y(1), far, far, router()))
+	}
+
+	@Test
+	fun testAdoptCarriesFollowNext() {
+		val direction = direction()
+		assertFalse(direction.isFollowNext())
+		direction.setFollowNext(true)
+		assertTrue(direction.adopt(x(1), y(1), x(4), y(4), router())!!.isFollowNext())
+	}
+
+	@Test
+	fun testTimeEstimateGrowsWithTheDistanceFromTheStart() {
+		val adopted = direction().adopt(x(0), y(0), x(5), y(5), router())!!
+		// measured from the start, so it is the time already spent getting there
+		val early = adopted.timeEstimate(x(0), y(0), x(1), y(1))
+		val late = adopted.timeEstimate(x(0), y(0), x(4), y(4))
+		assertTrue(early > 0, "expected a positive estimate, got $early")
+		assertTrue(late > early, "expected $late to be more than $early")
+	}
+
+	@Test
+	fun testTimeEstimateFromTheEndCountsWhatIsLeft() {
+		val adopted = direction().adopt(x(0), y(0), x(5), y(5), router())!!
+		// measured against the target, so it is the time still to come
+		val near = adopted.timeEstimate(x(5), y(5), x(4), y(4))
+		val far = adopted.timeEstimate(x(5), y(5), x(1), y(1))
+		assertTrue(near > 0, "expected a positive estimate, got $near")
+		assertTrue(far > near, "expected $far to be more than $near")
+	}
+
+	@Test
+	fun testTimeEstimateHasNothingToSayAtTheVeryEnds() {
+		val adopted = direction().adopt(x(0), y(0), x(5), y(5), router())!!
+		assertEquals(-1f, adopted.timeEstimate(x(0), y(0), x(0), y(0)))
+		assertEquals(-1f, adopted.timeEstimate(x(5), y(5), x(5), y(5)))
+	}
+
+	@Test
+	fun testTimeEstimateRefusesTwoPointsThatAreNeitherEnd() {
+		val adopted = direction().adopt(x(0), y(0), x(5), y(5), router())!!
+		try {
+			adopted.timeEstimate(x(1), y(1), x(2), y(2))
+			throw AssertionError("expected the estimate to refuse two interior points")
+		} catch (e: UnsupportedOperationException) {
+			assertTrue(e.message!!.contains("startPoint:"), e.message!!)
+		}
+	}
+
+	@Test
+	fun testPreciseStartAndEndCanBeMovedAfterwards() {
+		val adopted = direction().adopt(x(0), y(0), x(5), y(5), router())!!
+		assertTrue(adopted.timeEstimate(x(0), y(0), x(2), y(2)) > 0)
+
+		// the planner snapped the real start and target onto roads a point along
+		adopted.updatePreciseStartEnd(x(1), y(1), x(4), y(4))
+		val after = adopted.timeEstimate(x(1), y(1), x(2), y(2))
+		assertTrue(after > 0, "expected a positive estimate from the new start, got $after")
+
+		// and the old start is no longer one of the two ends it will measure against
+		try {
+			adopted.timeEstimate(x(0), y(0), x(2), y(2))
+			throw AssertionError("expected the old start to be refused")
+		} catch (e: UnsupportedOperationException) {
+			assertTrue(e.message!!.contains("startPoint:"), e.message!!)
+		}
+	}
+
+	@Test
+	fun testBuildFromARouteTrimsBothEnds() {
+		val segments = segments(300f, 300f, 300f, 300f)
+		// 350 m off each end leaves the two middle segments
+		val direction = PrecalculatedRouteDirection.build(segments, 350f, 20f)
+		assertNotNull(direction)
+
+		// and nothing is left when the cutoff eats the whole route
+		assertNull(PrecalculatedRouteDirection.build(segments, 5000f, 20f))
+	}
+
+	private fun segments(vararg distances: Float): List<RouteSegmentResult> {
+		val region = RouteRegion()
+		region.initRouteEncodingRule(0, "", "")
+		region.initRouteEncodingRule(1, "highway", "primary")
+		return distances.mapIndexed { i, distance ->
+			val road = RouteDataObject(region)
+			road.id = (i + 1).toLong() shl 6
+			road.types = intArrayOf(1)
+			road.pointsX = intArrayOf(x(i), x(i + 1))
+			road.pointsY = intArrayOf(y(i), y(i + 1))
+			val segment = RouteSegmentResult(road, 0, 1)
+			segment.setDistance(distance)
+			segment
+		}
+	}
+}

--- a/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/routing/RouteConditionalHelperTest.kt
+++ b/OsmAnd-shared/src/commonTest/kotlin/net/osmand/shared/routing/RouteConditionalHelperTest.kt
@@ -1,0 +1,154 @@
+package net.osmand.shared.routing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RouteConditionalHelperTest {
+
+	private val helper = RouteConditionalHelper()
+
+	/** A region with the rules given, with the conditional ones wired to the values they resolve to. */
+	private fun region(vararg tags: Pair<String, String?>): RouteRegion {
+		val region = RouteRegion()
+		// id 0 is never a real rule, the readers count rules from 1
+		region.initRouteEncodingRule(0, "", "")
+		for ((i, tag) in tags.withIndex()) {
+			region.initRouteEncodingRule(i + 1, tag.first, tag.second)
+		}
+		region.completeRouteEncodingRules()
+		return region
+	}
+
+	private fun road(region: RouteRegion, vararg types: Int): RouteDataObject {
+		val road = RouteDataObject(region)
+		road.id = 64
+		road.types = types.toList().toIntArray()
+		return road
+	}
+
+	private fun tagsOf(road: RouteDataObject): List<Pair<String, String?>> =
+		road.types!!.map { road.region!!.quickGetEncodingRule(it)!!.let { r -> r.getTag() to r.getValue() } }
+
+	@Test
+	fun testConditionalTagIsWrittenOntoTheRoadAsAPlainOne() {
+		val region = region("highway" to "primary", "access:conditional" to "no @ (24/7)")
+		assertTrue(region.quickGetEncodingRule(2)!!.conditional())
+
+		val road = road(region, 1, 2)
+		helper.processConditionalTags(road, 0L)
+
+		// access=no, which completeRouteEncodingRules created for the condition, is on the road now
+		assertTrue(tagsOf(road).contains("access" to "no"), tagsOf(road).toString())
+	}
+
+	@Test
+	fun testAConditionNobodyCanReadChangesNothing() {
+		val region = region("highway" to "primary", "access:conditional" to "no @ (whenever)")
+		assertTrue(region.quickGetEncodingRule(2)!!.conditional())
+
+		val road = road(region, 1, 2)
+		val before = road.types!!.toList()
+		helper.processConditionalTags(road, 0L)
+		assertEquals(before, road.types!!.toList())
+	}
+
+	@Test
+	fun testPointTypesGetTheirConditionalsResolvedToo() {
+		val region = region("highway" to "primary", "access:conditional" to "no @ (24/7)")
+		val road = road(region, 1)
+		road.pointTypes = arrayOf(intArrayOf(2), null)
+
+		helper.processConditionalTags(road, 0L)
+
+		val resolved = region.searchRouteEncodingRule("access", "no")
+		assertTrue(resolved > 0)
+		// the point keeps the conditional rule and gains the one it resolved to
+		assertEquals(listOf(2, resolved), road.pointTypes!![0]!!.toList())
+		assertNull(road.pointTypes!![1])
+	}
+
+	@Test
+	fun testAmbiguousMaxKeepsTheLargerOfTheTwoValues() {
+		val region = region(
+			"highway" to "primary",
+			"maxspeed" to "50",
+			"maxspeed:conditional" to "70 @ (22:00-06:00)"
+		)
+		val road = road(region, 1, 2, 3)
+
+		helper.resolveAmbiguousConditionalTags(road, mapOf("maxspeed:conditional" to RouteConditionalHelper.RULE_INT_MAX))
+
+		// the conditional 70 beats the plain 50, and replaces it in place
+		assertTrue(tagsOf(road).contains("maxspeed" to "70"), tagsOf(road).toString())
+		assertTrue(!tagsOf(road).contains("maxspeed" to "50"), tagsOf(road).toString())
+	}
+
+	@Test
+	fun testAmbiguousMaxLeavesTheLargerPlainValueAlone() {
+		val region = region(
+			"highway" to "primary",
+			"maxspeed" to "90",
+			"maxspeed:conditional" to "70 @ (22:00-06:00)"
+		)
+		val road = road(region, 1, 2, 3)
+
+		helper.resolveAmbiguousConditionalTags(road, mapOf("maxspeed:conditional" to RouteConditionalHelper.RULE_INT_MAX))
+
+		assertTrue(tagsOf(road).contains("maxspeed" to "90"), tagsOf(road).toString())
+	}
+
+	@Test
+	fun testAPlainRuleSetsTheValueItNames() {
+		val region = region("highway" to "primary", "access:conditional" to "no @ (22:00-06:00)", "access" to "yes")
+		val road = road(region, 1, 2)
+
+		helper.resolveAmbiguousConditionalTags(road, mapOf("access:conditional" to "yes"))
+
+		assertTrue(tagsOf(road).contains("access" to "yes"), tagsOf(road).toString())
+	}
+
+	@Test
+	fun testTagsNobodyAskedAboutAreLeftAlone() {
+		val region = region("highway" to "primary", "maxspeed:conditional" to "70 @ (22:00-06:00)")
+		val road = road(region, 1, 2)
+		val before = road.types!!.toList()
+
+		helper.resolveAmbiguousConditionalTags(road, mapOf("access:conditional" to "yes"))
+
+		assertEquals(before, road.types!!.toList())
+	}
+
+	@Test
+	fun testUpdatingByAValueTheRegionDoesNotKnowChangesNothing() {
+		val region = region("highway" to "primary")
+		val road = road(region, 1)
+
+		helper.updateTypesByTagValue(road, "surface", "gravel")
+
+		assertEquals(listOf(1), road.types!!.toList())
+	}
+
+	@Test
+	fun testUpdatingByRuleIdAppendsWhenTheTagIsNew() {
+		val region = region("highway" to "primary", "surface" to "gravel")
+		val road = road(region, 1)
+
+		helper.updateTypesByTagRuleId(road, "surface", 2)
+
+		assertEquals(listOf(1, 2), road.types!!.toList())
+	}
+
+	@Test
+	fun testUpdatingByRuleIdReplacesWhenTheTagIsAlreadyThere() {
+		val region = region("highway" to "primary", "surface" to "gravel", "surface" to "asphalt")
+		val road = road(region, 1, 2)
+
+		helper.updateTypesByTagRuleId(road, "surface", 3)
+
+		assertEquals(listOf(1, 3), road.types!!.toList())
+		assertNotNull(road.region)
+	}
+}


### PR DESCRIPTION
Part of the routing-to-OsmAnd-shared series: the java classes stay in `OsmAnd-java` and android, tools and the C++ core keep using them; each step adds a copy to `OsmAnd-shared` and a test that the copy behaves like the original. The copies are for iOS, which will call them instead of its own C++ turn preparation.

`PrecalculatedRouteDirection` and `RouteConditionalHelper`, with `KMapUtils.getProjectionPoint31` checked bit for bit against `MapUtils` in `KMapUtilsProjectionCompatTest`. `PrecalculatedRouteCompatTest` builds directions from chains of real road segments on both sides, adopts them for a start and a target the way a calculation does, and compares estimates, deviations and indices; and runs the conditional helper over every road at four moments and compares the road's types afterwards.

One thing the converter had to learn from that: the java reader calls `completeRouteEncodingRules()` once a region's rules are in, which gives every conditional rule the id of its value's rule; a region copied without that answers 0 to every conditional.

Supersedes #25922.
