### PR TITLE
Copy the route bundles to OsmAnd-shared

### DIFF
--- a/OsmAnd-java/src/test/java/net/osmand/binary/StringBundleCompatTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/binary/StringBundleCompatTest.java
@@ -1,0 +1,124 @@
+package net.osmand.binary;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Random;
+
+import org.junit.Test;
+
+/**
+ * Route gpx files are written through the shared {@link net.osmand.shared.util.StringBundle} now,
+ * and the files already in the wild were written through {@link StringBundle}. This runs the same
+ * values through both and asserts they produce the same text and read it back the same way.
+ *
+ * These live here because this is the only module where both implementations are on the classpath.
+ */
+public class StringBundleCompatTest {
+
+	private static final String KEY = "k";
+
+	private String javaText(java.util.function.Consumer<StringBundle> write) {
+		StringBundle bundle = new StringBundle();
+		write.accept(bundle);
+		return bundle.getString(KEY, null);
+	}
+
+	private String sharedText(java.util.function.Consumer<net.osmand.shared.util.StringBundle> write) {
+		net.osmand.shared.util.StringBundle bundle = new net.osmand.shared.util.StringBundle();
+		write.accept(bundle);
+		return bundle.getString(KEY, null);
+	}
+
+	@Test
+	public void testScalarsProduceTheSameText() {
+		assertEquals(javaText(b -> b.putInt(KEY, -42)), sharedText(b -> b.putInt(KEY, -42)));
+		assertEquals(javaText(b -> b.putLong(KEY, 1234567890123L)), sharedText(b -> b.putLong(KEY, 1234567890123L)));
+		assertEquals(javaText(b -> b.putBoolean(KEY, true)), sharedText(b -> b.putBoolean(KEY, true)));
+		assertEquals(javaText(b -> b.putString(KEY, "text")), sharedText(b -> b.putString(KEY, "text")));
+		assertEquals(javaText(b -> b.putFloat(KEY, 12.5f)), sharedText(b -> b.putFloat(KEY, 12.5f)));
+		for (int digits = 2; digits <= 6; digits++) {
+			int d = digits;
+			assertEquals("digits " + d,
+					javaText(b -> b.putFloat(KEY, 63.456f, d)), sharedText(b -> b.putFloat(KEY, 63.456f, d)));
+			assertEquals("digits " + d,
+					javaText(b -> b.putFloat(KEY, 3f, d)), sharedText(b -> b.putFloat(KEY, 3f, d)));
+		}
+	}
+
+	@Test
+	public void testIntArrayRoundTrip() {
+		int[][] arrays = {{}, {1}, {1, 2, 3}, {-5, 0, 7}};
+		for (int[] array : arrays) {
+			String java = javaText(b -> b.putArray(KEY, array));
+			String shared = sharedText(b -> b.putArray(KEY, array));
+			assertEquals(java, shared);
+
+			StringBundle javaBundle = new StringBundle();
+			javaBundle.putArray(KEY, array);
+			net.osmand.shared.util.StringBundle sharedBundle = new net.osmand.shared.util.StringBundle();
+			sharedBundle.putArray(KEY, array);
+			assertArrayEquals(javaBundle.getIntArray(KEY, null), sharedBundle.getIntArray(KEY, null));
+		}
+	}
+
+	@Test
+	public void testIntIntArrayRoundTripWithEmptyRows() {
+		// null rows are what point types look like for a point that carries none
+		int[][] array = {{1, 2}, null, {3}, {}, {4, 5, 6}};
+
+		StringBundle javaBundle = new StringBundle();
+		javaBundle.putArray(KEY, array);
+		net.osmand.shared.util.StringBundle sharedBundle = new net.osmand.shared.util.StringBundle();
+		sharedBundle.putArray(KEY, array);
+		assertEquals(javaBundle.getString(KEY, null), sharedBundle.getString(KEY, null));
+
+		int[][] fromJava = javaBundle.getIntIntArray(KEY, null);
+		int[][] fromShared = sharedBundle.getIntIntArray(KEY, null);
+		assertEquals(fromJava.length, fromShared.length);
+		for (int i = 0; i < fromJava.length; i++) {
+			assertArrayEquals("row " + i, fromJava[i], fromShared[i]);
+		}
+	}
+
+	@Test
+	public void testTrailingEmptyRowsAreDroppedByBoth() {
+		// java's String.split drops the empty parts at the end, so the last rows do not come back
+		int[][] array = {{1}, null, null};
+		StringBundle javaBundle = new StringBundle();
+		javaBundle.putArray(KEY, array);
+		net.osmand.shared.util.StringBundle sharedBundle = new net.osmand.shared.util.StringBundle();
+		sharedBundle.putArray(KEY, array);
+		assertEquals(1, javaBundle.getIntIntArray(KEY, null).length);
+		assertEquals(1, sharedBundle.getIntIntArray(KEY, null).length);
+	}
+
+	@Test
+	public void testUnparseableValuesFallBackTheSameWay() {
+		StringBundle javaBundle = new StringBundle();
+		javaBundle.putString(KEY, "not a number");
+		net.osmand.shared.util.StringBundle sharedBundle = new net.osmand.shared.util.StringBundle();
+		sharedBundle.putString(KEY, "not a number");
+
+		assertEquals(javaBundle.getInt(KEY, 7), (int) sharedBundle.getInt(KEY, 7));
+		assertEquals(javaBundle.getLong(KEY, 7L), (long) sharedBundle.getLong(KEY, 7L));
+		assertEquals(javaBundle.getFloat(KEY, 7f), sharedBundle.getFloat(KEY, 7f), 1e-6f);
+		assertEquals(javaBundle.getBoolean(KEY, true), sharedBundle.getBoolean(KEY, true));
+		assertNull(javaBundle.getIntArray(KEY, null));
+		assertNull(sharedBundle.getIntArray(KEY, null));
+	}
+
+	@Test
+	public void testRandomFloatsProduceTheSameText() {
+		Random random = new Random(20260908L);
+		for (int digits = 2; digits <= 6; digits++) {
+			int d = digits;
+			for (int i = 0; i < 20_000; i++) {
+				float value = (random.nextFloat() - 0.3f) * (float) Math.pow(10, random.nextInt(6));
+				assertEquals(value + " at " + d,
+						javaText(b -> b.putFloat(KEY, value, d)), sharedText(b -> b.putFloat(KEY, value, d)));
+			}
+		}
+	}
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteDataBundle.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteDataBundle.kt
@@ -1,0 +1,21 @@
+package net.osmand.shared.routing
+
+import net.osmand.shared.util.StringBundle
+
+/** A [StringBundle] that carries the route wide state a segment needs while it is read or written. */
+class RouteDataBundle : StringBundle {
+
+	private val resources: RouteDataResources
+
+	constructor(resources: RouteDataResources) : super() {
+		this.resources = resources
+	}
+
+	constructor(resources: RouteDataResources, bundle: StringBundle) : super(bundle) {
+		this.resources = resources
+	}
+
+	override fun newInstance(): StringBundle = RouteDataBundle(resources)
+
+	fun getResources(): RouteDataResources = resources
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteDataResources.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RouteDataResources.kt
@@ -1,0 +1,55 @@
+package net.osmand.shared.routing
+
+import net.osmand.shared.data.KLocation
+import kotlin.jvm.JvmOverloads
+
+/**
+ * The state shared by every segment of one route while it is written to or read from a gpx file.
+ *
+ * Segments are visited in order and each one consumes a run of [locations], so the reader has to
+ * remember where the previous segment stopped. The encoding rules are collected here too, because
+ * a gpx file carries one table of them for the whole route rather than one per segment.
+ */
+class RouteDataResources @JvmOverloads constructor(
+	private val locations: MutableList<KLocation> = ArrayList(),
+	private val routePointIndexes: MutableList<Int> = ArrayList()
+) {
+
+	private val rules: MutableMap<RouteTypeRule, Int> = LinkedHashMap()
+
+	private val pointNamesMap: MutableMap<RouteDataObject, Array<IntArray?>> = HashMap()
+
+	private var currentSegmentStartLocationIndex: Int = 0
+
+	fun getRules(): MutableMap<RouteTypeRule, Int> = rules
+
+	fun getLocations(): MutableList<KLocation> = locations
+
+	fun getRoutePointIndexes(): MutableList<Int> = routePointIndexes
+
+	fun getCurrentSegmentLocation(offset: Int): KLocation {
+		val locationIndex = currentSegmentStartLocationIndex + offset
+		if (locationIndex >= locations.size) {
+			throw IllegalStateException("Locations index: $locationIndex out of bounds")
+		}
+		return locations[locationIndex]
+	}
+
+	fun getCurrentSegmentStartLocationIndex(): Int = currentSegmentStartLocationIndex
+
+	/**
+	 * Moves the cursor past the segment just handled. Consecutive segments share their meeting
+	 * point, except where a route point falls on it, so the step is usually one short of the length.
+	 */
+	fun updateNextSegmentStartLocation(currentSegmentLength: Int) {
+		val routePointIndex = routePointIndexes.indexOf(currentSegmentStartLocationIndex + currentSegmentLength)
+		val overlappingNextRouteSegment = !(routePointIndex > 0 && routePointIndex < routePointIndexes.size - 1)
+		currentSegmentStartLocationIndex += if (overlappingNextRouteSegment) {
+			currentSegmentLength - 1
+		} else {
+			currentSegmentLength
+		}
+	}
+
+	fun getPointNamesMap(): MutableMap<RouteDataObject, Array<IntArray?>> = pointNamesMap
+}

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/StringBundle.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/StringBundle.kt
@@ -1,11 +1,24 @@
 package net.osmand.shared.util
 
-import kotlin.math.pow
-import kotlin.math.round
+import net.osmand.shared.util.collections.KTIntObjectMap
+import kotlin.math.abs
+import kotlin.math.floor
 
-class StringBundle {
+open class StringBundle {
 
-	private val map: MutableMap<String, Item<*>> = LinkedHashMap()
+	private val map: MutableMap<String, Item<*>>
+
+	constructor() {
+		map = LinkedHashMap()
+	}
+
+	/** Shares the contents of [bundle], so a subclass can be built around an existing bundle. */
+	protected constructor(bundle: StringBundle) {
+		this.map = bundle.map
+	}
+
+	/** An empty bundle of the same kind, so a reader can build nested bundles of a subclass. */
+	open fun newInstance(): StringBundle = StringBundle()
 
 	enum class ItemType {
 		STRING,
@@ -36,31 +49,106 @@ class StringBundle {
 		}
 
 		fun asBoolean(defaultValue: Boolean?): Boolean? {
-			return value?.toBooleanStrictOrNull()
+			// java read this with Boolean.parseBoolean, which answers false for anything but "true"
+			return if (value == null) defaultValue else value.equals("true", ignoreCase = true)
 		}
 
 		fun asIntArray(defaultValue: IntArray?): IntArray? {
 			return try {
-				value?.split(",")!!.map { it.toInt() }.toIntArray()
+				val text = value ?: return defaultValue
+				splitDroppingTrailingEmpty(text, ",").map { it.toInt() }.toIntArray()
 			} catch (e: NumberFormatException) {
 				defaultValue
 			}
 		}
 
-		fun asIntIntArray(defaultValue: Array<IntArray>?): Array<IntArray>? {
+		fun asIntIntArray(defaultValue: Array<IntArray?>?): Array<IntArray?>? {
 			return try {
-				value?.split(";")!!.map {
-					it.split(",").map { num -> num.toInt() }.toIntArray()
-				}.toTypedArray()
+				val text = value ?: return defaultValue
+				val items = splitDroppingTrailingEmpty(text, ";")
+				Array(items.size) { i ->
+					val item = items[i]
+					// an empty item stands for a row that had no values, and reads back as null
+					if (item.isEmpty()) {
+						null
+					} else {
+						item.split(",").map { num -> num.toInt() }.toIntArray()
+					}
+				}
 			} catch (e: NumberFormatException) {
 				defaultValue
 			}
 		}
 
 		companion object {
+
+			/**
+			 * Splits the way `String.split(regex)` does on the jvm, which drops the empty parts at
+			 * the end. The text these arrays are read from was written by that, so the two agree.
+			 */
+			private fun splitDroppingTrailingEmpty(text: String, separator: String): List<String> {
+				if (!text.contains(separator)) {
+					// java answers with the whole input when the separator does not occur in it
+					return listOf(text)
+				}
+				val parts = text.split(separator)
+				var end = parts.size
+				while (end > 0 && parts[end - 1].isEmpty()) {
+					end--
+				}
+				return parts.subList(0, end)
+			}
+
+			/**
+			 * The same text `DecimalFormat("#.##")` and its wider siblings produced on the jvm:
+			 * at most [maxDigits] fraction digits, half even rounding of the exact value, trailing
+			 * zeros and a bare decimal point dropped.
+			 *
+			 * Java only had formatters for two to six digits and fell back to the plain text of the
+			 * number otherwise; so does this, and so does a value too large to scale into a Long.
+			 */
 			private fun formatValue(value: Float, maxDigits: Int): String {
-				val factor = 10.0.pow(maxDigits).toFloat()
-				return (round(value * factor) / factor).toString()
+				if (maxDigits < 2 || maxDigits > 6) {
+					return value.toString()
+				}
+				if (value.isNaN()) {
+					return "NaN"
+				}
+				if (value.isInfinite()) {
+					return if (value > 0) "\u221E" else "-\u221E"
+				}
+				val d = value.toDouble()
+				if (abs(d) >= 1e12) {
+					return value.toString()
+				}
+				var factor = 1L
+				repeat(maxDigits) { factor *= 10L }
+				val scaled = abs(d) * factor
+				var rounded = floor(scaled)
+				val rest = scaled - rounded
+				if (rest > 0.5 || (rest == 0.5 && rounded.toLong() % 2L != 0L)) {
+					rounded += 1.0
+				}
+				val units = rounded.toLong()
+				val builder = StringBuilder()
+				// the sign survives a value that rounds to zero, and so does the sign of -0.0
+				if (value.toRawBits() < 0) {
+					builder.append('-')
+				}
+				builder.append(units / factor)
+				var fraction = units % factor
+				if (fraction != 0L) {
+					var digits = maxDigits
+					while (fraction % 10L == 0L) {
+						fraction /= 10L
+						digits--
+					}
+					val text = fraction.toString()
+					builder.append('.')
+					repeat(digits - text.length) { builder.append('0') }
+					builder.append(text)
+				}
+				return builder.toString()
 			}
 		}
 	}
@@ -150,13 +238,16 @@ class StringBundle {
 		return (map[key] as? StringItem)?.asIntArray(defaultValue) ?: defaultValue
 	}
 
-	fun putArray(key: String, array: Array<IntArray>?) {
-		array?.let {
-			map[key] = StringItem(key, it.joinToString(";") { it.joinToString(",") })
+	/** Rows may be null or empty, and are written as an empty item, the way the java bundle did. */
+	fun putArray(key: String, array: Array<IntArray?>?) {
+		array?.let { rows ->
+			map[key] = StringItem(key, rows.joinToString(";") { row ->
+				if (row == null) "" else row.joinToString(",")
+			})
 		}
 	}
 
-	fun getIntIntArray(key: String, defaultValue: Array<IntArray>?): Array<IntArray>? {
+	fun getIntIntArray(key: String, defaultValue: Array<IntArray?>?): Array<IntArray?>? {
 		return (map[key] as? StringItem)?.asIntIntArray(defaultValue) ?: defaultValue
 	}
 
@@ -172,11 +263,11 @@ class StringBundle {
 		}
 	}
 
-//	fun <T> putMap(key: String, map: Map<Int, T>) {
-//		val bundle = StringBundle()
-//		map.forEach { (k, v) -> bundle.putString(k.toString(), v.toString()) }
-//		this.map[key] = StringBundleItem(key, bundle)
-//	}
+	fun <T : Any> putMap(key: String, map: KTIntObjectMap<T>) {
+		val bundle = StringBundle()
+		map.forEach { k, v -> bundle.putString(k.toString(), v.toString()) }
+		this.map[key] = StringBundleItem(key, bundle)
+	}
 
 	fun <K, V> putMap(key: String, map: Map<K, V>) {
 		val bundle = StringBundle()

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/StringExternalizable.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/util/StringExternalizable.kt
@@ -1,0 +1,9 @@
+package net.osmand.shared.util
+
+/** Something that can be written to and read back from a [StringBundle] of type [T]. */
+interface StringExternalizable<T : StringBundle> {
+
+	fun writeToBundle(bundle: T)
+
+	fun readFromBundle(bundle: T)
+}

--- a/OsmAnd-shared/src/jvmTest/kotlin/net/osmand/shared/util/StringBundleFormatJvmTest.kt
+++ b/OsmAnd-shared/src/jvmTest/kotlin/net/osmand/shared/util/StringBundleFormatJvmTest.kt
@@ -1,0 +1,71 @@
+package net.osmand.shared.util
+
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
+import java.util.Locale
+import java.util.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The float formatting of [StringBundle] used to be `java.text.DecimalFormat`, and the route gpx
+ * files already in the wild were written with it. This pins the common implementation to the same
+ * text by running both over the same values.
+ */
+class StringBundleFormatJvmTest {
+
+	private fun reference(maxDigits: Int): DecimalFormat {
+		val pattern = "#." + "#".repeat(maxDigits)
+		return DecimalFormat(pattern, DecimalFormatSymbols.getInstance(Locale.US))
+	}
+
+	private fun formatted(value: Float, maxDigits: Int): String? {
+		val bundle = StringBundle()
+		bundle.putFloat("v", value, maxDigits)
+		return bundle.getString("v", null)
+	}
+
+	@Test
+	fun testMatchesDecimalFormatOnFixedValues() {
+		val values = floatArrayOf(
+			0f, 0.5f, 1f, 3f, 12.5f, 12.345f, 12.344f, -0.5f, -3f, -12.345f,
+			1234.5677f, 0.004f, 0.005f, 0.015f, 100f, 1e7f, 0.1f + 0.2f, 1f / 3f, 99.999f,
+			// a negative that rounds to zero keeps its sign, and so does -0.0
+			-0.0022246838f, -0.0f
+		)
+		for (maxDigits in 2..6) {
+			val reference = reference(maxDigits)
+			for (value in values) {
+				assertEquals(reference.format(value), formatted(value, maxDigits), "$value at $maxDigits digits")
+			}
+		}
+	}
+
+	@Test
+	fun testMatchesDecimalFormatOnRandomValues() {
+		val random = Random(20260908L)
+		for (maxDigits in 2..6) {
+			val reference = reference(maxDigits)
+			repeat(20_000) {
+				// the shapes a route bundle carries: seconds, metres per second, distances
+				val value = when (it % 4) {
+					0 -> random.nextFloat() * 100
+					1 -> random.nextFloat() * 100_000
+					2 -> random.nextFloat()
+					else -> (random.nextFloat() - 0.5f) * 2000
+				}
+				assertEquals(reference.format(value), formatted(value, maxDigits), "$value at $maxDigits digits")
+			}
+		}
+	}
+
+	@Test
+	fun testOutsideTheFormattedRange() {
+		// java had no formatter for these and printed the plain text of the number
+		assertEquals("1.5", formatted(1.5f, 1))
+		assertEquals("1.5", formatted(1.5f, 7))
+		assertEquals("NaN", formatted(Float.NaN, 2))
+		assertEquals("∞", formatted(Float.POSITIVE_INFINITY, 2))
+		assertEquals("-∞", formatted(Float.NEGATIVE_INFINITY, 2))
+	}
+}


### PR DESCRIPTION
Part of the routing-to-OsmAnd-shared series: the java classes stay in `OsmAnd-java` and android, tools and the C++ core keep using them; each step adds a copy to `OsmAnd-shared` and a test that the copy behaves like the original. The copies are for iOS, which will call them instead of its own C++ turn preparation.

`RouteDataBundle`, `RouteDataResources` and `StringExternalizable`, the serialisation a route goes through on its way into a gpx. `StringBundleCompatTest` checks the bundle format against java's.

Supersedes #25908.
