### PR TITLE
Copy RoutingConfiguration to OsmAnd-shared

### DIFF
--- a/OsmAnd-java/src/test/java/net/osmand/router/RoutingConfigurationDefaultTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/router/RoutingConfigurationDefaultTest.java
@@ -1,0 +1,42 @@
+package net.osmand.router;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import net.osmand.shared.routing.GeneralRouter;
+import net.osmand.shared.routing.GeneralRouterProfile;
+import net.osmand.shared.routing.RoutingConfiguration;
+
+import org.junit.Test;
+
+/**
+ * The one thing about {@link RoutingConfiguration} that only this module can check.
+ *
+ * The class lives in OsmAnd-shared now, but the `routing.xml` it parses by default does not: this
+ * module's `collectRoutingResources` task copies it out of the `resources` repository into
+ * `net/osmand/router/`, and the shared class looks it up at that path. Nothing fails to compile if
+ * the two drift apart - routing just stops having a profile.
+ */
+public class RoutingConfigurationDefaultTest {
+
+	@Test
+	public void testDefaultConfigurationIsParsedFromTheBundledRoutingXml() {
+		RoutingConfiguration.Builder builder = RoutingConfiguration.getDefault();
+		assertNotNull(builder);
+		assertEquals("car", builder.getDefaultRouter());
+		assertFalse(builder.getAllRouters().isEmpty());
+
+		GeneralRouter car = builder.getRouter("car");
+		assertNotNull("routing.xml must declare a car profile", car);
+		assertEquals(GeneralRouterProfile.CAR, car.getProfile());
+		assertTrue("the car profile must carry rules", car.getMaxSpeed() > 0);
+	}
+
+	@Test
+	public void testDefaultConfigurationIsParsedOnce() {
+		assertSame(RoutingConfiguration.getDefault(), RoutingConfiguration.getDefault());
+	}
+}

--- a/OsmAnd-java/src/test/java/net/osmand/shared/compat/DirectionPointsCompatTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/shared/compat/DirectionPointsCompatTest.java
@@ -1,0 +1,141 @@
+package net.osmand.shared.compat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import net.osmand.data.QuadRect;
+import net.osmand.data.QuadTree;
+import net.osmand.osm.edit.Node;
+import net.osmand.shared.data.KQuadRect;
+import net.osmand.shared.data.KQuadTree;
+import net.osmand.shared.routing.DirectionPoint;
+import net.osmand.shared.routing.NativeDirectionPoint;
+import net.osmand.shared.routing.RoutingConfiguration;
+import net.osmand.util.MapUtils;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * {@link DirectionPoint} is a copy of {@link net.osmand.router.RoutingConfiguration.DirectionPoint},
+ * with one difference by design: java's is an OSM {@link Node}, the copy carries the place and the
+ * tags itself. This gives both builders the same points and compares what a configuration hands the
+ * router - the points, their tags and angle, the flattened form - and that each build gets its own.
+ */
+public class DirectionPointsCompatTest {
+
+	private static final double[][] PLACES = {{50.0, 10.0}, {50.001, 10.002}, {-33.9, 151.2}, {0, 0}, {89.9, -179.9}};
+
+	private static final String[][] TAGS = {
+			{"osmand_dp", "yes"}, {"Osmand_DP", "yes"}, {"apply_direction_angle", "90"},
+			{"apply_direction_angle", "-45.5"}, {"highway", "residential"}, {"NAME", "Mixed Case"},
+	};
+
+	private static QuadRect world() {
+		return new QuadRect(0, 0, Integer.MAX_VALUE, Integer.MAX_VALUE);
+	}
+
+	private static KQuadRect kworld() {
+		return new KQuadRect(0, 0, Integer.MAX_VALUE, Integer.MAX_VALUE);
+	}
+
+	private static net.osmand.router.RoutingConfiguration javaConfig(QuadTree<Node> tree) {
+		net.osmand.router.RoutingConfiguration.Builder builder = net.osmand.router.RoutingConfiguration.getDefault();
+		builder.setDirectionPoints(tree);
+		return builder.build("car", new net.osmand.router.RoutingConfiguration.RoutingMemoryLimits(30, 256));
+	}
+
+	private static RoutingConfiguration copyConfig(KQuadTree<DirectionPoint> tree) {
+		RoutingConfiguration.Builder builder = RoutingConfiguration.getDefault();
+		builder.setDirectionPoints(tree);
+		return builder.build("car", new RoutingConfiguration.RoutingMemoryLimits(30, 256));
+	}
+
+	private static List<net.osmand.router.RoutingConfiguration.DirectionPoint> javaPoints(net.osmand.router.RoutingConfiguration c) {
+		List<net.osmand.router.RoutingConfiguration.DirectionPoint> points = c.getDirectionPoints().queryInBox(world(), new ArrayList<>());
+		points.sort(Comparator.comparingDouble(Node::getLatitude).thenComparingDouble(Node::getLongitude));
+		return points;
+	}
+
+	private static List<DirectionPoint> copyPoints(RoutingConfiguration c) {
+		List<DirectionPoint> points = c.getDirectionPoints().queryInBox(kworld(), new ArrayList<>());
+		points.sort(Comparator.comparingDouble(DirectionPoint::getLatitude).thenComparingDouble(DirectionPoint::getLongitude));
+		return points;
+	}
+
+	@Test
+	public void testNoPointsFlattenToNothingOnBothSides() {
+		assertEquals(0, net.osmand.router.RoutingConfiguration.getDefault()
+				.build("car", new net.osmand.router.RoutingConfiguration.RoutingMemoryLimits(30, 256)).getNativeDirectionPoints().length);
+		assertEquals(0, RoutingConfiguration.getDefault()
+				.build("car", new RoutingConfiguration.RoutingMemoryLimits(30, 256)).getNativeDirectionPoints().length);
+	}
+
+	@Test
+	public void testPointsComeOutTheSame() {
+		QuadTree<Node> jtree = new QuadTree<>(world(), 15, 0.5f);
+		KQuadTree<DirectionPoint> ktree = new KQuadTree<>(kworld(), 15, 0.5f);
+		for (int i = 0; i < PLACES.length; i++) {
+			Node node = new Node(PLACES[i][0], PLACES[i][1], i + 1);
+			DirectionPoint point = new DirectionPoint(PLACES[i][0], PLACES[i][1]);
+			for (int t = 0; t <= i && t < TAGS.length; t++) {
+				node.putTag(TAGS[t][0], TAGS[t][1]);
+				point.putTag(TAGS[t][0], TAGS[t][1]);
+			}
+			int x = MapUtils.get31TileNumberX(PLACES[i][1]);
+			int y = MapUtils.get31TileNumberY(PLACES[i][0]);
+			jtree.insert(node, new QuadRect(x, y, x, y));
+			ktree.insert(point, new KQuadRect(x, y, x, y));
+		}
+		net.osmand.router.RoutingConfiguration j = javaConfig(jtree);
+		RoutingConfiguration k = copyConfig(ktree);
+
+		List<net.osmand.router.RoutingConfiguration.DirectionPoint> jp = javaPoints(j);
+		List<DirectionPoint> kp = copyPoints(k);
+		assertEquals(PLACES.length, jp.size());
+		assertEquals(jp.size(), kp.size());
+		for (int i = 0; i < jp.size(); i++) {
+			String m = "point " + i;
+			assertEquals(m, jp.get(i).getLatitude(), kp.get(i).getLatitude(), 0d);
+			assertEquals(m, jp.get(i).getLongitude(), kp.get(i).getLongitude(), 0d);
+			assertEquals(m, jp.get(i).getTags(), kp.get(i).getTags());
+			assertEquals(m, jp.get(i).getAngle(), kp.get(i).getAngle(), 0d);
+			assertEquals(m, jp.get(i).distance, kp.get(i).distance, 0d);
+			assertEquals(m, jp.get(i).connectedx, kp.get(i).connectedx);
+			assertEquals(m, jp.get(i).types.size(), kp.get(i).types.size());
+		}
+
+		net.osmand.NativeLibrary.NativeDirectionPoint[] jn = j.getNativeDirectionPoints();
+		NativeDirectionPoint[] kn = k.getNativeDirectionPoints();
+		assertEquals(jn.length, kn.length);
+		for (int i = 0; i < jn.length; i++) {
+			String m = "native point " + i;
+			assertEquals(m, jn[i].x31, kn[i].x31);
+			assertEquals(m, jn[i].y31, kn[i].y31);
+			assertEquals(m, jn[i].tags.length, kn[i].tags.length);
+			for (int t = 0; t < jn[i].tags.length; t++) {
+				assertEquals(m + " tag " + t, jn[i].tags[t][0], kn[i].tags[t][0]);
+				assertEquals(m + " tag " + t, jn[i].tags[t][1], kn[i].tags[t][1]);
+			}
+		}
+
+		// each build hands out fresh points on both sides, so what one route writes the next does not see
+		net.osmand.router.RoutingConfiguration.DirectionPoint jFirst = javaPoints(javaConfig(jtree)).get(0);
+		net.osmand.router.RoutingConfiguration.DirectionPoint jSecond = javaPoints(javaConfig(jtree)).get(0);
+		DirectionPoint kFirst = copyPoints(copyConfig(ktree)).get(0);
+		DirectionPoint kSecond = copyPoints(copyConfig(ktree)).get(0);
+		assertNotSame(jFirst, jSecond);
+		assertNotSame(kFirst, kSecond);
+		jFirst.distance = 1;
+		kFirst.distance = 1;
+		jFirst.types.add(3);
+		kFirst.types.add(3);
+		assertEquals(Double.MAX_VALUE, jSecond.distance, 0d);
+		assertEquals(Double.MAX_VALUE, kSecond.distance, 0d);
+		assertEquals(0, jSecond.types.size());
+		assertEquals(0, kSecond.types.size());
+	}
+}

