### PR TITLE
RoutingRequest and RouteCalculationMode for OsmAnd-shared

### DIFF
--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteCalculationMode.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteCalculationMode.kt
@@ -1,0 +1,17 @@
+package net.osmand.shared.routing
+
+/**
+ * How much of the road network a route calculation is allowed to see.
+ *
+ * BASE is the coarse network a basemap carries, NORMAL the detailed one, and COMPLEX means both:
+ * a base route first, which then guides the detailed search as a [PrecalculatedRouteDirection].
+ *
+ * A copy of `RoutePlannerFrontEnd.RouteCalculationMode`, which stays in OsmAnd-java; this copy is
+ * for iOS. The C++ router reads the java enum by `ordinal()`, so keep the constants in the same
+ * order here, if only so a mode can be handed between the two by number.
+ */
+enum class RouteCalculationMode {
+	BASE,
+	NORMAL,
+	COMPLEX
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RoutingRequest.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RoutingRequest.kt
@@ -1,0 +1,76 @@
+package net.osmand.shared.routing
+
+import kotlin.jvm.JvmField
+
+/**
+ * What a route calculation is asked for: where it starts, where it has to reach, on what profile,
+ * and where to report progress. Not how it is worked out - the search itself, its tile cache and its
+ * graph nodes belong to whichever planner runs, and stay there.
+ *
+ * This is the request half of `net.osmand.router.RoutingContext`, which stays whole in OsmAnd-java
+ * for android and tools. The copy exists for iOS: the shared turn preparation reads the profile, the
+ * calculation mode and the side of the road off it, and iOS fills those in from its C++ context.
+ * The field names are java's, so the two can be compared side by side.
+ */
+open class RoutingRequest(
+	/** The profile and the limits this calculation runs under. */
+	@JvmField val config: RoutingConfiguration,
+	/** How much of the network the calculation may see. */
+	@JvmField val calculationMode: RouteCalculationMode
+) {
+
+	// 1. Where the route runs
+
+	@JvmField var startX: Int = 0
+	@JvmField var startY: Int = 0
+	@JvmField var startRoadId: Long = 0
+	@JvmField var startSegmentInd: Int = 0
+	@JvmField var startTransportStop: Boolean = false
+
+	@JvmField var targetX: Int = 0
+	@JvmField var targetY: Int = 0
+	@JvmField var targetRoadId: Long = 0
+	@JvmField var targetSegmentInd: Int = 0
+	@JvmField var targetTransportStop: Boolean = false
+
+	@JvmField var intermediatesX: IntArray? = null
+	@JvmField var intermediatesY: IntArray? = null
+
+	@JvmField var publicTransport: Boolean = false
+
+	/** Names of the regions the ends fall into, so a route across a missing map can be reported. */
+	@JvmField var regionsCoveringStartAndTargets: Array<String> = emptyArray()
+
+	// 2. Progress, and a route to lean on
+
+	@JvmField var calculationProgress: RouteCalculationProgress? = null
+
+	@JvmField var precalculatedRouteDirection: PrecalculatedRouteDirection? = null
+
+	// 3. Counters the core writes back into
+
+	@JvmField var alertFasterRoadToVisitedSegments: Int = 0
+	@JvmField var alertSlowerSegmentedWasVisitedEarlier: Int = 0
+
+	// What the request says about the profile, which lives on the configuration
+
+	fun setRouter(router: GeneralRouter) {
+		config.router = router
+	}
+
+	fun getRouter(): VehicleRouter = config.router
+
+	fun setHeuristicCoefficient(heuristicCoefficient: Float) {
+		config.heuristicCoefficient = heuristicCoefficient
+	}
+
+	fun planRouteIn2Directions(): Boolean = config.planRoadDirection == 0
+
+	fun getPlanRoadDirection(): Int = config.planRoadDirection
+
+	// What the request says about how far it has got
+
+	fun getVisitedSegments(): Int = calculationProgress?.visitedSegments ?: 0
+
+	fun getLoadedTiles(): Int = calculationProgress?.loadedTiles ?: 0
+}


### PR DESCRIPTION
Part of the routing-to-OsmAnd-shared series: the java classes stay in `OsmAnd-java` and android, tools and the C++ core keep using them; each step adds a copy to `OsmAnd-shared` and a test that the copy behaves like the original. The copies are for iOS, which will call them instead of its own C++ turn preparation.

`RouteCalculationMode` and `RoutingRequest`, the request half of java's `RoutingContext`: the profile, the mode, the side of the road, the points and the progress. This is the context the shared turn preparation reads, and what iOS fills in from its C++ context. Java's `RoutingContext` is not changed - the earlier plan to make it extend this class is dropped with the JNI lockstep.

Supersedes #25949 and #25952.
