### PR TITLE
Expose the atoms of a spatial search result

### DIFF
--- a/OsmAnd-java/src/main/java/net/osmand/search/core/spatial/SpatialSearchResult.java
+++ b/OsmAnd-java/src/main/java/net/osmand/search/core/spatial/SpatialSearchResult.java
@@ -101,11 +101,16 @@ public class SpatialSearchResult implements Comparable<SpatialSearchResult> {
 		});
 	}
 
-	SpatialSearchResultRef getFirstRef() {
+	public SpatialSearchResultRef getFirstRef() {
 		if (objs.size() > 0) {
 			return objs.get(0);
 		}
 		return null;
+	}
+
+	/** atoms of the combination this result stands for, one per query token */
+	public List<NameIndexAtom> getAtoms() {
+		return parent.getRawAtoms(parentInd);
 	}
 	
 	private MapObject getFirstRefObject(boolean useUnited) {


### PR DESCRIPTION
Fixes the OsmAndMapCreator build (Jenkins #13468) after osmandapp/OsmAnd-tools#1709.

`SpatialResultFormatter` moved to `net.osmand.search.core.spatial.test` in tools and reads the atoms of a result from outside the package:
- `SpatialSearchResult.getFirstRef()` becomes public;
- new `getAtoms()` returns the atoms of the combination the result stands for.

No behaviour change.

## AI disclaimer

Produced with Claude Code (Opus 5).

Prompts used (summarised):
1. Move the new search-test classes from `spatial` to a `spatial/test` package, since android and the server do not need them.
2. Commit and update the tools PR.
3. The OsmAndMapCreator build failed — find what was forgotten.
4. Open a pull request on android.

Decided by the agent, not requested explicitly: exposing `getFirstRef()` and adding `getAtoms()` instead of keeping the formatter in the `spatial` package.