--- a/OsmAnd-java/src/test/java/net/osmand/shared/compat/GeneralRouterCompatTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/shared/compat/GeneralRouterCompatTest.java
@@ -1,0 +1,66 @@
+package net.osmand.shared.compat;
+
+import static org.junit.Assert.assertEquals;
+
+import net.osmand.shared.routing.GeneralRouter;
+import net.osmand.shared.routing.RouteDataObject;
+import net.osmand.shared.routing.RoutingConfiguration;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@link GeneralRouter} is a copy of {@link net.osmand.router.GeneralRouter}; this is the cost model
+ * of every profile in {@code routing.xml}, asked about every real road in the test obf files, with
+ * the profile's parameters at their defaults, every switch on, and every choice at its first value.
+ *
+ * Speeds, obstacles, priorities and one-way answers are what the search ranks roads by, so a rule
+ * evaluated differently here is a different route.
+ */
+public class GeneralRouterCompatTest {
+
+	@Test
+	public void testEveryProfileRanksEveryRoadTheSame() throws IOException {
+		List<net.osmand.binary.RouteDataObject> roads = TestObf.roads(700);
+		assertEquals(true, roads.size() > 2000);
+		JavaToShared convert = new JavaToShared();
+		net.osmand.router.RoutingConfiguration.Builder jb = RoutingConfigurationCompatTest.javaDefault();
+		RoutingConfiguration.Builder kb = RoutingConfigurationCompatTest.copyDefault();
+		for (String name : jb.getAllRouters().keySet()) {
+			for (Map<String, String> params : RoutingConfigurationCompatTest.variants(jb.getRouter(name))) {
+				net.osmand.router.GeneralRouter j = jb.build(name,
+						new net.osmand.router.RoutingConfiguration.RoutingMemoryLimits(30, 256), params).router;
+				GeneralRouter k = kb.build(name, new RoutingConfiguration.RoutingMemoryLimits(30, 256),
+						new java.util.LinkedHashMap<>(params)).router;
+				for (net.osmand.binary.RouteDataObject jr : roads) {
+					RouteDataObject kr = convert.road(jr);
+					String m = name + " " + params + " road " + jr.id;
+					assertEquals(m, j.acceptLine(jr), k.acceptLine(kr));
+					assertEquals(m, j.isOneWay(jr), k.isOneWay(kr));
+					assertEquals(m, j.isArea(jr), k.isArea(kr));
+					assertEquals(m, j.getPenaltyTransition(jr), k.getPenaltyTransition(kr), 0f);
+					assertEquals(m, j.defineDestinationPriority(jr), k.defineDestinationPriority(kr), 0f);
+					for (boolean dir : new boolean[] {false, true}) {
+						assertEquals(m + " dir " + dir, j.defineRoutingSpeed(jr, dir), k.defineRoutingSpeed(kr, dir), 0f);
+						assertEquals(m + " dir " + dir, j.defineVehicleSpeed(jr, dir), k.defineVehicleSpeed(kr, dir), 0f);
+						assertEquals(m + " dir " + dir, j.defineSpeedPriority(jr, dir), k.defineSpeedPriority(kr, dir), 0f);
+					}
+					int n = jr.getPointsLength();
+					for (int i = 0; i < n; i++) {
+						for (boolean back : new boolean[] {false, true}) {
+							assertEquals(m + " point " + i, j.defineObstacle(jr, i, back), k.defineObstacle(kr, i, back), 0f);
+							assertEquals(m + " point " + i, j.defineRoutingObstacle(jr, i, back), k.defineRoutingObstacle(kr, i, back), 0f);
+						}
+					}
+					if (n > 1) {
+						assertEquals(m, j.defineHeightObstacle(jr, (short) 0, (short) (n - 1)), k.defineHeightObstacle(kr, (short) 0, (short) (n - 1)), 0d);
+						assertEquals(m, j.defineHeightObstacle(jr, (short) (n - 1), (short) 0), k.defineHeightObstacle(kr, (short) (n - 1), (short) 0), 0d);
+					}
+				}
+			}
+		}
+	}
+}

--- a/OsmAnd-java/src/test/java/net/osmand/shared/compat/RoutingConfigurationCompatTest.java
+++ b/OsmAnd-java/src/test/java/net/osmand/shared/compat/RoutingConfigurationCompatTest.java
@@ -1,0 +1,145 @@
+package net.osmand.shared.compat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import net.osmand.shared.routing.GeneralRouter;
+import net.osmand.shared.routing.RoutingConfiguration;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@link RoutingConfiguration} is a copy of {@link net.osmand.router.RoutingConfiguration}, parser
+ * included; this lets both read the bundled {@code routing.xml} and compares every profile, every
+ * parameter and every configuration they build from it.
+ */
+public class RoutingConfigurationCompatTest {
+
+	static net.osmand.router.RoutingConfiguration.Builder javaDefault() {
+		return net.osmand.router.RoutingConfiguration.getDefault();
+	}
+
+	static RoutingConfiguration.Builder copyDefault() {
+		return RoutingConfiguration.getDefault();
+	}
+
+	/** Parameter sets a configuration is built with: none, every switch on, every choice at its first value. */
+	static List<Map<String, String>> variants(net.osmand.router.GeneralRouter router) {
+		Map<String, String> switches = new LinkedHashMap<>();
+		Map<String, String> choices = new LinkedHashMap<>();
+		for (net.osmand.router.GeneralRouter.RoutingParameter p : router.getParameters().values()) {
+			if (p.getType() == net.osmand.router.GeneralRouter.RoutingParameterType.BOOLEAN) {
+				switches.put(p.getId(), "true");
+			} else if (p.getPossibleValues() != null && p.getPossibleValues().length > 0) {
+				choices.put(p.getId(), String.valueOf(p.getPossibleValues()[0]));
+			}
+		}
+		List<Map<String, String>> variants = new ArrayList<>();
+		variants.add(new LinkedHashMap<>());
+		variants.add(switches);
+		variants.add(choices);
+		return variants;
+	}
+
+	@Test
+	public void testProfilesAndParametersAgree() {
+		net.osmand.router.RoutingConfiguration.Builder jb = javaDefault();
+		RoutingConfiguration.Builder kb = copyDefault();
+		assertEquals(jb.getDefaultRouter(), kb.getDefaultRouter());
+		assertEquals(jb.getAllRouters().keySet(), kb.getAllRouters().keySet());
+		assertEquals(jb.getAttributes(), kb.getAttributes());
+		for (String name : jb.getAllRouters().keySet()) {
+			net.osmand.router.GeneralRouter jr = jb.getRouter(name);
+			GeneralRouter kr = kb.getRouter(name);
+			assertNotNull(name, kr);
+			assertRouter(name, jr, kr);
+			assertEquals(name, jb.getRoutingProfileKeyByFileName(name), kb.getRoutingProfileKeyByFileName(name));
+		}
+	}
+
+	@Test
+	public void testBuiltConfigurationsAgree() {
+		net.osmand.router.RoutingConfiguration.Builder jb = javaDefault();
+		RoutingConfiguration.Builder kb = copyDefault();
+		jb.addImpassableRoad(42);
+		kb.addImpassableRoad(42);
+		for (String name : jb.getAllRouters().keySet()) {
+			for (Map<String, String> params : variants(jb.getRouter(name))) {
+				String m = name + " " + params;
+				net.osmand.router.RoutingConfiguration j = jb.build(name,
+						new net.osmand.router.RoutingConfiguration.RoutingMemoryLimits(30, 256), params);
+				RoutingConfiguration k = kb.build(name, new RoutingConfiguration.RoutingMemoryLimits(30, 256),
+						new LinkedHashMap<>(params));
+				assertEquals(m, j.routerName, k.routerName);
+				assertEquals(m, j.attributes, k.attributes);
+				assertEquals(m, j.heuristicCoefficient, k.heuristicCoefficient, 0f);
+				assertEquals(m, j.ZOOM_TO_LOAD_TILES, k.ZOOM_TO_LOAD_TILES);
+				assertEquals(m, j.memoryLimitation, k.memoryLimitation);
+				assertEquals(m, j.memoryMaxHits, k.memoryMaxHits);
+				assertEquals(m, j.nativeMemoryLimitation, k.nativeMemoryLimitation);
+				assertEquals(m, j.planRoadDirection, k.planRoadDirection);
+				assertEquals(m, j.initialDirection, k.initialDirection);
+				assertEquals(m, j.targetDirection, k.targetDirection);
+				assertEquals(m, j.penaltyForReverseDirection, k.penaltyForReverseDirection, 0d);
+				assertEquals(m, j.recalculateDistance, k.recalculateDistance, 0f);
+				assertEquals(m, j.routeCalculationTime, k.routeCalculationTime);
+				assertEquals(m, j.ambiguousConditionalTags, k.ambiguousConditionalTags);
+				assertEquals(m, j.MAX_VISITED, k.MAX_VISITED);
+				assertEquals(m, j.altHorizon, k.altHorizon, 0d);
+				assertEquals(m, j.directionPointsRadius, k.directionPointsRadius);
+				assertEquals(m, j.minPointApproximation, k.minPointApproximation, 0f);
+				assertEquals(m, j.minStepApproximation, k.minStepApproximation, 0f);
+				assertEquals(m, j.maxStepApproximation, k.maxStepApproximation, 0f);
+				assertEquals(m, j.smoothenPointsNoRoute, k.smoothenPointsNoRoute, 0f);
+				assertEquals(m, j.showMinorTurns, k.showMinorTurns);
+				assertRouter(m, j.router, k.router);
+				assertEquals(m, j.router.getParameterValues(), k.router.getParameterValues());
+				assertEquals(m, Arrays.toString(j.router.getImpassableRoadIds()), Arrays.toString(k.router.getImpassableRoadIds()));
+				assertEquals(m, j.router.serializeParameterValues(params), k.router.serializeParameterValues(params));
+			}
+		}
+	}
+
+	static void assertRouter(String m, net.osmand.router.GeneralRouter j, GeneralRouter k) {
+		assertEquals(m, j.getProfileName(), k.getProfileName());
+		assertEquals(m, j.getProfile().name(), k.getProfile().name());
+		assertEquals(m, j.getFilename(), k.getFilename());
+		assertEquals(m, j.getHeightObstacles(), k.getHeightObstacles());
+		assertEquals(m, j.restrictionsAware(), k.restrictionsAware());
+		assertEquals(m, j.isAllowPrivate(), k.isAllowPrivate());
+		assertEquals(m, j.getMinSpeed(), k.getMinSpeed(), 0f);
+		assertEquals(m, j.getMaxSpeed(), k.getMaxSpeed(), 0f);
+		assertEquals(m, j.getDefaultSpeed(), k.getDefaultSpeed(), 0f);
+		for (Map.Entry<String, String> attribute : j.attributes.entrySet()) {
+			assertEquals(m + " " + attribute.getKey(), true, k.containsAttribute(attribute.getKey()));
+			assertEquals(m + " " + attribute.getKey(), attribute.getValue(), k.getAttribute(attribute.getKey()));
+			String key = attribute.getKey();
+			Same.outcome(m + " " + key, () -> j.getFloatAttribute(key, -1), () -> k.getFloatAttribute(key, -1));
+			Same.outcome(m + " " + key, () -> j.getIntAttribute(key, -1), () -> k.getIntAttribute(key, -1));
+		}
+		assertEquals(m, false, k.containsAttribute("no such attribute"));
+		assertEquals(m, j.getParameters().keySet(), k.getParameters().keySet());
+		for (Map.Entry<String, net.osmand.router.GeneralRouter.RoutingParameter> e : j.getParameters().entrySet()) {
+			net.osmand.router.GeneralRouter.RoutingParameter jp = e.getValue();
+			GeneralRouter.RoutingParameter kp = k.getParameters().get(e.getKey());
+			String p = m + " parameter " + e.getKey();
+			assertEquals(p, jp.getId(), kp.getId());
+			assertEquals(p, jp.getGroup(), kp.getGroup());
+			assertEquals(p, jp.getName(), kp.getName());
+			assertEquals(p, jp.getDescription(), kp.getDescription());
+			assertEquals(p, jp.getType().name(), kp.getType().name());
+			assertEquals(p, Arrays.toString(jp.getPossibleValues()), Arrays.toString(kp.getPossibleValues()));
+			assertEquals(p, Arrays.toString(jp.getPossibleValueDescriptions()), Arrays.toString(kp.getPossibleValueDescriptions()));
+			assertEquals(p, Arrays.toString(jp.getProfiles()), Arrays.toString(kp.getProfiles()));
+			assertEquals(p, jp.getDefaultBoolean(), kp.getDefaultBoolean());
+			assertEquals(p, jp.getDefaultNumeric(), kp.getDefaultNumeric(), 0d);
+			assertEquals(p, jp.getDefaultString(), kp.getDefaultString());
+		}
+	}
+}

--- a/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/routing/BundledRoutingXml.kt
+++ b/OsmAnd-shared/src/androidMain/kotlin/net/osmand/shared/routing/BundledRoutingXml.kt
@@ -1,0 +1,7 @@
+package net.osmand.shared.routing
+
+import okio.Source
+import okio.source
+
+internal actual fun openBundledRoutingXml(): Source? =
+	RoutingConfiguration::class.java.getResourceAsStream("/net/osmand/router/routing.xml")?.source()

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/BundledRoutingXml.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/BundledRoutingXml.kt
@@ -1,0 +1,15 @@
+package net.osmand.shared.routing
+
+import okio.Source
+
+/**
+ * The `routing.xml` that ships with the application, or null where there is none.
+ *
+ * The file itself has not moved with this class: OsmAnd-java's `collectRoutingResources` task copies
+ * it out of the `resources` repository into `net/osmand/router/`, and that is still the path the jvm
+ * and android builds package it at, so the lookup is the one [RoutingConfiguration] always did.
+ *
+ * iOS has no classpath and does not route through this class - its C++ core reads its own copy of
+ * the file - so there is nothing to open there.
+ */
+internal expect fun openBundledRoutingXml(): Source?

--- a/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RoutingConfiguration.kt
+++ b/OsmAnd-shared/src/commonMain/kotlin/net/osmand/shared/routing/RoutingConfiguration.kt
@@ -1,0 +1,558 @@
+package net.osmand.shared.routing
+
+import net.osmand.shared.data.KQuadRect
+import net.osmand.shared.data.KQuadTree
+import net.osmand.shared.io.KFile
+import net.osmand.shared.routing.GeneralRouter.RouteAttributeContext
+import net.osmand.shared.routing.GeneralRouter.RouteDataObjectAttribute
+import net.osmand.shared.util.KAlgorithms
+import net.osmand.shared.util.KMapUtils
+import net.osmand.shared.xml.XmlPullParser
+import okio.Source
+import kotlin.jvm.JvmField
+import kotlin.jvm.JvmOverloads
+import kotlin.jvm.JvmStatic
+
+/**
+ * Everything one route calculation is configured with: which profile to route on, how much memory
+ * the tile cache may take, and the tweaks that come out of `routing.xml`.
+ *
+ * A configuration is built, not edited: [Builder] holds what the XML declared and hands out a fresh
+ * configuration per calculation.
+ *
+ * A copy of `net.osmand.router.RoutingConfiguration`, which stays in OsmAnd-java: android, tools and the C++ core keep using
+ * the original, and this copy is for iOS. Keep the two identical; `RoutingConfigurationCompatTest` checks that they behave
+ * the same.
+ */
+class RoutingConfiguration {
+
+	@JvmField
+	var attributes: MutableMap<String, String> = LinkedHashMap()
+
+	// 1. parameters of routing and different tweaks
+	// Influence on A* : f(x) + heuristicCoefficient*g(X)
+	@JvmField
+	var heuristicCoefficient: Float = 1f
+
+	// 1.1 tile load parameters (should not affect routing)
+	@JvmField
+	var ZOOM_TO_LOAD_TILES: Int = 16
+
+	@JvmField
+	var memoryLimitation: Long = 0
+
+	@JvmField
+	var memoryMaxHits: Long = -1
+
+	@JvmField
+	var nativeMemoryLimitation: Long = 0
+
+	// 1.2 Build A* graph in backward/forward direction (can affect results)
+	// 0 - 2 ways, 1 - direct way, -1 - reverse way
+	@JvmField
+	var planRoadDirection: Int = 0
+
+	// 1.3 Router specific coefficients and restrictions
+	// use GeneralRouter and not interface to simplify native access !
+	@JvmField
+	var router: GeneralRouter = GeneralRouter(GeneralRouterProfile.CAR, LinkedHashMap())
+
+	@JvmField
+	var routerName: String = ""
+
+	// 1.4 Used to calculate route in movement
+	@JvmField
+	var initialDirection: Double? = null
+
+	@JvmField
+	var targetDirection: Double? = null
+
+	// -1 means reverse is forbidden
+	@JvmField
+	var penaltyForReverseDirection: Double = DEFAULT_PENALTY_FOR_REVERSE_DIRECTION
+
+	// 1.5 Recalculate distance help
+	@JvmField
+	var recalculateDistance: Float = 20000f
+
+	// 1.6 Time to calculate all access restrictions based on conditions
+	@JvmField
+	var routeCalculationTime: Long = 0
+
+	// 1.6.1. Apply "unlimited" :conditional tags (used by HHRoutingShortcutCreator)
+	@JvmField
+	var ambiguousConditionalTags: MutableMap<String, String>? = null
+
+	// 1.7 Maximum visited segments
+	@JvmField
+	var MAX_VISITED: Int = -1
+
+	/**
+	 * Set only while alternative routes are being searched (see HHAlternativeRoutes): the bidirectional
+	 * search then does not stop at the first meeting point but keeps settling until both queues leave
+	 * the (1 + this) * optimum band, so that the two trees overlap enough to compare routes through them.
+	 */
+	@JvmField
+	var altHorizon: Double = 0.0
+
+	// extra points to be inserted in ways (quad tree is based on 31 coords)
+	private var directionPoints: KQuadTree<DirectionPoint>? = null
+
+	@JvmField
+	var directionPointsRadius: Int = 30 // 30 m
+
+	// ! MAIN parameter to approximate (35m good for custom recorded tracks)
+	@JvmField
+	var minPointApproximation: Float = 50f
+
+	// don't search subsegments shorter than specified distance (also used to step back for car turns)
+	@JvmField
+	var minStepApproximation: Float = 100f
+
+	// This parameter could speed up or slow down evaluation (better to make bigger for long routes and smaller for short)
+	@JvmField
+	var maxStepApproximation: Float = 3000f
+
+	// Parameter to smoother the track itself (could be 0 if it's not recorded track)
+	@JvmField
+	var smoothenPointsNoRoute: Float = 5f
+
+	@JvmField
+	var showMinorTurns: Boolean = false
+
+	fun getDirectionPoints(): KQuadTree<DirectionPoint>? = directionPoints
+
+	fun getNativeDirectionPoints(): Array<NativeDirectionPoint> {
+		val points = directionPoints ?: return emptyArray()
+		val rect = KQuadRect(0.0, 0.0, Int.MAX_VALUE.toDouble(), Int.MAX_VALUE.toDouble())
+		val list = points.queryInBox(rect, ArrayList())
+		return Array(list.size) {
+			val point = list[it]
+			NativeDirectionPoint(point.getLatitude(), point.getLongitude(), point.getTags())
+		}
+	}
+
+	class RoutingMemoryLimits(
+		@JvmField var memoryLimitMb: Int,
+		@JvmField var nativeMemoryLimitMb: Int
+	)
+
+	class Builder {
+		// Design time storage
+		private var defaultRouter: String? = ""
+		private val routers: MutableMap<String, GeneralRouter> = LinkedHashMap()
+		private val attributes: MutableMap<String, String> = LinkedHashMap()
+		private val impassableRoadLocations: MutableSet<Long> = HashSet()
+		private var directionPointsBuilder: KQuadTree<DirectionPoint>? = null
+
+		constructor()
+
+		constructor(defaultAttributes: Map<String, String>) {
+			attributes.putAll(defaultAttributes)
+		}
+
+		@JvmOverloads
+		fun build(
+			router: String,
+			memoryLimits: RoutingMemoryLimits,
+			params: MutableMap<String, String> = LinkedHashMap()
+		): RoutingConfiguration = build(router, null, memoryLimits, params)
+
+		fun build(
+			router: String,
+			direction: Double?,
+			memoryLimits: RoutingMemoryLimits,
+			params: MutableMap<String, String>
+		): RoutingConfiguration {
+			var selectedRouter: String? = router
+			var derivedProfile: String? = null
+			if (!routers.containsKey(router)) {
+				for (r in routers.entries) {
+					val derivedProfiles = r.value.getAttribute("derivedProfiles")
+					if (derivedProfiles != null && derivedProfiles.contains(router)) {
+						derivedProfile = router
+						selectedRouter = r.key
+						break
+					}
+				}
+				if (derivedProfile == null) {
+					selectedRouter = defaultRouter
+				}
+			}
+			if (derivedProfile != null) {
+				params["profile_$derivedProfile"] = true.toString()
+			}
+			val i = RoutingConfiguration()
+			val profileRouter = if (selectedRouter != null) routers[selectedRouter] else null
+			if (profileRouter != null) {
+				i.router = profileRouter.build(params)
+				i.routerName = selectedRouter!!
+			}
+			// a missing defaultProfile leaves nothing to name; java put a null here
+			attributes["routerName"] = selectedRouter ?: ""
+			i.attributes.putAll(attributes)
+			i.initialDirection = direction
+			i.recalculateDistance = parseSilentFloat(getAttribute(i.router, "recalculateDistanceHelp"), i.recalculateDistance)
+			i.heuristicCoefficient = parseSilentFloat(getAttribute(i.router, "heuristicCoefficient"), i.heuristicCoefficient)
+			i.minPointApproximation = parseSilentFloat(getAttribute(i.router, "minPointApproximation"), i.minPointApproximation)
+			i.minStepApproximation = parseSilentFloat(getAttribute(i.router, "minStepApproximation"), i.minStepApproximation)
+			i.maxStepApproximation = parseSilentFloat(getAttribute(i.router, "maxStepApproximation"), i.maxStepApproximation)
+			i.smoothenPointsNoRoute = parseSilentFloat(getAttribute(i.router, "smoothenPointsNoRoute"), i.smoothenPointsNoRoute)
+			i.penaltyForReverseDirection = parseSilentFloat(
+				getAttribute(i.router, "penaltyForReverseDirection"), i.penaltyForReverseDirection.toFloat()
+			).toDouble()
+
+			i.router.setImpassableRoads(HashSet(impassableRoadLocations))
+			i.ZOOM_TO_LOAD_TILES = parseSilentInt(getAttribute(i.router, "zoomToLoadTiles"), i.ZOOM_TO_LOAD_TILES)
+			var memoryLimitMB = memoryLimits.memoryLimitMb
+			val desirable = parseSilentInt(getAttribute(i.router, "memoryLimitInMB"), 0)
+			if (desirable != 0) {
+				i.memoryLimitation = desirable * (1L shl 20)
+			} else {
+				if (memoryLimitMB == 0) {
+					memoryLimitMB = DEFAULT_MEMORY_LIMIT
+				}
+				i.memoryLimitation = memoryLimitMB * (1L shl 20)
+			}
+			val desirableNativeLimit = parseSilentInt(getAttribute(i.router, "nativeMemoryLimitInMB"), 0)
+			if (desirableNativeLimit != 0) {
+				i.nativeMemoryLimitation = desirableNativeLimit * (1L shl 20)
+			} else {
+				i.nativeMemoryLimitation = memoryLimits.nativeMemoryLimitMb * (1L shl 20)
+			}
+			i.planRoadDirection = parseSilentInt(getAttribute(i.router, "planRoadDirection"), i.planRoadDirection)
+			val builderPoints = directionPointsBuilder
+			if (builderPoints != null) {
+				val rect = KQuadRect(0.0, 0.0, Int.MAX_VALUE.toDouble(), Int.MAX_VALUE.toDouble())
+				val lst = builderPoints.queryInBox(rect, ArrayList())
+				val points = KQuadTree<DirectionPoint>(rect, 14, 0.5f)
+				for (p in lst) {
+					// a copy per calculation: the router writes onto the point as it attaches it
+					val dp = DirectionPoint(p)
+					val x = KMapUtils.get31TileNumberX(dp.getLongitude())
+					val y = KMapUtils.get31TileNumberY(dp.getLatitude())
+					points.insert(dp, KQuadRect(x.toDouble(), y.toDouble(), x.toDouble(), y.toDouble()))
+				}
+				i.directionPoints = points
+			}
+			return i
+		}
+
+		fun setDirectionPoints(directionPoints: KQuadTree<DirectionPoint>?): Builder {
+			this.directionPointsBuilder = directionPoints
+			return this
+		}
+
+		fun clearImpassableRoadLocations() {
+			impassableRoadLocations.clear()
+		}
+
+		fun getImpassableRoadLocations(): MutableSet<Long> = impassableRoadLocations
+
+		fun addImpassableRoad(routeId: Long): Builder {
+			impassableRoadLocations.add(routeId)
+			return this
+		}
+
+		fun getAttributes(): MutableMap<String, String> = attributes
+
+		private fun getAttribute(router: VehicleRouter, propertyName: String): String? {
+			if (router.containsAttribute(propertyName)) {
+				return router.getAttribute(propertyName)
+			}
+			return attributes[propertyName]
+		}
+
+		fun getDefaultRouter(): String? = defaultRouter
+
+		fun getRouter(routingProfileName: String): GeneralRouter? = routers[routingProfileName]
+
+		fun getRoutingProfileKeyByFileName(fileName: String?): String? {
+			if (fileName != null) {
+				for (router in routers.entries) {
+					if (fileName == router.value.getFilename()) {
+						return router.key
+					}
+				}
+			}
+			return null
+		}
+
+		fun getAllRouters(): MutableMap<String, GeneralRouter> = routers
+
+		fun removeImpassableRoad(routeId: Long) {
+			impassableRoadLocations.remove(routeId)
+		}
+
+		internal fun setDefaultRouter(name: String?) {
+			defaultRouter = name
+		}
+
+		internal fun putAttribute(name: String, value: String) {
+			attributes[name] = value
+		}
+
+		internal fun putRouter(name: String, router: GeneralRouter) {
+			routers[name] = router
+		}
+	}
+
+	private class RoutingRule {
+		var tagName: String? = null
+		var t: String? = null
+		var v: String? = null
+		var param: String? = null
+		var value1: String? = null
+		var value2: String? = null
+		var type: String? = null
+	}
+
+	companion object {
+
+		const val DEFAULT_MEMORY_LIMIT = 30
+		const val DEFAULT_NATIVE_MEMORY_LIMIT = 256
+		const val DEVIATION_RADIUS = 3000f
+
+		// if no penaltyForReverseDirection in xml
+		const val DEFAULT_PENALTY_FOR_REVERSE_DIRECTION = 60.0
+
+		@JvmStatic
+		fun parseSilentInt(t: String?, v: Int): Int {
+			if (t == null || t.length == 0) {
+				return v
+			}
+			return t.toInt()
+		}
+
+		@JvmStatic
+		fun parseSilentFloat(t: String?, v: Float): Float {
+			if (t == null || t.length == 0) {
+				return v
+			}
+			return t.toFloat()
+		}
+
+		private var DEFAULT: Builder? = null
+
+		@JvmStatic
+		fun getDefault(): Builder {
+			var d = DEFAULT
+			if (d == null) {
+				d = parseDefault()
+				DEFAULT = d
+			}
+			return d
+		}
+
+		@JvmStatic
+		fun parseDefault(): Builder {
+			try {
+				val source = openBundledRoutingXml()
+					?: throw IllegalStateException("no routing.xml is bundled on this platform")
+				return parseFromSource(source, null, Builder())
+			} catch (e: Exception) {
+				throw IllegalStateException(e)
+			}
+		}
+
+		@JvmStatic
+		@JvmOverloads
+		fun parseFromFile(file: KFile, filename: String? = null, config: Builder = Builder()): Builder =
+			parseFromSource(file.source(), filename, config)
+
+		/**
+		 * Takes a path rather than a [KFile] so that java callers do not have to name one: okio is
+		 * an implementation dependency of this module and its `Path` is not on their classpath.
+		 */
+		@JvmStatic
+		@JvmOverloads
+		fun parseFromFile(filePath: String, filename: String? = null, config: Builder = Builder()): Builder =
+			parseFromFile(KFile(filePath), filename, config)
+
+		@JvmStatic
+		@JvmOverloads
+		fun parseFromSource(source: Source, filename: String? = null, config: Builder = Builder()): Builder {
+			val parser = XmlPullParser()
+			var currentRouter: GeneralRouter? = null
+			var currentAttribute: RouteDataObjectAttribute? = null
+			var preType: String? = null
+			val rulesStck = ArrayList<RoutingRule>()
+			try {
+				parser.setInput(source, "UTF-8")
+				while (true) {
+					val tok = parser.next()
+					if (tok == XmlPullParser.END_DOCUMENT) {
+						break
+					}
+					if (tok == XmlPullParser.START_TAG) {
+						val name = parser.getName()
+						if ("osmand_routing_config" == name) {
+							config.setDefaultRouter(parser.getAttributeValue("", "defaultProfile"))
+						} else if ("routingProfile" == name) {
+							currentRouter = parseRoutingProfile(parser, config, filename)
+						} else if ("attribute" == name) {
+							parseAttribute(parser, config, currentRouter)
+						} else if ("parameter" == name) {
+							parseRoutingParameter(parser, currentRouter!!)
+						} else if ("point" == name || "way" == name) {
+							val attribute = parser.getAttributeValue("", "attribute")
+							currentAttribute =
+								if (attribute != null) RouteDataObjectAttribute.getValueOf(attribute) else null
+							preType = parser.getAttributeValue("", "type")
+						} else {
+							parseRoutingRule(parser, currentRouter!!, currentAttribute, preType, rulesStck)
+						}
+					} else if (tok == XmlPullParser.END_TAG) {
+						val pname = parser.getName()
+						if (checkTag(pname)) {
+							rulesStck.removeAt(rulesStck.size - 1)
+						}
+					}
+				}
+			} finally {
+				// java closed the stream only on the way out; a failed parse used to leak it
+				source.close()
+			}
+			return config
+		}
+
+		private fun parseRoutingParameter(parser: XmlPullParser, currentRouter: GeneralRouter) {
+			val description = parser.getAttributeValue("", "description")
+			val group = parser.getAttributeValue("", "group")
+			val name = parser.getAttributeValue("", "name")
+			val id = parser.getAttributeValue("", "id")
+			val type = parser.getAttributeValue("", "type")
+			val profilesList = parser.getAttributeValue("", "profiles")
+			val profiles = if (KAlgorithms.isEmpty(profilesList)) null else profilesList!!.split(",").toTypedArray()
+			if ("boolean".equals(type, ignoreCase = true)) {
+				val defaultBoolean = parser.getAttributeValue("", "default").toBoolean()
+				currentRouter.registerBooleanParameter(
+					id!!, if (KAlgorithms.isEmpty(group)) null else group,
+					name, description, profiles, defaultBoolean
+				)
+			} else if ("numeric".equals(type, ignoreCase = true)) {
+				val defaultNumeric = KAlgorithms.parseDoubleSilently(parser.getAttributeValue("", "default"), 0.0)
+				val values = parser.getAttributeValue("", "values")
+				val valueDescriptions = parser.getAttributeValue("", "valueDescriptions")
+				val vlsDesc = valueDescriptions!!.split(",").toTypedArray()
+				val strValues = values!!.split(",").toTypedArray()
+				val vls = Array<Any>(strValues.size) { strValues[it].trim().toDouble() }
+				currentRouter.registerNumericParameter(id!!, name, description, profiles, vls, vlsDesc, defaultNumeric)
+			} else {
+				throw UnsupportedOperationException("Unsupported routing parameter type - $type")
+			}
+		}
+
+		private fun parseRoutingRule(
+			parser: XmlPullParser, currentRouter: GeneralRouter, attr: RouteDataObjectAttribute?,
+			parentType: String?, stack: MutableList<RoutingRule>
+		) {
+			val pname = parser.getName()
+			if (checkTag(pname)) {
+				if (attr == null) {
+					throw NullPointerException("Select tag filter outside road attribute < $pname > : " + parser.getLineNumber())
+				}
+				val rr = RoutingRule()
+				rr.tagName = pname
+				rr.t = parser.getAttributeValue("", "t")
+				rr.v = parser.getAttributeValue("", "v")
+				rr.param = parser.getAttributeValue("", "param")
+				rr.value1 = parser.getAttributeValue("", "value1")
+				rr.value2 = parser.getAttributeValue("", "value2")
+				rr.type = parser.getAttributeValue("", "type")
+				if ((rr.type == null || rr.type!!.length == 0) && parentType != null && parentType.length > 0) {
+					rr.type = parentType
+				}
+
+				val ctx = currentRouter.getObjContext(attr)
+				if ("select" == rr.tagName) {
+					// the grammar requires these, and a rule built without one is broken anyway
+					val v = parser.getAttributeValue("", "value")
+					val type = rr.type
+					ctx.registerNewRule(v!!, type)
+					addSubclause(rr, ctx)
+					for (i in stack.indices) {
+						addSubclause(stack[i], ctx)
+					}
+				} else if ("min" == rr.tagName || "max" == rr.tagName) {
+					val initVal = parser.getAttributeValue("", "value1")
+					val type = rr.type
+					ctx.registerNewRule(initVal!!, type)
+					addSubclause(rr, ctx)
+				} else if (stack.size > 0 && "select" == stack[stack.size - 1].tagName) {
+					addSubclause(rr, ctx)
+				}
+				stack.add(rr)
+			}
+		}
+
+		private fun checkTag(pname: String?): Boolean {
+			return "select" == pname || "if" == pname || "ifnot" == pname
+					|| "gt" == pname || "ge" == pname || "lt" == pname || "le" == pname
+					|| "eq" == pname || "min" == pname || "max" == pname
+		}
+
+		private fun addSubclause(rr: RoutingRule, ctx: RouteAttributeContext) {
+			val not = "ifnot" == rr.tagName
+			if (!KAlgorithms.isEmpty(rr.param)) {
+				if (rr.param!!.contains(",")) {
+					val params = rr.param!!.split(",")
+					for (p in params) {
+						val trimmed = p.trim()
+						if (!KAlgorithms.isEmpty(trimmed)) {
+							ctx.getLastRule().registerAndParamCondition(trimmed, not)
+						}
+					}
+				} else {
+					ctx.getLastRule().registerAndParamCondition(rr.param!!, not)
+				}
+			}
+			if (!KAlgorithms.isEmpty(rr.t)) {
+				ctx.getLastRule().registerAndTagValueCondition(rr.t!!, if (KAlgorithms.isEmpty(rr.v)) null else rr.v, not)
+			}
+			when (rr.tagName) {
+				"gt" -> ctx.getLastRule().registerGreatCondition(rr.value1!!, rr.value2!!, rr.type)
+				"ge" -> ctx.getLastRule().registerGreatOrEqualCondition(rr.value1!!, rr.value2!!, rr.type)
+				"lt" -> ctx.getLastRule().registerLessCondition(rr.value1!!, rr.value2!!, rr.type)
+				"le" -> ctx.getLastRule().registerLessOrEqualCondition(rr.value1!!, rr.value2!!, rr.type)
+				"eq" -> ctx.getLastRule().registerEqualCondition(rr.value1!!, rr.value2!!, rr.type)
+				"min" -> ctx.getLastRule().registerMinExpression(rr.value1!!, rr.value2!!, rr.type)
+				"max" -> ctx.getLastRule().registerMaxExpression(rr.value1!!, rr.value2!!, rr.type)
+			}
+		}
+
+		private fun parseRoutingProfile(parser: XmlPullParser, config: Builder, filename: String?): GeneralRouter {
+			var currentSelectedRouterName = parser.getAttributeValue("", "name")
+			val attrs = LinkedHashMap<String, String>()
+			for (i in 0 until parser.getAttributeCount()) {
+				attrs[parser.getAttributeName(i)!!] = parser.getAttributeValue(i)!!
+			}
+			val baseProfile = parser.getAttributeValue("", "baseProfile")
+			val c = GeneralRouterProfile.entries.firstOrNull { it.name.equals(baseProfile, ignoreCase = true) }
+				?: GeneralRouterProfile.CAR
+			val currentRouter = GeneralRouter(c, attrs)
+			currentRouter.setProfileName(currentSelectedRouterName!!)
+			if (filename != null) {
+				currentRouter.setFilename(filename)
+				currentSelectedRouterName = "$filename/$currentSelectedRouterName"
+			}
+
+			config.putRouter(currentSelectedRouterName!!, currentRouter)
+			return currentRouter
+		}
+
+		private fun parseAttribute(parser: XmlPullParser, config: Builder, currentRouter: GeneralRouter?) {
+			if (currentRouter != null) {
+				currentRouter.addAttribute(
+					parser.getAttributeValue("", "name")!!,
+					parser.getAttributeValue("", "value")!!
+				)
+			} else {
+				config.putAttribute(
+					parser.getAttributeValue("", "name")!!,
+					parser.getAttributeValue("", "value")!!
+				)
+			}
+		}
+	}
+}

--- a/OsmAnd-shared/src/iosMain/kotlin/net/osmand/shared/routing/BundledRoutingXml.kt
+++ b/OsmAnd-shared/src/iosMain/kotlin/net/osmand/shared/routing/BundledRoutingXml.kt
@@ -1,0 +1,5 @@
+package net.osmand.shared.routing
+
+import okio.Source
+
+internal actual fun openBundledRoutingXml(): Source? = null

--- a/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/routing/BundledRoutingXml.kt
+++ b/OsmAnd-shared/src/jvmMain/kotlin/net/osmand/shared/routing/BundledRoutingXml.kt
@@ -1,0 +1,7 @@
+package net.osmand.shared.routing
+
+import okio.Source
+import okio.source
+
+internal actual fun openBundledRoutingXml(): Source? =
+	RoutingConfiguration::class.java.getResourceAsStream("/net/osmand/router/routing.xml")?.source()

--- a/OsmAnd-shared/src/jvmTest/kotlin/net/osmand/shared/routing/RoutingConfigurationTest.kt
+++ b/OsmAnd-shared/src/jvmTest/kotlin/net/osmand/shared/routing/RoutingConfigurationTest.kt
@@ -1,0 +1,208 @@
+package net.osmand.shared.routing
+
+import okio.Buffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Lives in jvmTest rather than commonTest: the parsing goes through [net.osmand.shared.xml.XmlPullParser],
+ * whose iOS implementation is an API the host app injects at startup, so nothing XML can be parsed
+ * from a Kotlin/Native test binary. Everything under test here is common code either way.
+ */
+class RoutingConfigurationTest {
+
+	private val xml = """
+		<?xml version="1.0" encoding="UTF-8"?>
+		<osmand_routing_config defaultProfile="car">
+			<attribute name="zoomToLoadTiles" value="15"/>
+			<attribute name="planRoadDirection" value="1"/>
+			<routingProfile name="car" baseProfile="car" maxSpeed="30" derivedProfiles="truck">
+				<attribute name="heuristicCoefficient" value="2"/>
+				<attribute name="minPointApproximation" value="35"/>
+				<parameter id="short_way" group="driving_style" name="Short" description="Shortest"
+						type="boolean" default="true"/>
+				<parameter id="weight" name="Weight" description="Vehicle weight" profiles="car,truck"
+						type="numeric" values="3.5, 7.5, 11.5" valueDescriptions="light,medium,heavy" default="7.5"/>
+				<way attribute="access">
+					<select value="-1" t="highway" v="motorway"/>
+					<select value="1"/>
+				</way>
+				<way attribute="speed">
+					<select value="20" t="highway" v="primary"/>
+				</way>
+			</routingProfile>
+			<routingProfile name="bicycle" baseProfile="bicycle">
+				<attribute name="memoryLimitInMB" value="7"/>
+			</routingProfile>
+		</osmand_routing_config>
+	""".trimIndent()
+
+	private fun parse(filename: String? = null): RoutingConfiguration.Builder =
+		RoutingConfiguration.parseFromSource(Buffer().writeUtf8(xml), filename, RoutingConfiguration.Builder())
+
+	private fun limits() = RoutingConfiguration.RoutingMemoryLimits(0, 0)
+
+	@Test
+	fun testProfilesAreReadWithTheirBaseProfile() {
+		val builder = parse()
+		assertEquals("car", builder.getDefaultRouter())
+		assertEquals(setOf("car", "bicycle"), builder.getAllRouters().keys)
+		assertEquals(GeneralRouterProfile.CAR, builder.getRouter("car")!!.getProfile())
+		assertEquals(GeneralRouterProfile.BICYCLE, builder.getRouter("bicycle")!!.getProfile())
+	}
+
+	@Test
+	fun testUnknownBaseProfileFallsBackToCar() {
+		val source = Buffer().writeUtf8(
+			"""<osmand_routing_config defaultProfile="x">
+				<routingProfile name="x" baseProfile="hovercraft"/>
+			</osmand_routing_config>"""
+		)
+		val builder = RoutingConfiguration.parseFromSource(source)
+		assertEquals(GeneralRouterProfile.CAR, builder.getRouter("x")!!.getProfile())
+	}
+
+	@Test
+	fun testProfileAttributesReachTheConfiguration() {
+		val config = parse().build("car", limits())
+		assertEquals(2f, config.heuristicCoefficient)
+		assertEquals(35f, config.minPointApproximation)
+	}
+
+	@Test
+	fun testGlobalAttributesAreUsedWhenTheProfileIsSilent() {
+		val config = parse().build("car", limits())
+		assertEquals(15, config.ZOOM_TO_LOAD_TILES)
+		assertEquals(1, config.planRoadDirection)
+		// nothing declares it, so the field keeps its own default
+		assertEquals(20000f, config.recalculateDistance)
+	}
+
+	@Test
+	fun testMemoryLimitComesFromTheProfileOrTheCaller() {
+		assertEquals(7L shl 20, parse().build("bicycle", limits()).memoryLimitation)
+		assertEquals(
+			64L shl 20,
+			parse().build("car", RoutingConfiguration.RoutingMemoryLimits(64, 0)).memoryLimitation
+		)
+		// no profile limit and no caller limit falls back to the constant
+		assertEquals(
+			RoutingConfiguration.DEFAULT_MEMORY_LIMIT.toLong() shl 20,
+			parse().build("car", limits()).memoryLimitation
+		)
+	}
+
+	@Test
+	fun testUnknownProfileFallsBackToTheDefaultOne() {
+		val config = parse().build("hovercraft", limits())
+		assertEquals("car", config.routerName)
+	}
+
+	@Test
+	fun testDerivedProfileRoutesOnItsParentWithAFlag() {
+		val builder = parse()
+		val params = LinkedHashMap<String, String>()
+		val config = builder.build("truck", null, limits(), params)
+		assertEquals("car", config.routerName)
+		assertEquals("true", params["profile_truck"])
+	}
+
+	@Test
+	fun testBooleanAndNumericParametersAreRegistered() {
+		val router = parse().getRouter("car")!!
+		val shortWay = router.getParameters()["short_way"]
+		assertNotNull(shortWay)
+		assertEquals(GeneralRouter.RoutingParameterType.BOOLEAN, shortWay.type)
+		assertEquals("driving_style", shortWay.group)
+		assertTrue(shortWay.defaultBoolean)
+		assertNull(shortWay.profiles)
+
+		val weight = router.getParameters()["weight"]
+		assertNotNull(weight)
+		assertEquals(GeneralRouter.RoutingParameterType.NUMERIC, weight.type)
+		assertEquals(7.5, weight.defaultNumeric)
+		assertEquals(listOf("car", "truck"), weight.profiles!!.toList())
+		// the values are trimmed, the descriptions are not
+		assertEquals(listOf(3.5, 7.5, 11.5), weight.possibleValues!!.toList())
+		assertEquals(listOf("light", "medium", "heavy"), weight.possibleValueDescriptions!!.toList())
+	}
+
+	@Test
+	fun testRulesLandInTheAttributeTheyWereDeclaredUnder() {
+		val router = parse().getRouter("car")!!
+		assertEquals(2, router.getObjContext(GeneralRouter.RouteDataObjectAttribute.ACCESS).getRules().size)
+		assertEquals(1, router.getObjContext(GeneralRouter.RouteDataObjectAttribute.ROAD_SPEED).getRules().size)
+		assertEquals(0, router.getObjContext(GeneralRouter.RouteDataObjectAttribute.ONEWAY).getRules().size)
+	}
+
+	@Test
+	fun testAFilenameNamesTheProfilesItBrought() {
+		val builder = parse("bike.xml")
+		assertEquals(setOf("bike.xml/car", "bike.xml/bicycle"), builder.getAllRouters().keys)
+		assertEquals("bike.xml/car", builder.getRoutingProfileKeyByFileName("bike.xml"))
+		assertNull(builder.getRoutingProfileKeyByFileName("other.xml"))
+		assertNull(builder.getRoutingProfileKeyByFileName(null))
+	}
+
+	@Test
+	fun testImpassableRoadsReachTheRouterOfEveryBuild() {
+		val builder = parse()
+		builder.addImpassableRoad(42L)
+		assertEquals(setOf(42L), builder.getImpassableRoadLocations())
+
+		val config = builder.build("car", limits())
+		assertTrue(config.router.getImpassableRoadIds().contains(42L))
+
+		builder.clearImpassableRoadLocations()
+		assertTrue(builder.getImpassableRoadLocations().isEmpty())
+		// the configuration that was already built keeps the set it was given
+		assertTrue(config.router.getImpassableRoadIds().contains(42L))
+	}
+
+	@Test
+	fun testEachBuildProducesItsOwnConfiguration() {
+		val builder = parse()
+		val first = builder.build("car", limits())
+		val second = builder.build("car", limits())
+		assertNotSame(first, second)
+		first.showMinorTurns = true
+		assertFalse(second.showMinorTurns)
+	}
+
+	@Test
+	fun testRouterNameIsRecordedInTheAttributes() {
+		val config = parse().build("bicycle", limits())
+		assertEquals("bicycle", config.routerName)
+		assertEquals("bicycle", config.attributes["routerName"])
+		assertEquals("15", config.attributes["zoomToLoadTiles"])
+	}
+
+	@Test
+	fun testDirectionIsCarriedIntoTheConfiguration() {
+		val config = parse().build("car", 1.25, limits(), LinkedHashMap())
+		assertEquals(1.25, config.initialDirection)
+		assertNull(config.targetDirection)
+	}
+
+	@Test
+	fun testParseSilentHelpersKeepTheDefaultOnEmptyInput() {
+		assertEquals(7, RoutingConfiguration.parseSilentInt(null, 7))
+		assertEquals(7, RoutingConfiguration.parseSilentInt("", 7))
+		assertEquals(3, RoutingConfiguration.parseSilentInt("3", 7))
+		assertEquals(7f, RoutingConfiguration.parseSilentFloat(null, 7f))
+		assertEquals(7f, RoutingConfiguration.parseSilentFloat("", 7f))
+		assertEquals(2.5f, RoutingConfiguration.parseSilentFloat("2.5", 7f))
+	}
+
+	@Test
+	fun testConfigurationWithoutDirectionPoints() {
+		val config = parse().build("car", limits())
+		assertNull(config.getDirectionPoints())
+		assertEquals(0, config.getNativeDirectionPoints().size)
+	}
+}


### PR DESCRIPTION
Part of the routing-to-OsmAnd-shared series: the java classes stay in `OsmAnd-java` and android, tools and the C++ core keep using them; each step adds a copy to `OsmAnd-shared` and a test that the copy behaves like the original. The copies are for iOS, which will call them instead of its own C++ turn preparation.

`RoutingConfiguration`, its `Builder` and the `routing.xml` parser, reading the bundled file through `BundledRoutingXml` (jvm and android open it from the classpath, iOS has none). Three comparisons come with it:

- `RoutingConfigurationCompatTest`: both parsers read the same `routing.xml`; every profile, every attribute, every parameter and every configuration built with no parameters, every switch on and every choice at its first value.
- `GeneralRouterCompatTest`: every profile in the three parameter states asked about every real road in the test obf files - acceptance, one-way, speeds, priorities, obstacles at every point.
- `DirectionPointsCompatTest`: the same points through both builders, and the flattened form the C++ router gets.

Supersedes #25920.

One more commit since the review started: `RoutingConfiguration.DEFAULT_PENALTY_FOR_REVERSE_DIRECTION` is exported to Objective-C as `defaultPenaltyForReverseDirection`. The iOS app includes the C++ core's headers next to `OsmAndShared.h`, and it is a macro there, so with the Kotlin name in the framework header the app's own sources stop compiling. Only the selector the framework publishes changes (`@ObjCName`); the Kotlin name, and so the side-by-side comparison with java, stays.